### PR TITLE
feat: archive-terminal cap + plumb webhook secrets through compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,3 +31,8 @@ services:
       - OTEL_BSP_SCHEDULE_DELAY=${OTEL_BSP_SCHEDULE_DELAY:-30000}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      # Webhook auth tokens — referenced by influx.toml `auth_token_env` /
+      # `rfc_password_env` for the openclaw-agent and agent-zero-inbox-rfc
+      # outbound webhooks (FR-NOT-*).
+      - OPENCLAW_TOKEN=${OPENCLAW_TOKEN:-}
+      - AGENT_ZERO_RFC_PASSWORD=${AGENT_ZERO_RFC_PASSWORD:-}

--- a/src/influx/notes.py
+++ b/src/influx/notes.py
@@ -279,6 +279,10 @@ _INFLUX_OWNED_EXACT: frozenset[str] = frozenset(
         # the same broken extraction (mirrors influx:text-terminal).
         "influx:tier2-terminal",
         "influx:tier3-terminal",
+        # Set after repeated oversize (or other counted-class) archive
+        # download failures — caps the archive_retry stage in select_stages
+        # the same way tier{2,3}-terminal cap their respective stages.
+        "influx:archive-terminal",
     }
 )
 

--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -341,9 +341,11 @@ def select_stages(
     is_text_terminal = "influx:text-terminal" in tag_set
     is_tier2_terminal = "influx:tier2-terminal" in tag_set
     is_tier3_terminal = "influx:tier3-terminal" in tag_set
+    is_archive_terminal = "influx:archive-terminal" in tag_set
 
-    # 1. Archive retry: influx:archive-missing present (AC-06-A).
-    archive_retry = "influx:archive-missing" in tag_set
+    # 1. Archive retry: influx:archive-missing present (AC-06-A) AND
+    #    the per-stage archive-terminal cap has not been reached.
+    archive_retry = "influx:archive-missing" in tag_set and not is_archive_terminal
 
     # 2. Text-extraction retry: no text:* tag present.
     has_text_tag = any(t.startswith("text:") for t in tag_set)
@@ -417,11 +419,11 @@ def _restore_note(note: dict[str, Any], snapshot: dict[str, Any]) -> None:
 class RepairCounters:
     """Per-stage attempt counters tracked in the note's ``## Repair`` section.
 
-    ``tier{2,3}_attempts`` count *counted-toward-cap* failures only —
-    transient HTTP / network failures are not bumped (see
-    :func:`classify_failure`).  When ``tier{N}_attempts`` reaches the
-    configured cap, the sweep adds the ``influx:tier{N}-terminal`` tag
-    and stops re-running that stage on subsequent passes.
+    ``{archive,tier2,tier3}_attempts`` count *counted-toward-cap*
+    failures only — transient HTTP / network failures are not bumped
+    (see :func:`classify_failure`).  When ``<stage>_attempts`` reaches
+    the configured cap, the sweep adds the ``influx:<stage>-terminal``
+    tag and stops re-running that stage on subsequent passes.
     """
 
     tier2_attempts: int = 0
@@ -430,6 +432,9 @@ class RepairCounters:
     tier3_attempts: int = 0
     tier3_last_stage: str = ""
     tier3_last_error: str = ""
+    archive_attempts: int = 0
+    archive_last_kind: str = ""
+    archive_last_error: str = ""
 
     def bump_tier2(self, *, stage: str, error: str) -> RepairCounters:
         """Return a new counters value with Tier 2 attempts incremented."""
@@ -447,6 +452,23 @@ class RepairCounters:
             tier3_attempts=self.tier3_attempts + 1,
             tier3_last_stage=stage,
             tier3_last_error=_collapse_to_single_line(error),
+        )
+
+    def bump_archive(self, *, kind: str, error: str) -> RepairCounters:
+        """Return a new counters value with archive attempts incremented.
+
+        *kind* is the underlying failure classifier — typically the
+        ``stage`` from ``ExtractionError`` or the ``kind`` from
+        ``NetworkError`` (e.g. ``"oversize"``).  Stored verbatim so an
+        operator inspecting the note can tell at a glance whether the
+        archive is being terminated for size, content-type mismatch,
+        or some other persistent reason.
+        """
+        return replace(
+            self,
+            archive_attempts=self.archive_attempts + 1,
+            archive_last_kind=kind,
+            archive_last_error=_collapse_to_single_line(error),
         )
 
 
