### PR TITLE
Wire text_extraction_retry hook in repair sweep (FR-REP-1 stage 2)

### DIFF
--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -40,6 +40,7 @@ __all__ = [
     "StageSelection",
     "SweepHooks",
     "SweepWriteError",
+    "TextExtractionHook",
     "Tier2EnrichHook",
     "Tier3ExtractHook",
     "apply_abstract_only_reextraction",
@@ -271,6 +272,43 @@ class ArchiveDownloadHook(Protocol):
     def __call__(self, note: dict[str, object]) -> str: ...
 
 
+class TextExtractionHook(Protocol):
+    """Callable protocol for text-extraction retry (FR-REP-1 stage 2).
+
+    Called by the sweep when a note carries no ``text:*`` tag at all
+    — typically a legacy note from before ``text:*`` was always set,
+    or one whose tag was hand-stripped.  Distinct from
+    ``re_extract_archive``, which upgrades ``text:abstract-only``
+    against an existing archive.
+
+    Implementations run the source-specific extraction cascade and
+    return the new ``text:*`` tag (e.g. ``"text:html"``,
+    ``"text:pdf"``, or ``"text:abstract-only"`` when the cascade
+    falls all the way through).
+
+    Parameters
+    ----------
+    note:
+        The current note state (as returned by ``lithos_read``).
+
+    Returns
+    -------
+    str
+        The replacement ``text:*`` tag to add to the note.
+
+    Raises
+    ------
+    ExtractionError
+        On extraction failure — the sweep treats this as "stage
+        failed this pass" and keeps ``influx:repair-needed``.
+    LithosError
+        On Lithos API failure — propagated to the sweep's error
+        handling.
+    """
+
+    def __call__(self, note: dict[str, object]) -> str: ...
+
+
 @dataclass(frozen=True, slots=True)
 class SweepHooks:
     """Optional hook callables for stage execution within the sweep.
@@ -284,6 +322,7 @@ class SweepHooks:
     re_extract_archive: ReExtractArchiveHook | None = None
     tier2_enrich: Tier2EnrichHook | None = None
     tier3_extract: Tier3ExtractHook | None = None
+    text_extraction: TextExtractionHook | None = None
 
 
 # ── Per-note stage selection (§5.2) ────────────────────────────────
@@ -1186,9 +1225,37 @@ async def _process_sweep_note(
                 exc=exc,
             )
 
-    # Text extraction retry hook intentionally not wired yet (issue #24,
-    # FR-REP-1 stage 2).  Until that lands, notes lacking any ``text:*``
-    # tag fall through to abstract-only re-extraction below.
+    # Text extraction retry (FR-REP-1 stage 2).  Runs when the note
+    # carries no ``text:*`` tag at all — distinct from the abstract-
+    # only re-extraction stage below, which upgrades ``text:abstract-
+    # only`` against an existing archive.  No new terminal tag is
+    # introduced here (out of scope for #24); failures roll back the
+    # in-place note mutations and re-enter the sweep next pass.
+    if stages.text_extraction_retry and hooks.text_extraction:
+        note["tags"] = list(current_tags)
+        snapshot = _snapshot_note(note)
+        tracer = get_tracer()
+        try:
+            with tracer.span(
+                "influx.repair.text_extraction",
+                attributes={
+                    "influx.note_id": note.get("id", ""),
+                    "influx.profile": profile,
+                    "influx.run_id": current_run_id.get() or "",
+                },
+            ):
+                new_text_tag = hooks.text_extraction(note)
+            if new_text_tag and not any(t.startswith("text:") for t in current_tags):
+                current_tags.append(new_text_tag)
+                note["tags"] = list(current_tags)
+        except (ExtractionError, LCMAError, LithosError) as exc:
+            _restore_note(note, snapshot)
+            _log_stage_failure(
+                "text_extraction",
+                note=note,
+                profile=profile,
+                exc=exc,
+            )
 
     # Abstract-only re-extraction.
     # Re-evaluate eligibility if archive just succeeded this pass

--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -21,9 +21,10 @@ import trafilatura
 
 from influx.config import AppConfig
 from influx.enrich import tier3_extract as _tier3_extract
-from influx.errors import ExtractionError, LCMAError
+from influx.errors import ExtractionError, LCMAError, NetworkError
 from influx.extraction.html import _clean_html_fragments, _strip_tags
 from influx.extraction.pdf import extract_pdf
+from influx.extraction.pipeline import extract_arxiv_text
 from influx.notes import parse_archive_path, parse_note
 from influx.repair import (
     ArchiveDownloadHook,
@@ -31,6 +32,7 @@ from influx.repair import (
     ReExtractArchiveHook,
     ReExtractionResult,
     SweepHooks,
+    TextExtractionHook,
     Tier2EnrichHook,
     Tier3ExtractHook,
 )
@@ -329,6 +331,61 @@ def _make_archive_download_hook(config: AppConfig) -> ArchiveDownloadHook:
     return hook
 
 
+def _make_text_extraction_hook(config: AppConfig) -> TextExtractionHook:
+    """Create the production ``text_extraction`` hook (FR-REP-1 stage 2).
+
+    The hook re-runs the source-specific extraction cascade for a note
+    that carries no ``text:*`` tag and returns the resulting tag.  On
+    cascade fall-through (both HTML and PDF failed) the underlying
+    helper raises :class:`ExtractionError`; we surface it to the sweep
+    so the per-stage failure logging path fires.
+
+    Currently scoped to ``source:arxiv`` — RSS support follows when
+    the multi-source resolver lands (out of scope for issue #24).
+    """
+
+    def hook(note: dict[str, object]) -> str:
+        raw_tags = note.get("tags", [])
+        tags: list[str] = list(raw_tags) if isinstance(raw_tags, list) else []
+        source = _find_tag(tags, _SOURCE_TAG_PREFIX) or ""
+        if source != "arxiv":
+            raise ExtractionError(
+                f"text_extraction retry: source {source!r} not supported",
+                stage="unsupported_source",
+                detail=f"note id={note.get('id', '?')}",
+            )
+
+        arxiv_id = _find_tag(tags, _ARXIV_ID_TAG_PREFIX)
+        if not arxiv_id:
+            raise ExtractionError(
+                "Cannot retry text extraction: no arxiv-id tag on note",
+                stage="resolve",
+                detail=f"note id={note.get('id', '?')}",
+            )
+
+        try:
+            result = extract_arxiv_text(arxiv_id, config)
+        except NetworkError as exc:
+            # extract_arxiv_text raises ExtractionError on full cascade
+            # fall-through, but a NetworkError can leak from helpers it
+            # calls (e.g. SSRF guards on the PDF fetch).  Re-wrap so the
+            # sweep's ``(ExtractionError, ...)`` branch handles it.
+            raise ExtractionError(
+                f"text_extraction retry network failure: {exc.kind}",
+                url=getattr(exc, "url", "") or "",
+                stage=exc.kind or "network",
+                detail=str(exc),
+            ) from exc
+        _log.info(
+            "text_extraction retry succeeded for %s tag=%s",
+            note.get("id", "?"),
+            result.source_tag,
+        )
+        return result.source_tag
+
+    return hook
+
+
 def _make_re_extract_archive_hook(
     config: AppConfig,
 ) -> ReExtractArchiveHook:
@@ -463,7 +520,7 @@ def _make_tier3_extract_hook(config: AppConfig) -> Tier3ExtractHook:
 class DefaultSweepHooks:
     """Production-default sweep hook wiring with non-optional callables.
 
-    Holds the four production hooks with non-``Optional`` types so
+    Holds the five production hooks with non-``Optional`` types so
     pyright can statically know they are wired, while the parent
     :class:`~influx.repair.SweepHooks` keeps them ``| None`` to preserve
     the test-injection seam.
@@ -476,6 +533,7 @@ class DefaultSweepHooks:
     re_extract_archive: ReExtractArchiveHook
     tier2_enrich: Tier2EnrichHook
     tier3_extract: Tier3ExtractHook
+    text_extraction: TextExtractionHook
 
     def to_sweep_hooks(self) -> SweepHooks:
         """Return a :class:`SweepHooks` carrying these production hooks."""
@@ -484,6 +542,7 @@ class DefaultSweepHooks:
             re_extract_archive=self.re_extract_archive,
             tier2_enrich=self.tier2_enrich,
             tier3_extract=self.tier3_extract,
+            text_extraction=self.text_extraction,
         )
 
 
@@ -503,4 +562,5 @@ def make_default_sweep_hooks(config: AppConfig) -> DefaultSweepHooks:
         re_extract_archive=_make_re_extract_archive_hook(config),
         tier2_enrich=_make_tier2_enrich_hook(config),
         tier3_extract=_make_tier3_extract_hook(config),
+        text_extraction=_make_text_extraction_hook(config),
     )

