### PR TITLE
feat: opt-in OpenAI structured-outputs response_format for tier1/tier3

### DIFF
--- a/influx.example.toml
+++ b/influx.example.toml
@@ -189,6 +189,12 @@ temperature = 0.2
 request_timeout = 30
 max_retries = 2
 json_mode = true
+# OpenAI's structured-outputs mode pins the response shape to the
+# `Tier1Enrichment` Pydantic schema, so the model can't return
+# unexpected element types (e.g. dicts in `contributions`).  Only set
+# this `true` for OpenAI models that explicitly support structured
+# outputs; OpenRouter routes to non-OpenAI backends may reject it.
+json_schema_strict = true
 
 [models.extract]
 provider = "openrouter"
@@ -197,6 +203,11 @@ temperature = 0.2
 request_timeout = 60
 max_retries = 2
 json_mode = true
+# Leave `json_schema_strict` off when routing through OpenRouter to
+# non-OpenAI models — Claude via OpenRouter doesn't accept the strict
+# `json_schema` response_format.  Switch to true if you point this slot
+# at a native OpenAI model that supports structured outputs (e.g.
+# `provider = "openai"`, `model = "gpt-4.1"`).
 
 # ---------------------------------------------------------------------------
 # Prompts (filter / tier1_enrich / tier3_extract)
@@ -240,7 +251,12 @@ From the full text of the paper, extract structured information.
 Title: {title}
 Full text: {full_text}
 
-Return JSON with: claims, datasets, builds_on, open_questions, potential_connections.
+Return JSON with five keys: claims, datasets, builds_on, open_questions,
+potential_connections.  Every value must be a list of plain strings —
+do NOT wrap items as objects with sub-fields like {{"claim": "...",
+"score": 0.8}}.  Use natural-language sentences as the list elements.
+For builds_on, include arXiv references in the form "arXiv:<id>" when
+known; for example "Attention is all you need (arXiv:1706.03762)".
 """
 
 # ---------------------------------------------------------------------------

--- a/src/influx/config.py
+++ b/src/influx/config.py
@@ -360,6 +360,15 @@ class ModelSlotConfig(BaseModel):
     request_timeout: int = 30
     max_retries: int = 2
     json_mode: bool = False
+    # When true, the slot's caller (e.g. ``tier3_extract``) sends the
+    # OpenAI ``response_format = {"type": "json_schema", "strict": true}``
+    # variant pinning its Pydantic output schema.  Constrains the model
+    # to emit conforming JSON or fail at the API boundary, eliminating
+    # the validate-stage failures that PR #11/#13 were forced to absorb
+    # downstream (issue #16).  Requires an OpenAI-compatible provider
+    # that supports structured outputs; falls back to ``json_object``
+    # mode automatically when the slot has no associated schema class.
+    json_schema_strict: bool = False
 
 
 # ── Prompts ──────────────────────────────────────────────────────────

--- a/src/influx/enrich.py
+++ b/src/influx/enrich.py
@@ -17,13 +17,17 @@ import logging
 import os
 from typing import Any
 
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from influx.config import AppConfig
 from influx.errors import LCMAError, NetworkError
 from influx.http_client import guarded_post_json_fetch
 from influx.prompts import load_prompt
-from influx.schemas import Tier1Enrichment, Tier3Extraction
+from influx.schemas import (
+    Tier1Enrichment,
+    Tier3Extraction,
+    openai_strict_response_format,
+)
 
 __all__ = [
     "tier1_enrich",
@@ -40,12 +44,20 @@ def _call_json_model(
     config: AppConfig,
     slot_name: str,
     prompt: str,
+    *,
+    schema_class: type[BaseModel] | None = None,
 ) -> dict[str, Any]:
     """Call a JSON-mode model slot and return the parsed response dict.
 
     Resolves the model slot and provider from *config*, constructs an
     OpenAI-compatible ``/chat/completions`` request, and parses the
     JSON content from the response.
+
+    When *schema_class* is provided AND the slot has
+    ``json_schema_strict = true``, sends the OpenAI structured-outputs
+    ``response_format = {"type": "json_schema", "strict": true, ...}``
+    variant so the model is constrained to emit JSON conforming to
+    *schema_class*.  Falls back to plain ``json_object`` mode otherwise.
 
     Provider compatibility
     ----------------------