@@ -498,12 +520,14 @@ def parse_repair_section(content: str) -> RepairCounters:
     body = content[body_start + 1 : end]
 
     fields: dict[str, Any] = {}
-    int_keys = {"tier2_attempts", "tier3_attempts"}
+    int_keys = {"tier2_attempts", "tier3_attempts", "archive_attempts"}
     str_keys = {
         "tier2_last_stage",
         "tier2_last_error",
         "tier3_last_stage",
         "tier3_last_error",
+        "archive_last_kind",
+        "archive_last_error",
     }
     for line in body.splitlines():
         bm = _REPAIR_BULLET_RE.match(line)
@@ -533,6 +557,12 @@ def render_repair_section(counters: RepairCounters) -> str:
         f"- tier3_attempts: {counters.tier3_attempts}",
         f'- tier3_last_stage: "{counters.tier3_last_stage}"',
         f'- tier3_last_error: "{_collapse_to_single_line(counters.tier3_last_error)}"',
+        f"- archive_attempts: {counters.archive_attempts}",
+        f'- archive_last_kind: "{counters.archive_last_kind}"',
+        (
+            "- archive_last_error: "
+            f'"{_collapse_to_single_line(counters.archive_last_error)}"'
+        ),
     ]
     return "\n".join(lines) + "\n"
 
