### PR TITLE
feat: surface swallowed source-fetch failures as degraded runs

### DIFF
--- a/scripts/influx-report.py
+++ b/scripts/influx-report.py
@@ -109,14 +109,24 @@ def _print_runs(runs_payload: dict[str, object]) -> None:
     for raw in runs:
         if not isinstance(raw, dict):
             continue
+        status = raw.get("status")
+        if raw.get("degraded"):
+            status = f"{status} (degraded)"
         print(
             "  "
             f"{raw.get('completed_at')} {raw.get('profile')} {raw.get('kind')} "
-            f"{raw.get('status')} checked={raw.get('sources_checked')} "
+            f"{status} checked={raw.get('sources_checked')} "
             f"ingested={raw.get('ingested')} duration={raw.get('duration_seconds')}"
         )
         if raw.get("error"):
             print(f"    error={raw.get('error')}")
+        for src_err in raw.get("source_acquisition_errors") or []:
+            if isinstance(src_err, dict):
+                print(
+                    f"    source_error: source={src_err.get('source')} "
+                    f"kind={src_err.get('kind')} "
+                    f"detail={src_err.get('detail')}"
+                )
 
 
 def main() -> int:

--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -57,6 +57,8 @@ class RunLedger:
             "sources_checked": None,
             "ingested": None,
             "error": None,
+            "degraded": False,
+            "source_acquisition_errors": [],
         }
         try:
             active = self._read_active()
@@ -71,14 +73,25 @@ class RunLedger:
         run_id: str,
         sources_checked: int | None,
         ingested: int | None,
+        source_acquisition_errors: list[dict[str, str]] | None = None,
     ) -> None:
-        """Mark an active run as completed and append it to history."""
+        """Mark an active run as completed and append it to history.
+
+        *source_acquisition_errors* records source-fetch failures that
+        were swallowed during the run (e.g. arxiv HTTP 5xx, RSS
+        timeout).  When non-empty the run is flagged ``degraded=True``
+        in the ledger so dashboards can distinguish a partial-failure
+        run from a genuinely quiet window (issue #20).
+        """
+        errors = list(source_acquisition_errors or [])
         self._finish(
             run_id=run_id,
             status="completed",
             sources_checked=sources_checked,
             ingested=ingested,
             error=None,
+            degraded=bool(errors),
+            source_acquisition_errors=errors,
         )
 
     def fail(self, *, run_id: str, error: str) -> None:
@@ -89,6 +102,8 @@ class RunLedger:
             sources_checked=None,
             ingested=None,
             error=error,
+            degraded=False,
+            source_acquisition_errors=[],
         )
 
     def active_runs(self) -> list[RunEntry]:
@@ -117,6 +132,10 @@ class RunLedger:
                             completed_at,
                         ),
                         "error": reason,
+                        "degraded": entry.get("degraded", False),
+                        "source_acquisition_errors": list(
+                            entry.get("source_acquisition_errors") or []
+                        ),
                     }
                 )
                 self._append(entry)
@@ -171,6 +190,8 @@ class RunLedger:
         sources_checked: int | None,
         ingested: int | None,
         error: str | None,
+        degraded: bool = False,
+        source_acquisition_errors: list[dict[str, str]] | None = None,
     ) -> None:
         try:
             active = self._read_active()
@@ -198,6 +219,8 @@ class RunLedger:
                     "sources_checked": sources_checked,
                     "ingested": ingested,
                     "error": error,
+                    "degraded": degraded,
+                    "source_acquisition_errors": list(source_acquisition_errors or []),
                 }
             )
             self._append(entry)

--- a/src/influx/scheduler.py
+++ b/src/influx/scheduler.py
@@ -47,7 +47,11 @@ from influx.rejection_rate import record_filter_result
 from influx.repair import SweepWriteError
 from influx.repair import sweep as repair_sweep
 from influx.run_ledger import RunLedger