@@ -93,7 +105,9 @@ def _call_json_model(
     }
     if slot.max_tokens is not None:
         body["max_tokens"] = slot.max_tokens
-    if slot.json_mode:
+    if slot.json_schema_strict and schema_class is not None:
+        body["response_format"] = openai_strict_response_format(schema_class)
+    elif slot.json_mode:
         body["response_format"] = {"type": "json_object"}
 
     attempts = slot.max_retries + 1
@@ -202,7 +216,7 @@ def tier1_enrich(
         profile_summary=profile_summary,
     )
 
-    raw = _call_json_model(config, "enrich", rendered)
+    raw = _call_json_model(config, "enrich", rendered, schema_class=Tier1Enrichment)
 
     try:
         return Tier1Enrichment.model_validate(raw)
@@ -261,7 +275,7 @@ def tier3_extract(
         full_text=full_text,
     )
 
-    raw = _call_json_model(config, "extract", rendered)
+    raw = _call_json_model(config, "extract", rendered, schema_class=Tier3Extraction)
 
     try:
         return Tier3Extraction.model_validate(raw)

--- a/src/influx/schemas.py
+++ b/src/influx/schemas.py
@@ -6,6 +6,8 @@ with bounded score and tag-list constraints.
 
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, Field, field_validator
 
 _TIER3_MAX_CHARS = 500
@@ -122,3 +124,102 @@ class FilterResponse(BaseModel):
     """Top-level wrapper for a batch of filter results (FR-FLT-3)."""
 
     results: list[FilterResult]
+
+
+# ── OpenAI structured-outputs response_format builder ────────────────
+
+
+# OpenAI's structured-outputs ``json_schema`` mode rejects several
+# JSON-Schema keywords that Pydantic generates (length / range bounds,
+# patterns, defaults, etc.); per-element type enforcement is what we
+# care about here, so we strip the rest.
+_UNSUPPORTED_KEYWORDS: tuple[str, ...] = (
+    "minLength",
+    "maxLength",
+    "minItems",
+    "maxItems",
+    "minimum",
+    "maximum",
+    "exclusiveMinimum",
+    "exclusiveMaximum",
+    "pattern",
+    "format",
+    "default",
+    "examples",
+    "title",
+)
+
+
+def _harden_for_openai_strict(node: Any) -> Any:
+    """Mutate *node* in place so a Pydantic JSON Schema satisfies OpenAI's
+    structured-outputs ``strict`` requirements.
+
+    Strict mode requires every object schema to set
+    ``additionalProperties: false`` and to list every property in
+    ``required``; any unsupported keyword (length/range bounds, etc.)
+    causes the API call to fail with a 400 before the model runs.
+
+    The function descends into nested ``properties``, ``items``,
+    ``$defs``/``definitions``, ``anyOf``/``oneOf``/``allOf``.
+    """
+    if not isinstance(node, dict):
+        return node
+
+    for key in _UNSUPPORTED_KEYWORDS:
+        node.pop(key, None)
+
+    node_type = node.get("type")
+    if node_type == "object":
+        node["additionalProperties"] = False
+        props = node.get("properties")
+        if isinstance(props, dict):
+            node["required"] = list(props.keys())
+            for child in props.values():
+                _harden_for_openai_strict(child)
+    elif node_type == "array":
+        items = node.get("items")
+        if items is not None:
+            _harden_for_openai_strict(items)
+
+    for combinator in ("anyOf", "oneOf", "allOf"):
+        children = node.get(combinator)
+        if isinstance(children, list):
+            for child in children:
+                _harden_for_openai_strict(child)
+
+    for defs_key in ("$defs", "definitions"):
+        defs = node.get(defs_key)
+        if isinstance(defs, dict):
+            for child in defs.values():
+                _harden_for_openai_strict(child)
+
+    return node
+
+
+def openai_strict_response_format(
+    schema_class: type[BaseModel],
+    *,
+    name: str | None = None,
+) -> dict[str, Any]:
+    """Return an OpenAI ``response_format`` dict pinning *schema_class*.
+
+    When passed in a chat-completions request body alongside a model
+    that supports structured outputs, this forces the model to emit
+    JSON conforming exactly to the Pydantic schema — list-of-string
+    fields cannot regress to list-of-dict, missing fields cannot be
+    omitted, etc.  Out-of-shape responses are rejected by the API
+    before the model finishes, surfaced as HTTP 400.
+
+    *name* defaults to the Pydantic class name with the OpenAI-imposed
+    32-character cap applied.
+    """
+    schema = schema_class.model_json_schema()
+    _harden_for_openai_strict(schema)
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": (name or schema_class.__name__)[:64],
+            "strict": True,
+            "schema": schema,
+        },
+    }

