### PR TITLE
test: gate Influx-owned warnings + fix unawaited-coroutine in telemetry test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,26 @@ typeCheckingMode = "standard"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+# Make Influx-owned warnings fail CI.  The unawaited-coroutine pattern
+# from issue #3 is emitted from a destructor and pytest wraps it as a
+# ``PytestUnraisableExceptionWarning``, so we error on both that and
+# plain ``RuntimeWarning``.  Known third-party teardown noise from
+# anyio MCP-client streams, file descriptors, and sockets is ignored
+# narrowly so the gate doesn't drown in upstream resource leaks.
+#
+# ``DeprecationWarning`` is dominated by upstream packages
+# (``websockets`` via MCP/uvicorn) and left at default verbosity.
+#
+# Re-tighten as upstream packages are updated.
+filterwarnings = [
+    # Anyio MCP-client teardown leaks (third-party, not actionable here).
+    # pytest filter strings use ``:`` as a separator, so we match against
+    # the substrings that follow the ``Exception ignored in:`` prefix.
+    "ignore:.*MemoryObjectReceiveStream",
+    "ignore:.*<_io\\.FileIO",
+    "ignore:.*<_io\\.BufferedReader",
+    "ignore:.*<socket\\.socket",
+    # Influx-owned regressions.
+    "error::RuntimeWarning",
+    "error::pytest.PytestUnraisableExceptionWarning",
+]

--- a/tests/unit/test_telemetry_wiring.py
+++ b/tests/unit/test_telemetry_wiring.py
@@ -303,8 +303,14 @@ class TestInfluxFilterSpan:
                     return_value=test_items,
                 ),
                 patch(
+                    # ``build_arxiv_note_item`` is synchronous — see
+                    # src/influx/sources/arxiv.py:531.  Using ``AsyncMock``
+                    # here returned an unawaited coroutine to the provider
+                    # (which calls the helper synchronously), producing
+                    # ``RuntimeWarning: coroutine '...' was never awaited``
+                    # on every test run (issue #3).
                     "influx.sources.arxiv.build_arxiv_note_item",
-                    new_callable=AsyncMock,
+                    new_callable=MagicMock,
                     return_value={
                         "title": "Test Paper",
                         "source_url": "http://example.com",


### PR DESCRIPTION
Closes #3, closes #4.

## Summary

- **#3 fix:** `tests/unit/test_telemetry_wiring.py::test_filter_span_via_provider` patched the **synchronous** `build_arxiv_note_item` (`src/influx/sources/arxiv.py:531`) with `AsyncMock`. The production call site got back an unawaited coroutine instead of a dict and emitted `RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited` on every CI run. Swapped for `MagicMock` and noted the gotcha inline so future authors don't repeat it.

- **#4 fix:** Added pytest `filterwarnings` rules to `[tool.pytest.ini_options]`:
  - `error::RuntimeWarning` — catches Influx-owned async-test mistakes emitted during the test.
  - `error::pytest.PytestUnraisableExceptionWarning` — catches the same shape when CPython's destructor emits the warning at GC time and pytest re-wraps it (the path that originally hid #3 — see _Verification_ below).
  - Narrow `ignore` rules for known anyio MCP-client teardown noise (`MemoryObjectReceiveStream`, `_io.FileIO`/`BufferedReader`, `socket.socket`) so the gate doesn't drown in third-party resource leaks we can't fix here.
  - `DeprecationWarning` left at default verbosity — dominated by `websockets` via MCP/uvicorn, both tracked upstream.

## Verification

`make check`: 1,433 passed, 2 warnings (the existing `websockets` deprecations only).

Confirmed the gate actually fires on the original incident shape:

```bash
$ git stash push -- tests/unit/test_telemetry_wiring.py
$ uv run pytest tests/unit/test_telemetry_wiring.py::TestInfluxFilterSpan::test_filter_span_via_provider
... PytestUnraisableExceptionWarning
1 failed
$ git stash pop
$ uv run pytest tests/unit/test_telemetry_wiring.py
22 passed
```

So a future regression of the same async-test mock shape now turns CI red instead of buried-in-summary green.

## Test plan

- [x] Local: `make check` — 1,433 tests pass, 2 (third-party) warnings.
- [x] Gate verified by reverting the test fix and confirming the unraisable-coroutine warning now FAILS the test.
- [x] CI to run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)