@@ -589,9 +619,16 @@ def classify_failure(exc: BaseException) -> Literal["transient", "counted"]:
     """
     if isinstance(exc, (LCMAError, ExtractionError)):
         stage = getattr(exc, "stage", "") or ""
-        if stage in ("parse", "validate"):
+        if stage in _COUNTED_STAGES:
             return "counted"
     return "transient"
+
+
+# Stage / kind discriminators that mean "rerunning will almost certainly
+# fail the same way" — bump the attempt counter toward the cap.  Includes
+# both LCMA-side schema failures (parse, validate) and archive-side
+# size violations (oversize) which won't shrink on retry.
+_COUNTED_STAGES: frozenset[str] = frozenset({"parse", "validate", "oversize"})
 
 
 def _log_stage_failure(
@@ -1110,6 +1147,38 @@ async def _process_sweep_note(
             # Restore the note dict so partial in-place mutations from
             # the failing hook are NOT persisted (finding #1).
             _restore_note(note, snapshot)
+            if classify_failure(exc) == "counted":
+                counters = parse_repair_section(str(note.get("content", "")))
+                kind = (
+                    getattr(exc, "stage", "")
+                    or getattr(exc, "kind", "")
+                    or "archive_failed"
+                )
+                counters = counters.bump_archive(kind=kind, error=str(exc))
+                note["content"] = upsert_repair_section(
+                    str(note.get("content", "")), counters
+                )
+                if (
+                    counters.archive_attempts >= REPAIR_COUNTED_CAP
+                    and "influx:archive-terminal" not in current_tags
+                ):
+                    current_tags.append("influx:archive-terminal")
+                    note["tags"] = list(current_tags)
+                    logger.warning(
+                        "sweep: archive marked terminal after %d failures for %s",
+                        counters.archive_attempts,
+                        note.get("id", "?"),
+                        extra={
+                            "sweep_stage": "archive_terminal_flip",
+                            "note_id": note.get("id"),
+                            "profile": profile,
+                            "run_id": current_run_id.get() or "",
+                            "archive_attempts": counters.archive_attempts,
+                            "exc_type": type(exc).__name__,
+                            "kind": kind,
+                            "detail": getattr(exc, "detail", None),
+                        },
+                    )
             _log_stage_failure(
                 "archive_download",
                 note=note,

--- a/tests/unit/test_repair_self_repair.py
+++ b/tests/unit/test_repair_self_repair.py
@@ -159,6 +159,22 @@ class TestRenderRepairSection:
         assert "- tier3_attempts: 2" in rendered
         assert '- tier3_last_stage: "validate"' in rendered
         assert '- tier3_last_error: "bad json"' in rendered
+        # Archive fields are always rendered, even when zero, so the
+        # bullet schema stays stable across notes.
+        assert "- archive_attempts: 0" in rendered
+        assert '- archive_last_kind: ""' in rendered
+
+    def test_renders_archive_fields(self) -> None:
+        rendered = render_repair_section(
+            RepairCounters(
+                archive_attempts=2,
+                archive_last_kind="oversize",
+                archive_last_error="exceeds 100000000 bytes",
+            )
+        )
+        assert "- archive_attempts: 2" in rendered
+        assert '- archive_last_kind: "oversize"' in rendered
+        assert '- archive_last_error: "exceeds 100000000 bytes"' in rendered
 
     def test_strips_newlines_in_last_error(self) -> None:
         rendered = render_repair_section(
@@ -209,9 +225,26 @@ class TestUpsertRepairSection:
             tier3_attempts=1,
             tier3_last_stage="validate",
             tier3_last_error="bad",
+            archive_attempts=2,
+            archive_last_kind="oversize",
+            archive_last_error="too big",
         )
         roundtripped = parse_repair_section(upsert_repair_section(original, counters))
         assert roundtripped == counters
+
+    def test_archive_fields_round_trip_through_parse(self) -> None:
+        body = (
+            "## Repair\n"
+            "- tier2_attempts: 0\n"
+            "- tier3_attempts: 0\n"
+            "- archive_attempts: 2\n"
+            '- archive_last_kind: "oversize"\n'
+            '- archive_last_error: "exceeds 100000000 bytes"\n'
+        )
+        c = parse_repair_section(body)
+        assert c.archive_attempts == 2
+        assert c.archive_last_kind == "oversize"
+        assert c.archive_last_error == "exceeds 100000000 bytes"
 
 
 # ── Counter mutation ─────────────────────────────────────────────────
@@ -235,3 +268,44 @@ class TestRepairCountersBump:
         assert c2.tier3_attempts == 3
         assert c2.tier3_last_stage == "validate"
         assert c2.tier3_last_error == "mismatch"
+
+    def test_bump_archive_returns_new_instance_with_incremented_count(self) -> None:
+        c = RepairCounters(archive_attempts=1)
+        c2 = c.bump_archive(kind="oversize", error="exceeds 100000000 bytes")
+        assert c is not c2
+        assert c.archive_attempts == 1
+        assert c2.archive_attempts == 2
+        assert c2.archive_last_kind == "oversize"
+        assert c2.archive_last_error.startswith("exceeds")
+
+
+class TestClassifyArchiveFailure:
+    """``classify_failure`` treats oversize archive failures as counted —
+    a 200 MB PDF will not shrink on retry, so the cap should engage.
+    """
+
+    def test_extraction_oversize_stage_is_counted(self) -> None:
+        assert (
+            classify_failure(
+                ExtractionError("too big", url="http://x", stage="oversize")
+            )
+            == "counted"
+        )
+
+    def test_extraction_archive_read_stage_is_transient(self) -> None:
+        # archive_read covers transient filesystem / IO errors that may
+        # heal on retry — must NOT bump the cap.
+        assert (
+            classify_failure(
+                ExtractionError("io error", url="http://x", stage="archive_read")
+            )
+            == "transient"
+        )
+
+    def test_lithos_error_during_archive_is_transient(self) -> None:
+        assert (
+            classify_failure(
+                LithosError("transport flake", operation="archive_download")
+            )
+            == "transient"
+        )

--- a/tests/unit/test_repair_stage_selection.py
+++ b/tests/unit/test_repair_stage_selection.py
@@ -378,6 +378,38 @@ class TestTier3TerminalPresent:
         assert s.tier2_retry is True
 
 
+class TestArchiveTerminalPresent:
+    """``influx:archive-terminal`` caps the archive_retry stage so a
+    permanently-oversize PDF stops being retried every sweep.
+    """
+
+    def test_archive_retry_not_selected_with_archive_terminal(self) -> None:
+        s = _select(
+            [
+                "influx:repair-needed",
+                "influx:archive-missing",
+                "influx:archive-terminal",
+                "text:abstract-only",
+            ],
+        )
+        assert s.archive_retry is False
+
+    def test_other_stages_still_eligible_with_only_archive_terminal(self) -> None:
+        """Tier 2 / Tier 3 are independent of archive-terminal."""
+        s = _select(
+            [
+                "influx:repair-needed",
+                "influx:archive-missing",
+                "influx:archive-terminal",
+                "text:html",
+            ],
+            max_profile_score=HIGH_SCORE,
+        )
+        assert s.archive_retry is False
+        assert s.tier2_retry is True
+        assert s.tier3_retry is True
+
+
 # ── Abstract-only re-extraction with stored archive path ─────────────
 
 

--- a/tests/unit/test_repair_sweep.py
+++ b/tests/unit/test_repair_sweep.py
@@ -17,7 +17,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from influx.config import AppConfig, RepairConfig
-from influx.errors import LCMAError, LithosError
+from influx.errors import ExtractionError, LCMAError, LithosError
 from influx.repair import ContentTooLargeSkipped, SweepHooks, SweepWriteError, sweep
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -1056,6 +1056,182 @@ class TestSweepCapCounterAndTerminalFlip:
             client=client,
             config=config,
             hooks=SweepHooks(tier3_extract=spy),
+        )
+
+        assert call_count == 0
+
+
+class TestSweepArchiveTerminalCap:
+    """Repeated counted-class archive failures (e.g. oversize) flip
+    ``influx:archive-terminal`` so the sweep stops re-attempting a
+    download that will never succeed.
+    """
+
+    @staticmethod
+    def _note_for_archive(note_id: str) -> dict[str, Any]:
+        # influx:archive-missing tagged so archive_retry is selected.
+        body = (
+            "---\n"
+            f"source_url: https://arxiv.org/abs/{note_id}\n"
+            "tags: []\n"
+            "confidence: 0.9\n"
+            "---\n"
+            "# Paper\n\n"
+            "## Archive\n\n"
+            "## Summary\nSummary\n\n"
+            "## Profile Relevance\n"
+            "### ai-robotics\nScore: 9/10\nRelevant\n\n"
+            "## User Notes\n"
+        )
+        return {
+            "id": note_id,
+            "title": "Paper",
+            "content": body,
+            "tags": ["influx:repair-needed", "influx:archive-missing"],
+            "source_url": f"https://arxiv.org/abs/{note_id}",
+            "confidence": 0.9,
+        }
+
+    @staticmethod
+    def _last_write_args(client: AsyncMock) -> dict[str, Any]:
+        write_calls = [
+            c for c in client.call_tool.call_args_list if c.args[0] == "lithos_write"
+        ]
+        assert write_calls, "expected lithos_write call"
+        return dict(write_calls[-1].args[1])
+
+    async def test_oversize_failure_bumps_archive_counter(self) -> None:
+        """One counted oversize failure increments archive_attempts."""
+        items = [{"id": "n1", "title": "Paper"}]
+        note = self._note_for_archive("n1")
+
+        def failing(note: dict[str, object]) -> str:
+            del note
+            raise ExtractionError(
+                "Response body exceeds 100000000 bytes",
+                url="https://arxiv.org/pdf/x.pdf",
+                stage="oversize",
+            )
+
+        config = _make_config()
+        client = _make_client(list_items=items, read_responses=[note])
+
+        await sweep(
+            "ai-robotics",
+            client=client,
+            config=config,
+            hooks=SweepHooks(archive_download=failing),
+        )
+
+        rewritten = self._last_write_args(client)
+        content = rewritten["content"]
+        assert "## Repair" in content
+        assert "archive_attempts: 1" in content
+        assert 'archive_last_kind: "oversize"' in content
+        assert "influx:archive-terminal" not in rewritten["tags"]
+
+    async def test_transient_archive_failure_does_not_bump_counter(self) -> None:
+        """LithosError-class archive failures (transport flakes) must NOT
+        advance the cap counter — they may heal on retry.
+        """
+        items = [{"id": "n1", "title": "Paper"}]
+        note = self._note_for_archive("n1")
+
+        def failing(note: dict[str, object]) -> str:
+            del note
+            raise LithosError("connection refused", operation="archive_download")
+
+        config = _make_config()
+        client = _make_client(list_items=items, read_responses=[note])
+
+        await sweep(
+            "ai-robotics",
+            client=client,
+            config=config,
+            hooks=SweepHooks(archive_download=failing),
+        )
+
+        rewritten = self._last_write_args(client)
+        content = rewritten["content"]
+        if "## Repair" in content:
+            assert "archive_attempts: 0" in content
+        assert "influx:archive-terminal" not in rewritten["tags"]
+
+    async def test_third_oversize_failure_flips_archive_terminal(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """At cap=3, ``influx:archive-terminal`` is added and a WARNING is logged."""
+        import logging
+
+        items = [{"id": "n1", "title": "Paper"}]
+        note = self._note_for_archive("n1")
+        note["content"] = note["content"].replace(
+            "## User Notes\n",
+            (
+                "## Repair\n"
+                "- archive_attempts: 2\n"
+                '- archive_last_kind: "oversize"\n'
+                '- archive_last_error: "earlier failure"\n\n'
+                "## User Notes\n"
+            ),
+        )
+
+        def failing(note: dict[str, object]) -> str:
+            del note
+            raise ExtractionError(
+                "Response body exceeds 100000000 bytes",
+                url="https://arxiv.org/pdf/x.pdf",
+                stage="oversize",
+            )
+
+        config = _make_config()
+        client = _make_client(list_items=items, read_responses=[note])
+
+        with caplog.at_level(logging.WARNING, logger="influx.repair"):
+            await sweep(
+                "ai-robotics",
+                client=client,
+                config=config,
+                hooks=SweepHooks(archive_download=failing),
+            )
+
+        rewritten = self._last_write_args(client)
+        assert "influx:archive-terminal" in rewritten["tags"]
+        assert "archive_attempts: 3" in rewritten["content"]
+
+        flip_logs = [
+            r
+            for r in caplog.records
+            if getattr(r, "sweep_stage", None) == "archive_terminal_flip"
+        ]
+        assert flip_logs, "expected archive_terminal_flip log"
+        rec = flip_logs[0]
+        assert getattr(rec, "archive_attempts", None) == 3
+        assert getattr(rec, "kind", None) == "oversize"
+
+    async def test_archive_terminal_present_skips_archive_retry(self) -> None:
+        """Once ``influx:archive-terminal`` is set, archive_download is not called."""
+        items = [{"id": "n1", "title": "Paper"}]
+        note = self._note_for_archive("n1")
+        note["tags"] = list(note["tags"]) + ["influx:archive-terminal"]
+
+        call_count = 0
+
+        def spy(note: dict[str, object]) -> str:
+            nonlocal call_count
+            del note
+            call_count += 1
+            return "x.pdf"
+
+        config = _make_config()
+        client = _make_client(list_items=items, read_responses=[note])
+
+        await sweep(
+            "ai-robotics",
+            client=client,
+            config=config,
+            hooks=SweepHooks(archive_download=spy),
         )
 
         assert call_count == 0


### PR DESCRIPTION
Two operational fixes from staging logs 2026-05-01.

1. Webhook secrets now reach the container.

   docker-compose.yml only enumerated a fixed list of env vars under `environment:` (`INFLUX_*`, `OTEL_*`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`).  The compose `--env-file` flag from run.sh feeds vars into compose's substitution context, not the container runtime, so `OPENCLAW_TOKEN` and `AGENT_ZERO_RFC_PASSWORD` from docker/.env.staging never reached the influx process — every webhook fanout logged "missing auth token".  Adding both names to the environment block plumbs them through.

2. Archive-terminal cap (data layer).

   Mirrors the existing influx:tier{2,3}-terminal pattern (PR #11) for archive_download failures.  Counted-toward-cap classifier now recognises ExtractionError(stage="oversize") as counted (a 200 MB PDF will not shrink on retry); transport-level LithosError stays transient.  RepairCounters gains archive_attempts / archive_last_kind / archive_last_error fields, parse/render/upsert handle them, and select_stages skips archive_retry when influx:archive-terminal is set.

   Caveat: archive_download hook is still None in production (repair_hooks.py:356, "PRD 04 responsibility").  This change is the data-layer foundation; until the hook is wired, the cap is dormant and the inspector-side oversize warnings continue.  Inspector-side short-circuit on existing archive-terminal notes is filed as a follow-up issue.

   Tests cover: counter round-trip including archive fields, classifier mapping for oversize / archive_read / LithosError, stage selection suppression, sweep cap-flip integration with structured warning log, and terminal-tag-skips-hook behaviour.