--- a/tests/unit/test_repair_hooks_production.py
+++ b/tests/unit/test_repair_hooks_production.py
@@ -140,11 +140,17 @@ class TestMakeDefaultSweepHooks:
         assert sweep_hooks.re_extract_archive is not None
         assert sweep_hooks.tier2_enrich is not None
         assert sweep_hooks.tier3_extract is not None
+        assert sweep_hooks.text_extraction is not None
 
     def test_archive_download_wired(self, tmp_path: Path) -> None:
         config = _make_config(tmp_path)
         hooks = make_default_sweep_hooks(config)
         assert callable(hooks.archive_download)
+
+    def test_text_extraction_wired(self, tmp_path: Path) -> None:
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        assert callable(hooks.text_extraction)
 
 
 # ── re_extract_archive hook ──────────────────────────────────────────
@@ -544,6 +550,7 @@ class TestSweepHooksInjectionSeam:
         assert hooks.tier2_enrich is None
         assert hooks.tier3_extract is None
         assert hooks.archive_download is None
+        assert hooks.text_extraction is None
 
 
 # ── archive_download hook (issue #23, FR-REP-1 stage 1) ───────────────
@@ -714,4 +721,141 @@ class TestArchiveDownloadHookMetadataRecovery:
             hooks.archive_download(note)
         assert exc_info.value.stage == "unsupported_source"
         # Still transient — RSS support can land later without a forced cap.
