### PR TITLE
fix: surface lithos slug_collision existing_id in WriteResult.detail

### DIFF
--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -670,7 +670,25 @@ class LithosClient:
             )
 
         if status == "slug_collision":
-            return WriteResult(status="slug_collision", source_url=source_url)
+            # Lithos's slug_collision envelope carries ``existing_id`` and
+            # ``message`` (lithos/server.py); preserve them as ``detail`` so
+            # the operator-facing WARNING in scheduler.py can name the
+            # squatting note rather than logging an empty string.  See the
+            # 2026-05-02 staging incident: the only signal of the colliding
+            # doc was thrown away here.
+            existing_id = body.get("existing_id", "")
+            message = body.get("message", "")
+            if existing_id and message:
+                detail = f"existing_id={existing_id}; {message}"
+            elif existing_id:
+                detail = f"existing_id={existing_id}"
+            else:
+                detail = message
+            return WriteResult(
+                status="slug_collision",
+                source_url=source_url,
+                detail=detail,
+            )
 
         if status == "version_conflict":
             note_id = body.get("note_id", "")

--- a/tests/contract/test_lithos_client.py
+++ b/tests/contract/test_lithos_client.py
@@ -1218,6 +1218,59 @@ class TestWriteEnvelopeSlugCollision:
         finally:
             await client.close()
 
+    async def test_slug_collision_envelope_surfaces_existing_id(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+    ) -> None:
+        """``slug_collision`` envelope's ``existing_id`` and ``message``
+        round-trip into ``WriteResult.detail`` so the operator-facing
+        WARNING in scheduler.py names the squatting note rather than
+        logging an empty string (2026-05-02 staging incident).
+        """
+        fake_lithos_server.write_responses.extend(
+            [
+                # First attempt collides — lithos returns the diagnostic envelope.
+                (
+                    '{"status": "slug_collision",'
+                    ' "existing_id": "doc-squatter-123",'
+                    ' "message": "Slug \'omnirobothome-...\' already in use'
+                    " by document 'doc-squatter-123'\","
+                    ' "warnings": []}'
+                ),
+                # Suffix retry collides as well — same diagnostic shape.
+                (
+                    '{"status": "slug_collision",'
+                    ' "existing_id": "doc-squatter-456",'
+                    ' "message": "Slug \'omnirobothome-...-arxiv-2601-77777\''
+                    " already in use by document 'doc-squatter-456'\","
+                    ' "warnings": []}'
+                ),
+            ]
+        )
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            result = await client.write_note(
+                title="Diagnostic Slug",
+                content="# Summary\nContent.",
+                path="papers/arxiv/2026/03",
+                source_url="https://arxiv.org/abs/2601.77777",
+                tags=["profile:ml-research"],
+                confidence=0.8,
+            )
+        finally:
+            await client.close()
+
+        assert result.status == "slug_collision"
+        # The diagnostic from the *retry* response wins (it is the value
+        # actually returned to the scheduler), and it must include both
+        # the colliding doc id and lithos's human-readable message.
+        assert result.detail
+        assert "doc-squatter-456" in result.detail
+        assert "existing_id=" in result.detail
+        assert "already in use" in result.detail
+
 
 # ── Write envelopes — version_conflict (FR-MCP-7, AC-05-E) ────────
 


### PR DESCRIPTION
## Summary

Lithos's ``slug_collision`` response envelope already carries ``existing_id`` and ``message`` (``lithos/server.py:1259``), but ``LithosClient._parse_write_response`` was discarding both. The operator-facing WARNING in ``scheduler.py`` therefore logged ``status=slug_collision detail=''``, leaving no breadcrumb to the squatting note.

This PR plumbs ``existing_id`` and the human-readable ``message`` into ``WriteResult.detail`` so the WARNING reads e.g.

```
status=slug_collision detail=\"existing_id=doc-XYZ; Slug 'omni…' already in use by document 'doc-XYZ'\"
```

Operators can ``lithos_read`` the squatter directly to decide whether to relabel, delete, or merge.

## Why

Discovered during the **2026-05-02 staging incident**: arXiv paper ``2604.28197`` (``OmniRobotHome…``) was permanently dropped because two existing notes already squatted both the unsuffixed and the ``[arXiv …]`` suffixed slugs — but the influx logs showed only ``detail=''`` so there was no operator-actionable signal pointing at the squatter.

Companion PR in lithos adds a server-side WARNING for the same incident: agent-lore/lithos#219.

Self-healing recovery path tracked separately in #31.

## Test plan

- [x] ``uv run pytest tests/contract/test_lithos_client.py -k slug_collision`` — 5/5 pass (4 existing + 1 new ``test_slug_collision_envelope_surfaces_existing_id``).
- [x] ``uv run ruff check`` clean on modified files.
- [x] ``uv run pyright src/influx/lithos_client.py`` — 0 errors.
- [ ] Verify in staging that the next slug collision logs ``detail=\"existing_id=…\"`` end-to-end (post-merge).