### PR TITLE
feat: add OTEL metrics for run lifecycle, source funnel, and failure counters

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -638,7 +638,31 @@ Readiness is degraded when:
 
 ### 13.2 Telemetry
 
-When telemetry is enabled, spans are emitted for run, source fetch, archive download, enrichment, Lithos write, and Lithos retrieve operations. The service name and export interval are configured under `[telemetry]`.
+When telemetry is enabled (`INFLUX_OTEL_ENABLED=true`), Influx exports OTEL traces and metrics. Both signals share the same toggle, the same OTLP endpoint configuration (`OTEL_EXPORTER_OTLP_ENDPOINT`), and the same resource attributes (`service.name=influx`, `deployment.environment=<INFLUX_ENVIRONMENT>`).
+
+Spans are emitted for run, source fetch, archive download, enrichment, Lithos write, and Lithos retrieve operations.
+
+Metric instruments cover run lifecycle, the source funnel, write outcomes, and failure modes. Label values are bounded by construction — per-item identifiers (`run_id`, `note_id`, `arxiv_id`, `source_url`, `title`) are never used as labels.
+
+| Instrument | Type | Labels |
+|---|---|---|
+| `influx_run_starts_total` | Counter | `profile`, `run_type` |
+| `influx_run_completions_total` | Counter | `profile`, `run_type`, `outcome` (`success` \| `failure` \| `degraded`) |
+| `influx_run_duration_seconds` | Histogram (s) | `profile`, `run_type` |
+| `influx_active_runs` | UpDownCounter | `profile` |
+| `influx_source_candidates_fetched_total` | Counter | `profile`, `source` |
+| `influx_articles_filtered_total` | Counter | `profile`, `decision` (`pass` \| `drop`) |
+| `influx_articles_inspected_total` | Counter | `profile`, `source` |
+| `influx_cache_hits_total` | Counter | `profile`, `source` |
+| `influx_lithos_writes_total` | Counter | `profile`, `source`, `status` |
+| `influx_repair_candidates_total` | Counter | `profile`, `kind` (`archive` \| `text_extraction` \| `tier2` \| `tier3`) |
+| `influx_llm_validation_failures_total` | Counter | `profile`, `tier` (`1` \| `3`) |
+| `influx_archive_missing_total` | Counter | `profile`, `source` |
+| `influx_source_acquisition_errors_total` | Counter | `profile`, `source`, `kind` |
+
+When `OTEL_EXPORTER_OTLP_ENDPOINT` is set the OTLP HTTP exporter is used. With `INFLUX_OTEL_CONSOLE_FALLBACK=true` and no endpoint configured, both spans and metrics are written to stdout for local development.
+
+OTEL log export remains stdout-only in this revision; structured-log OTEL export is tracked separately.
 
 ### 13.3 Logging
 