--- a/tests/unit/test_enrich.py
+++ b/tests/unit/test_enrich.py
@@ -23,8 +23,9 @@ from unittest.mock import patch
 import pytest
 
 from influx.config import AppConfig, load_config
-from influx.enrich import tier1_enrich, tier3_extract
+from influx.enrich import _call_json_model, tier1_enrich, tier3_extract
 from influx.errors import LCMAError
+from influx.http_client import FetchResult
 from influx.schemas import Tier1Enrichment, Tier3Extraction
 
 
@@ -197,7 +198,9 @@ class TestTier1EnrichPromptRendering:
         payload = _valid_tier1_response()
         captured_prompt: list[str] = []
 
-        def fake_call(cfg: Any, slot: str, prompt: str) -> dict[str, Any]:
+        def fake_call(
+            cfg: Any, slot: str, prompt: str, **kwargs: Any
+        ) -> dict[str, Any]:
             captured_prompt.append(prompt)
             return payload
 
@@ -223,7 +226,9 @@ class TestTier1EnrichPromptRendering:
         payload = _valid_tier1_response()
         captured: list[str] = []
 
-        def fake_call(cfg: Any, slot: str, prompt: str) -> dict[str, Any]:
+        def fake_call(
+            cfg: Any, slot: str, prompt: str, **kwargs: Any
+        ) -> dict[str, Any]:
             captured.append(prompt)
             return payload
 
@@ -247,7 +252,9 @@ class TestTier1EnrichModelSlot:
         payload = _valid_tier1_response()
         captured_slot: list[str] = []
 
-        def fake_call(cfg: Any, slot: str, prompt: str) -> dict[str, Any]:
+        def fake_call(
+            cfg: Any, slot: str, prompt: str, **kwargs: Any
+        ) -> dict[str, Any]:
             captured_slot.append(slot)
             return payload
 
@@ -268,7 +275,9 @@ class TestTier1EnrichModelSlot:
         payload = _valid_tier1_response()
         captured_cfg: list[AppConfig] = []
 
-        def fake_call(cfg: Any, slot: str, prompt: str) -> dict[str, Any]:
+        def fake_call(
+            cfg: Any, slot: str, prompt: str, **kwargs: Any
+        ) -> dict[str, Any]:
             captured_cfg.append(cfg)
             return payload
 
@@ -500,7 +509,9 @@ class TestTier3ExtractPromptRendering:
         payload = _valid_tier3_response()
         captured_prompt: list[str] = []
 
-        def fake_call(cfg: Any, slot: str, prompt: str) -> dict[str, Any]:
+        def fake_call(
+            cfg: Any, slot: str, prompt: str, **kwargs: Any
+        ) -> dict[str, Any]:
             captured_prompt.append(prompt)
             return payload
 
@@ -523,7 +534,9 @@ class TestTier3ExtractPromptRendering:
         payload = _valid_tier3_response()
         captured: list[str] = []
 
-        def fake_call(cfg: Any, slot: str, prompt: str) -> dict[str, Any]:
+        def fake_call(
+            cfg: Any, slot: str, prompt: str, **kwargs: Any
+        ) -> dict[str, Any]:
             captured.append(prompt)
             return payload
 
@@ -546,7 +559,9 @@ class TestTier3ExtractModelSlot:
         payload = _valid_tier3_response()
         captured_slot: list[str] = []
 
-        def fake_call(cfg: Any, slot: str, prompt: str) -> dict[str, Any]:
+        def fake_call(
+            cfg: Any, slot: str, prompt: str, **kwargs: Any
+        ) -> dict[str, Any]:
             captured_slot.append(slot)
             return payload
 
@@ -566,7 +581,9 @@ class TestTier3ExtractModelSlot:
         payload = _valid_tier3_response()
         captured_cfg: list[AppConfig] = []
 
-        def fake_call(cfg: Any, slot: str, prompt: str) -> dict[str, Any]:
+        def fake_call(
+            cfg: Any, slot: str, prompt: str, **kwargs: Any
+        ) -> dict[str, Any]:
             captured_cfg.append(cfg)
             return payload
 