-from influx.telemetry import current_run_id, get_tracer
+from influx.telemetry import (
+    current_run_id,
+    current_source_acquisition_errors,
+    get_tracer,
+)
 
 __all__ = [
     "InfluxScheduler",
@@ -157,6 +161,11 @@ async def run_profile(
         run_range=run_range,
     )
     run_id_token = current_run_id.set(run_id)
+    # Initialise the per-run record of swallowed source-fetch failures.
+    # Source providers (arxiv/rss) append on ``NetworkError`` paths via
+    # ``record_source_acquisition_error``; we drain the list before the
+    # ledger entry is finalised below.  See issue #20.
+    source_errors_token = current_source_acquisition_errors.set([])
     tracer = get_tracer()
     started_at = datetime.now(UTC)
     logger.info(
@@ -198,22 +207,27 @@ async def run_profile(
                     run_id=run_id,
                     sources_checked=None,
                     ingested=None,
+                    source_acquisition_errors=current_source_acquisition_errors.get()
+                    or [],
                 )
             else:
+                source_errors = current_source_acquisition_errors.get() or []
                 logger.info(
                     "run completed profile=%s kind=%s run_id=%s duration=%.1fs "
-                    "sources_checked=%d ingested=%d",
+                    "sources_checked=%d ingested=%d degraded=%s",
                     profile,
                     kind.value,
                     run_id,
                     elapsed,
                     result.stats.sources_checked,
                     result.stats.ingested,
+                    bool(source_errors),
                 )
                 ledger.complete(
                     run_id=run_id,
                     sources_checked=result.stats.sources_checked,
                     ingested=result.stats.ingested,
+                    source_acquisition_errors=source_errors,
                 )
             return result
     except Exception as exc:
@@ -229,6 +243,7 @@ async def run_profile(
         raise
     finally:
         current_run_id.reset(run_id_token)
+        current_source_acquisition_errors.reset(source_errors_token)
 
 
 async def _run_profile_body(

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -43,7 +43,11 @@ from influx.http_client import guarded_fetch
 from influx.notes import ProfileRelevanceEntry, render_note
 from influx.schemas import Tier1Enrichment, Tier3Extraction
 from influx.storage import download_archive
-from influx.telemetry import current_run_id, get_tracer
+from influx.telemetry import (
+    current_run_id,
+    get_tracer,
+    record_source_acquisition_error,
+)
 
 if TYPE_CHECKING:
     from influx.sources import FetchCache
@@ -968,11 +972,18 @@ def make_arxiv_item_provider(
                     items = await cache.get_or_fetch(cache_key, _do_fetch)
                 else:
                     items = await _do_fetch()
-            except NetworkError:
+            except NetworkError as exc:
                 _log.warning(
                     "arxiv fetch failed for profile %r; yielding zero items",
                     profile,
                     exc_info=True,
+                )
+                # Surface to the run ledger so a degraded run is no longer
+                # indistinguishable from a quiet window (issue #20).
+                record_source_acquisition_error(
+                    source="arxiv",
+                    kind=exc.kind or "unknown",
+                    detail=str(exc),
                 )
                 return ()
             fetch_span.set_attribute("influx.item_count", len(items))

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -41,7 +41,11 @@ from influx.notes import ProfileRelevanceEntry, render_note
 from influx.schemas import FilterResponse, Tier1Enrichment, Tier3Extraction
 from influx.slugs import slugify_feed_name
 from influx.storage import download_archive
-from influx.telemetry import current_run_id, get_tracer
+from influx.telemetry import (
+    current_run_id,
+    get_tracer,
+    record_source_acquisition_error,
+)
 from influx.urls import normalise_url, url_hash
 
 if TYPE_CHECKING:
@@ -607,11 +611,18 @@ async def _fetch_rss_feed(
                 max_download_bytes=max_download_bytes,
                 timeout_seconds=timeout_seconds,
             )
-        except NetworkError:
+        except NetworkError as exc:
             _log.warning(
                 "RSS feed fetch failed for %r; yielding zero items",
                 feed_entry.name,
                 exc_info=True,
+            )
+            # Issue #20: surface to the run ledger so the degraded
+            # outcome is distinguishable from a quiet feed.
+            record_source_acquisition_error(
+                source="rss",
+                kind=exc.kind or "unknown",
+                detail=f"{feed_entry.name}: {exc}",
             )
             return None
         return result.body

--- a/src/influx/telemetry.py
+++ b/src/influx/telemetry.py
@@ -27,15 +27,66 @@ if TYPE_CHECKING:
 
 __all__ = [
     "InfluxTracer",
+    "SourceAcquisitionError",
     "SpanWrapper",
     "current_run_id",
+    "current_source_acquisition_errors",
     "get_tracer",
+    "record_source_acquisition_error",
 ]
 
 # Context variable for the current run ID — set by ``run_profile()`` so
 # that downstream call sites (e.g. filter scorer, source fetchers) can
 # attach ``influx.run_id`` to their spans without interface changes.
 current_run_id: ContextVar[str | None] = ContextVar("current_run_id", default=None)
+
+
+# Concrete shape of a source-acquisition error record:
+#   {"source": "arxiv" | "rss" | ..., "kind": "oversize" | "timeout" |
+#    "ssrf" | ..., "detail": "<short diagnostic>"}
+# Plain dicts so they round-trip through ``json.dumps`` in the run
+# ledger without a custom encoder.
+SourceAcquisitionError = dict[str, str]
+
+
+# Context variable carrying any source-acquisition failures the current
+# run has swallowed without aborting.  ``run_profile()`` sets it to an
+# empty list at run start; providers append on ``NetworkError`` paths
+# that today return zero items silently (issue #20).  The scheduler
+# reads it before writing the ledger entry so a degraded run is no
+# longer indistinguishable from a quiet window.
+current_source_acquisition_errors: ContextVar[list[SourceAcquisitionError] | None] = (
+    ContextVar("current_source_acquisition_errors", default=None)
+)
+
+
+def record_source_acquisition_error(
+    *,
+    source: str,
+    kind: str,
+    detail: str,
+) -> None:
+    """Append a swallowed source-fetch failure to the current run's record.
+
+    Safe to call outside a run context — silently no-ops when
+    :data:`current_source_acquisition_errors` is unset.  Callers
+    should still emit their existing structured WARNING log; this
+    helper only adds the run-ledger linkage.
+    """
+    errors = current_source_acquisition_errors.get()
+    if errors is None:
+        return
+    errors.append(
+        SourceAcquisitionError(
+            {
+                "source": source,
+                "kind": kind,
+                "detail": detail[:300],
+            }
+        )
+    )
+
+
 logger = logging.getLogger(__name__)
 
 

--- a/tests/unit/test_run_ledger.py
+++ b/tests/unit/test_run_ledger.py
@@ -81,3 +81,79 @@ def test_run_ledger_abandons_stale_active_runs(tmp_path: Path) -> None:
     assert recent[0]["run_id"] == "run-1"
     assert recent[0]["status"] == "abandoned"
     assert recent[0]["error"] == "process restarted"
+
+
+# ── Issue #20: surface swallowed source-acquisition failures ────────
+
+
+def test_complete_without_source_errors_marks_run_not_degraded(
+    tmp_path: Path,
+) -> None:
+    """A clean run carries ``degraded=false`` and an empty error list so
+    dashboards can grep on the field reliably (issue #20)."""
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(
+        run_id="run-1",
+        profile="ai-robotics",
+        kind="scheduled",
+        run_range=None,
+    )
+    ledger.complete(run_id="run-1", sources_checked=10, ingested=4)
+
+    entry = ledger.recent()[0]
+    assert entry["degraded"] is False
+    assert entry["source_acquisition_errors"] == []
+
+
+def test_complete_with_source_errors_marks_run_degraded(tmp_path: Path) -> None:
+    """A run that swallowed a fetch failure surfaces as ``degraded=true``
+    with the structured error list preserved verbatim (issue #20).
+
+    Distinguishes a partial-failure run from a quiet window in which the
+    source legitimately had no items — both used to land as
+    ``sources_checked=0, error=null``.
+    """
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(
+        run_id="run-1",
+        profile="ai-robotics",
+        kind="scheduled",
+        run_range=None,
+    )
+    errors = [
+        {
+            "source": "arxiv",
+            "kind": "http",
+            "detail": "HTTP 500 from arXiv API",
+        }
+    ]
+    ledger.complete(
+        run_id="run-1",
+        sources_checked=0,
+        ingested=0,
+        source_acquisition_errors=errors,
+    )
+
+    entry = ledger.recent()[0]
+    assert entry["status"] == "completed"
+    assert entry["degraded"] is True
+    assert entry["source_acquisition_errors"] == errors
+
+
+def test_failed_run_has_degraded_false(tmp_path: Path) -> None:
+    """``fail`` always lands ``degraded=false`` so the field's semantics
+    stay narrow: it means *partial source-fetch failure on an otherwise
+    completed run*, not "anything went wrong".
+    """
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(
+        run_id="run-1",
+        profile="ai-robotics",
+        kind="scheduled",
+        run_range=None,
+    )
+    ledger.fail(run_id="run-1", error="RuntimeError: boom")
+
+    entry = ledger.recent()[0]
+    assert entry["degraded"] is False
+    assert entry["source_acquisition_errors"] == []

--- a/tests/unit/test_source_acquisition_errors.py
+++ b/tests/unit/test_source_acquisition_errors.py
@@ -1,0 +1,194 @@
+"""End-to-end wiring for swallowed source-fetch failures (issue #20).
+
+Verifies that when a source provider catches ``NetworkError`` and
+returns zero items, the failure is surfaced through
+``current_source_acquisition_errors`` so the run ledger can mark the
+run ``degraded=True`` instead of indistinguishable from a quiet window.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from influx.config import (
+    AppConfig,
+    ProfileConfig,
+    PromptEntryConfig,
+    PromptsConfig,
+    ScheduleConfig,
+)
+from influx.coordinator import RunKind
+from influx.errors import NetworkError
+from influx.sources.arxiv import make_arxiv_item_provider
+from influx.telemetry import (
+    current_run_id,
+    current_source_acquisition_errors,
+)
+
+
+def _make_minimal_config() -> AppConfig:
+    """Smallest AppConfig that ``make_arxiv_item_provider`` accepts."""
+    return AppConfig(
+        schedule=ScheduleConfig(cron="0 6 * * *", timezone="UTC"),
+        profiles=[ProfileConfig(name="ai-robotics")],
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="x"),
+            tier1_enrich=PromptEntryConfig(text="x"),
+            tier3_extract=PromptEntryConfig(text="x"),
+        ),
+    )
+
+
+class TestArxivProviderRecordsSwallowedNetworkError:
+    """When ``fetch_arxiv`` raises ``NetworkError`` the provider returns
+    zero items (existing behaviour) and now also records a structured
+    error against the current run's contextvar (issue #20).
+    """
+
+    async def test_network_error_appends_to_run_context(self) -> None:
+        config = _make_minimal_config()
+
+        run_token = current_run_id.set("test-run-degraded")
+        errors_token = current_source_acquisition_errors.set([])
+        try:
+            provider = make_arxiv_item_provider(config)
+
+            with patch(
+                "influx.sources.arxiv.fetch_arxiv",
+                side_effect=NetworkError(
+                    "HTTP 500 from arXiv API",
+                    url="https://arxiv.org",
+                    kind="http",
+                    reason="upstream 500",
+                ),
+            ):
+                result = await provider(
+                    "ai-robotics", RunKind.SCHEDULED, None, "prompt"
+                )
+                # The provider yields an empty iterable on swallow.
+                assert list(result) == []
+
+            errors = current_source_acquisition_errors.get() or []
+        finally:
+            current_run_id.reset(run_token)
+            current_source_acquisition_errors.reset(errors_token)
+
+        assert len(errors) == 1
+        record = errors[0]
+        assert record["source"] == "arxiv"
+        assert record["kind"] == "http"
+        assert "HTTP 500" in record["detail"]
+
+    async def test_no_record_when_fetch_succeeds(self) -> None:
+        """Successful fetches must NOT pollute the degraded-run signal."""
+        config = _make_minimal_config()
+
+        run_token = current_run_id.set("test-run-clean")
+        errors_token = current_source_acquisition_errors.set([])
+        try:
+            provider = make_arxiv_item_provider(config)
+            with patch("influx.sources.arxiv.fetch_arxiv", return_value=[]):
+                result = await provider(
+                    "ai-robotics", RunKind.SCHEDULED, None, "prompt"
+                )
+                assert list(result) == []
+
+            errors = current_source_acquisition_errors.get() or []
+        finally:
+            current_run_id.reset(run_token)
+            current_source_acquisition_errors.reset(errors_token)
+
+        assert errors == []
+
+    async def test_record_outside_run_context_is_ignored(self) -> None:
+        """Calling the helper outside a run context (e.g. CLI smoke
+        commands) must NOT raise and must NOT leak across into a
+        subsequent run's record.
+        """
+        # No contextvar set → record_source_acquisition_error is a no-op.
+        config = _make_minimal_config()
+        provider = make_arxiv_item_provider(config)
+
+        with patch(
+            "influx.sources.arxiv.fetch_arxiv",
+            side_effect=NetworkError("boom", url="x", kind="timeout", reason="t"),
+        ):
+            result = await provider("ai-robotics", RunKind.SCHEDULED, None, "prompt")
+            assert list(result) == []
+        # Did not raise.  No assertion on the contextvar state — there
+        # isn't one set in this test.
+
+
+async def test_scheduler_drains_context_into_ledger_complete(
+    tmp_path: Any,
+) -> None:
+    """``run_profile`` reads the contextvar after the run body returns
+    and forwards the structured errors to ``ledger.complete``.
+
+    Mocks out the run body so the test stays focused on the
+    contextvar-→-ledger linkage that issue #20 introduces; the upstream
+    swallow path is covered by
+    ``TestArxivProviderRecordsSwallowedNetworkError`` above.
+    """
+    from unittest.mock import AsyncMock
+
+    from influx.run_ledger import RunLedger
+    from influx.scheduler import run_profile
+    from influx.telemetry import record_source_acquisition_error
+
+    config = _make_minimal_config()
+    ledger = RunLedger(tmp_path / "state")
+
+    async def fake_body(*_args: Any, **_kwargs: Any) -> None:
+        # Inside the body — the scheduler has already initialised the
+        # contextvar.  Mimic an arxiv NetworkError swallow.
+        record_source_acquisition_error(
+            source="arxiv", kind="http", detail="HTTP 500 from arXiv API"
+        )
+        return None
+
+    fake = AsyncMock(side_effect=fake_body)
+    with patch("influx.scheduler._run_profile_body", new=fake):
+        await run_profile(
+            "ai-robotics",
+            RunKind.SCHEDULED,
+            config=config,
+            run_ledger=ledger,
+        )
+
+    entry = ledger.recent()[0]
+    assert entry["status"] == "completed"
+    assert entry["degraded"] is True
+    assert entry["source_acquisition_errors"] == [
+        {"source": "arxiv", "kind": "http", "detail": "HTTP 500 from arXiv API"}
+    ]
+
+
+async def test_scheduler_writes_clean_ledger_on_no_errors(tmp_path: Any) -> None:
+    """A run with no swallowed errors writes ``degraded=false`` and an
+    empty list — preserves the dashboard semantics that "degraded" means
+    "the source genuinely failed mid-run".
+    """
+    from unittest.mock import AsyncMock
+
+    from influx.run_ledger import RunLedger
+    from influx.scheduler import run_profile
+
+    config = _make_minimal_config()
+    ledger = RunLedger(tmp_path / "state")
+
+    with patch(
+        "influx.scheduler._run_profile_body",
+        new=AsyncMock(return_value=None),
+    ):
+        await run_profile(
+            "ai-robotics",
+            RunKind.SCHEDULED,
+            config=config,
+            run_ledger=ledger,
+        )
+
+    entry = ledger.recent()[0]
+    assert entry["degraded"] is False
+    assert entry["source_acquisition_errors"] == []

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -557,3 +557,63 @@ class TestAC10ARegressionGuard:
             s.set_attribute("influx.profile", "test")
             # The span wrapper wraps the no-op — no OTEL calls made
             assert isinstance(s, SpanWrapper)
+
+
+# ── Issue #20: source-acquisition error context ────────────────────
+
+
+from influx.telemetry import (  # noqa: E402
+    current_source_acquisition_errors,
+    record_source_acquisition_error,
+)
+
+
+class TestRecordSourceAcquisitionError:
+    """``record_source_acquisition_error`` is the linkage between
+    swallowed-NetworkError paths in source providers and the run
+    ledger's ``source_acquisition_errors`` field (issue #20).
+    """
+
+    def test_no_op_outside_run_context(self) -> None:
+        """Outside a run context the contextvar is unset; calling the
+        helper must NOT raise so legitimate uses (e.g. CLI smoke
+        commands that share the provider code path) keep working.
+        """
+        # No token set → contextvar is None.  Should silently do nothing.
+        record_source_acquisition_error(
+            source="arxiv", kind="http", detail="500 from arxiv"
+        )
+
+    def test_appends_inside_run_context(self) -> None:
+        token = current_source_acquisition_errors.set([])
+        try:
+            record_source_acquisition_error(
+                source="arxiv", kind="http", detail="500 from arxiv"
+            )
+            record_source_acquisition_error(
+                source="rss", kind="timeout", detail="connect timeout"
+            )
+            errors = current_source_acquisition_errors.get()
+        finally:
+            current_source_acquisition_errors.reset(token)
+
+        assert errors == [
+            {"source": "arxiv", "kind": "http", "detail": "500 from arxiv"},
+            {"source": "rss", "kind": "timeout", "detail": "connect timeout"},
+        ]
+
+    def test_detail_is_truncated(self) -> None:
+        """Long error bodies are capped so the run ledger doesn't grow
+        unbounded if a provider returns a stack trace as the message.
+        """
+        token = current_source_acquisition_errors.set([])
+        try:
+            record_source_acquisition_error(
+                source="arxiv", kind="http", detail="x" * 1000
+            )
+            errors = current_source_acquisition_errors.get()
+        finally:
+            current_source_acquisition_errors.reset(token)
+
+        assert errors is not None
+        assert len(errors[0]["detail"]) == 300


### PR DESCRIPTION
Closes #20.

## Summary

Today an arxiv (or RSS) `NetworkError` is caught at the provider's fetch site, logged as a WARNING, and turned into a zero-item return. The run then completes with `sources_checked: 0`, `ingested: 0`, `error: null`, `status: completed` — visually identical to a legitimately quiet window. Today's 18:00 UTC staging runs hit this exact shape (both profiles `sources_checked: 0`).

This PR makes a degraded run distinguishable from a quiet one **without** changing the existing failure handling (transient blip should NOT fail the whole run).

## What changed

- **`telemetry.current_source_acquisition_errors`** — new ContextVar carrying a list of structured error dicts for the current run. `record_source_acquisition_error(source=, kind=, detail=)` is the helper providers call; safely no-ops outside a run context.
- **`arxiv.py` / `rss.py`** — bind the `NetworkError` in their existing `except` clauses and call the recorder before returning zero items. WARNING log shape unchanged.
- **`scheduler.run_profile`** — initialises the contextvar at run start, drains it before `ledger.complete(...)`, and forwards `source_acquisition_errors=...`. Resets the token in `finally`.
- **`run_ledger`** — `complete()` accepts the errors list; entries now carry `degraded: bool` (true iff the list is non-empty) and the full `source_acquisition_errors` array. `fail()` always lands `degraded: false` so the field's semantics stay narrow (\"partial fetch failure on an otherwise completed run\", not \"anything went wrong\").
- **`scripts/influx-report.py`** — recent-runs output now prints `(degraded)` next to the status when set, and lists each `source_error: source=… kind=… detail=…` line beneath, so the operator gets the new signal without a separate query.

## Verification

`make check`: 1,456 passed, 2 (third-party) warnings.

New tests:
- `tests/unit/test_telemetry.py::TestRecordSourceAcquisitionError` — no-op outside context, append inside context, detail truncation cap at 300 chars.
- `tests/unit/test_run_ledger.py` — three new cases for `degraded`/`source_acquisition_errors` semantics across `complete` (clean), `complete` (errors), and `fail`.
- `tests/unit/test_source_acquisition_errors.py` — end-to-end wiring: arxiv provider records on `NetworkError`, successful fetch records nothing, record outside context is a safe no-op, `run_profile` drains the contextvar into `ledger.complete`.

## What this enables (out of scope here)

- **#6 (OTEL metrics)** becomes meaningfully easier — a \"fetch health\" metric can key off the `degraded` field directly without scraping logs.
- **#17 (runbook)** can document a clean grep against the run ledger: `jq 'select(.degraded)'`.
- A future operator alert could fire on N consecutive degraded runs for a given profile.

## Test plan

- [x] Local: `make check` clean (1,456 pass, lint clean).
- [ ] CI to run on this PR.
- [ ] Once merged + deployed, watch the run ledger over the next 24h. Expectation: a transient arxiv 5xx now shows up as `status=completed, degraded=true, source_acquisition_errors=[{source: arxiv, kind: http, detail: ...}]` instead of being indistinguishable from a quiet window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)