--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -201,7 +201,32 @@ note after fixing the underlying cause:
 The full per-stage cap contract lives in
 [`docs/SPECIFICATION.md` §11.1](../SPECIFICATION.md#111-per-stage-cap-and-self-repair).
 
-## 7. Reference
+## 7. Reading metrics from the OTEL backend
+
+When the staging deployment has `INFLUX_OTEL_ENABLED=true` and an OTLP
+endpoint configured, Influx exports metrics alongside spans. Use these
+to answer "is the run progressing?" without `docker logs`.
+
+| Question | Instrument |
+| -------- | ---------- |
+| Is anything actually running right now? | `sum(influx_active_runs)` per `profile`. |
+| When did the last run start / finish? | `rate(influx_run_starts_total[15m])` and `rate(influx_run_completions_total[15m])` filtered by `outcome`. |
+| How long are runs taking? | `histogram_quantile(0.95, influx_run_duration_seconds_bucket)` by `profile`. |
+| Are runs degrading? | `sum by (profile, outcome) (rate(influx_run_completions_total[1h]))` — non-zero `outcome="degraded"` means swallowed source-fetch errors. |
+| Is the source funnel narrowing as expected? | `rate(influx_source_candidates_fetched_total[1h])` → `rate(influx_articles_filtered_total{decision="pass"}[1h])` → `rate(influx_articles_inspected_total[1h])` → `rate(influx_lithos_writes_total{status=~"created\\|updated"}[1h])`. |
+| Are writes failing silently? | `rate(influx_lithos_writes_total{status!~"created\\|updated"}[15m])` by `status`. |
+| Is the LLM pipeline degrading? | `rate(influx_llm_validation_failures_total[1h])` by `tier`. |
+| Is the repair sweep stuck on one stage? | `rate(influx_repair_candidates_total[1h])` by `kind`. |
+| Are upstream sources flapping? | `rate(influx_source_acquisition_errors_total[1h])` by `source, kind`. |
+
+Resource attributes on every metric: `service.name=influx` plus
+`deployment.environment=<INFLUX_ENVIRONMENT>` (e.g. `staging`). Filter
+by these on the collector if multiple environments share a backend.
+
+OTEL log export is **not** wired in this revision; the runbook still
+relies on `docker logs` (and `influx-diagnose.py`) for log inspection.
+
+## 8. Reference
 
 - Run ledger schema: `src/influx/run_ledger.py` (`RunEntry` TypedDict).
 - Admin endpoints: `src/influx/http_api.py` (`/live`, `/ready`,
@@ -210,6 +235,8 @@ The full per-stage cap contract lives in
   in `src/influx/`. The `terminal-flips` and `warnings` subcommands
   pull these structured fields without forcing operators to remember
   the JSON keys.
+- Metric instruments: `src/influx/metrics.py` (helper per instrument)
+  and `docs/SPECIFICATION.md` §13.2 for the label contract.
 - Master spec for the sweep: `docs/SPECIFICATION.md` §11.
 - Terminal cap rationale and prior incident notes: PR #11 (initial
   data layer), PR #15 (archive cap), PR #25 (archive_download hook),

--- a/src/influx/metrics.py
+++ b/src/influx/metrics.py
@@ -1,0 +1,204 @@
+"""OTEL metric instrument helpers for influx (issue #6).
+
+Centralises the named instruments and their bounded label sets so call
+sites do not have to remember instrument names, units, or descriptions.
+Every helper returns the cached instrument from the module-level
+:class:`~influx.telemetry.InfluxMeter` singleton — when OTEL is disabled
+the meter returns the shared no-op instrument, so call sites pay zero
+work in the disabled path (AC-10-A discipline extended to metrics).
+
+Cardinality discipline
+----------------------
+Label values are bounded by construction:
+
+* ``profile`` — known profile names from the loaded config.
+* ``run_type`` — :class:`~influx.coordinator.RunKind` values.
+* ``source`` — ``"arxiv"`` / ``"rss"``.
+* ``status`` — Lithos write outcomes from
+  :func:`~influx.lithos_client._parse_write_response`.
+* ``decision`` — ``"pass"`` / ``"drop"``.
+* ``kind`` — repair stage names or source-acquisition error kinds.
+* ``tier`` — ``"1"`` / ``"3"``.
+* ``outcome`` — ``"success"`` / ``"failure"`` / ``"degraded"``.
+
+Per-item identifiers (``run_id``, ``note_id``, ``arxiv_id``,
+``source_url``, ``title``) are **not** label values for any instrument
+and must not be added without a fresh cardinality review.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from influx.telemetry import get_meter
+
+__all__ = [
+    "active_runs",
+    "archive_missing",
+    "articles_filtered",
+    "articles_inspected",
+    "cache_hits",
+    "candidates_fetched",
+    "lithos_writes",
+    "llm_validation_failures",
+    "repair_candidates",
+    "run_completions",
+    "run_duration",
+    "run_starts",
+    "source_acquisition_errors",
+]
+
+
+def run_starts() -> Any:
+    """Counter incremented once when a run begins.
+
+    Labels: ``profile``, ``run_type``.
+    """
+    return get_meter().counter(
+        "influx_run_starts_total",
+        description="Number of influx runs started.",
+    )
+
+
+def run_completions() -> Any:
+    """Counter incremented once when a run reaches a terminal outcome.
+
+    Labels: ``profile``, ``run_type``, ``outcome``
+    (``success`` | ``failure`` | ``degraded``).
+    """
+    return get_meter().counter(
+        "influx_run_completions_total",
+        description="Number of influx runs that reached a terminal outcome.",
+    )
+
+
+def run_duration() -> Any:
+    """Histogram of run wall-clock duration in seconds.
+
+    Labels: ``profile``, ``run_type``.
+    """
+    return get_meter().histogram(
+        "influx_run_duration_seconds",
+        unit="s",
+        description="Wall-clock duration of an influx run in seconds.",
+    )
+
+
+def active_runs() -> Any:
+    """Up-down counter tracking currently in-flight runs.
+
+    Labels: ``profile``.
+    """
+    return get_meter().up_down_counter(
+        "influx_active_runs",
+        description="Number of influx runs currently in flight.",
+    )
+
+
+def candidates_fetched() -> Any:
+    """Counter of candidate items returned by source acquisition.
+
+    Labels: ``profile``, ``source``.
+    """
+    return get_meter().counter(
+        "influx_source_candidates_fetched_total",
+        description="Candidate items returned by a source fetch.",
+    )
+
+
+def articles_filtered() -> Any:
+    """Counter of items processed by the LLM filter.
+
+    Labels: ``profile``, ``decision`` (``pass`` | ``drop``).
+    """
+    return get_meter().counter(
+        "influx_articles_filtered_total",
+        description="Items processed by the LLM filter, broken down by decision.",
+    )
+
+
+def articles_inspected() -> Any:
+    """Counter of items the scheduler inspected (post-filter).
+
+    Labels: ``profile``, ``source``.
+    """
+    return get_meter().counter(
+        "influx_articles_inspected_total",
+        description="Items inspected by the scheduler write loop.",
+    )
+
+
+def cache_hits() -> Any:
+    """Counter of Lithos cache hits during the inspection loop.
+
+    Labels: ``profile``, ``source``.
+    """
+    return get_meter().counter(
+        "influx_cache_hits_total",
+        description="Lithos cache hits during the scheduler write loop.",
+    )
+
+
+def lithos_writes() -> Any:
+    """Counter of Lithos write attempts, broken down by outcome.
+
+    Labels: ``profile``, ``source``, ``status`` (Lithos write status —
+    ``created``, ``updated``, ``duplicate``, ``slug_collision``,
+    ``version_conflict``, ``invalid_input``, ``content_too_large_skipped``,
+    or any other status returned by ``lithos_write``).
+    """
+    return get_meter().counter(
+        "influx_lithos_writes_total",
+        description="Lithos write attempts broken down by outcome status.",
+    )
+
+
+def repair_candidates() -> Any:
+    """Counter of repair-sweep candidates visited per stage.
+
+    Labels: ``profile``, ``kind``
+    (``archive`` | ``text_extraction`` | ``tier2`` | ``tier3``).
+    """
+    return get_meter().counter(
+        "influx_repair_candidates_total",
+        description="Repair-sweep candidates visited per stage.",
+    )
+
+
+def llm_validation_failures() -> Any:
+    """Counter of LLM enrichment failures.
+
+    Labels: ``profile``, ``tier`` (``1`` | ``3``).
+    """
+    return get_meter().counter(
+        "influx_llm_validation_failures_total",
+        description="LLM enrichment failures (Tier 1 or Tier 3).",
+    )
+
+
+def archive_missing() -> Any:
+    """Counter of items tagged ``influx:archive-missing`` during a run.
+
+    Labels: ``profile``, ``source``.
+    """
+    return get_meter().counter(
+        "influx_archive_missing_total",
+        description="Items tagged influx:archive-missing during a run.",
+    )
+
+
+def source_acquisition_errors() -> Any:
+    """Counter of swallowed source-acquisition errors.
+
+    Mirrors the ledger's ``source_acquisition_errors`` field (issue
+    #20): every increment corresponds to one entry written through
+    :func:`~influx.telemetry.record_source_acquisition_error`.
+
+    Labels: ``profile``, ``source``, ``kind``
+    (network-error kind from :class:`~influx.http_client.NetworkError`,
+    e.g. ``"timeout"``, ``"ssrf"``, ``"http"``, ``"unknown"``).
+    """
+    return get_meter().counter(
+        "influx_source_acquisition_errors_total",
+        description="Swallowed source-acquisition errors per run.",
+    )

--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -1156,9 +1156,7 @@ async def _process_sweep_note(
         # Snapshot before the hook so a raise rolls back any partial
         # in-place note mutations the hook applied (finding #1).
         snapshot = _snapshot_note(note)
-        metrics.repair_candidates().add(
-            1, {"profile": profile, "kind": "archive"}
-        )
+        metrics.repair_candidates().add(1, {"profile": profile, "kind": "archive"})
         tracer = get_tracer()
         try:
             with tracer.span(
@@ -1297,9 +1295,7 @@ async def _process_sweep_note(
         # the expected pre-hook state — including the latest current_tags
         # rather than whatever was on the note before this stage ran.
         snapshot = _snapshot_note(note)
-        metrics.repair_candidates().add(
-            1, {"profile": profile, "kind": "tier2"}
-        )
+        metrics.repair_candidates().add(1, {"profile": profile, "kind": "tier2"})
         tracer = get_tracer()
         try:
             with tracer.span(
@@ -1360,9 +1356,7 @@ async def _process_sweep_note(
     if stages.tier3_retry and hooks.tier3_extract:
         note["tags"] = list(current_tags)
         snapshot = _snapshot_note(note)
-        metrics.repair_candidates().add(
-            1, {"profile": profile, "kind": "tier3"}
-        )
+        metrics.repair_candidates().add(1, {"profile": profile, "kind": "tier3"})
         tracer = get_tracer()
         try:
             with tracer.span(

--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -21,6 +21,7 @@ import re
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 
+from influx import metrics
 from influx.errors import ExtractionError, LCMAError, LithosError
 from influx.notes import merge_tags
 from influx.telemetry import current_run_id, get_tracer
@@ -1155,6 +1156,9 @@ async def _process_sweep_note(
         # Snapshot before the hook so a raise rolls back any partial
         # in-place note mutations the hook applied (finding #1).
         snapshot = _snapshot_note(note)
+        metrics.repair_candidates().add(
+            1, {"profile": profile, "kind": "archive"}
+        )
         tracer = get_tracer()
         try:
             with tracer.span(
@@ -1234,6 +1238,9 @@ async def _process_sweep_note(
     if stages.text_extraction_retry and hooks.text_extraction:
         note["tags"] = list(current_tags)
         snapshot = _snapshot_note(note)
+        metrics.repair_candidates().add(
+            1, {"profile": profile, "kind": "text_extraction"}
+        )
         tracer = get_tracer()
         try:
             with tracer.span(
@@ -1290,6 +1297,9 @@ async def _process_sweep_note(
         # the expected pre-hook state — including the latest current_tags
         # rather than whatever was on the note before this stage ran.
         snapshot = _snapshot_note(note)
+        metrics.repair_candidates().add(
+            1, {"profile": profile, "kind": "tier2"}
+        )
         tracer = get_tracer()
         try:
             with tracer.span(
@@ -1350,6 +1360,9 @@ async def _process_sweep_note(
     if stages.tier3_retry and hooks.tier3_extract:
         note["tags"] = list(current_tags)
         snapshot = _snapshot_note(note)
+        metrics.repair_candidates().add(
+            1, {"profile": profile, "kind": "tier3"}
+        )
         tracer = get_tracer()
         try:
             with tracer.span(

--- a/src/influx/scheduler.py
+++ b/src/influx/scheduler.py
@@ -34,6 +34,7 @@ from typing import Any
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
+from influx import metrics
 from influx.config import AppConfig
 from influx.coordinator import Coordinator, ProfileBusyError, RunKind
 from influx.errors import LCMAError
@@ -86,6 +87,25 @@ ItemProviderFactory = Callable[[], tuple[ItemProvider, Any]]
 # APScheduler's ``max_instances`` is never the gate on a slow tick.
 # Same-profile non-overlap is enforced by the coordinator alone.
 _TICK_MAX_INSTANCES = 1
+
+
+def _item_source(item: ProfileItem) -> str:
+    """Derive the source family (``"arxiv"`` | ``"rss"`` | ``"unknown"``).
+
+    Used as a bounded metric label.  Builders may stamp the ``source``
+    key directly; this helper falls back to scanning ``tags`` for the
+    canonical ``source:*`` provenance entry so RSS feeds with custom
+    ``source_tag`` values (e.g. ``"blog"``) still roll up to ``"rss"``
+    at the metric layer rather than fan out into per-feed cardinality.
+    """
+    direct = item.get("source")
+    if isinstance(direct, str) and direct:
+        return direct
+    for tag in item.get("tags", []) or []:
+        if isinstance(tag, str) and tag.startswith("source:"):
+            value = tag.split(":", 1)[1]
+            return "rss" if value not in ("arxiv",) else "arxiv"
+    return "unknown"
 
 
 async def default_item_provider(
@@ -169,6 +189,12 @@ async def run_profile(
     source_errors_token = current_source_acquisition_errors.set([])
     tracer = get_tracer()
     started_at = datetime.now(UTC)
+    # Run-lifecycle metrics (issue #6): start counter + active-runs gauge
+    # bracket the run end-to-end so dashboards can answer "is anything
+    # actually running?" without relying on docker logs.
+    run_metric_attrs = {"profile": profile, "run_type": kind.value}
+    metrics.run_starts().add(1, run_metric_attrs)
+    metrics.active_runs().add(1, {"profile": profile})
     logger.info(
         "run started profile=%s kind=%s run_id=%s range=%s",
         profile,
@@ -195,6 +221,8 @@ async def run_profile(
                 probe_loop=probe_loop,
             )
             elapsed = (datetime.now(UTC) - started_at).total_seconds()
+            source_errors = current_source_acquisition_errors.get() or []
+            outcome = "degraded" if source_errors else "success"
             if result is None:
                 logger.info(
                     "run completed profile=%s kind=%s run_id=%s duration=%.1fs "
@@ -208,11 +236,9 @@ async def run_profile(
                     run_id=run_id,
                     sources_checked=None,
                     ingested=None,
-                    source_acquisition_errors=current_source_acquisition_errors.get()
-                    or [],
+                    source_acquisition_errors=source_errors,
                 )
             else:
-                source_errors = current_source_acquisition_errors.get() or []
                 logger.info(
                     "run completed profile=%s kind=%s run_id=%s duration=%.1fs "
                     "sources_checked=%d ingested=%d degraded=%s",
@@ -230,6 +256,8 @@ async def run_profile(
                     ingested=result.stats.ingested,
                     source_acquisition_errors=source_errors,
                 )
+            metrics.run_duration().record(elapsed, run_metric_attrs)
+            metrics.run_completions().add(1, {**run_metric_attrs, "outcome": outcome})
             return result
     except Exception as exc:
         elapsed = (datetime.now(UTC) - started_at).total_seconds()
@@ -241,8 +269,11 @@ async def run_profile(
             elapsed,
         )
         ledger.fail(run_id=run_id, error=f"{type(exc).__name__}: {exc}")
+        metrics.run_duration().record(elapsed, run_metric_attrs)
+        metrics.run_completions().add(1, {**run_metric_attrs, "outcome": "failure"})
         raise
     finally:
+        metrics.active_runs().add(-1, {"profile": profile})
         current_run_id.reset(run_id_token)
         current_source_acquisition_errors.reset(source_errors_token)
 
@@ -389,6 +420,13 @@ async def _run_profile_body(
                 # filter-tag entries to the rejection-rate map.
                 record_filter_result(profile, title, item.get("filter_tags", []))
                 source_url = item["source_url"]
+                # Source family for metric labels — derived from the
+                # ``source:*`` provenance tag when build_*_note_item did
+                # not stamp the dedicated key directly.
+                item_source = item.get("source") or _item_source(item)
+                metrics.articles_inspected().add(
+                    1, {"profile": profile, "source": item_source}
+                )
                 logger.info(
                     "article inspected profile=%s source_url=%s title=%r "
                     "score=%s path=%s tags=%s",
@@ -408,6 +446,9 @@ async def _run_profile_body(
                     cache_result.content[0].text  # type: ignore[union-attr]
                 )
                 if cache_body.get("hit"):
+                    metrics.cache_hits().add(
+                        1, {"profile": profile, "source": item_source}
+                    )
                     logger.info(
                         "article cache hit profile=%s source_url=%s title=%r "
                         "kind=%s action=%s",
@@ -441,6 +482,14 @@ async def _run_profile_body(
                             tags=list(item.get("tags", [])),
                             confidence=float(item.get("confidence", 0.0)),
                         )
+                    metrics.lithos_writes().add(
+                        1,
+                        {
+                            "profile": profile,
+                            "source": item_source,
+                            "status": write_result.status,
+                        },
+                    )
                     if write_result.status in ("created", "updated"):
                         logger.info(
                             "article write completed profile=%s source_url=%s "
@@ -499,6 +548,14 @@ async def _run_profile_body(
                         tags=list(item.get("tags", [])),
                         confidence=float(item.get("confidence", 0.0)),
                     )
+                metrics.lithos_writes().add(
+                    1,
+                    {
+                        "profile": profile,
+                        "source": item_source,
+                        "status": write_result.status,
+                    },
+                )
                 if write_result.status in ("created", "updated"):
                     logger.info(
                         "article write completed profile=%s source_url=%s title=%r "

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -27,6 +27,7 @@ from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from influx import metrics
 from influx.config import (
     AppConfig,
     ArxivSourceConfig,
@@ -606,6 +607,9 @@ def build_arxiv_note_item(
         tags.append("influx:archive-missing")
         tags.append("influx:archive-terminal")
         repair_needed = True
+        metrics.archive_missing().add(
+            1, {"profile": profile_name, "source": "arxiv"}
+        )
         _log.info(
             "archive download skipped (terminal) profile=%s arxiv_id=%s",
             profile_name,
@@ -638,6 +642,9 @@ def build_arxiv_note_item(
         else:
             tags.append("influx:archive-missing")
             repair_needed = True
+            metrics.archive_missing().add(
+                1, {"profile": profile_name, "source": "arxiv"}
+            )
 
     # ── Extraction cascade ────────────────────────────────────────
     extracted_text: str | None = None
@@ -698,6 +705,9 @@ def build_arxiv_note_item(
             except LCMAError:
                 _log.warning("Tier 1 enrichment failed for %s", item.arxiv_id)
                 repair_needed = True
+                metrics.llm_validation_failures().add(
+                    1, {"profile": profile_name, "tier": "1"}
+                )
             except Exception:
                 # Defensive: any unexpected failure during Tier 1
                 # (e.g. an LLM response shape that bypasses the schema's
@@ -710,6 +720,9 @@ def build_arxiv_note_item(
                     exc_info=True,
                 )
                 repair_needed = True
+                metrics.llm_validation_failures().add(
+                    1, {"profile": profile_name, "tier": "1"}
+                )
 
     # ── Tier 3 deep extraction (FR-ENR-5) ─────────────────────────
     tier3_result: Tier3Extraction | None = None
@@ -733,6 +746,9 @@ def build_arxiv_note_item(
             except LCMAError:
                 _log.warning("Tier 3 extraction failed for %s", item.arxiv_id)
                 repair_needed = True
+                metrics.llm_validation_failures().add(
+                    1, {"profile": profile_name, "tier": "3"}
+                )
             except Exception:
                 # Defensive: same rationale as the Tier 1 catch — a
                 # validator bug or unforeseen response shape must not
@@ -744,6 +760,9 @@ def build_arxiv_note_item(
                     exc_info=True,
                 )
                 repair_needed = True
+                metrics.llm_validation_failures().add(
+                    1, {"profile": profile_name, "tier": "3"}
+                )
 
     # influx:deep-extracted iff all four Tier 3 sections exist.
     if tier3_result is not None:
@@ -788,6 +807,7 @@ def build_arxiv_note_item(
     return {
         "id": f"arxiv-{item.arxiv_id}",
         "title": item.title,
+        "source": "arxiv",
         "source_url": source_url,
         "content": content,
         "tags": tags,
@@ -1003,8 +1023,19 @@ def make_arxiv_item_provider(
                     kind=exc.kind or "unknown",
                     detail=str(exc),
                 )
+                metrics.source_acquisition_errors().add(
+                    1,
+                    {
+                        "profile": profile,
+                        "source": "arxiv",
+                        "kind": exc.kind or "unknown",
+                    },
+                )
                 return ()
             fetch_span.set_attribute("influx.item_count", len(items))
+            metrics.candidates_fetched().add(
+                len(items), {"profile": profile, "source": "arxiv"}
+            )
             _log.info(
                 "arxiv fetch completed profile=%s kind=%s items=%d",
                 profile,
@@ -1068,10 +1099,13 @@ def make_arxiv_item_provider(
                     )
 
         results: list[dict[str, Any]] = []
+        drop_attrs = {"profile": profile, "decision": "drop"}
+        pass_attrs = {"profile": profile, "decision": "pass"}
         for arxiv_item in items:
             if scorer is not None:
                 score_result: ArxivScoreResult | None = scorer(arxiv_item, profile)
                 if score_result is None:
+                    metrics.articles_filtered().add(1, drop_attrs)
                     _log.info(
                         "article inspected source=arxiv profile=%s arxiv_id=%s "
                         "published=%s score=none decision=drop reason=scorer_none "
@@ -1084,6 +1118,7 @@ def make_arxiv_item_provider(
                     continue
             elif filter_scorer is not None:
                 if filter_failed:
+                    metrics.articles_filtered().add(1, drop_attrs)
                     _log.info(
                         "article inspected source=arxiv profile=%s arxiv_id=%s "
                         "published=%s score=none decision=drop reason=filter_failed "
@@ -1099,6 +1134,7 @@ def make_arxiv_item_provider(
                     # dropped entirely — the filter explicitly chose not
                     # to score them (typically because they fell below
                     # ``filter.min_score_in_results``).
+                    metrics.articles_filtered().add(1, drop_attrs)
                     _log.info(
                         "article inspected source=arxiv profile=%s arxiv_id=%s "
                         "published=%s score=none decision=drop "
@@ -1112,6 +1148,7 @@ def make_arxiv_item_provider(
                 else:
                     score_result = batch_scores[arxiv_item.arxiv_id]
             else:
+                metrics.articles_filtered().add(1, drop_attrs)
                 _log.info(
                     "article inspected source=arxiv profile=%s arxiv_id=%s "
                     "published=%s score=none decision=drop reason=no_scorer "
@@ -1124,6 +1161,7 @@ def make_arxiv_item_provider(
                 continue
 
             if score_result.score < thresholds.relevance:
+                metrics.articles_filtered().add(1, drop_attrs)
                 _log.info(
                     "article inspected source=arxiv profile=%s arxiv_id=%s "
                     "published=%s score=%d threshold=%d decision=drop "
@@ -1137,6 +1175,7 @@ def make_arxiv_item_provider(
                 )
                 continue
 
+            metrics.articles_filtered().add(1, pass_attrs)
             _log.info(
                 "article inspected source=arxiv profile=%s arxiv_id=%s "
                 "published=%s score=%d threshold=%d decision=accept title=%r",

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -607,9 +607,7 @@ def build_arxiv_note_item(
         tags.append("influx:archive-missing")
         tags.append("influx:archive-terminal")
         repair_needed = True
-        metrics.archive_missing().add(
-            1, {"profile": profile_name, "source": "arxiv"}
-        )
+        metrics.archive_missing().add(1, {"profile": profile_name, "source": "arxiv"})
         _log.info(
             "archive download skipped (terminal) profile=%s arxiv_id=%s",
             profile_name,

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any
 
 import feedparser
 
+from influx import metrics
 from influx.coordinator import RunKind
 from influx.enrich import tier1_enrich, tier3_extract
 from influx.errors import ExtractionError, LCMAError, NetworkError
@@ -332,6 +333,7 @@ def build_rss_note_item(
     return {
         "id": f"rss-{feed_slug}-{hash_val}",
         "title": item.title,
+        "source": "rss",
         "source_url": source_url,
         "content": content,
         "tags": tags,
@@ -484,6 +486,10 @@ def make_rss_item_provider(
                     cache,
                     max_download_bytes=config.storage.max_download_bytes,
                     timeout_seconds=config.storage.download_timeout_seconds,
+                    profile=profile,
+                )
+                metrics.candidates_fetched().add(
+                    len(items), {"profile": profile, "source": "rss"}
                 )
                 _log.info(
                     "rss feed fetch completed profile=%s feed=%r items=%d",
@@ -513,9 +519,12 @@ def make_rss_item_provider(
                     len(items),
                     len(scores),
                 )
+                drop_attrs = {"profile": profile, "decision": "drop"}
+                pass_attrs = {"profile": profile, "decision": "pass"}
                 for item in items:
                     scored = scores.get(_rss_filter_id(item))
                     if scored is None:
+                        metrics.articles_filtered().add(1, drop_attrs)
                         _log.info(
                             "article inspected source=rss profile=%s feed=%r "
                             "published=%s score=none decision=drop "
@@ -528,6 +537,7 @@ def make_rss_item_provider(
                         )
                         continue
                     if scored.score < profile_cfg.thresholds.relevance:
+                        metrics.articles_filtered().add(1, drop_attrs)
                         _log.info(
                             "article inspected source=rss profile=%s feed=%r "
                             "published=%s score=%d threshold=%d decision=drop "
@@ -541,6 +551,7 @@ def make_rss_item_provider(
                             item.url,
                         )
                         continue
+                    metrics.articles_filtered().add(1, pass_attrs)
                     _log.info(
                         "article inspected source=rss profile=%s feed=%r "
                         "published=%s score=%d threshold=%d decision=accept "
@@ -589,6 +600,7 @@ async def _fetch_rss_feed(
     *,
     max_download_bytes: int | None = None,
     timeout_seconds: int | None = None,
+    profile: str = "",
 ) -> list[RssFeedItem]:
     """Fetch raw feed bytes, then parse-and-stamp per *feed_entry*.
 
@@ -623,6 +635,14 @@ async def _fetch_rss_feed(
                 source="rss",
                 kind=exc.kind or "unknown",
                 detail=f"{feed_entry.name}: {exc}",
+            )
+            metrics.source_acquisition_errors().add(
+                1,
+                {
+                    "profile": profile,
+                    "source": "rss",
+                    "kind": exc.kind or "unknown",
+                },
             )
             return None
         return result.body

--- a/src/influx/telemetry.py
+++ b/src/influx/telemetry.py
@@ -1,7 +1,7 @@
 """Opt-in OTEL telemetry wrapper.
 
-Provides a thin API for span creation and attribute setting that is a
-complete no-op when:
+Provides a thin API for span creation, metric recording, and attribute
+setting that is a complete no-op when:
 
 * ``INFLUX_OTEL_ENABLED`` is unset or ``false`` (FR-OBS-2, AC-10-A), OR
 * the ``opentelemetry`` optional packages are not installed (AC-M4-3).
@@ -26,12 +26,14 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "InfluxMeter",
     "InfluxTracer",
     "SourceAcquisitionError",
     "SpanWrapper",
     "current_archive_terminal_arxiv_ids",
     "current_run_id",
     "current_source_acquisition_errors",
+    "get_meter",
     "get_tracer",
     "record_source_acquisition_error",
 ]
@@ -163,6 +165,26 @@ class SpanWrapper:
 _NOOP_SPAN_WRAPPER = SpanWrapper(_NOOP_SPAN)
 
 
+class _NoOpInstrument:
+    """Shared no-op metric instrument.
+
+    Mirrors :class:`_NoOpSpan`: when OTEL is disabled the meter returns
+    this singleton so that increment / record sites do zero work and
+    allocate no objects (AC-10-A discipline extended to metrics).
+    """
+
+    __slots__ = ()
+
+    def add(self, value: float, attributes: dict[str, Any] | None = None) -> None:  # noqa: ARG002
+        pass
+
+    def record(self, value: float, attributes: dict[str, Any] | None = None) -> None:  # noqa: ARG002
+        pass
+
+
+_NOOP_INSTRUMENT = _NoOpInstrument()
+
+
 class InfluxTracer:
     """Tracer that wraps OTEL or falls back to no-op.
 
@@ -232,6 +254,24 @@ def _parse_resource_attributes(value: str) -> dict[str, str]:
     return attrs
 
 
+def _build_resource_attributes() -> dict[str, str]:
+    """Build the OTEL resource attributes shared by traces and metrics.
+
+    The attribute set is identical for every signal so dashboards can
+    correlate runs, spans, and metrics by ``service.name`` /
+    ``deployment.environment`` without per-signal divergence.
+    """
+    service_name = os.environ.get("OTEL_SERVICE_NAME", "influx")
+    resource_attrs = _parse_resource_attributes(
+        os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
+    )
+    resource_attrs["service.name"] = service_name
+    environment = os.environ.get("INFLUX_ENVIRONMENT", "")
+    if environment and "deployment.environment" not in resource_attrs:
+        resource_attrs["deployment.environment"] = environment
+    return resource_attrs
+
+
 def _build_tracer() -> InfluxTracer:
     """Construct an ``InfluxTracer`` based on current env + package state."""
     if not _otel_enabled():
@@ -245,14 +285,7 @@ def _build_tracer() -> InfluxTracer:
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
 
-    service_name = os.environ.get("OTEL_SERVICE_NAME", "influx")
-    resource_attrs = _parse_resource_attributes(
-        os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
-    )
-    resource_attrs["service.name"] = service_name
-    environment = os.environ.get("INFLUX_ENVIRONMENT", "")
-    if environment and "deployment.environment" not in resource_attrs:
-        resource_attrs["deployment.environment"] = environment
+    resource_attrs = _build_resource_attributes()
     provider = TracerProvider(resource=Resource.create(resource_attrs))
 
     if _otlp_endpoint_configured():
@@ -288,9 +321,170 @@ def _build_tracer() -> InfluxTracer:
     return InfluxTracer(enabled=True, tracer=tracer)
 
 
-# Module-level singleton — rebuilt by ``get_tracer(force_rebuild=True)``
-# or by tests that need to toggle OTEL on/off.
+class InfluxMeter:
+    """Meter that wraps OTEL or falls back to no-op.
+
+    Mirrors :class:`InfluxTracer`.  Instruments are created lazily and
+    cached, so the second call to ``counter("influx_run_starts_total")``
+    returns the same underlying OTEL ``Counter`` — required by the OTEL
+    SDK, which raises if the same instrument name is registered twice
+    on a meter.
+
+    When disabled the meter returns the shared :data:`_NOOP_INSTRUMENT`
+    so increment sites pay only a hash lookup, not an OTEL SDK call.
+    """
+
+    __slots__ = (
+        "_counters",
+        "_enabled",
+        "_histograms",
+        "_meter",
+        "_resource",
+        "_up_down_counters",
+    )
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = False,
+        meter: Any = None,
+        resource: Any = None,
+    ) -> None:
+        self._enabled = enabled
+        self._meter = meter
+        self._resource = resource
+        self._counters: dict[str, Any] = {}
+        self._up_down_counters: dict[str, Any] = {}
+        self._histograms: dict[str, Any] = {}
+
+    @property
+    def resource(self) -> Any:
+        """OTEL ``Resource`` attached to this meter (or ``None`` when disabled).
+
+        Exposed so tests can verify ``service.name`` /
+        ``deployment.environment`` without poking at private SDK
+        attributes.
+        """
+        return self._resource
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def counter(self, name: str, *, unit: str = "1", description: str = "") -> Any:
+        """Return (and cache) a monotonic counter instrument."""
+        if not self._enabled:
+            return _NOOP_INSTRUMENT
+        cached = self._counters.get(name)
+        if cached is not None:
+            return cached
+        instrument = self._meter.create_counter(
+            name=name,
+            unit=unit,
+            description=description,
+        )
+        self._counters[name] = instrument
+        return instrument
+
+    def up_down_counter(
+        self, name: str, *, unit: str = "1", description: str = ""
+    ) -> Any:
+        """Return (and cache) an up-down counter instrument."""
+        if not self._enabled:
+            return _NOOP_INSTRUMENT
+        cached = self._up_down_counters.get(name)
+        if cached is not None:
+            return cached
+        instrument = self._meter.create_up_down_counter(
+            name=name,
+            unit=unit,
+            description=description,
+        )
+        self._up_down_counters[name] = instrument
+        return instrument
+
+    def histogram(self, name: str, *, unit: str = "1", description: str = "") -> Any:
+        """Return (and cache) a histogram instrument."""
+        if not self._enabled:
+            return _NOOP_INSTRUMENT
+        cached = self._histograms.get(name)
+        if cached is not None:
+            return cached
+        instrument = self._meter.create_histogram(
+            name=name,
+            unit=unit,
+            description=description,
+        )
+        self._histograms[name] = instrument
+        return instrument
+
+
+def _build_meter() -> InfluxMeter:
+    """Construct an ``InfluxMeter`` based on current env + package state.
+
+    Parallels :func:`_build_tracer`: shares the ``INFLUX_OTEL_ENABLED``
+    toggle, the ``OTEL_EXPORTER_OTLP_ENDPOINT`` configuration, and the
+    same resource-attribute set, so traces and metrics always describe
+    the same service from the collector's point of view.
+    """
+    if not _otel_enabled():
+        return InfluxMeter(enabled=False)
+    if not _otel_packages_available():
+        return InfluxMeter(enabled=False)
+
+    try:
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+        from opentelemetry.sdk.resources import Resource
+    except ImportError:
+        logger.warning("OTEL metrics SDK not installed; metrics will not be exported")
+        return InfluxMeter(enabled=False)
+
+    resource_attrs = _build_resource_attributes()
+    readers: list[Any] = []
+
+    if _otlp_endpoint_configured():
+        try:
+            from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+                OTLPMetricExporter,
+            )
+        except ImportError:
+            if not _console_fallback_enabled():
+                logger.warning(
+                    "OTEL enabled but OTLP HTTP metric exporter is not installed; "
+                    "metrics will not be exported"
+                )
+        else:
+            readers.append(PeriodicExportingMetricReader(OTLPMetricExporter()))
+            logger.info(
+                "OTEL OTLP metric exporter configured endpoint=%s metrics_endpoint=%s",
+                os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", ""),
+                os.environ.get("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", ""),
+            )
+
+    if _console_fallback_enabled() and not _otlp_endpoint_configured():
+        from opentelemetry.sdk.metrics.export import ConsoleMetricExporter
+
+        readers.append(PeriodicExportingMetricReader(ConsoleMetricExporter()))
+        logger.info("OTEL console metric exporter configured")
+
+    resource = Resource.create(resource_attrs)
+    provider = MeterProvider(
+        resource=resource,
+        metric_readers=readers,
+    )
+    return InfluxMeter(
+        enabled=True,
+        meter=provider.get_meter("influx"),
+        resource=resource,
+    )
+
+
+# Module-level singletons — rebuilt by ``get_tracer(force_rebuild=True)``
+# / ``get_meter(force_rebuild=True)`` or by tests that need to toggle
+# OTEL on/off between cases.
 _tracer: InfluxTracer | None = None
