### PR TITLE
fix: degrade Tier 1/Tier 3 enrichment crashes to per-paper repair

### DIFF
--- a/src/influx/schemas.py
+++ b/src/influx/schemas.py
@@ -13,8 +13,21 @@ _FILTER_MAX_TAGS = 5
 
 
 def _trim_and_truncate(values: list[str]) -> list[str]:
-    """Trim whitespace and truncate each element to 500 chars (FR-ENR-5)."""
-    return [v.strip()[:_TIER3_MAX_CHARS] for v in values]
+    """Trim whitespace and truncate each element to 500 chars (FR-ENR-5).
+
+    Raises ``ValueError`` when an element is not a string so Pydantic
+    surfaces the failure as ``ValidationError`` rather than letting an
+    ``AttributeError`` escape — the latter bypasses ``LCMAError``-only
+    callers and aborts the whole run (staging incident 2026-05-01).
+    """
+    out: list[str] = []
+    for v in values:
+        if not isinstance(v, str):
+            raise ValueError(
+                f"List element must be a string, got {type(v).__name__}: {v!r:.100}"
+            )
+        out.append(v.strip()[:_TIER3_MAX_CHARS])
+    return out
 
 
 def _check_non_empty(values: list[str]) -> list[str]:

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -676,6 +676,18 @@ def build_arxiv_note_item(
             except LCMAError:
                 _log.warning("Tier 1 enrichment failed for %s", item.arxiv_id)
                 repair_needed = True
+            except Exception:
+                # Defensive: any unexpected failure during Tier 1
+                # (e.g. an LLM response shape that bypasses the schema's
+                # validators with an AttributeError, per staging incident
+                # 2026-05-01) must degrade to a per-paper repair, not
+                # take the whole scheduler run down.
+                _log.warning(
+                    "Tier 1 enrichment crashed unexpectedly for %s",
+                    item.arxiv_id,
+                    exc_info=True,
+                )
+                repair_needed = True
 
     # ── Tier 3 deep extraction (FR-ENR-5) ─────────────────────────
     tier3_result: Tier3Extraction | None = None
@@ -698,6 +710,17 @@ def build_arxiv_note_item(
                 )
             except LCMAError:
                 _log.warning("Tier 3 extraction failed for %s", item.arxiv_id)
+                repair_needed = True
+            except Exception:
+                # Defensive: same rationale as the Tier 1 catch — a
+                # validator bug or unforeseen response shape must not
+                # turn a single bad paper into a run-level abort
+                # (staging incident 2026-05-01).
+                _log.warning(
+                    "Tier 3 extraction crashed unexpectedly for %s",
+                    item.arxiv_id,
+                    exc_info=True,
+                )
                 repair_needed = True
 
     # influx:deep-extracted iff all four Tier 3 sections exist.

--- a/tests/unit/test_build_arxiv_note_item.py
+++ b/tests/unit/test_build_arxiv_note_item.py
@@ -854,6 +854,66 @@ class TestTier3ExtractionFailure:
 
         assert "influx:repair-needed" in result["tags"]
 
+    @patch("influx.sources.arxiv.tier3_extract")
+    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.sources.arxiv.extract_arxiv_text")
+    def test_unexpected_tier3_exception_degrades_to_repair(
+        self, mock_ext: object, mock_t1: object, mock_t3: object
+    ) -> None:
+        """A non-LCMAError raised by tier3_extract (e.g. an AttributeError
+        from a validator that bypassed Pydantic's ValidationError wrapper)
+        must degrade to ``influx:repair-needed`` for this paper, not abort
+        the run with an uncaught exception (staging incident 2026-05-01).
+        """
+        mock_ext.return_value = ArxivExtractionResult(  # type: ignore[union-attr]
+            text="text", source_tag="text:html"
+        )
+        mock_t1.return_value = _make_tier1()  # type: ignore[union-attr]
+        mock_t3.side_effect = AttributeError(  # type: ignore[union-attr]
+            "'dict' object has no attribute 'strip'"
+        )
+        config = _make_config(relevance=7, full_text=8, deep_extract=9)
+
+        # Must not raise.
+        result = build_arxiv_note_item(
+            item=_make_item(),
+            score=9,
+            confidence=0.9,
+            reason="R",
+            profile_name="ai-robotics",
+            config=config,
+        )
+
+        assert "influx:repair-needed" in result["tags"]
+        assert "influx:deep-extracted" not in result["tags"]
+        assert "## Claims" not in result["content"]
+
+    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.sources.arxiv.extract_arxiv_text")
+    def test_unexpected_tier1_exception_degrades_to_repair(
+        self, mock_ext: object, mock_t1: object
+    ) -> None:
+        """Same defence-in-depth for Tier 1 — an unexpected exception must
+        not abort the run.
+        """
+        mock_ext.return_value = ArxivExtractionResult(  # type: ignore[union-attr]
+            text="text", source_tag="text:html"
+        )
+        mock_t1.side_effect = TypeError("bad shape")  # type: ignore[union-attr]
+        config = _make_config(relevance=7, deep_extract=100)
+
+        result = build_arxiv_note_item(
+            item=_make_item(),
+            score=7,
+            confidence=0.7,
+            reason="R",
+            profile_name="ai-robotics",
+            config=config,
+        )
+
+        assert "influx:repair-needed" in result["tags"]
+        assert "## Summary" not in result["content"]
+
 
 # ── Per-tier failure independence (AC-07-D) ──────────────────────
 

--- a/tests/unit/test_enrich.py
+++ b/tests/unit/test_enrich.py
@@ -466,6 +466,29 @@ class TestTier3ExtractValidationFailure:
         assert exc_info.value.stage == "validate"
         assert exc_info.value.model == "extract"
 
+    def test_dict_elements_raise_lcma_validate_error(
+        self, influx_config_env: Any, tmp_path: Any
+    ) -> None:
+        """Some extract models occasionally emit ``[{"claim": "...", ...}]``
+        instead of plain strings.  The schema-level validator must surface
+        this as ``LCMAError(stage="validate")`` so the per-paper failure
+        path runs (``influx:repair-needed``) rather than aborting the
+        whole scheduler run with a bare ``AttributeError`` (staging
+        incident 2026-05-01).
+        """
+        config = load_config()
+        payload = _valid_tier3_response(
+            claims=[{"claim": "x", "score": 0.8}],  # type: ignore[list-item]
+        )
+
+        with (
+            patch("influx.enrich._call_json_model", return_value=payload),
+            pytest.raises(LCMAError) as exc_info,
+        ):
+            tier3_extract(title="T", full_text="F", config=config)
+        assert exc_info.value.stage == "validate"
+        assert exc_info.value.model == "extract"
+
 
 class TestTier3ExtractPromptRendering:
     """Prompt is rendered with both required variables."""

--- a/tests/unit/test_tier3_schema.py
+++ b/tests/unit/test_tier3_schema.py
@@ -142,6 +142,29 @@ class TestTier3ExtractionNegative:
         with pytest.raises(ValidationError):
             Tier3Extraction(**_valid(potential_connections=[""]))
 
+    def test_dict_element_in_claims_raises_validation_error(self) -> None:
+        """Non-string list elements (e.g. dict per item from a model that
+        emitted structured output) must raise ``ValidationError`` rather
+        than ``AttributeError`` so callers see the standard Pydantic
+        contract.  Staging incident 2026-05-01.
+        """
+        with pytest.raises(ValidationError):
+            Tier3Extraction(**_valid(claims=[{"claim": "x", "score": 0.8}]))  # type: ignore[arg-type]
+
+    def test_dict_element_in_builds_on_raises_validation_error(self) -> None:
+        with pytest.raises(ValidationError):
+            Tier3Extraction(
+                **_valid(builds_on=[{"title": "FooNet", "arxiv_id": "2412.12345"}])  # type: ignore[arg-type]
+            )
+
+    def test_dict_element_in_potential_connections_raises_validation_error(
+        self,
+    ) -> None:
+        with pytest.raises(ValidationError):
+            Tier3Extraction(
+                **_valid(potential_connections=[{"title": "Foo"}])  # type: ignore[arg-type]
+            )
+
     def test_missing_claims(self) -> None:
         with pytest.raises(ValidationError):
             Tier3Extraction(


### PR DESCRIPTION
Staging incident 2026-05-01: a staging-ai scheduled run aborted with ``AttributeError: 'dict' object has no attribute 'strip'`` and lost the entire run. Two-part fix:

1. ``schemas._trim_and_truncate`` (used as a Pydantic ``mode="before"`` validator on Tier3Extraction list fields) raises ValueError on non-string elements, so the failure surfaces as ValidationError → LCMAError(stage="validate") instead of escaping as AttributeError. Some extract-slot models occasionally emit ``[{"claim":"...","score":N}]`` instead of plain string lists; the previous validator died on ``v.strip()``.

2. ``sources/arxiv.build_arxiv_note_item`` widens the Tier 1 / Tier 3 except clauses to also catch generic Exception. Defence-in-depth: the validator fix alone closes the known case, but any future bypass of the structured-error path (validator bug, response-shape drift) must still degrade to a single per-paper failure (``influx:repair-needed``) rather than aborting the whole run.

Tests cover the schema-level dict rejection, the LCMAError mapping in tier3_extract, and the end-to-end repair-tag fallback in build_arxiv_note_item for both AttributeError and TypeError.