### PR TITLE
feat: inspector skips download for archive-terminal arxiv papers

### DIFF
--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -752,6 +752,71 @@ class LithosClient:
             args["limit"] = limit
         return await self.call_tool("lithos_list", args)
 
+    async def list_archive_terminal_arxiv_ids(
+        self,
+        *,
+        profile: str,
+    ) -> frozenset[str]:
+        """Return the arxiv-ids of notes tagged ``influx:archive-terminal``
+        for *profile* (issue #14).
+
+        Used by the inspector to short-circuit ``download_archive`` for
+        papers whose archive is known to be permanently unfetchable
+        (e.g. >100 MB PDFs that already accumulated the cap of counted
+        download failures during the repair sweep).  Returns an empty
+        frozenset when Lithos is unreachable or returns no items so the
+        run continues at worst as today.
+        """
+        try:
+            result = await self.list_notes(
+                tags=["influx:archive-terminal", f"profile:{profile}"],
+            )
+        except (LithosError, McpError):
+            logger.warning(
+                "list_archive_terminal_arxiv_ids: lithos_list failed for "
+                "profile %r; assuming empty terminal set",
+                profile,
+                exc_info=True,
+            )
+            return frozenset()
+
+        if getattr(result, "isError", False) is True:
+            logger.warning(
+                "list_archive_terminal_arxiv_ids: lithos_list returned "
+                "isError=True for profile %r; assuming empty terminal set",
+                profile,
+            )
+            return frozenset()
+
+        try:
+            text = result.content[0].text  # type: ignore[union-attr]
+            body = json.loads(text)
+        except (AttributeError, IndexError, json.JSONDecodeError, KeyError):
+            logger.warning(
+                "list_archive_terminal_arxiv_ids: malformed lithos_list "
+                "response for profile %r; assuming empty terminal set",
+                profile,
+                exc_info=True,
+            )
+            return frozenset()
+
+        items = body.get("items") if isinstance(body, dict) else None
+        if not isinstance(items, list):
+            return frozenset()
+
+        ids: set[str] = set()
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            tags = item.get("tags")
+            if not isinstance(tags, list):
+                continue
+            for tag in tags:
+                if isinstance(tag, str) and tag.startswith("arxiv-id:"):
+                    ids.add(tag[len("arxiv-id:") :])
+                    break
+        return frozenset(ids)
+
     # ── LCMA wrappers (PRD 08) ──────────────────────────────────────
 
     async def _call_lcma_tool(

--- a/src/influx/scheduler.py
+++ b/src/influx/scheduler.py
@@ -48,6 +48,7 @@ from influx.repair import SweepWriteError
 from influx.repair import sweep as repair_sweep
 from influx.run_ledger import RunLedger
 from influx.telemetry import (
+    current_archive_terminal_arxiv_ids,
     current_run_id,
     current_source_acquisition_errors,
     get_tracer,
@@ -353,7 +354,20 @@ async def _run_profile_body(
                 filter_prompt = prompt_text
 
             # 3. Source acquisition (PRD 04 plugs in arXiv + RSS).
-            items = list(await provider(profile, kind, run_range, filter_prompt))
+            #    Pre-fetch the set of arxiv-ids whose Lithos notes are
+            #    tagged ``influx:archive-terminal`` so the inspector can
+            #    skip ``download_archive`` for permanently-unfetchable
+            #    papers (issue #14).  One Lithos query per run, even
+            #    when the set is empty, so the contextvar contract is
+            #    consistent.
+            terminal_ids = await client.list_archive_terminal_arxiv_ids(
+                profile=profile,
+            )
+            terminal_token = current_archive_terminal_arxiv_ids.set(terminal_ids)
+            try:
+                items = list(await provider(profile, kind, run_range, filter_prompt))
+            finally:
+                current_archive_terminal_arxiv_ids.reset(terminal_token)
             logger.info(
                 "source acquisition completed profile=%s kind=%s candidates=%d",
                 profile,

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -44,6 +44,7 @@ from influx.notes import ProfileRelevanceEntry, render_note
 from influx.schemas import Tier1Enrichment, Tier3Extraction
 from influx.storage import download_archive
 from influx.telemetry import (
+    current_archive_terminal_arxiv_ids,
     current_run_id,
     get_tracer,
     record_source_acquisition_error,
@@ -594,32 +595,49 @@ def build_arxiv_note_item(
     archive_path: str | None = None
     pdf_url = f"https://arxiv.org/pdf/{item.arxiv_id}.pdf"
     tracer = get_tracer()
-    with tracer.span(
-        "influx.archive.download",
-        attributes={
-            "influx.profile": profile_name,
-            "influx.run_id": current_run_id.get() or "",
-            "influx.source": "arxiv",
-        },
-    ):
-        archive_result = download_archive(
-            url=pdf_url,
-            archive_root=Path(config.storage.archive_dir),
-            source="arxiv",
-            item_id=item.arxiv_id,
-            published_year=item.published.year,
-            published_month=item.published.month,
-            ext=".pdf",
-            allow_private_ips=config.security.allow_private_ips,
-            max_download_bytes=config.storage.max_download_bytes,
-            timeout_seconds=config.storage.download_timeout_seconds,
-            expected_content_type="pdf",
-        )
-    if archive_result.ok:
-        archive_path = archive_result.rel_posix_path
-    else:
+    archive_terminal_ids = current_archive_terminal_arxiv_ids.get()
+    is_archive_terminal = item.arxiv_id in archive_terminal_ids
+
+    if is_archive_terminal:
+        # Issue #14: this paper's archive download has been terminal-flipped
+        # by an earlier repair sweep (or hand-set by an operator).  Skip the
+        # download attempt entirely; the existing Lithos note's tags will
+        # be preserved by the canonical merge_tags path on rewrite.
         tags.append("influx:archive-missing")
+        tags.append("influx:archive-terminal")
         repair_needed = True
+        _log.info(
+            "archive download skipped (terminal) profile=%s arxiv_id=%s",
+            profile_name,
+            item.arxiv_id,
+        )
+    else:
+        with tracer.span(
+            "influx.archive.download",
+            attributes={
+                "influx.profile": profile_name,
+                "influx.run_id": current_run_id.get() or "",
+                "influx.source": "arxiv",
+            },
+        ):
+            archive_result = download_archive(
+                url=pdf_url,
+                archive_root=Path(config.storage.archive_dir),
+                source="arxiv",
+                item_id=item.arxiv_id,
+                published_year=item.published.year,
+                published_month=item.published.month,
+                ext=".pdf",
+                allow_private_ips=config.security.allow_private_ips,
+                max_download_bytes=config.storage.max_download_bytes,
+                timeout_seconds=config.storage.download_timeout_seconds,
+                expected_content_type="pdf",
+            )
+        if archive_result.ok:
+            archive_path = archive_result.rel_posix_path
+        else:
+            tags.append("influx:archive-missing")
+            repair_needed = True
 
     # ── Extraction cascade ────────────────────────────────────────
     extracted_text: str | None = None

--- a/src/influx/telemetry.py
+++ b/src/influx/telemetry.py
@@ -29,6 +29,7 @@ __all__ = [
     "InfluxTracer",
     "SourceAcquisitionError",
     "SpanWrapper",
+    "current_archive_terminal_arxiv_ids",
     "current_run_id",
     "current_source_acquisition_errors",
     "get_tracer",
@@ -57,6 +58,20 @@ SourceAcquisitionError = dict[str, str]
 # longer indistinguishable from a quiet window.
 current_source_acquisition_errors: ContextVar[list[SourceAcquisitionError] | None] = (
     ContextVar("current_source_acquisition_errors", default=None)
+)
+
+
+# Per-run set of arxiv-ids whose Lithos notes carry
+# ``influx:archive-terminal``.  Populated once at the start of each
+# scheduled / manual run by ``_run_profile_body`` after the LithosClient
+# is connected; consulted by ``build_arxiv_note_item`` so that papers
+# whose archive download has already been terminal-flipped (per the
+# repair sweep cap added in PR #15) are not re-downloaded on every
+# run (issue #14).  Defaults to the empty frozenset so behaviour
+# outside a run context (CLI smoke commands, unit tests) is unchanged.
+current_archive_terminal_arxiv_ids: ContextVar[frozenset[str]] = ContextVar(
+    "current_archive_terminal_arxiv_ids",
+    default=frozenset(),
 )
 
 

--- a/tests/contract/test_lithos_client.py
+++ b/tests/contract/test_lithos_client.py
@@ -2120,3 +2120,129 @@ class TestFeedbackTagIntegrity:
             assert "source:arxiv" in retry_tags
         finally:
             await client.close()
+
+
+# ── Inspector pre-check: list_archive_terminal_arxiv_ids (issue #14) ─
+
+
+class TestListArchiveTerminalArxivIds:
+    """``list_archive_terminal_arxiv_ids`` returns the set of arxiv-ids
+    whose Lithos notes are tagged ``influx:archive-terminal`` for a
+    given profile.  Used by ``_run_profile_body`` to populate the
+    ``current_archive_terminal_arxiv_ids`` contextvar so the inspector
+    can short-circuit ``download_archive`` for permanently-unfetchable
+    papers (issue #14).
+    """
+
+    async def test_extracts_arxiv_ids_from_tags(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+    ) -> None:
+        import json as _json
+
+        # Fake server returns two terminal-tagged notes.  Only the
+        # ``arxiv-id:`` tag is parsed; other tags are ignored.
+        fake_lithos_server.list_responses.append(
+            _json.dumps(
+                {
+                    "items": [
+                        {
+                            "id": "n1",
+                            "title": "Big paper 1",
+                            "tags": [
+                                "profile:ai-robotics",
+                                "arxiv-id:2604.27929",
+                                "influx:archive-missing",
+                                "influx:archive-terminal",
+                            ],
+                        },
+                        {
+                            "id": "n2",
+                            "title": "Big paper 2",
+                            "tags": [
+                                "profile:ai-robotics",
+                                "arxiv-id:2604.27792",
+                                "influx:archive-terminal",
+                            ],
+                        },
+                    ]
+                }
+            )
+        )
+
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            result = await client.list_archive_terminal_arxiv_ids(profile="ai-robotics")
+        finally:
+            await client.close()
+
+        assert result == frozenset({"2604.27929", "2604.27792"})
+        # Confirm the right tag filter was sent.
+        list_calls = [c for c in fake_lithos_server.calls if c[0] == "lithos_list"]
+        assert len(list_calls) == 1
+        assert list_calls[0][1]["tags"] == [
+            "influx:archive-terminal",
+            "profile:ai-robotics",
+        ]
+
+    async def test_empty_response_returns_empty_set(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+    ) -> None:
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            result = await client.list_archive_terminal_arxiv_ids(profile="ai-robotics")
+        finally:
+            await client.close()
+
+        # Default fake response is empty items list.
+        assert result == frozenset()
+
+    async def test_items_without_arxiv_id_tag_are_skipped(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+    ) -> None:
+        """Notes that happen to be archive-terminal but lack an
+        ``arxiv-id:`` tag (e.g. RSS-sourced notes) don't pollute the
+        returned set."""
+        import json as _json
+
+        fake_lithos_server.list_responses.append(
+            _json.dumps(
+                {
+                    "items": [
+                        {
+                            "id": "n1",
+                            "title": "RSS thing",
+                            "tags": [
+                                "profile:ai-robotics",
+                                "source:rss",
+                                "influx:archive-terminal",
+                            ],
+                        },
+                        {
+                            "id": "n2",
+                            "title": "Arxiv thing",
+                            "tags": [
+                                "arxiv-id:2604.27929",
+                                "influx:archive-terminal",
+                            ],
+                        },
+                    ]
+                }
+            )
+        )
+
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            result = await client.list_archive_terminal_arxiv_ids(profile="ai-robotics")
+        finally:
+            await client.close()
+
+        assert result == frozenset({"2604.27929"})

--- a/tests/integration/test_arxiv_to_lithos.py
+++ b/tests/integration/test_arxiv_to_lithos.py
@@ -488,9 +488,10 @@ class TestNegativeExamples:
         assert "Rejected Paper B" in prompt
         assert "Rejected Paper C" in prompt
 
-        # lithos_list was called: first by repair sweep, then by feedback.
+        # lithos_list was called: first by repair sweep, then by feedback,
+        # then by the inspector's archive-terminal pre-fetch (issue #14).
         list_calls = [c for c in fake_lithos.calls if c[0] == "lithos_list"]
-        assert len(list_calls) == 2
+        assert len(list_calls) == 3
         # First call: repair sweep (influx:repair-needed).
         assert list_calls[0][1]["tags"] == [
             "influx:repair-needed",
@@ -498,6 +499,11 @@ class TestNegativeExamples:
         ]
         # Second call: feedback rejection list.
         assert list_calls[1][1]["tags"] == ["influx:rejected:ai-robotics"]
+        # Third call: inspector's archive-terminal pre-fetch (issue #14).
+        assert list_calls[2][1]["tags"] == [
+            "influx:archive-terminal",
+            "profile:ai-robotics",
+        ]
 
 
 # ── AC-05-I: webhook fires for non-backfill, skips backfill ──────

--- a/tests/unit/test_build_arxiv_note_item.py
+++ b/tests/unit/test_build_arxiv_note_item.py
@@ -1181,3 +1181,100 @@ class TestFilterTagsPropagation:
             config=config,
         )
         assert result["filter_tags"] == []
+
+
+# ── Inspector pre-check for influx:archive-terminal (issue #14) ─────
+
+
+from influx.telemetry import current_archive_terminal_arxiv_ids  # noqa: E402
+
+
+class TestInspectorArchiveTerminalSkip:
+    """When the current run's contextvar contains the paper's arxiv-id,
+    ``build_arxiv_note_item`` skips ``download_archive`` and tags the
+    item with ``influx:archive-terminal`` directly so subsequent runs
+    don't re-attempt a permanently-unfetchable PDF (issue #14).
+    """
+
+    @patch("influx.sources.arxiv.download_archive")
+    def test_terminal_arxiv_id_skips_download(self, mock_download: object) -> None:
+        config = _make_config()
+        token = current_archive_terminal_arxiv_ids.set(frozenset({"2601.12345"}))
+        try:
+            result = build_arxiv_note_item(
+                item=_make_item(),  # arxiv_id = "2601.12345"
+                score=7,
+                confidence=0.7,
+                reason="R",
+                profile_name="ai-robotics",
+                config=config,
+            )
+        finally:
+            current_archive_terminal_arxiv_ids.reset(token)
+
+        # download_archive must NOT have been called.
+        mock_download.assert_not_called()  # type: ignore[attr-defined]
+        # And the canonical tag set carries archive-missing + archive-terminal
+        # + repair-needed so the existing repair semantics still apply on
+        # rewrite — the operator sees the note's terminal state without
+        # needing to read the ## Repair body.
+        assert "influx:archive-missing" in result["tags"]
+        assert "influx:archive-terminal" in result["tags"]
+        assert "influx:repair-needed" in result["tags"]
+
+    @patch("influx.sources.arxiv.download_archive")
+    def test_non_terminal_arxiv_id_still_downloads(self, mock_download: object) -> None:
+        """Sanity: an arxiv-id NOT in the terminal set follows the normal
+        download path."""
+        from influx.storage import ArchiveResult
+
+        mock_download.return_value = ArchiveResult(  # type: ignore[union-attr]
+            ok=True,
+            rel_posix_path="arxiv/2026/04/2601.12345.pdf",
+            error="",
+        )
+        config = _make_config()
+        token = current_archive_terminal_arxiv_ids.set(
+            frozenset({"9999.99999"})  # different id
+        )
+        try:
+            build_arxiv_note_item(
+                item=_make_item(),
+                score=7,
+                confidence=0.7,
+                reason="R",
+                profile_name="ai-robotics",
+                config=config,
+            )
+        finally:
+            current_archive_terminal_arxiv_ids.reset(token)
+
+        mock_download.assert_called_once()  # type: ignore[attr-defined]
+
+    @patch("influx.sources.arxiv.download_archive")
+    def test_empty_terminal_set_default_behaviour_unchanged(
+        self, mock_download: object
+    ) -> None:
+        """No contextvar set (default frozenset()) → downloads happen as
+        today.  Guards against a regression where an empty set is
+        treated as 'everything is terminal'.
+        """
+        from influx.storage import ArchiveResult
+
+        mock_download.return_value = ArchiveResult(  # type: ignore[union-attr]
+            ok=True,
+            rel_posix_path="arxiv/2026/04/p.pdf",
+            error="",
+        )
+        config = _make_config()
+
+        build_arxiv_note_item(
+            item=_make_item(),
+            score=7,
+            confidence=0.7,
+            reason="R",
+            profile_name="ai-robotics",
+            config=config,
+        )
+
+        mock_download.assert_called_once()  # type: ignore[attr-defined]

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -455,6 +455,11 @@ class TestSweepWriteErrorMarksReadinessDegraded:
         class _NoopClient:
             async def close(self) -> None: ...
 
+            async def list_archive_terminal_arxiv_ids(
+                self, *, profile: str
+            ) -> frozenset[str]:
+                return frozenset()
+
             async def task_create(self, **kwargs: Any) -> Any:
                 import json as _json
 
@@ -518,6 +523,11 @@ class TestSweepWriteErrorMarksReadinessDegraded:
 
         class _NoopClient:
             async def close(self) -> None: ...
+
+            async def list_archive_terminal_arxiv_ids(
+                self, *, profile: str
+            ) -> frozenset[str]:
+                return frozenset()
 
             async def cache_lookup_for_item(self, **kwargs: Any) -> Any:
                 # Should not be called — empty provider.
@@ -591,6 +601,11 @@ class TestSweepWriteErrorMarksReadinessDegraded:
         probe_loop = _FakeProbeLoop()
 
         class _NoopClient:
+            async def list_archive_terminal_arxiv_ids(
+                self, *, profile: str
+            ) -> frozenset[str]:
+                return frozenset()
+
             async def task_create(self, **kwargs: Any) -> Any:
                 import json as _json
 
@@ -663,6 +678,11 @@ class TestScheduledFireInvokesRepairSweep:
 
         class _NoopClient:
             async def close(self) -> None: ...
+
+            async def list_archive_terminal_arxiv_ids(
+                self, *, profile: str
+            ) -> frozenset[str]:
+                return frozenset()
 
             async def task_create(self, **kwargs: Any) -> Any:
                 import json as _json
@@ -753,6 +773,11 @@ class TestNegativeExampleMaxTitleCharsWired:
 
         class _NoopClient:
             async def close(self) -> None: ...
+
+            async def list_archive_terminal_arxiv_ids(
+                self, *, profile: str
+            ) -> frozenset[str]:
+                return frozenset()
 
             async def task_create(self, **kwargs: Any) -> Any:
                 import json as _json


### PR DESCRIPTION
Closes #14.

## Summary

PR #15 added the `influx:archive-terminal` data layer (counter, tag, stage-selection skip in the repair sweep), but the inspector in `arxiv.py:build_arxiv_note_item` calls `download_archive` unconditionally on every fetched item. Net effect: each scheduled run still produces an oversize WARNING for the same papers because the inspector path didn't know they'd been terminal-flipped.

This PR pre-fetches the set of archive-terminal arxiv-ids per profile per run and short-circuits the download for those ids.

## What changed

- **`LithosClient.list_archive_terminal_arxiv_ids(profile)`** — new method that calls `lithos_list(tags=[\"influx:archive-terminal\", f\"profile:...\"])`, parses the response, and returns a `frozenset[str]`. Defensive on transport / parse failures — falls back to empty so a Lithos hiccup never breaks the run.
- **`current_archive_terminal_arxiv_ids`** ContextVar in `telemetry.py` (default `frozenset()`) — same pattern as `current_run_id` / `current_source_acquisition_errors`.
- **`_run_profile_body`** queries the helper once per run after the LithosClient connects, sets the contextvar, and resets it in `finally`.
- **`build_arxiv_note_item`** reads the contextvar; when the paper's arxiv-id is in the set, it skips `download_archive` entirely and tags the item with `influx:archive-missing` + `influx:archive-terminal` + `influx:repair-needed`. Logs an INFO line so the operator can spot the skip.

## What's NOT in this PR

- **Wiring the repair sweep's `archive_download` hook** (still `None` per `repair_hooks.py:356` — \"PRD 04 responsibility\"). Today the cap on the sweep side won't actually flip any new notes; what this PR fixes is the *inspector-side* re-attempt loop for notes that were terminal-flipped through some other path (operator hand-setting the tag, future PRD-04 work, manual data fix). Issue #14's acceptance criterion is met for that case.
- **Per-call cost:** one additional `lithos_list` per run. Returns at most ~tens of items in steady state (count of permanently-broken papers), so this is a few-ms overhead on a multi-minute run.

## Verification

`make check`: 1,462 passed, 2 (third-party) warnings.

New tests:
- `tests/contract/test_lithos_client.py::TestListArchiveTerminalArxivIds` — happy path (extracts arxiv-ids from tags + verifies the request tag set), empty response returns empty set, items without `arxiv-id:` tag are skipped.
- `tests/unit/test_build_arxiv_note_item.py::TestInspectorArchiveTerminalSkip` — terminal id skips `download_archive`, non-terminal id still downloads, empty contextvar default preserves existing behaviour (regression guard).
- `tests/integration/test_arxiv_to_lithos.py` — `test_filter_prompt_contains_rejection_titles` updated to expect the new third `lithos_list` call (with its tag set verified).
- `tests/unit/test_scheduler.py` — five `_NoopClient` mocks updated with a stub for the new method.

## Knock-on benefits

- Issue #6 (OTEL metrics) gets a free `archive_download_skipped` counter from the new INFO log.
- The repair sweep's data-layer cap from PR #15 finally has a real-world way to engage once the sweep `archive_download` hook is wired (separate scope).

## Test plan

- [x] Local: `make check` clean (1,462 pass, lint clean).
- [ ] CI to run on this PR.
- [ ] Once merged + deployed, hand-set `influx:archive-terminal` on one of the squatted oversize notes (e.g. `arxiv-id:2604.27929`) and watch the next staging run — expect zero `Archive download failed for ...2604.27929` warnings, and an `archive download skipped (terminal)` INFO line instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)