+        assert classify_failure(exc_info.value) == "transient"
+
+
+# ── text_extraction hook (issue #24, FR-REP-1 stage 2) ───────────────
+
+
+def _make_textless_note(
+    *,
+    arxiv_id: str = "2604.26946",
+    archive_path: str | None = None,
+) -> dict[str, Any]:
+    """Build a note dict with no ``text:*`` tag at all."""
+    tags = [
+        "profile:ai-robotics",
+        "ingested-by:influx",
+        "source:arxiv",
+        f"arxiv-id:{arxiv_id}",
+        "influx:repair-needed",
+    ]
+    return {
+        "id": f"arxiv-{arxiv_id}",
+        "title": "Test Paper",
+        "source_url": f"https://arxiv.org/abs/{arxiv_id}",
+        "path": "papers/arxiv/2026/04",
+        "content": _sample_note_content(archive_path=archive_path),
+        "tags": tags,
+        "version": 1,
+    }
+
+
+class TestTextExtractionHookSuccess:
+    def test_returns_html_tag_on_html_cascade_hit(self, tmp_path: Path) -> None:
+        from influx.extraction.pipeline import ArxivExtractionResult
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_textless_note()
+
+        with patch("influx.repair_hooks.extract_arxiv_text") as mock_x:
+            mock_x.return_value = ArxivExtractionResult(
+                text="full body",
+                source_tag="text:html",
+            )
+            assert hooks.text_extraction is not None
+            tag = hooks.text_extraction(note)
+
+        assert tag == "text:html"
+        assert mock_x.call_args.args[0] == "2604.26946"
+
+    def test_returns_pdf_tag_when_html_falls_through(self, tmp_path: Path) -> None:
+        from influx.extraction.pipeline import ArxivExtractionResult
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_textless_note()
+
+        with patch("influx.repair_hooks.extract_arxiv_text") as mock_x:
+            mock_x.return_value = ArxivExtractionResult(
+                text="pdf body",
+                source_tag="text:pdf",
+            )
+            assert hooks.text_extraction is not None
+            tag = hooks.text_extraction(note)
+
+        assert tag == "text:pdf"
+
+
+class TestTextExtractionHookFailures:
+    def test_cascade_failure_propagates_extraction_error(self, tmp_path: Path) -> None:
+        from influx.repair import classify_failure
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_textless_note()
+
+        with patch("influx.repair_hooks.extract_arxiv_text") as mock_x:
+            mock_x.side_effect = ExtractionError(
+                "cascade fell through",
+                stage="cascade",
+                detail="both html and pdf failed",
+            )
+            assert hooks.text_extraction is not None
+            with pytest.raises(ExtractionError) as exc_info:
+                hooks.text_extraction(note)
+
+        assert exc_info.value.stage == "cascade"
+        # ``cascade`` is not in _COUNTED_STAGES, so it stays transient —
+        # the note re-enters the sweep next pass.
+        assert classify_failure(exc_info.value) == "transient"
+
+    def test_network_error_rewrapped_as_extraction_error(self, tmp_path: Path) -> None:
+        from influx.errors import NetworkError
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_textless_note()
+
+        with patch("influx.repair_hooks.extract_arxiv_text") as mock_x:
+            mock_x.side_effect = NetworkError(
+                "ssrf guard tripped",
+                url="https://arxiv.org/pdf/2604.26946.pdf",
+                kind="ssrf",
+            )
+            assert hooks.text_extraction is not None
+            with pytest.raises(ExtractionError) as exc_info:
+                hooks.text_extraction(note)
+
+        assert exc_info.value.stage == "ssrf"
+
+
+class TestTextExtractionHookMetadataRecovery:
+    def test_missing_arxiv_id_raises_resolve(self, tmp_path: Path) -> None:
+        from influx.repair import classify_failure
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_textless_note()
+        note["tags"] = [t for t in note["tags"] if not t.startswith("arxiv-id:")]
+
+        assert hooks.text_extraction is not None
+        with pytest.raises(ExtractionError) as exc_info:
+            hooks.text_extraction(note)
+        assert exc_info.value.stage == "resolve"
+        assert classify_failure(exc_info.value) == "transient"
+
+    def test_unsupported_source_raises_unsupported_source(self, tmp_path: Path) -> None:
+        from influx.repair import classify_failure
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_textless_note()
+        note["tags"] = [t.replace("source:arxiv", "source:rss") for t in note["tags"]]
+
+        assert hooks.text_extraction is not None
+        with pytest.raises(ExtractionError) as exc_info:
+            hooks.text_extraction(note)
+        assert exc_info.value.stage == "unsupported_source"
         assert classify_failure(exc_info.value) == "transient"

