### PR TITLE
fix: route slug-collision-masqueraded-as-error through existing retry

### DIFF
--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -73,6 +73,23 @@ def _first_non_empty_str(body: dict[str, Any], keys: tuple[str, ...]) -> str:
     return ""
 
 
+# Lithos currently bundles slug collisions into ``status="error"`` with a
+# message of the shape ``Slug '<slug>' already in use by document '<id>'``
+# (staging incident 2026-05-01).  The existing ``slug_collision`` retry
+# path in ``write_note`` recovers automatically once the parser routes
+# these responses to that branch.  Drop this shim once Lithos is updated
+# to emit ``status="slug_collision"`` directly.
+_SLUG_COLLISION_DETAIL_RE = re.compile(
+    r"slug\s+'[^']+'\s+already in use",
+    re.IGNORECASE,
+)
+
+
+def _looks_like_slug_collision(detail: str) -> bool:
+    """Return ``True`` when the Lithos error message describes a slug clash."""
+    return bool(detail) and _SLUG_COLLISION_DETAIL_RE.search(detail) is not None
+
+
 @dataclasses.dataclass(frozen=True)
 class WriteResult:
     """Result of a ``write_note`` call after envelope handling (FR-MCP-7).
@@ -700,6 +717,30 @@ class LithosClient:
         # is root-causable from logs alone — see staging incident
         # 2026-04-30 where a bare ``status=error`` left no breadcrumb.
         detail = _first_non_empty_str(body, ("reason", "detail", "error", "message"))
+
+        # Stopgap: Lithos returns slug collisions inside ``status="error"``
+        # rather than the documented ``status="slug_collision"``.  Re-route
+        # so the existing slug-collision retry (FR-MCP-7, AC-05-D) engages
+        # instead of skipping the write forever (staging incident
+        # 2026-05-01).  Remove once Lithos emits the proper status.
+        if _looks_like_slug_collision(detail):
+            logger.warning(
+                "lithos_write returned slug-collision masquerading as error for %s: %s",
+                source_url,
+                detail,
+                extra={
+                    "lithos_status": status,
+                    "source_url": source_url,
+                    "detail": detail,
+                    "rerouted_to": "slug_collision",
+                },
+            )
+            return WriteResult(
+                status="slug_collision",
+                source_url=source_url,
+                detail=detail,
+            )
+
         body_excerpt = "" if detail else json.dumps(body, default=str)[:500]
         logger.warning(
             "lithos_write returned non-success status=%s for %s: %s",

--- a/tests/contract/test_lithos_client.py
+++ b/tests/contract/test_lithos_client.py
@@ -1077,6 +1077,59 @@ class TestWriteEnvelopeUnknownStatus:
         finally:
             await client.close()
 
+    async def test_slug_collision_masqueraded_as_error_is_rerouted(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A ``status='error'`` body whose ``reason`` describes a slug clash
+        must be re-routed through the existing slug-collision retry, so the
+        write succeeds with a disambiguated title (staging incident
+        2026-05-01).
+        """
+        import logging
+
+        slug_msg = (
+            "Slug 'attention-is-all-you-need' already in use by "
+            "document 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'"
+        )
+        fake_lithos_server.write_responses.extend(
+            [
+                f'{{"status": "error", "reason": "{slug_msg}"}}',
+                '{"status": "created"}',
+            ]
+        )
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            with caplog.at_level(logging.WARNING, logger="influx.lithos_client"):
+                result = await client.write_note(
+                    title="Attention Is All You Need",
+                    content="# Summary\nTransformer paper.",
+                    path="papers/arxiv/2026/03",
+                    source_url="https://arxiv.org/abs/1706.03762",
+                    tags=["profile:ml-research"],
+                    confidence=0.9,
+                )
+            assert result.status == "created"
+            # Retry must have run with the disambiguating title suffix.
+            write_calls = [
+                c for c in fake_lithos_server.calls if c[0] == "lithos_write"
+            ]
+            assert len(write_calls) == 2
+            assert write_calls[1][1]["title"] == (
+                "Attention Is All You Need [arXiv 1706.03762]"
+            )
+            # The reroute itself is logged so operators can spot Lithos
+            # still mis-classifying these.
+            assert any(
+                "slug-collision masquerading as error" in r.getMessage()
+                for r in caplog.records
+            )
+        finally:
+            await client.close()
+
 
 # ── Write envelopes — slug_collision (FR-MCP-7, AC-05-D) ──────────
 


### PR DESCRIPTION
Lithos returns slug collisions as `status="error"` with a `Slug '...' already in use` message instead of the documented `status="slug_collision"`.  The existing FR-MCP-7 / AC-05-D slug-collision retry path was therefore never engaged, so the same articles re-failed every scheduled run with no progress.

Detect the slug-clash shape inside the error envelope and re-route to `slug_collision` so `_retry_slug_collision` re-runs with the disambiguating title suffix.  Logged separately so operators can spot the upstream classification bug and remove this shim once Lithos emits the correct status.

Refs staging incident 2026-05-01.