@@ -600,3 +617,149 @@ class TestTier3ExtractTransportFailure:
                 full_text="F",
                 config=config,
             )
+
+
+# ── OpenAI structured-outputs response_format wiring (issue #16) ────
+
+
+def _make_post_result(content_dict: dict[str, Any]) -> FetchResult:
+    """Build a minimal ``FetchResult`` mimicking an OpenAI chat-completions
+    success response."""
+    body = json.dumps(_make_chat_response(content_dict)).encode("utf-8")
+    return FetchResult(
+        body=body,
+        status_code=200,
+        content_type="application/json",
+        final_url="https://api.openai.com/v1/chat/completions",
+    )
+
+
+class TestCallJsonModelResponseFormat:
+    """``_call_json_model`` selects the right ``response_format`` shape based
+    on the slot's ``json_schema_strict`` flag.
+    """
+
+    def _capture_post(
+        self, response_dict: dict[str, Any]
+    ) -> tuple[list[dict[str, Any]], Any]:
+        """Patch ``guarded_post_json_fetch`` and return (captured-bodies, ctx)."""
+        captured: list[dict[str, Any]] = []
+
+        def fake_post(
+            url: str,
+            payload: dict[str, Any],
+            **kwargs: Any,
+        ) -> FetchResult:
+            captured.append(payload)
+            return _make_post_result(response_dict)
+
+        return captured, patch(
+            "influx.enrich.guarded_post_json_fetch", side_effect=fake_post
+        )
+
+    def test_json_object_when_strict_disabled(
+        self, influx_config_env: Any, tmp_path: Any
+    ) -> None:
+        """Default (json_mode=true, json_schema_strict=false) sends the loose
+        ``json_object`` response_format that callers shipped with."""
+        config = load_config()
+        config.models["extract"].json_schema_strict = False
+
+        captured, ctx = self._capture_post(_valid_tier3_response())
+        with ctx:
+            _call_json_model(config, "extract", "prompt", schema_class=Tier3Extraction)
+
+        assert len(captured) == 1
+        body = captured[0]
+        assert body["response_format"] == {"type": "json_object"}
+
+    def test_json_schema_strict_when_enabled(
+        self, influx_config_env: Any, tmp_path: Any
+    ) -> None:
+        """When the slot opts in, the body carries the strict json_schema
+        response_format pinning the Pydantic class."""
+        config = load_config()
+        config.models["extract"].json_schema_strict = True
+
+        captured, ctx = self._capture_post(_valid_tier3_response())
+        with ctx:
+            _call_json_model(config, "extract", "prompt", schema_class=Tier3Extraction)
+
+        body = captured[0]
+        rf = body["response_format"]
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["strict"] is True
+        assert rf["json_schema"]["name"] == "Tier3Extraction"
+
+        schema = rf["json_schema"]["schema"]
+        # OpenAI strict mode requirements.
+        assert schema["additionalProperties"] is False
+        assert set(schema["required"]) == {
+            "claims",
+            "datasets",
+            "builds_on",
+            "open_questions",
+            "potential_connections",
+        }
+        # Per-element type pinned to string for every list field — the
+        # whole point of the change for issue #16.
+        for field in ("claims", "datasets", "builds_on", "open_questions"):
+            assert schema["properties"][field]["type"] == "array"
+            assert schema["properties"][field]["items"]["type"] == "string"
+
+    def test_strict_mode_falls_back_when_no_schema_class(
+        self, influx_config_env: Any, tmp_path: Any
+    ) -> None:
+        """Strict flag without a schema class can't build a json_schema
+        body; falls back to plain json_object so the request still flies."""
+        config = load_config()
+        config.models["extract"].json_schema_strict = True
+
+        captured, ctx = self._capture_post(_valid_tier3_response())
+        with ctx:
+            _call_json_model(config, "extract", "prompt", schema_class=None)
+
+        assert captured[0]["response_format"] == {"type": "json_object"}
+
+
+class TestTier3ExtractStrictResponseFormat:
+    """End-to-end check that ``tier3_extract`` propagates ``Tier3Extraction``
+    into the request body when the slot opts in.
+    """
+
+    def test_strict_request_carries_tier3_schema(
+        self, influx_config_env: Any, tmp_path: Any
+    ) -> None:
+        config = load_config()
+        config.models["extract"].json_schema_strict = True
+
+        captured: list[dict[str, Any]] = []
+
+        def fake_post(url: str, payload: dict[str, Any], **kwargs: Any) -> FetchResult:
+            captured.append(payload)
+            return _make_post_result(_valid_tier3_response())
+
+        with patch("influx.enrich.guarded_post_json_fetch", side_effect=fake_post):
+            tier3_extract(title="T", full_text="F", config=config)
+
+        rf = captured[0]["response_format"]
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["name"] == "Tier3Extraction"
+
+    def test_strict_request_carries_tier1_schema(
+        self, influx_config_env: Any, tmp_path: Any
+    ) -> None:
+        config = load_config()
+        config.models["enrich"].json_schema_strict = True
+
+        captured: list[dict[str, Any]] = []
+
+        def fake_post(url: str, payload: dict[str, Any], **kwargs: Any) -> FetchResult:
+            captured.append(payload)
+            return _make_post_result(_valid_tier1_response())
+
+        with patch("influx.enrich.guarded_post_json_fetch", side_effect=fake_post):
+            tier1_enrich(title="T", abstract="A", profile_summary="P", config=config)
+
+        rf = captured[0]["response_format"]
+        assert rf["json_schema"]["name"] == "Tier1Enrichment"

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -189,3 +189,99 @@ class TestTier3Extraction:
     def test_too_many_datasets(self) -> None:
         with pytest.raises(ValidationError):
             Tier3Extraction(claims=["c"], datasets=[f"d{i}" for i in range(11)])
