### PR TITLE
Wire archive_download hook in repair sweep (FR-REP-1)

### DIFF
--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -1186,8 +1186,9 @@ async def _process_sweep_note(
                 exc=exc,
             )
 
-    # Text extraction retry (PRD 07 hook — not yet wired).
-    # Placeholder: text extraction hook would go here.
+    # Text extraction retry hook intentionally not wired yet (issue #24,
+    # FR-REP-1 stage 2).  Until that lands, notes lacking any ``text:*``
+    # tag fall through to abstract-only re-extraction below.
 
     # Abstract-only re-extraction.
     # Re-evaluate eligibility if archive just succeeded this pass

--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -35,6 +35,7 @@ from influx.repair import (
     Tier3ExtractHook,
 )
 from influx.schemas import Tier3Extraction
+from influx.storage import download_archive
 
 __all__ = ["DefaultSweepHooks", "make_default_sweep_hooks"]
 
@@ -186,7 +187,146 @@ def _extract_from_archive(
     return extracted, "text:html"
 
 
+# ── Archive download metadata recovery ──────────────────────────────
+
+_ARXIV_ID_TAG_PREFIX = "arxiv-id:"
+_SOURCE_TAG_PREFIX = "source:"
+_NOTE_PATH_RE = re.compile(r"papers/(?P<source>[^/]+)/(?P<year>\d{4})/(?P<month>\d{2})")
+
+
+def _find_tag(tags: list[str], prefix: str) -> str | None:
+    """Return the suffix of the first tag starting with *prefix*, or None."""
+    for tag in tags:
+        if tag.startswith(prefix):
+            return tag[len(prefix) :]
+    return None
+
+
+def _parse_year_month_from_note_path(note_path: str) -> tuple[int, int] | None:
+    """Pull ``(year, month)`` from a Lithos note path like ``papers/arxiv/2026/04``."""
+    m = _NOTE_PATH_RE.search(note_path)
+    if not m:
+        return None
+    try:
+        return int(m.group("year")), int(m.group("month"))
+    except ValueError:
+        return None
+
+
+def _classify_download_kind(error: str) -> str:
+    """Return the ``kind`` discriminator from an ``ArchiveResult.error`` string.
+
+    ``download_archive`` packs ``"<kind>: <message>"`` for ``NetworkError``
+    cases and ``"HTTP <code> for ..."`` / ``"write: ..."`` for the other
+    failure paths.  We surface a stable ``stage`` value to the sweep so
+    :func:`influx.repair.classify_failure` can decide counted vs transient.
+    """
+    if error.startswith("HTTP "):
+        return "http"
+    head, _, _rest = error.partition(":")
+    head = head.strip()
+    return head or "archive_failed"
+
+
+def _resolve_arxiv_download_args(
+    note: dict[str, object],
+    config: AppConfig,
+) -> dict[str, object]:
+    """Build kwargs for :func:`download_archive` from an arxiv note's state.
+
+    Raises :class:`ExtractionError` (stage ``"resolve"``) when the note is
+    missing fields needed to retry — the sweep treats this as transient
+    so an operator hand-fix lands the next pass.
+    """
+    raw_tags = note.get("tags", [])
+    tags: list[str] = list(raw_tags) if isinstance(raw_tags, list) else []
+    arxiv_id = _find_tag(tags, _ARXIV_ID_TAG_PREFIX)
+    if not arxiv_id:
+        raise ExtractionError(
+            "Cannot retry archive download: no arxiv-id tag on note",
+            stage="resolve",
+            detail=f"note id={note.get('id', '?')}",
+        )
+    note_path = str(note.get("path", ""))
+    ym = _parse_year_month_from_note_path(note_path)
+    if ym is None:
+        raise ExtractionError(
+            "Cannot retry archive download: note path missing year/month",
+            stage="resolve",
+            detail=f"path={note_path!r}",
+        )
+    year, month = ym
+    pdf_url = f"https://arxiv.org/pdf/{arxiv_id}.pdf"
+    return {
+        "url": pdf_url,
+        "archive_root": Path(config.storage.archive_dir),
+        "source": "arxiv",
+        "item_id": arxiv_id,
+        "published_year": year,
+        "published_month": month,
+        "ext": ".pdf",
+        "allow_private_ips": config.security.allow_private_ips,
+        "max_download_bytes": config.storage.max_download_bytes,
+        "timeout_seconds": config.storage.download_timeout_seconds,
+        "expected_content_type": "pdf",
+    }
+
+
 # ── Hook factories ──────────────────────────────────────────────────
+
+
+def _make_archive_download_hook(config: AppConfig) -> ArchiveDownloadHook:
+    """Create the production ``archive_download`` hook (FR-REP-1).
+
+    The hook re-runs :func:`influx.storage.download_archive` for a note
+    tagged ``influx:archive-missing`` and returns the relative POSIX
+    path on success.  On failure it raises :class:`ExtractionError` so
+    the sweep's existing ``(ExtractionError, LithosError)`` branch
+    bumps the per-note ``archive_attempts`` counter (only for
+    counted-class kinds — currently ``"oversize"``) and flips
+    ``influx:archive-terminal`` once the cap is reached.
+
+    Currently scoped to ``source:arxiv`` notes.  Other sources raise an
+    ``ExtractionError(stage="unsupported_source")`` which classifies as
+    transient — the note re-enters the sweep next pass and is fixed
+    automatically once a per-source resolver is added.
+    """
+
+    def hook(note: dict[str, object]) -> str:
+        raw_tags = note.get("tags", [])
+        tags: list[str] = list(raw_tags) if isinstance(raw_tags, list) else []
+        source = _find_tag(tags, _SOURCE_TAG_PREFIX) or ""
+        if source != "arxiv":
+            raise ExtractionError(
+                f"archive_download retry: source {source!r} not supported",
+                stage="unsupported_source",
+                detail=f"note id={note.get('id', '?')}",
+            )
+
+        kwargs = _resolve_arxiv_download_args(note, config)
+        result = download_archive(**kwargs)  # type: ignore[arg-type]
+        if result.ok and result.rel_posix_path:
+            _log.info(
+                "archive_download retry succeeded for %s path=%s",
+                note.get("id", "?"),
+                result.rel_posix_path,
+            )
+            return result.rel_posix_path
+
+        # The sweep classifies counted vs transient via
+        # ``influx.repair.classify_failure`` based on the ``stage``
+        # attribute below; surface the discriminator from
+        # ``ArchiveResult.error`` verbatim so e.g. ``"oversize"`` lines
+        # up with ``influx.repair._COUNTED_STAGES`` and bumps the cap.
+        stage = _classify_download_kind(result.error) or "archive_failed"
+        raise ExtractionError(
+            f"archive_download retry failed: {result.error}",
+            url=str(kwargs.get("url", "")),
+            stage=stage,
+            detail=result.error,
+        )
+
+    return hook
 
 
 def _make_re_extract_archive_hook(
@@ -323,20 +463,19 @@ def _make_tier3_extract_hook(config: AppConfig) -> Tier3ExtractHook:
 class DefaultSweepHooks:
     """Production-default sweep hook wiring with non-optional callables.
 
-    Holds the three production hooks with non-``Optional`` types so
+    Holds the four production hooks with non-``Optional`` types so
     pyright can statically know they are wired, while the parent
     :class:`~influx.repair.SweepHooks` keeps them ``| None`` to preserve
-    the test-injection seam.  ``archive_download`` remains optional —
-    it is owned by PRD 04 and not wired here.
+    the test-injection seam.
 
     Use :meth:`to_sweep_hooks` to obtain a ``SweepHooks`` instance for
     passing into :func:`influx.repair.sweep`.
     """
 
+    archive_download: ArchiveDownloadHook
     re_extract_archive: ReExtractArchiveHook
     tier2_enrich: Tier2EnrichHook
     tier3_extract: Tier3ExtractHook
-    archive_download: ArchiveDownloadHook | None = None
 
     def to_sweep_hooks(self) -> SweepHooks:
         """Return a :class:`SweepHooks` carrying these production hooks."""
@@ -352,8 +491,7 @@ def make_default_sweep_hooks(config: AppConfig) -> DefaultSweepHooks:
     """Create production-default sweep hooks for the repair sweep.
 
     Each hook bridges the PRD 06 hook signature to the lower-level
-    extraction and enrichment helpers from PRD 07.  The
-    ``archive_download`` hook is left ``None`` (PRD 04 responsibility).
+    fetch / extraction / enrichment helpers (FR-REP-1).
 
     Returns :class:`DefaultSweepHooks` (typed with non-optional
     callables) so callers and tests do not need to narrow ``Optional``
@@ -361,6 +499,7 @@ def make_default_sweep_hooks(config: AppConfig) -> DefaultSweepHooks:
     the sweep entrypoint via :meth:`DefaultSweepHooks.to_sweep_hooks`.
     """
     return DefaultSweepHooks(
+        archive_download=_make_archive_download_hook(config),
         re_extract_archive=_make_re_extract_archive_hook(config),
         tier2_enrich=_make_tier2_enrich_hook(config),
         tier3_extract=_make_tier3_extract_hook(config),

--- a/tests/unit/test_repair_hooks_production.py
+++ b/tests/unit/test_repair_hooks_production.py
@@ -45,6 +45,10 @@ def _make_config(
     config = MagicMock(spec=AppConfig)
     config.storage = MagicMock(spec=StorageConfig)
     config.storage.archive_dir = str(tmp_path / "archive")
+    config.storage.max_download_bytes = 10_000_000
+    config.storage.download_timeout_seconds = 30
+    config.security = MagicMock()
+    config.security.allow_private_ips = False
     config.extraction = MagicMock(spec=ExtractionConfig)
     config.extraction.min_html_chars = min_html_chars
     config.extraction.min_web_chars = min_web_chars
@@ -132,14 +136,15 @@ class TestMakeDefaultSweepHooks:
         config = _make_config(tmp_path)
         sweep_hooks = make_default_sweep_hooks(config).to_sweep_hooks()
         assert isinstance(sweep_hooks, SweepHooks)
+        assert sweep_hooks.archive_download is not None
         assert sweep_hooks.re_extract_archive is not None
         assert sweep_hooks.tier2_enrich is not None
         assert sweep_hooks.tier3_extract is not None
 
-    def test_archive_download_left_none(self, tmp_path: Path) -> None:
+    def test_archive_download_wired(self, tmp_path: Path) -> None:
         config = _make_config(tmp_path)
         hooks = make_default_sweep_hooks(config)
-        assert hooks.archive_download is None
+        assert callable(hooks.archive_download)
 
 
 # ── re_extract_archive hook ──────────────────────────────────────────
@@ -539,3 +544,174 @@ class TestSweepHooksInjectionSeam:
         assert hooks.tier2_enrich is None
         assert hooks.tier3_extract is None
         assert hooks.archive_download is None
+
+
+# ── archive_download hook (issue #23, FR-REP-1 stage 1) ───────────────
+
+
+def _make_archive_missing_note(
+    *,
+    arxiv_id: str = "2604.26946",
+    note_path: str = "papers/arxiv/2026/04",
+    extra_tags: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a note dict in the ``influx:archive-missing`` state."""
+    tags = [
+        "profile:ai-robotics",
+        "ingested-by:influx",
+        "source:arxiv",
+        f"arxiv-id:{arxiv_id}",
+        "text:abstract-only",
+        "influx:repair-needed",
+        "influx:archive-missing",
+    ]
+    if extra_tags:
+        tags.extend(extra_tags)
+    return {
+        "id": f"arxiv-{arxiv_id}",
+        "title": "Test Paper",
+        "source_url": f"https://arxiv.org/abs/{arxiv_id}",
+        "path": note_path,
+        "content": _sample_note_content(),
+        "tags": tags,
+        "version": 1,
+    }
+
+
+class TestArchiveDownloadHookSuccess:
+    def test_returns_relative_path_on_success(self, tmp_path: Path) -> None:
+        from influx.storage import ArchiveResult
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_archive_missing_note()
+
+        with patch("influx.repair_hooks.download_archive") as mock_dl:
+            mock_dl.return_value = ArchiveResult(
+                ok=True,
+                rel_posix_path="arxiv/2026/04/2604.26946.pdf",
+                error="",
+            )
+            assert hooks.archive_download is not None
+            result = hooks.archive_download(note)
+
+        assert result == "arxiv/2026/04/2604.26946.pdf"
+        # Verify the download was invoked with the recovered metadata.
+        kwargs = mock_dl.call_args.kwargs
+        assert kwargs["url"] == "https://arxiv.org/pdf/2604.26946.pdf"
+        assert kwargs["source"] == "arxiv"
+        assert kwargs["item_id"] == "2604.26946"
+        assert kwargs["published_year"] == 2026
+        assert kwargs["published_month"] == 4
+        assert kwargs["ext"] == ".pdf"
+        assert kwargs["expected_content_type"] == "pdf"
+
+
+class TestArchiveDownloadHookFailures:
+    def test_oversize_raises_extraction_error_with_oversize_stage(
+        self, tmp_path: Path
+    ) -> None:
+        """Oversize is a counted failure — the stage must round-trip."""
+        from influx.repair import classify_failure
+        from influx.storage import ArchiveResult
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_archive_missing_note()
+
+        with patch("influx.repair_hooks.download_archive") as mock_dl:
+            mock_dl.return_value = ArchiveResult(
+                ok=False,
+                rel_posix_path=None,
+                error="oversize: response body 12000000 bytes exceeds limit",
+            )
+            assert hooks.archive_download is not None
+            with pytest.raises(ExtractionError) as exc_info:
+                hooks.archive_download(note)
+
+        assert exc_info.value.stage == "oversize"
+        assert classify_failure(exc_info.value) == "counted"
+
+    def test_http_error_raises_transient(self, tmp_path: Path) -> None:
+        """HTTP 4xx/5xx is currently transient — the note retries next sweep."""
+        from influx.repair import classify_failure
+        from influx.storage import ArchiveResult
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_archive_missing_note()
+
+        with patch("influx.repair_hooks.download_archive") as mock_dl:
+            mock_dl.return_value = ArchiveResult(
+                ok=False,
+                rel_posix_path=None,
+                error="HTTP 503 for https://arxiv.org/pdf/2604.26946.pdf",
+            )
+            assert hooks.archive_download is not None
+            with pytest.raises(ExtractionError) as exc_info:
+                hooks.archive_download(note)
+
+        assert exc_info.value.stage == "http"
+        assert classify_failure(exc_info.value) == "transient"
+
+    def test_timeout_is_transient(self, tmp_path: Path) -> None:
+        from influx.repair import classify_failure
+        from influx.storage import ArchiveResult
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_archive_missing_note()
+
+        with patch("influx.repair_hooks.download_archive") as mock_dl:
+            mock_dl.return_value = ArchiveResult(
+                ok=False,
+                rel_posix_path=None,
+                error="timeout: read timed out after 30s",
+            )
+            assert hooks.archive_download is not None
+            with pytest.raises(ExtractionError) as exc_info:
+                hooks.archive_download(note)
+
+        assert exc_info.value.stage == "timeout"
+        assert classify_failure(exc_info.value) == "transient"
+
+
+class TestArchiveDownloadHookMetadataRecovery:
+    def test_missing_arxiv_id_tag_raises_resolve(self, tmp_path: Path) -> None:
+        from influx.repair import classify_failure
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_archive_missing_note()
+        note["tags"] = [t for t in note["tags"] if not t.startswith("arxiv-id:")]
+
+        assert hooks.archive_download is not None
+        with pytest.raises(ExtractionError) as exc_info:
+            hooks.archive_download(note)
+        assert exc_info.value.stage == "resolve"
+        assert classify_failure(exc_info.value) == "transient"
+
+    def test_missing_year_month_in_path_raises_resolve(self, tmp_path: Path) -> None:
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_archive_missing_note(note_path="papers/arxiv/")
+
+        assert hooks.archive_download is not None
+        with pytest.raises(ExtractionError) as exc_info:
+            hooks.archive_download(note)
+        assert exc_info.value.stage == "resolve"
+
+    def test_unsupported_source_raises_unsupported_source(self, tmp_path: Path) -> None:
+        from influx.repair import classify_failure
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_archive_missing_note()
+        note["tags"] = [t.replace("source:arxiv", "source:rss") for t in note["tags"]]
+
+        assert hooks.archive_download is not None
+        with pytest.raises(ExtractionError) as exc_info:
+            hooks.archive_download(note)
+        assert exc_info.value.stage == "unsupported_source"
+        # Still transient — RSS support can land later without a forced cap.
+        assert classify_failure(exc_info.value) == "transient"


### PR DESCRIPTION
## Summary

Closes #23.

The repair sweep now actually retries failed archive downloads. Up to today the `archive_download` slot in `SweepHooks` was always `None` in production, which meant:

- the `influx:archive-terminal` cap data layer shipped in PR #15 had no production trigger;
- the inspector pre-check shipped in PR #22 was reading an empty terminal-id set;
- the only way a note ever cleared `influx:archive-missing` was a brand-new initial download from `sources/arxiv.py`.

This PR wires the production hook in `repair_hooks.py`. The hook:

1. Reads `source` and `arxiv-id` from the note's tags;
2. Parses `year`/`month` from the note's Lithos path (`papers/arxiv/YYYY/MM`);
3. Builds the PDF URL (`https://arxiv.org/pdf/{id}.pdf`) and calls `storage.download_archive`;
4. Returns the relative POSIX path on success;
5. Raises `ExtractionError` with a stage that matches `repair._COUNTED_STAGES` (`oversize` → counted toward cap; HTTP / timeout / SSRF / write → transient).

Non-arxiv sources currently raise `ExtractionError(stage="unsupported_source")`, which classifies as transient — RSS/multi-source resolvers can land later without retroactively terminal-flipping existing notes. Filed as a follow-up consideration if needed.

The misleading `# PRD 04 responsibility` comment in `repair_hooks.py` and the `# Placeholder: text extraction hook would go here` comment in `repair.py` are both removed; the latter now points at issue #24 (the sibling unwired hook).

## Files changed

- `src/influx/repair_hooks.py` — new `_make_archive_download_hook`, helpers, four-required-hook `DefaultSweepHooks`.
- `src/influx/repair.py` — replace stale text-extraction-retry comment with a pointer to #24.
- `tests/unit/test_repair_hooks_production.py` — `_make_config` extended; new `TestArchiveDownloadHookSuccess` / `Failures` / `MetadataRecovery` classes covering oversize→counted, HTTP→transient, timeout→transient, missing tag/path/source error paths.

## Test plan

- [x] `make check` (ruff, ruff format, pyright 0 errors, pytest 1469 passed).
- [x] New unit tests cover the success path, the three failure-classification branches, and the three metadata-recovery error paths.
- [ ] Staging smoke after merge: confirm previously archive-missing arxiv notes either flip to a stored `path:` or, after three counted oversize attempts, gain `influx:archive-terminal` and stop being re-fetched on subsequent runs (validates PR #15 + this PR + PR #22 working as one flow).