+_meter: InfluxMeter | None = None
 
 
 def get_tracer(*, force_rebuild: bool = False) -> InfluxTracer:
@@ -307,3 +501,15 @@ def get_tracer(*, force_rebuild: bool = False) -> InfluxTracer:
     if _tracer is None or force_rebuild:
         _tracer = _build_tracer()
     return _tracer
+
+
+def get_meter(*, force_rebuild: bool = False) -> InfluxMeter:
+    """Return the module-level ``InfluxMeter`` singleton.
+
+    Mirrors :func:`get_tracer` so tests that toggle OTEL on/off can
+    rebuild both signals from the same environment in one place.
+    """
+    global _meter  # noqa: PLW0603
+    if _meter is None or force_rebuild:
+        _meter = _build_meter()
+    return _meter

--- a/tests/integration/test_otel_metrics.py
+++ b/tests/integration/test_otel_metrics.py
@@ -1,0 +1,432 @@
+"""End-to-end OTEL metric emission test (issue #6).
+
+Mirrors :mod:`tests.integration.test_otel_spans` but for metrics:
+configures the meter wrapper with an in-memory metric reader and runs
+the arXiv pipeline + an RSS feed through ``run_profile``, then asserts
+the documented instrument set fired with the expected label keys.
+
+A complementary test confirms zero metric exports with OTEL disabled
+(matching the ``test_otel_absent_service`` discipline for traces).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip(
+    "opentelemetry.sdk.metrics",
+    reason="OTEL metrics SDK required for metric integration tests",
+)
+
+from influx.coordinator import RunKind
+from influx.telemetry import InfluxMeter, InfluxTracer
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+def _make_inmemory_meter() -> tuple[InfluxMeter, Any]:
+    """Build an InfluxMeter backed by an InMemoryMetricReader."""
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    meter = InfluxMeter(enabled=True, meter=provider.get_meter("influx-int-test"))
+    return meter, reader
+
+
+def _disabled_tracer() -> InfluxTracer:
+    """A no-op tracer so the test does not also exercise span export."""
+    return InfluxTracer(enabled=False)
+
+
+def _full_config() -> Any:
+    """Build a config with arXiv + RSS sources (mirrors test_otel_spans)."""
+    from influx.config import (
+        AppConfig,
+        ExtractionConfig,
+        LithosConfig,
+        ProfileConfig,
+        ProfileSources,
+        ProfileThresholds,
+        PromptEntryConfig,
+        PromptsConfig,
+        RssSourceEntry,
+        ScheduleConfig,
+        SecurityConfig,
+    )
+
+    return AppConfig(
+        lithos=LithosConfig(url="http://localhost:0/sse"),
+        schedule=ScheduleConfig(cron="0 6 * * *", timezone="UTC"),
+        profiles=[
+            ProfileConfig(
+                name="ai-robotics",
+                description="AI and robotics research",
+                thresholds=ProfileThresholds(
+                    relevance=5,
+                    full_text=6,
+                    deep_extract=7,
+                ),
+                sources=ProfileSources(
+                    rss=[
+                        RssSourceEntry(
+                            name="Test Blog",
+                            url="https://example.com/feed.xml",
+                            source_tag="blog",
+                        ),
+                    ],
+                ),
+            ),
+        ],
+        providers={},
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(
+                text="{profile_description} {negative_examples} {min_score_in_results}",
+            ),
+            tier1_enrich=PromptEntryConfig(
+                text="{title} {abstract} {profile_summary}",
+            ),
+            tier3_extract=PromptEntryConfig(text="{title} {full_text}"),
+        ),
+        security=SecurityConfig(allow_private_ips=True),
+        extraction=ExtractionConfig(),
+    )
+
+
+def _mock_lithos_client() -> AsyncMock:
+    client = AsyncMock()
+    client.task_create.return_value = MagicMock(
+        content=[MagicMock(text='{"task_id": "task-1"}')],
+    )
+    client.cache_lookup_for_item.return_value = MagicMock(
+        content=[MagicMock(text='{"hit": false}')],
+    )
+    write_result = MagicMock()
+    write_result.status = "created"
+    write_result.note_id = "note-123"
+    client.write_note.return_value = write_result
+    client.retrieve.return_value = MagicMock(
+        content=[MagicMock(text='{"results": []}')],
+    )
+    client.close = AsyncMock()
+    client.task_complete = AsyncMock()
+    return client
+
+
+def _collect(reader: Any) -> dict[str, list[dict[str, Any]]]:
+    """Snapshot the in-memory reader and group data points by instrument name.
+
+    Returns ``{"influx_run_starts_total": [{"value": 1, "attributes": {...}}, ...]}``.
+    The shape ignores aggregation type (counter sums, histograms expose
+    ``sum`` / ``count``) so tests can assert "this counter was incremented
+    with these labels at least once".
+    """
+    metrics_data = reader.get_metrics_data()
+    out: dict[str, list[dict[str, Any]]] = {}
+    if metrics_data is None:
+        return out
+    for resource_metric in metrics_data.resource_metrics:
+        for scope_metric in resource_metric.scope_metrics:
+            for metric in scope_metric.metrics:
+                points = out.setdefault(metric.name, [])
+                for dp in metric.data.data_points:
+                    points.append(
+                        {
+                            "value": getattr(dp, "value", None)
+                            or getattr(dp, "sum", None)
+                            or getattr(dp, "count", None),
+                            "attributes": dict(dp.attributes or {}),
+                        }
+                    )
+    return out
+
+
+def _has_label_set(
+    points: list[dict[str, Any]], expected: dict[str, str]
+) -> bool:
+    """Return True iff at least one data point matches every expected label."""
+    return any(
+        all(point["attributes"].get(k) == v for k, v in expected.items())
+        for point in points
+    )
+
+
+# ── Scenario A: arXiv pipeline via run_profile ─────────────────────
+
+
+async def _run_arxiv_scenario(meter: InfluxMeter, config: Any) -> None:
+    """Exercise the arXiv pipeline end-to-end with the test meter."""
+    from influx.extraction.pipeline import ArxivExtractionResult
+    from influx.schemas import Tier1Enrichment, Tier3Extraction
+    from influx.sources.arxiv import (
+        ArxivItem,
+        ArxivScoreResult,
+        make_arxiv_item_provider,
+    )
+
+    arxiv_items = [
+        ArxivItem(
+            arxiv_id="2601.12345",
+            title="Test Paper",
+            abstract="Abstract text",
+            published=datetime(2026, 4, 25, tzinfo=UTC),
+            categories=["cs.AI"],
+        ),
+    ]
+
+    async def fake_filter_scorer(
+        items: list[Any], profile: str, prompt: str
+    ) -> dict[str, ArxivScoreResult]:
+        return {
+            item.arxiv_id: ArxivScoreResult(
+                score=10, confidence=0.95, reason="relevant"
+            )
+            for item in items
+        }
+
+    arxiv_provider = make_arxiv_item_provider(config, filter_scorer=fake_filter_scorer)
+
+    mock_client = _mock_lithos_client()
+    tracer = _disabled_tracer()
+
+    with (
+        patch("influx.scheduler.get_tracer", return_value=tracer),
+        patch("influx.sources.arxiv.get_tracer", return_value=tracer),
+        patch("influx.lcma.get_tracer", return_value=tracer),
+        # Route every metric helper at the call sites through our test meter
+        patch("influx.scheduler.metrics.get_meter", return_value=meter),
+        patch("influx.sources.arxiv.metrics.get_meter", return_value=meter),
+        patch("influx.sources.rss.metrics.get_meter", return_value=meter),
+        patch("influx.repair.metrics.get_meter", return_value=meter),
+        # ArXiv pipeline mocks
+        patch("influx.sources.arxiv.fetch_arxiv", return_value=arxiv_items),
+        patch(
+            "influx.sources.arxiv.extract_arxiv_text",
+            return_value=ArxivExtractionResult(
+                text="Full text here", source_tag="text:html"
+            ),
+        ),
+        patch(
+            "influx.sources.arxiv.tier1_enrich",
+            return_value=Tier1Enrichment(
+                contributions=["c1"], method="m", result="r", relevance="rel"
+            ),
+        ),
+        patch(
+            "influx.sources.arxiv.tier3_extract",
+            return_value=Tier3Extraction(claims=["claim1"], builds_on=["b1"]),
+        ),
+        patch("influx.scheduler.LithosClient", return_value=mock_client),
+        patch(
+            "influx.scheduler.build_negative_examples_block",
+            new_callable=AsyncMock,
+            return_value="",
+        ),
+        patch("influx.scheduler.repair_sweep", new_callable=AsyncMock),
+        patch("influx.service.post_run_webhook_hook"),
+    ):
+        from influx.scheduler import run_profile
+
+        await run_profile(
+            "ai-robotics",
+            RunKind.SCHEDULED,
+            config=config,
+            item_provider=arxiv_provider,
+        )
+
+
+# ── Tests ──────────────────────────────────────────────────────────
+
+
+class TestRunLifecycleAndFunnelMetrics:
+    """Issue #6: lifecycle + funnel + write counters fire with bounded labels."""
+
+    async def test_arxiv_run_emits_documented_metrics(self) -> None:
+        meter, reader = _make_inmemory_meter()
+        config = _full_config()
+
+        await _run_arxiv_scenario(meter, config)
+
+        points = _collect(reader)
+
+        # Run lifecycle: start + completion + duration + active_runs (up & down)
+        assert "influx_run_starts_total" in points
+        assert _has_label_set(
+            points["influx_run_starts_total"],
+            {"profile": "ai-robotics", "run_type": "scheduled"},
+        )
+        assert "influx_run_completions_total" in points
+        # Outcome is "success" (no source_acquisition_errors in the fake run).
+        assert _has_label_set(
+            points["influx_run_completions_total"],
+            {
+                "profile": "ai-robotics",
+                "run_type": "scheduled",
+                "outcome": "success",
+            },
+        )
+        assert "influx_run_duration_seconds" in points
+        # Active-runs registers both the +1 at start and -1 at finally;
+        # the up_down counter is a sum aggregation that nets to 0 — but
+        # the point must still exist for the profile dimension.
+        assert "influx_active_runs" in points
+        assert _has_label_set(
+            points["influx_active_runs"], {"profile": "ai-robotics"}
+        )
+
+        # Source funnel
+        assert "influx_source_candidates_fetched_total" in points
+        assert _has_label_set(
+            points["influx_source_candidates_fetched_total"],
+            {"profile": "ai-robotics", "source": "arxiv"},
+        )
+        assert "influx_articles_filtered_total" in points
+        # The single arxiv item passes the filter.
+        assert _has_label_set(
+            points["influx_articles_filtered_total"],
+            {"profile": "ai-robotics", "decision": "pass"},
+        )
+        assert "influx_articles_inspected_total" in points
+        assert _has_label_set(
+            points["influx_articles_inspected_total"],
+            {"profile": "ai-robotics", "source": "arxiv"},
+        )
+
+        # Lithos write outcome (mock returns status=created, no cache hit)
+        assert "influx_lithos_writes_total" in points
+        assert _has_label_set(
+            points["influx_lithos_writes_total"],
+            {"profile": "ai-robotics", "source": "arxiv", "status": "created"},
+        )
+
+    async def test_high_cardinality_labels_are_never_emitted(self) -> None:
+        """Cardinality guard: no instrument leaks per-item identifiers."""
+        meter, reader = _make_inmemory_meter()
+        config = _full_config()
+
+        await _run_arxiv_scenario(meter, config)
+
+        forbidden = {"run_id", "note_id", "arxiv_id", "source_url", "title"}
+        points = _collect(reader)
+        for instrument_name, datapoints in points.items():
+            for dp in datapoints:
+                leaked = forbidden.intersection(dp["attributes"].keys())
+                assert not leaked, (
+                    f"instrument {instrument_name!r} leaked high-cardinality "
+                    f"label(s) {sorted(leaked)} on data point {dp}"
+                )
+
+
+class TestOtelDisabledZeroMetrics:
+    """OTEL disabled → in-memory reader sees no metric data points."""
+
+    async def test_disabled_meter_emits_no_metrics(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Run the same arXiv scenario with the meter disabled; no exports."""
+        # Build a real, disabled meter (mirrors the disabled-tracer test).
+        disabled_meter = InfluxMeter(enabled=False)
+
+        # Separately, an in-memory reader to confirm no spillover anywhere.
+        _meter, reader = _make_inmemory_meter()
+
+        config = _full_config()
+
+        from influx.extraction.pipeline import ArxivExtractionResult
+        from influx.schemas import Tier1Enrichment, Tier3Extraction
+        from influx.sources.arxiv import (
+            ArxivItem,
+            ArxivScoreResult,
+            make_arxiv_item_provider,
+        )
+
+        arxiv_items = [
+            ArxivItem(
+                arxiv_id="2601.12345",
+                title="Test Paper",
+                abstract="Abstract text",
+                published=datetime(2026, 4, 25, tzinfo=UTC),
+                categories=["cs.AI"],
+            ),
+        ]
+
+        async def fake_filter_scorer(
+            items: list[Any], profile: str, prompt: str
+        ) -> dict[str, ArxivScoreResult]:
+            return {
+                item.arxiv_id: ArxivScoreResult(
+                    score=10, confidence=0.95, reason="relevant"
+                )
+                for item in items
+            }
+
+        arxiv_provider = make_arxiv_item_provider(
+            config, filter_scorer=fake_filter_scorer
+        )
+
+        mock_client = _mock_lithos_client()
+        tracer = _disabled_tracer()
+
+        with (
+            patch("influx.scheduler.get_tracer", return_value=tracer),
+            patch("influx.sources.arxiv.get_tracer", return_value=tracer),
+            patch("influx.lcma.get_tracer", return_value=tracer),
+            patch(
+                "influx.scheduler.metrics.get_meter", return_value=disabled_meter
+            ),
+            patch(
+                "influx.sources.arxiv.metrics.get_meter", return_value=disabled_meter
+            ),
+            patch(
+                "influx.sources.rss.metrics.get_meter", return_value=disabled_meter
+            ),
+            patch(
+                "influx.repair.metrics.get_meter", return_value=disabled_meter
+            ),
+            patch("influx.sources.arxiv.fetch_arxiv", return_value=arxiv_items),
+            patch(
+                "influx.sources.arxiv.extract_arxiv_text",
+                return_value=ArxivExtractionResult(
+                    text="Full text here", source_tag="text:html"
+                ),
+            ),
+            patch(
+                "influx.sources.arxiv.tier1_enrich",
+                return_value=Tier1Enrichment(
+                    contributions=["c1"],
+                    method="m",
+                    result="r",
+                    relevance="rel",
+                ),
+            ),
+            patch(
+                "influx.sources.arxiv.tier3_extract",
+                return_value=Tier3Extraction(claims=["claim1"], builds_on=["b1"]),
+            ),
+            patch("influx.scheduler.LithosClient", return_value=mock_client),
+            patch(
+                "influx.scheduler.build_negative_examples_block",
+                new_callable=AsyncMock,
+                return_value="",
+            ),
+            patch("influx.scheduler.repair_sweep", new_callable=AsyncMock),
+            patch("influx.service.post_run_webhook_hook"),
+        ):
+            from influx.scheduler import run_profile
+
+            await run_profile(
+                "ai-robotics",
+                RunKind.SCHEDULED,
+                config=config,
+                item_provider=arxiv_provider,
+            )
+
+        # The in-memory reader was not wired to the disabled meter, so
+        # it must see zero metric data — confirms no spurious sink.
+        points = _collect(reader)
+        assert points == {}, f"Expected zero metric exports, got: {sorted(points)}"

--- a/tests/integration/test_otel_metrics.py
+++ b/tests/integration/test_otel_metrics.py
@@ -146,9 +146,7 @@ def _collect(reader: Any) -> dict[str, list[dict[str, Any]]]:
     return out
 
 
-def _has_label_set(
-    points: list[dict[str, Any]], expected: dict[str, str]
-) -> bool:
+def _has_label_set(points: list[dict[str, Any]], expected: dict[str, str]) -> bool:
     """Return True iff at least one data point matches every expected label."""
     return any(
         all(point["attributes"].get(k) == v for k, v in expected.items())
@@ -275,9 +273,7 @@ class TestRunLifecycleAndFunnelMetrics:
         # the up_down counter is a sum aggregation that nets to 0 — but
         # the point must still exist for the profile dimension.
         assert "influx_active_runs" in points
-        assert _has_label_set(
-            points["influx_active_runs"], {"profile": "ai-robotics"}
-        )
+        assert _has_label_set(points["influx_active_runs"], {"profile": "ai-robotics"})
 
         # Source funnel
         assert "influx_source_candidates_fetched_total" in points
@@ -376,18 +372,12 @@ class TestOtelDisabledZeroMetrics:
             patch("influx.scheduler.get_tracer", return_value=tracer),
             patch("influx.sources.arxiv.get_tracer", return_value=tracer),
             patch("influx.lcma.get_tracer", return_value=tracer),
-            patch(
-                "influx.scheduler.metrics.get_meter", return_value=disabled_meter
-            ),
+            patch("influx.scheduler.metrics.get_meter", return_value=disabled_meter),
             patch(
                 "influx.sources.arxiv.metrics.get_meter", return_value=disabled_meter
             ),
-            patch(
-                "influx.sources.rss.metrics.get_meter", return_value=disabled_meter
-            ),
-            patch(
-                "influx.repair.metrics.get_meter", return_value=disabled_meter
-            ),
+            patch("influx.sources.rss.metrics.get_meter", return_value=disabled_meter),
+            patch("influx.repair.metrics.get_meter", return_value=disabled_meter),
             patch("influx.sources.arxiv.fetch_arxiv", return_value=arxiv_items),
             patch(
                 "influx.sources.arxiv.extract_arxiv_text",

--- a/tests/unit/test_metrics_module.py
+++ b/tests/unit/test_metrics_module.py
@@ -111,9 +111,7 @@ class TestEnabledMeterCachesInstruments:
 class TestInstrumentNames:
     """Instrument names follow the documented contract (issue #6 plan §2)."""
 
-    def test_instrument_names_match_plan(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_instrument_names_match_plan(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _enable(monkeypatch)
         for helper_name, expected_metric_name in HELPERS.items():
             instrument = getattr(metrics, helper_name)()
@@ -143,11 +141,7 @@ class TestCardinalityDiscipline:
 
         for name in HELPERS:
             sig = inspect.signature(getattr(metrics, name))
-            forbidden = [
-                p
-                for p in sig.parameters
-                if p in HIGH_CARDINALITY_FIELDS
-            ]
+            forbidden = [p for p in sig.parameters if p in HIGH_CARDINALITY_FIELDS]
             assert not forbidden, (
                 f"helper {name!r} exposes high-cardinality kwargs: {forbidden}"
             )

--- a/tests/unit/test_metrics_module.py
+++ b/tests/unit/test_metrics_module.py
@@ -1,0 +1,153 @@
+"""Unit tests for :mod:`influx.metrics` (issue #6).
+
+Covers:
+
+  (1) Every helper returns the SAME cached instrument across calls.
+  (2) Disabled meter → every helper returns the shared no-op.
+  (3) Cardinality discipline: instrument names follow ``influx_*`` and
+      no helper emits ``run_id`` / ``note_id`` / ``arxiv_id`` /
+      ``source_url`` / ``title`` as a label.
+  (4) Helpers are wired through :func:`influx.telemetry.get_meter` so
+      ``force_rebuild=True`` swaps every caller's instrument in lock
+      step.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from influx import metrics
+from influx.telemetry import _NOOP_INSTRUMENT, get_meter
+
+try:
+    import opentelemetry.sdk.metrics  # noqa: F401
+
+    _has_otel = True
+except ImportError:
+    _has_otel = False
+
+_needs_otel = pytest.mark.skipif(
+    not _has_otel,
+    reason="opentelemetry metrics SDK not installed",
+)
+
+
+def _disable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("INFLUX_OTEL_ENABLED", raising=False)
+    get_meter(force_rebuild=True)
+
+
+def _enable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INFLUX_OTEL_ENABLED", "true")
+    get_meter(force_rebuild=True)
+
+
+# Helper → expected instrument name.  The instrument names are part of
+# the operator-facing contract (dashboard / alert queries reference
+# them).  Pin them so an accidental rename breaks this test rather
+# than silently breaking dashboards.
+HELPERS: dict[str, str] = {
+    "run_starts": "influx_run_starts_total",
+    "run_completions": "influx_run_completions_total",
+    "run_duration": "influx_run_duration_seconds",
+    "active_runs": "influx_active_runs",
+    "candidates_fetched": "influx_source_candidates_fetched_total",
+    "articles_filtered": "influx_articles_filtered_total",
+    "articles_inspected": "influx_articles_inspected_total",
+    "cache_hits": "influx_cache_hits_total",
+    "lithos_writes": "influx_lithos_writes_total",
+    "repair_candidates": "influx_repair_candidates_total",
+    "llm_validation_failures": "influx_llm_validation_failures_total",
+    "archive_missing": "influx_archive_missing_total",
+    "source_acquisition_errors": "influx_source_acquisition_errors_total",
+}
+
+
+class TestHelperContract:
+    """Every helper is exported and bound to a documented instrument name."""
+
+    def test_all_helpers_exported(self) -> None:
+        missing = [name for name in HELPERS if name not in metrics.__all__]
+        assert not missing, f"Helpers missing from __all__: {missing}"
+        for name in HELPERS:
+            assert callable(getattr(metrics, name))
+
+
+class TestDisabledMeterUsesNoop:
+    """OTEL off → every helper hands out the shared no-op singleton."""
+
+    def test_every_helper_returns_noop_when_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _disable(monkeypatch)
+        for name in HELPERS:
+            instrument = getattr(metrics, name)()
+            assert instrument is _NOOP_INSTRUMENT, (
+                f"helper {name!r} did not return _NOOP_INSTRUMENT in disabled mode"
+            )
+
+
+@_needs_otel
+class TestEnabledMeterCachesInstruments:
+    """OTEL on → repeated helper calls return the same OTEL instrument.
+
+    This is required by the OTEL SDK, which raises if the same
+    instrument name is registered twice on a meter.  Helpers must
+    delegate to the meter's instrument cache.
+    """
+
+    def test_repeated_helper_calls_return_same_instrument(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _enable(monkeypatch)
+        for name in HELPERS:
+            helper = getattr(metrics, name)
+            first = helper()
+            second = helper()
+            assert first is second, f"helper {name!r} did not cache its instrument"
+
+
+@_needs_otel
+class TestInstrumentNames:
+    """Instrument names follow the documented contract (issue #6 plan §2)."""
+
+    def test_instrument_names_match_plan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _enable(monkeypatch)
+        for helper_name, expected_metric_name in HELPERS.items():
+            instrument = getattr(metrics, helper_name)()
+            actual = getattr(instrument, "name", None)
+            assert actual == expected_metric_name, (
+                f"helper {helper_name!r} created instrument {actual!r}, "
+                f"expected {expected_metric_name!r}"
+            )
+
+
+# ── Cardinality discipline ────────────────────────────────────────────
+
+
+# These keys are explicitly disallowed as label values by issue #6
+# ("avoid high-cardinality labels such as article title or full URL").
+# The audit lives at the call-site level, not the instrument level, so
+# this test just guards that the helper module itself does not encourage
+# them by exposing them as helper kwargs or signature parameters.
+HIGH_CARDINALITY_FIELDS = ("run_id", "note_id", "arxiv_id", "source_url", "title")
+
+
+class TestCardinalityDiscipline:
+    """No helper signature accepts high-cardinality identifiers as kwargs."""
+
+    def test_no_helper_takes_high_cardinality_kwargs(self) -> None:
+        import inspect
+
+        for name in HELPERS:
+            sig = inspect.signature(getattr(metrics, name))
+            forbidden = [
+                p
+                for p in sig.parameters
+                if p in HIGH_CARDINALITY_FIELDS
+            ]
+            assert not forbidden, (
+                f"helper {name!r} exposes high-cardinality kwargs: {forbidden}"
+            )

--- a/tests/unit/test_telemetry_metrics.py
+++ b/tests/unit/test_telemetry_metrics.py
@@ -1,0 +1,192 @@
+"""Unit tests for the OTEL metrics wrapper (issue #6).
+
+Mirrors :mod:`tests.unit.test_telemetry`'s structure for the trace
+wrapper.  Covers:
+
+  (1) Meter is a no-op when ``INFLUX_OTEL_ENABLED`` is unset / false.
+  (2) Meter is enabled when ``INFLUX_OTEL_ENABLED=true`` and OTEL
+      packages are installed.
+  (3) Disabled meter never allocates a per-call instrument: every
+      ``counter()`` / ``histogram()`` / ``up_down_counter()`` call
+      returns the shared ``_NOOP_INSTRUMENT`` singleton.
+  (4) Enabled meter caches instruments by name (the OTEL SDK rejects
+      duplicate registrations on the same meter).
+  (5) Resource attributes are shared with the tracer (same
+      ``service.name`` / ``deployment.environment``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from influx.telemetry import (
+    _NOOP_INSTRUMENT,
+    InfluxMeter,
+    get_meter,
+    get_tracer,
+)
+
+try:
+    import opentelemetry.sdk.metrics  # noqa: F401
+
+    _has_otel = True
+except ImportError:
+    _has_otel = False
+
+_needs_otel = pytest.mark.skipif(
+    not _has_otel,
+    reason="opentelemetry metrics SDK not installed",
+)
+
+
+def _rebuild(monkeypatch: pytest.MonkeyPatch, env_value: str | None) -> None:
+    if env_value is None:
+        monkeypatch.delenv("INFLUX_OTEL_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv("INFLUX_OTEL_ENABLED", env_value)
+
+
+# ── (1) Disabled paths ────────────────────────────────────────────────
+
+
+class TestMeterDisabled:
+    """OTEL off → meter returns shared no-op instruments."""
+
+    def test_meter_disabled_when_env_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _rebuild(monkeypatch, None)
+        meter = get_meter(force_rebuild=True)
+        assert not meter.enabled
+
+    def test_meter_disabled_when_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _rebuild(monkeypatch, "false")
+        meter = get_meter(force_rebuild=True)
+        assert not meter.enabled
+
+    def test_disabled_counter_is_shared_noop(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC-10-A discipline: disabled meter allocates nothing per call."""
+        _rebuild(monkeypatch, "false")
+        meter = get_meter(force_rebuild=True)
+        a = meter.counter("influx_run_starts_total")
+        b = meter.counter("influx_run_completions_total")
+        c = meter.histogram("influx_run_duration_seconds")
+        d = meter.up_down_counter("influx_active_runs")
+        # Every kind returns the SAME shared singleton — proving the
+        # disabled body performs no per-instrument allocation.
+        assert a is b is c is d is _NOOP_INSTRUMENT
+
+    def test_disabled_instrument_methods_never_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _rebuild(monkeypatch, None)
+        meter = get_meter(force_rebuild=True)
+        counter = meter.counter("influx_run_starts_total")
+        counter.add(1)
+        counter.add(5, {"profile": "ai"})
+        histogram = meter.histogram("influx_run_duration_seconds")
+        histogram.record(0.5)
+        histogram.record(12.3, {"profile": "web"})
+        up_down = meter.up_down_counter("influx_active_runs")
+        up_down.add(1, {"profile": "ai"})
+        up_down.add(-1, {"profile": "ai"})
+
+
+# ── (2) Enabled path ──────────────────────────────────────────────────
+
+
+@_needs_otel
+class TestMeterEnabled:
+    """OTEL on → meter creates real OTEL instruments."""
+
+    def test_meter_enabled_when_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _rebuild(monkeypatch, "true")
+        meter = get_meter(force_rebuild=True)
+        assert meter.enabled
+
+    def test_enabled_counter_is_real_instrument(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _rebuild(monkeypatch, "true")
+        meter = get_meter(force_rebuild=True)
+        counter = meter.counter("influx_test_counter")
+        # Real OTEL counters expose ``add``; calling it must not raise
+        # even without an exporter wired.
+        counter.add(1, {"profile": "ai"})
+
+
+# ── (3) Instrument caching ───────────────────────────────────────────
+
+
+@_needs_otel
+class TestInstrumentCaching:
+    """Same-name lookups return the same OTEL instrument."""
+
+    def test_counter_cached_by_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _rebuild(monkeypatch, "true")
+        meter = get_meter(force_rebuild=True)
+        a = meter.counter("influx_test_cached_counter")
+        b = meter.counter("influx_test_cached_counter")
+        assert a is b
+
+    def test_histogram_cached_by_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _rebuild(monkeypatch, "true")
+        meter = get_meter(force_rebuild=True)
+        a = meter.histogram("influx_test_cached_histogram")
+        b = meter.histogram("influx_test_cached_histogram")
+        assert a is b
+
+    def test_up_down_counter_cached_by_name(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _rebuild(monkeypatch, "true")
+        meter = get_meter(force_rebuild=True)
+        a = meter.up_down_counter("influx_test_cached_up_down")
+        b = meter.up_down_counter("influx_test_cached_up_down")
+        assert a is b
+
+
+# ── (4) Shared resource attributes ───────────────────────────────────
+
+
+@_needs_otel
+class TestSharedResourceAttributes:
+    """Tracer and meter describe the same service to the collector."""
+
+    def test_service_name_shared(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _rebuild(monkeypatch, "true")
+        monkeypatch.delenv("OTEL_RESOURCE_ATTRIBUTES", raising=False)
+        monkeypatch.delenv("INFLUX_ENVIRONMENT", raising=False)
+        tracer = get_tracer(force_rebuild=True)
+        meter = get_meter(force_rebuild=True)
+        tracer_resource = tracer._tracer.resource  # type: ignore[attr-defined]  # noqa: SLF001
+        assert tracer_resource.attributes["service.name"] == "influx"
+        assert meter.resource is not None
+        assert meter.resource.attributes["service.name"] == "influx"
+
+    def test_deployment_environment_shared(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _rebuild(monkeypatch, "true")
+        monkeypatch.setenv("INFLUX_ENVIRONMENT", "staging")
+        monkeypatch.delenv("OTEL_RESOURCE_ATTRIBUTES", raising=False)
+        tracer = get_tracer(force_rebuild=True)
+        meter = get_meter(force_rebuild=True)
+        tracer_resource = tracer._tracer.resource  # type: ignore[attr-defined]  # noqa: SLF001
+        assert tracer_resource.attributes["deployment.environment"] == "staging"
+        assert meter.resource is not None
+        assert meter.resource.attributes["deployment.environment"] == "staging"
+
+
+# ── (5) Direct InfluxMeter construction ──────────────────────────────
+
+
+class TestInfluxMeterDirect:
+    """Direct InfluxMeter API works independently of the singleton."""
+
+    def test_disabled_meter_constructed_directly(self) -> None:
+        meter = InfluxMeter(enabled=False)
+        c = meter.counter("influx_test")
+        assert c is _NOOP_INSTRUMENT


### PR DESCRIPTION
Closes #6.

## Summary

Wires a real OTEL ``MeterProvider`` alongside the existing ``TracerProvider`` so the OTLP collector can answer "is the run progressing, stalled, or failing?" without ``docker logs``. Both signals share ``INFLUX_OTEL_ENABLED``, the same OTLP endpoint, and the same resource attributes (``service.name=influx``, ``deployment.environment=<INFLUX_ENVIRONMENT>``).

## Instruments

All labels are bounded by construction — no ``run_id`` / ``note_id`` / ``arxiv_id`` / ``source_url`` / ``title`` leaks (cardinality-discipline test guards this).

| Instrument | Type | Labels |
|---|---|---|
| ``influx_run_starts_total`` | Counter | ``profile``, ``run_type`` |
| ``influx_run_completions_total`` | Counter | ``profile``, ``run_type``, ``outcome`` (``success`` \| ``failure`` \| ``degraded``) |
| ``influx_run_duration_seconds`` | Histogram (s) | ``profile``, ``run_type`` |
| ``influx_active_runs`` | UpDownCounter | ``profile`` |
| ``influx_source_candidates_fetched_total`` | Counter | ``profile``, ``source`` |
| ``influx_articles_filtered_total`` | Counter | ``profile``, ``decision`` |
| ``influx_articles_inspected_total`` | Counter | ``profile``, ``source`` |
| ``influx_cache_hits_total`` | Counter | ``profile``, ``source`` |
| ``influx_lithos_writes_total`` | Counter | ``profile``, ``source``, ``status`` |
| ``influx_repair_candidates_total`` | Counter | ``profile``, ``kind`` |
| ``influx_llm_validation_failures_total`` | Counter | ``profile``, ``tier`` |
| ``influx_archive_missing_total`` | Counter | ``profile``, ``source`` |
| ``influx_source_acquisition_errors_total`` | Counter | ``profile``, ``source``, ``kind`` |

Disabled path keeps AC-10-A discipline: every helper returns a single shared ``_NOOP_INSTRUMENT`` singleton — zero per-call allocation when ``INFLUX_OTEL_ENABLED`` is unset.

## Scope decision

OTEL log export is intentionally deferred to #28 so this PR stays focused on metrics. ``stderr`` JSON remains the only log sink in this revision.

## Test plan

- [x] ``uv run pytest`` — 1499 tests pass, including existing telemetry / scheduler / OTEL absent-service suites.
- [x] New tests: ``tests/unit/test_telemetry_metrics.py`` (12), ``tests/unit/test_metrics_module.py`` (5), ``tests/integration/test_otel_metrics.py`` (3).
- [x] ``uv run pyright`` clean on every modified file.
- [x] ``uv run ruff check`` clean on every modified file.
- [x] Smoke: ``INFLUX_OTEL_ENABLED=true INFLUX_OTEL_CONSOLE_FALLBACK=true`` emits metrics with ``service.name=influx`` + ``deployment.environment`` resource attrs.
- [x] Smoke: ``INFLUX_OTEL_ENABLED`` unset → ``_NOOP_INSTRUMENT`` returned, zero output.
- [ ] Verify in staging that the OTLP collector receives the new instruments end-to-end (post-merge).

## Docs

- ``docs/SPECIFICATION.md`` §13.2 now lists every instrument and its label set.
- ``docs/operations/staging-runbook.md`` gains a "Reading metrics from the OTEL backend" section with example queries per operator question.