+
+
+# ── OpenAI structured-outputs response_format builder ────────────────
+
+
+from influx.schemas import openai_strict_response_format  # noqa: E402
+
+
+class TestOpenAIStrictResponseFormat:
+    """``openai_strict_response_format`` produces a body that satisfies
+    OpenAI's structured-outputs ``strict`` schema requirements.
+    """
+
+    def test_top_level_envelope_shape(self) -> None:
+        rf = openai_strict_response_format(Tier3Extraction)
+        assert rf["type"] == "json_schema"
+        spec = rf["json_schema"]
+        assert spec["strict"] is True
+        assert spec["name"] == "Tier3Extraction"
+        assert "schema" in spec
+
+    def test_explicit_name_override(self) -> None:
+        rf = openai_strict_response_format(Tier3Extraction, name="MyAlias")
+        assert rf["json_schema"]["name"] == "MyAlias"
+
+    def test_object_required_lists_all_properties(self) -> None:
+        """Strict mode requires every property to be in ``required``."""
+        rf = openai_strict_response_format(Tier3Extraction)
+        schema = rf["json_schema"]["schema"]
+        assert set(schema["required"]) == set(schema["properties"].keys())
+
+    def test_object_additional_properties_false(self) -> None:
+        rf = openai_strict_response_format(Tier3Extraction)
+        assert rf["json_schema"]["schema"]["additionalProperties"] is False
+
+    def test_array_items_typed_as_string(self) -> None:
+        """Per-list-element type pinning is the durable fix for the
+        dict-where-string-expected failures (issue #16).
+        """
+        rf = openai_strict_response_format(Tier3Extraction)
+        schema = rf["json_schema"]["schema"]
+        for field_name in (
+            "claims",
+            "datasets",
+            "builds_on",
+            "open_questions",
+            "potential_connections",
+        ):
+            field_schema = schema["properties"][field_name]
+            assert field_schema["type"] == "array"
+            assert field_schema["items"]["type"] == "string"
+
+    def test_unsupported_keywords_stripped(self) -> None:
+        """OpenAI strict mode rejects ``minLength``/``maxItems``/``default``
+        and similar — Pydantic emits them, the builder must strip them.
+        """
+        rf = openai_strict_response_format(Tier3Extraction)
+
+        def _walk(node: object) -> None:
+            if not isinstance(node, dict):
+                return
+            for forbidden in (
+                "minLength",
+                "maxLength",
+                "minItems",
+                "maxItems",
+                "minimum",
+                "maximum",
+                "pattern",
+                "format",
+                "default",
+                "examples",
+                "title",
+            ):
+                assert forbidden not in node, (
+                    f"strict schema must not carry {forbidden!r}: {node}"
+                )
+            for v in node.values():
+                if isinstance(v, list):
+                    for item in v:
+                        _walk(item)
+                else:
+                    _walk(v)
+
+        _walk(rf["json_schema"]["schema"])
+
+    def test_tier1_envelope(self) -> None:
+        """Same hardening applies to Tier1Enrichment."""
+        rf = openai_strict_response_format(Tier1Enrichment)
+        schema = rf["json_schema"]["schema"]
+        assert schema["additionalProperties"] is False
+        assert "contributions" in schema["required"]
+        assert schema["properties"]["contributions"]["items"]["type"] == "string"
+        # method/result/relevance pinned to string.
+        for field in ("method", "result", "relevance"):
+            assert schema["properties"][field]["type"] == "string"