--- a/tests/unit/test_repair_sweep.py
+++ b/tests/unit/test_repair_sweep.py
@@ -1235,3 +1235,117 @@ class TestSweepArchiveTerminalCap:
         )
 
         assert call_count == 0
+
+
+class TestSweepTextExtractionRetry:
+    """text_extraction stage executes when the note has no ``text:*`` tag.
+
+    Verifies issue #24 wiring: select_stages selects the stage, the
+    executor calls the hook, and a successful return appends the new
+    ``text:*`` tag to the rewritten note.
+    """
+
+    @staticmethod
+    def _note_textless(note_id: str) -> dict[str, Any]:
+        body = (
+            "---\n"
+            f"source_url: https://arxiv.org/abs/{note_id}\n"
+            "tags: []\n"
+            "confidence: 0.9\n"
+            "---\n"
+            "# Paper\n\n"
+            "## Archive\n"
+            "path: arxiv/2026/04/x.pdf\n\n"
+            "## Summary\nSummary\n\n"
+            "## Profile Relevance\n"
+            "### ai-robotics\nScore: 5/10\nRelevant\n\n"
+            "## User Notes\n"
+        )
+        return {
+            "id": note_id,
+            "title": "Paper",
+            "content": body,
+            "tags": ["influx:repair-needed"],
+            "source_url": f"https://arxiv.org/abs/{note_id}",
+            "confidence": 0.9,
+        }
+
+    @staticmethod
+    def _last_write_args(client: AsyncMock) -> dict[str, Any]:
+        write_calls = [
+            c for c in client.call_tool.call_args_list if c.args[0] == "lithos_write"
+        ]
+        assert write_calls, "expected lithos_write call"
+        return dict(write_calls[-1].args[1])
+
+    async def test_success_appends_text_tag(self) -> None:
+        items = [{"id": "n1", "title": "Paper"}]
+        note = self._note_textless("n1")
+
+        def hook(note: dict[str, object]) -> str:
+            del note
+            return "text:html"
+
+        config = _make_config()
+        client = _make_client(list_items=items, read_responses=[note])
+
+        await sweep(
+            "ai-robotics",
+            client=client,
+            config=config,
+            hooks=SweepHooks(text_extraction=hook),
+        )
+
+        rewritten = self._last_write_args(client)
+        assert "text:html" in rewritten["tags"]
+
+    async def test_skipped_when_text_tag_already_present(self) -> None:
+        items = [{"id": "n1", "title": "Paper"}]
+        note = self._note_textless("n1")
+        note["tags"] = list(note["tags"]) + ["text:abstract-only"]
+
+        call_count = 0
+
+        def hook(note: dict[str, object]) -> str:
+            nonlocal call_count
+            del note
+            call_count += 1
+            return "text:html"
+
+        config = _make_config()
+        client = _make_client(list_items=items, read_responses=[note])
+
+        await sweep(
+            "ai-robotics",
+            client=client,
+            config=config,
+            hooks=SweepHooks(text_extraction=hook),
+        )
+
+        assert call_count == 0
+
+    async def test_failure_keeps_note_textless_and_repair_needed(self) -> None:
+        items = [{"id": "n1", "title": "Paper"}]
+        note = self._note_textless("n1")
+
+        def hook(note: dict[str, object]) -> str:
+            del note
+            raise ExtractionError(
+                "cascade fell through",
+                stage="cascade",
+                detail="all paths failed",
+            )
+
+        config = _make_config()
+        client = _make_client(list_items=items, read_responses=[note])
+
+        await sweep(
+            "ai-robotics",
+            client=client,
+            config=config,
+            hooks=SweepHooks(text_extraction=hook),
+        )
+
+        rewritten = self._last_write_args(client)
+        assert not any(t.startswith("text:") for t in rewritten["tags"])
+        assert "influx:repair-needed" in rewritten["tags"]