### PR DESCRIPTION
Refs #16.

## Summary

The 2026-05-01 staging logs showed Tier 3 extraction failing for many distinct papers in a single run on `staging-robotics` (13 in 30 minutes), all surfacing as `LCMAError(stage="validate")` thanks to PR #11's structured logger. The `models.extract` slot points at `gpt-4.1-mini` with a permissive prompt that just says \"Use short strings\" — small models occasionally emit list-of-dict where list-of-string is required, validation fails downstream, and PR #13's `_trim_and_truncate` defence catches the AttributeError.

This PR adds Option 3 from #16: pin the Pydantic schema as OpenAI's structured-outputs `response_format = {\"type\":\"json_schema\", \"strict\":true}` so the API itself rejects malformed responses before they reach Influx. It is **opt-in per model slot**, so nothing changes at runtime until an operator flips the flag.

## What changed

- `schemas.openai_strict_response_format(cls)` derives an OpenAI strict-mode response_format envelope from any Pydantic v2 model. Walks the schema, sets `additionalProperties: false`, marks every property `required`, and strips keywords OpenAI strict mode rejects (length / range bounds, patterns, defaults).
- `ModelSlotConfig.json_schema_strict: bool = False` — opt-in flag per `[models.*]` slot. Off by default so non-OpenAI providers (Claude via OpenRouter etc.) keep working as today.
- `enrich._call_json_model` accepts `schema_class`. When the slot opts in and a class is provided, sends the strict envelope; otherwise falls back to the existing `json_object` mode.
- `tier1_enrich` / `tier3_extract` propagate `Tier1Enrichment` / `Tier3Extraction` respectively.
- `prompts.tier3_extract` in `influx.example.toml` tightened to forbid list-of-dict shapes explicitly — defence in depth for slots that can't enable strict mode (e.g. Claude routing through OpenRouter).

## What's NOT in this PR

- Flipping `json_schema_strict = true` in deployed config. That's an operator-side decision per slot — staging change goes alongside this PR but lives in `data/staging/config/influx.toml` (outside the repo).
- Bumping the model itself (mini → 4.1). Independent config change.
- Empirical validate-dominance proof. Staging logs since 12:00 UTC carry no fresh Tier 3 failures — likely because PR #11's cap=3 terminal-flipped the offending notes from yesterday. The fix here is opt-in so it's safe to ship without that data.

## Verification

- `make check`: 1,445 passed, 2 (third-party) warnings.
- New `TestOpenAIStrictResponseFormat` in `tests/unit/test_schemas.py` covers the envelope shape, name override, required-list completeness, `additionalProperties`, list-element type pinning, unsupported-keyword stripping, and Tier1Enrichment as a separate target.
- New `TestCallJsonModelResponseFormat` in `tests/unit/test_enrich.py` asserts the request-body shape sent to the LLM provider in three modes: json_object default, json_schema strict opt-in, and the fallback-to-json_object path when no schema_class is passed.
- End-to-end mocked-transport tests confirm `tier1_enrich` and `tier3_extract` carry their schema through to the request body.

## Tangential observation (not blocking)

While checking the run ledger I noticed the 18:00 UTC scheduled runs both have `sources_checked: 0` / `ingested: 0` / `error: null`. The arxiv fetcher swallows transient HTTP failures as \"zero items\" (we saw HTTP 500 from arxiv earlier on the 06:00 run). Worth filing as a separate issue if it persists; not in scope here.

## Test plan

- [x] Local: `make check` clean (1,445 pass, lint clean).
- [ ] CI to run on this PR.
- [ ] Once merged + deployed, set `json_schema_strict = true` on `[models.extract]` (and optionally `[models.enrich]`) in staging `influx.toml` and restart the container.
- [ ] Watch the next two scheduled runs for `Tier 3 extraction failed` warnings; expect rate to drop substantially. If validate-stage failures persist with strict mode on, the model needs bumping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)