### PR DESCRIPTION
## Summary

Closes #24.

The repair sweep's `text_extraction_retry` stage was a placeholder. `select_stages` already returned `text_extraction_retry: True` when the note carried no `text:*` tag, but `_process_sweep_note` had nothing wired beyond a TODO comment, so the sweep just rewrote the note unchanged each pass.

This PR adds the executor and production hook:

- New `TextExtractionHook` Protocol in `repair.py` — same shape as the other hooks; returns the new `text:*` tag.
- Executor block in `_process_sweep_note` between `archive_retry` and `apply_abstract_only_reextraction` (mirrors the order in `select_stages`); snapshot/restore rollback on raise; OTEL `influx.repair.text_extraction` span; failures route through the existing `_log_stage_failure` warning path.
- `_make_text_extraction_hook` in `repair_hooks.py` calls the existing `extraction.pipeline.extract_arxiv_text` cascade and returns the resulting tag (`text:html`, `text:pdf`). `NetworkError` is rewrapped as `ExtractionError` so the sweep's `(ExtractionError, ...)` branch handles it.
- `DefaultSweepHooks` now requires all five hooks; `make_default_sweep_hooks` populates the new field.

Out of scope (called out in the issue): a separate `influx:text-extraction-terminal` tag, and the RSS retry path. Non-arxiv sources raise `ExtractionError(stage=\"unsupported_source\")` (transient) so RSS support can land later without retroactive terminal flips.

## Files changed

- `src/influx/repair.py` — new Protocol, `text_extraction` field on `SweepHooks`, executor block.
- `src/influx/repair_hooks.py` — new factory, wired into `DefaultSweepHooks` + `make_default_sweep_hooks`.
- `tests/unit/test_repair_hooks_production.py` — `TestTextExtractionHookSuccess` / `Failures` / `MetadataRecovery` (HTML/PDF success, cascade fall-through, NetworkError rewrap, missing tag, unsupported source).
- `tests/unit/test_repair_sweep.py` — `TestSweepTextExtractionRetry` covers the end-to-end executor path: success appends the tag, hook is skipped when a `text:*` tag is already present, and failure leaves the note text-less + repair-needed.

## Test plan

- [x] `make check` (ruff, ruff format, pyright 0 errors, pytest 1479 passed = 10 new).
- [ ] Staging soak after merge: confirm any text-less notes (rare, but they exist) get a `text:*` tag set within one sweep pass instead of being silently rewritten.