### PR TITLE
feat: diagnose script gains squatters subcommand and standardised --env flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,19 +131,19 @@ Each environment can set:
 Use the report script to summarize a running Influx environment:
 
 ```bash
-scripts/influx-report.py staging --limit 10
+scripts/influx-report.py --env staging --limit 10
 ```
 
-The positional environment name maps to `docker/.env.<env>`. The script reads
-that file to find the admin URL, archive path, and state path, then calls
-`/status` and `/runs/recent`.
+`--env <name>` maps to `docker/.env.<name>` (default: `staging`). The script
+reads that file to find the admin URL, archive path, and state path, then
+calls `/status` and `/runs/recent`.
 
 Useful options:
 
 ```bash
-scripts/influx-report.py dev
-scripts/influx-report.py staging --limit 50
-scripts/influx-report.py staging --base-url http://127.0.0.1:18080
+scripts/influx-report.py --env dev
+scripts/influx-report.py --env staging --limit 50
+scripts/influx-report.py --env staging --base-url http://127.0.0.1:18080
 ```
 
 The report includes service readiness, package version, per-profile scheduler

--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -226,7 +226,53 @@ by these on the collector if multiple environments share a backend.
 OTEL log export is **not** wired in this revision; the runbook still
 relies on `docker logs` (and `influx-diagnose.py`) for log inspection.
 
-## 8. Reference
+## 8. Cleaning up slug-collision squatters
+
+When ``lithos_write`` returns ``slug_collision`` and the suffix retry
+also fails, Influx logs a WARNING but otherwise drops the article.
+The same paper will hit the same collision on every subsequent sweep
+until the squatting Lithos document is removed (see
+[#31](https://github.com/agent-lore/influx/issues/31) for the planned
+self-healing path).
+
+The ``squatters`` subcommand surfaces them and offers a confirmed
+deletion path:
+
+```
+# 1. Read-only scan — list every squatter from the WARNING stream.
+./scripts/influx-diagnose.py squatters --since 7d
+
+# 2. Inspect the squatting doc body (recommended before deletion).
+#    The output of step 1 prints `doc_id=<uuid>`; pass it to lithos_read
+#    via your usual MCP client / influx admin path.
+
+# 3. Delete one squatter, with audit trail.
+./scripts/influx-diagnose.py squatters --apply --yes <doc-id>
+
+# 4. Or wipe every squatter the scan found (use with care).
+./scripts/influx-diagnose.py squatters --apply --yes-to-all
+```
+
+Safety properties:
+- Default mode is a pure log scan — no Lithos connection.
+- ``--apply`` requires either ``--yes <doc-id>`` (per-id confirmation,
+  repeatable) or ``--yes-to-all``; passing ``--apply`` alone aborts.
+- Before deleting, the script reads the doc and refuses unless its
+  tags include ``ingested-by:influx``.  Pass
+  ``--no-require-influx-authored`` to override (use only after manual
+  review).
+- Each delete is recorded in Lithos with ``agent=influx-diagnose``
+  (override with ``--agent <name>``).
+
+Today only the **second** collision (the suffix retry) appears in the
+WARNING ``detail`` field, so cleaning the listed squatter unblocks
+*one* of the two squatted slugs.  The next sweep typically exposes
+the unsuffixed-slug squatter, which can be removed the same way.
+[#32](https://github.com/agent-lore/influx/issues/32) tracks
+surfacing both squatters in a single WARNING so they can be cleaned
+in one pass.
+
+## 9. Reference
 
 - Run ledger schema: `src/influx/run_ledger.py` (`RunEntry` TypedDict).
 - Admin endpoints: `src/influx/http_api.py` (`/live`, `/ready`,

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -16,24 +16,31 @@ Subcommands
     run RUN_ID      Show ledger entry + matching log lines for one run
     warnings        WARNING/ERROR docker log lines (filterable by run_id)
     terminal-flips  Per-stage terminal-flip log events with note IDs
+    squatters       Find Lithos docs squatting slugs that block Influx
+                    writes; optionally delete them with --apply --yes
     cancel          Print the curl line for cancelling an in-flight run
                     (this script never sends destructive HTTP itself)
 
-The script is read-only: no HTTP POSTs, no docker exec, no ledger
-writes.  Every command it emits is an inspection.
+Posture
+-------
+Subcommands default to read-only: no HTTP POSTs, no docker exec, no
+ledger writes.  The ``squatters`` subcommand can delete Lithos
+documents but only when ``--apply`` is combined with an explicit
+per-id ``--yes <doc-id>`` confirmation (or ``--yes-to-all``); the
+default invocation is a pure log scan.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import re
 import shutil
 import subprocess
 import sys
 from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Any
-
 
 # ── env-file loader (mirrors scripts/influx-report.py) ──────────────
 
@@ -59,10 +66,7 @@ def _load_env(name: str) -> dict[str, str]:
 def _state_dir(env: dict[str, str]) -> Path:
     state = env.get("INFLUX_STATE_PATH")
     if not state:
-        sys.exit(
-            "INFLUX_STATE_PATH not set in env file; "
-            "cannot locate runs.jsonl"
-        )
+        sys.exit("INFLUX_STATE_PATH not set in env file; cannot locate runs.jsonl")
     return Path(state)
 
 
@@ -177,13 +181,9 @@ def _docker_logs_iter(
         text=True,
     )
     if proc.returncode != 0:
-        sys.exit(
-            f"docker logs failed (exit={proc.returncode}): "
-            f"{proc.stderr.strip()}"
-        )
+        sys.exit(f"docker logs failed (exit={proc.returncode}): {proc.stderr.strip()}")
     # docker mixes streams; emit both.
-    for line in (proc.stdout + proc.stderr).splitlines():
-        yield line
+    yield from (proc.stdout + proc.stderr).splitlines()
 
 
 def _parse_json_log(line: str) -> dict[str, Any] | None:
@@ -389,6 +389,274 @@ def cmd_terminal_flips(args: argparse.Namespace) -> int:
     return 0
 
 
+# ── slug-collision squatter discovery ───────────────────────────────
+
+
+# Slug-collision WARNINGs from ``influx.scheduler`` carry the lithos
+# diagnostic in their ``detail`` extra (PR #30).  Two shapes are
+# possible: today only the suffix-retry's response surfaces (covered
+# by the ``existing_id=<uuid>; Slug '<slug>' …`` form); a future
+# follow-up (#32) will enumerate both attempts in a single detail
+# string.  The regexes match on substrings so either shape works.
+_SQUATTER_ID_RE = re.compile(
+    # Match bare ``existing_id=<uuid>`` (PR #30 shape) and any
+    # ``*_existing_id=<uuid>`` prefix variant that #32 may introduce
+    # (e.g. ``first_existing_id=`` / ``retry_existing_id=``).
+    r"(?:^|[^a-zA-Z0-9])(?:[a-zA-Z]+_)?existing_id=([0-9a-fA-F-]{8,})"
+)
+_SQUATTER_SLUG_RE = re.compile(r"Slug '([^']+)' already in use")
+
+
+def _extract_squatters_from_logs(
+    records: Iterable[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Scan WARNING records for slug_collision squatters.
+
+    Returns a dict keyed by squatter doc-id.  Each value carries the
+    slug, the colliding incoming source_url + title (if present in the
+    log record's ``extra`` fields), and first/last/total seen counts.
+
+    Pure function: no I/O.  Unit-tested without docker by feeding it a
+    list of dicts shaped like ``InfluxJsonFormatter`` output.
+    """
+    squatters: dict[str, dict[str, Any]] = {}
+    for rec in records:
+        if rec.get("level") != "WARNING":
+            continue
+        if rec.get("status") != "slug_collision" and (
+            "slug_collision" not in str(rec.get("message", ""))
+        ):
+            continue
+        # The structured ``detail`` field carries the diagnostic; fall
+        # back to the message text if a slimmer log shape ever appears.
+        detail = str(rec.get("detail") or "")
+        if not detail:
+            detail = str(rec.get("message", ""))
+        # A single detail string may reference multiple squatters once
+        # #32 lands; iterate every match so both ids are captured.
+        ids = _SQUATTER_ID_RE.findall(detail)
+        slugs = _SQUATTER_SLUG_RE.findall(detail)
+        ts = rec.get("timestamp") or ""
+        source_url = str(rec.get("source_url") or "")
+        title = str(rec.get("title") or "")
+        for idx, doc_id in enumerate(ids):
+            entry = squatters.setdefault(
+                doc_id,
+                {
+                    "doc_id": doc_id,
+                    "slugs": [],
+                    "source_urls": set(),
+                    "titles": set(),
+                    "first_seen": ts,
+                    "last_seen": ts,
+                    "count": 0,
+                },
+            )
+            slug = slugs[idx] if idx < len(slugs) else ""
+            if slug and slug not in entry["slugs"]:
+                entry["slugs"].append(slug)
+            if source_url:
+                entry["source_urls"].add(source_url)
+            if title:
+                entry["titles"].add(title)
+            if ts:
+                if not entry["first_seen"] or ts < entry["first_seen"]:
+                    entry["first_seen"] = ts
+                if ts > entry["last_seen"]:
+                    entry["last_seen"] = ts
+            entry["count"] += 1
+    return squatters
+
+
+def _print_squatter(entry: dict[str, Any]) -> None:
+    print(f"SQUATTER doc_id={entry['doc_id']}")
+    for slug in entry["slugs"]:
+        print(f"   slug={slug!r}")
+    if entry["first_seen"] or entry["last_seen"]:
+        print(
+            f"   seen {entry['count']}x  "
+            f"first={entry['first_seen']}  last={entry['last_seen']}"
+        )
+    for url in sorted(entry["source_urls"]):
+        print(f"   colliding source_url={url}")
+    for title in sorted(entry["titles"]):
+        print(f"   colliding title={title!r}")
+
+
+def _read_lithos_url(args: argparse.Namespace, env: dict[str, str]) -> str:
+    """Resolve the Lithos MCP/SSE URL for ``--apply`` mode.
+
+    Resolution order:
+      1. ``--lithos-url`` CLI flag (explicit override).
+      2. ``LITHOS_URL`` env var on the host.
+      3. ``[lithos] url`` in ``${INFLUX_DATA_PATH}/influx.toml``.
+    """
+    if getattr(args, "lithos_url", None):
+        return str(args.lithos_url)
+    import os
+
+    if "LITHOS_URL" in os.environ:
+        return os.environ["LITHOS_URL"]
+    data_path = env.get("INFLUX_DATA_PATH")
+    if data_path:
+        toml_path = Path(data_path) / "influx.toml"
+        if toml_path.exists():
+            try:
+                import tomllib
+            except ImportError:  # pragma: no cover — Python < 3.11
+                sys.exit("tomllib unavailable; pass --lithos-url explicitly")
+            with toml_path.open("rb") as fh:
+                cfg = tomllib.load(fh)
+            url = cfg.get("lithos", {}).get("url")
+            if isinstance(url, str) and url:
+                return url
+    sys.exit(
+        "Lithos URL not resolved.  Pass --lithos-url, set $LITHOS_URL, "
+        "or ensure [lithos] url is set in $INFLUX_DATA_PATH/influx.toml."
+    )
+
+
+async def _delete_squatter(
+    *,
+    lithos_url: str,
+    doc_id: str,
+    agent: str,
+    require_influx_authored: bool,
+) -> tuple[bool, str]:
+    """Read-then-delete one squatter.  Returns ``(deleted, reason)``."""
+    # Imported lazily so the read-only invocation never pays the cost.
+    from influx.lithos_client import LithosClient
+
+    client = LithosClient(url=lithos_url)
+    try:
+        try:
+            doc = await client.read_note(note_id=doc_id)
+        except Exception as exc:  # noqa: BLE001
+            return False, f"read failed: {type(exc).__name__}: {exc}"
+
+        tags = list(doc.get("tags") or [])
+        if require_influx_authored and "ingested-by:influx" not in tags:
+            return (
+                False,
+                "refused: doc is not influx-authored "
+                "(missing 'ingested-by:influx' tag); "
+                "pass --no-require-influx-authored to override",
+            )
+
+        try:
+            result = await client.call_tool(
+                "lithos_delete",
+                {"id": doc_id, "agent": agent},
+            )
+        except Exception as exc:  # noqa: BLE001
+            return False, f"delete failed: {type(exc).__name__}: {exc}"
+
+        # Lithos returns either the bare success envelope or an error
+        # envelope with ``status="error"``; surface either back to the
+        # caller for printing.
+        try:
+            body = json.loads(result.content[0].text)  # type: ignore[union-attr]
+        except (AttributeError, IndexError, TypeError, json.JSONDecodeError):
+            body = {"status": "deleted"}
+        if body.get("status") == "error":
+            return False, f"lithos_delete error: {body.get('message', body)}"
+        return True, "deleted"
+    finally:
+        await client.close()
+
+
+def cmd_squatters(args: argparse.Namespace) -> int:
+    env = _load_env(args.env)
+    container = _container_name(env)
+
+    records = list(
+        _filter_log_records(
+            _docker_logs_iter(container, since=args.since, tail=args.tail),
+            levels={"WARNING"},
+            message_substr="slug_collision",
+        )
+    )
+    squatters = _extract_squatters_from_logs(records)
+
+    if not squatters:
+        print(
+            f"No slug_collision squatters found in container {container!r} "
+            f"(window: --since {args.since} --tail {args.tail})."
+        )
+        return 0
+
+    print(
+        f"{len(squatters)} squatter(s) found in container {container!r} "
+        f"(window: --since {args.since} --tail {args.tail}):\n"
+    )
+    # Sorted by last_seen desc so the freshest pain is at the top.
+    ordered = sorted(
+        squatters.values(),
+        key=lambda e: str(e.get("last_seen") or ""),
+        reverse=True,
+    )
+    for entry in ordered:
+        _print_squatter(entry)
+        print()
+
+    if not args.apply:
+        print(
+            "Default mode is read-only.  To delete a squatter, re-run with:\n"
+            "    --apply --yes <doc-id>     (per-id confirmation, repeatable)\n"
+            "    --apply --yes-to-all       (delete every squatter listed above)\n"
+            "Pre-delete safety: each doc is fetched and its tags checked to\n"
+            "ensure it carries 'ingested-by:influx' before deletion."
+        )
+        return 0
+
+    confirmed: set[str] = set(args.yes or [])
+    if args.yes_to_all:
+        confirmed.update(squatters.keys())
+    if not confirmed:
+        sys.exit(
+            "--apply requires at least one --yes <doc-id> (or --yes-to-all).  Aborted."
+        )
+    unknown = confirmed - set(squatters.keys())
+    if unknown:
+        print(
+            "Warning: --yes ids not present in the log scan results: "
+            + ", ".join(sorted(unknown))
+        )
+        confirmed -= unknown
+    if not confirmed:
+        sys.exit("No matching --yes ids; nothing to delete.")
+
+    lithos_url = _read_lithos_url(args, env)
+    print(
+        f"Apply mode: deleting {len(confirmed)} squatter(s) via "
+        f"lithos_delete on {lithos_url}\n"
+    )
+
+    import asyncio
+
+    deleted = 0
+    refused = 0
+    for doc_id in sorted(confirmed):
+        deleted_ok, reason = asyncio.run(
+            _delete_squatter(
+                lithos_url=lithos_url,
+                doc_id=doc_id,
+                agent=args.agent,
+                require_influx_authored=not args.no_require_influx_authored,
+            )
+        )
+        if deleted_ok:
+            print(f"DELETED  doc_id={doc_id}  ({reason})")
+            deleted += 1
+        else:
+            print(f"REFUSED  doc_id={doc_id}  reason={reason}")
+            refused += 1
+
+    print()
+    print(f"Summary: deleted={deleted} refused={refused}")
+    return 0 if refused == 0 else 1
+
+
 def cmd_cancel(args: argparse.Namespace) -> int:
     env = _load_env(args.env)
     host = env.get("INFLUX_ADMIN_BIND_HOST", "127.0.0.1")
@@ -406,7 +674,9 @@ def cmd_cancel(args: argparse.Namespace) -> int:
         "(see run_ledger.abandon_active)."
     )
     print()
-    print(f"Inspect the active ledger first: cat {_state_dir(env) / 'active-runs.json'}")
+    print(
+        f"Inspect the active ledger first: cat {_state_dir(env) / 'active-runs.json'}"
+    )
     print(
         f"Restart command: cd $(git rev-parse --show-toplevel) && "
         f"./docker/run.sh {args.env} restart"
@@ -437,7 +707,9 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_recent.set_defaults(func=cmd_recent)
 
-    p_failures = sub.add_parser("failures", help="recent failed/abandoned/degraded runs")
+    p_failures = sub.add_parser(
+        "failures", help="recent failed/abandoned/degraded runs"
+    )
     p_failures.add_argument("--profile")
     p_failures.add_argument("--limit", type=int, default=20)
     p_failures.set_defaults(func=cmd_failures)
@@ -476,6 +748,71 @@ def _build_parser() -> argparse.ArgumentParser:
     p_flips.add_argument("--since", default="7d")
     p_flips.add_argument("--tail", type=int, default=50000)
     p_flips.set_defaults(func=cmd_terminal_flips)
+
+    p_squatters = sub.add_parser(
+        "squatters",
+        help=(
+            "find Lithos docs squatting slugs that block influx writes; "
+            "default is read-only (log scan), --apply enables deletion"
+        ),
+    )
+    p_squatters.add_argument(
+        "--since",
+        default="7d",
+        help="docker logs --since window (default: 7d)",
+    )
+    p_squatters.add_argument(
+        "--tail",
+        type=int,
+        default=50000,
+        help="docker logs --tail (default: 50000)",
+    )
+    p_squatters.add_argument(
+        "--apply",
+        action="store_true",
+        help=(
+            "actually delete squatters (default: dry-run / log scan only). "
+            "Must be combined with --yes <doc-id> or --yes-to-all."
+        ),
+    )
+    p_squatters.add_argument(
+        "--yes",
+        action="append",
+        metavar="DOC_ID",
+        help=(
+            "confirm deletion of a specific squatter (repeatable). "
+            "Required with --apply unless --yes-to-all is set."
+        ),
+    )
+    p_squatters.add_argument(
+        "--yes-to-all",
+        action="store_true",
+        help=("with --apply, delete every squatter listed in the scan. Use with care."),
+    )
+    p_squatters.add_argument(
+        "--agent",
+        default="influx-diagnose",
+        help=(
+            "agent name passed to lithos_delete for the audit trail "
+            "(default: influx-diagnose)"
+        ),
+    )
+    p_squatters.add_argument(
+        "--lithos-url",
+        help=(
+            "override the Lithos MCP/SSE URL.  Default resolution: "
+            "$LITHOS_URL, then [lithos] url in $INFLUX_DATA_PATH/influx.toml."
+        ),
+    )
+    p_squatters.add_argument(
+        "--no-require-influx-authored",
+        action="store_true",
+        help=(
+            "skip the safety check that refuses to delete docs that lack "
+            "the 'ingested-by:influx' tag.  Use only after manual review."
+        ),
+    )
+    p_squatters.set_defaults(func=cmd_squatters)
 
     p_cancel = sub.add_parser(
         "cancel",

--- a/scripts/influx-report.py
+++ b/scripts/influx-report.py
@@ -131,17 +131,36 @@ def _print_runs(runs_payload: dict[str, object]) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    # Standardised on ``--env <name>`` to match scripts/influx-diagnose.py.
+    # The legacy positional is preserved as a backwards-compat alias so
+    # existing operator muscle memory (``./scripts/influx-report.py dev``)
+    # keeps working; ``--env`` wins if both are given.
+    parser.add_argument(
+        "--env",
+        dest="env",
+        default="staging",
+        help="environment name matching docker/.env.<name> (default: staging)",
+    )
     parser.add_argument(
         "environment",
         nargs="?",
-        default="dev",
-        help="environment name matching docker/.env.<name>",
+        default=None,
+        help=argparse.SUPPRESS,  # legacy positional alias for --env
     )
     parser.add_argument("--base-url", help="override admin API base URL")
     parser.add_argument("--limit", type=int, default=20)
     args = parser.parse_args()
 
-    env_path = _repo_root() / "docker" / f".env.{args.environment}"
+    # ``--env`` wins when explicitly set; otherwise honour the legacy
+    # positional.  We can't directly tell whether ``--env`` was passed
+    # (argparse hides that), so we fall back to the positional only when
+    # ``--env`` still holds the default and a positional was given.
+    environment = (
+        args.environment
+        if args.environment is not None and args.env == "staging"
+        else args.env
+    )
+    env_path = _repo_root() / "docker" / f".env.{environment}"
     if not env_path.exists():
         print(f"Environment file not found: {env_path}", file=sys.stderr)
         return 2
@@ -165,7 +184,7 @@ def main() -> int:
         print(f"Failed to query {base_url}: {exc}", file=sys.stderr)
         return 1
 
-    print(f"Influx Report: {args.environment}")
+    print(f"Influx Report: {environment}")
     print(f"Admin API: {base_url}")
     _print_status(status)
     _print_runs(runs)

--- a/scripts/influx-report.py
+++ b/scripts/influx-report.py
@@ -131,36 +131,16 @@ def _print_runs(runs_payload: dict[str, object]) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    # Standardised on ``--env <name>`` to match scripts/influx-diagnose.py.
-    # The legacy positional is preserved as a backwards-compat alias so
-    # existing operator muscle memory (``./scripts/influx-report.py dev``)
-    # keeps working; ``--env`` wins if both are given.
     parser.add_argument(
         "--env",
-        dest="env",
         default="staging",
         help="environment name matching docker/.env.<name> (default: staging)",
-    )
-    parser.add_argument(
-        "environment",
-        nargs="?",
-        default=None,
-        help=argparse.SUPPRESS,  # legacy positional alias for --env
     )
     parser.add_argument("--base-url", help="override admin API base URL")
     parser.add_argument("--limit", type=int, default=20)
     args = parser.parse_args()
 
-    # ``--env`` wins when explicitly set; otherwise honour the legacy
-    # positional.  We can't directly tell whether ``--env`` was passed
-    # (argparse hides that), so we fall back to the positional only when
-    # ``--env`` still holds the default and a positional was given.
-    environment = (
-        args.environment
-        if args.environment is not None and args.env == "staging"
-        else args.env
-    )
-    env_path = _repo_root() / "docker" / f".env.{environment}"
+    env_path = _repo_root() / "docker" / f".env.{args.env}"
     if not env_path.exists():
         print(f"Environment file not found: {env_path}", file=sys.stderr)
         return 2
@@ -184,7 +164,7 @@ def main() -> int:
         print(f"Failed to query {base_url}: {exc}", file=sys.stderr)
         return 1
 
-    print(f"Influx Report: {environment}")
+    print(f"Influx Report: {args.env}")
     print(f"Admin API: {base_url}")
     _print_status(status)
     _print_runs(runs)

--- a/tests/unit/test_diagnose_squatters.py
+++ b/tests/unit/test_diagnose_squatters.py
@@ -1,0 +1,182 @@
+"""Unit tests for the ``influx-diagnose squatters`` log-scan helper.
+
+The helper is the only piece of the subcommand that does not require
+docker or a live Lithos connection; covering it here means the
+deduplication, regex matching, and first/last-seen aggregation are
+locked down independent of the I/O paths exercised end-to-end during
+operator use.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+
+def _load_script() -> Any:
+    """Load ``scripts/influx-diagnose.py`` as a module for direct testing."""
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "influx_diagnose",
+        repo_root / "scripts" / "influx-diagnose.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_DIAGNOSE = _load_script()
+_extract = _DIAGNOSE._extract_squatters_from_logs
+
+
+def _record(
+    *,
+    timestamp: str,
+    detail: str,
+    source_url: str = "",
+    title: str = "",
+    level: str = "WARNING",
+    status: str = "slug_collision",
+    message: str = "article write skipped",
+) -> dict[str, Any]:
+    return {
+        "timestamp": timestamp,
+        "level": level,
+        "logger": "influx.scheduler",
+        "message": message,
+        "status": status,
+        "detail": detail,
+        "source_url": source_url,
+        "title": title,
+    }
+
+
+class TestExtractSquatters:
+    def test_returns_empty_dict_when_no_warnings(self) -> None:
+        assert _extract([]) == {}
+
+    def test_skips_non_warning_records(self) -> None:
+        records = [
+            _record(
+                timestamp="2026-05-02T06:00:48+00:00",
+                detail=(
+                    "existing_id=006bbcb8-ee01-4616-aa43-473f292eba0e; "
+                    "Slug 'omnirobothome-…-arxiv-260428197' already in use"
+                ),
+                level="INFO",
+            ),
+        ]
+        assert _extract(records) == {}
+
+    def test_extracts_doc_id_and_slug_from_single_warning(self) -> None:
+        records = [
+            _record(
+                timestamp="2026-05-02T06:00:48+00:00",
+                detail=(
+                    "existing_id=006bbcb8-ee01-4616-aa43-473f292eba0e; "
+                    "Slug 'omnirobothome-test-arxiv-260428197' already in use"
+                ),
+                source_url="https://arxiv.org/abs/2604.28197",
+                title="OmniRobotHome: …",
+            ),
+        ]
+        result = _extract(records)
+        assert list(result.keys()) == ["006bbcb8-ee01-4616-aa43-473f292eba0e"]
+        entry = result["006bbcb8-ee01-4616-aa43-473f292eba0e"]
+        assert entry["slugs"] == ["omnirobothome-test-arxiv-260428197"]
+        assert entry["source_urls"] == {"https://arxiv.org/abs/2604.28197"}
+        assert entry["titles"] == {"OmniRobotHome: …"}
+        assert entry["count"] == 1
+
+    def test_dedups_same_doc_id_across_multiple_runs(self) -> None:
+        # Same squatter blocking the same paper across two consecutive runs.
+        records = [
+            _record(
+                timestamp="2026-05-02T00:00:48+00:00",
+                detail=(
+                    "existing_id=006bbcb8-ee01-4616-aa43-473f292eba0e; "
+                    "Slug 'omnirobothome' already in use"
+                ),
+                source_url="https://arxiv.org/abs/2604.28197",
+                title="OmniRobotHome",
+            ),
+            _record(
+                timestamp="2026-05-02T06:00:48+00:00",
+                detail=(
+                    "existing_id=006bbcb8-ee01-4616-aa43-473f292eba0e; "
+                    "Slug 'omnirobothome' already in use"
+                ),
+                source_url="https://arxiv.org/abs/2604.28197",
+                title="OmniRobotHome",
+            ),
+        ]
+        result = _extract(records)
+        assert len(result) == 1
+        entry = result["006bbcb8-ee01-4616-aa43-473f292eba0e"]
+        assert entry["count"] == 2
+        assert entry["first_seen"] == "2026-05-02T00:00:48+00:00"
+        assert entry["last_seen"] == "2026-05-02T06:00:48+00:00"
+
+    def test_handles_multiple_distinct_squatters(self) -> None:
+        records = [
+            _record(
+                timestamp="2026-05-02T06:00:48+00:00",
+                detail=(
+                    "existing_id=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa; "
+                    "Slug 'paper-a' already in use"
+                ),
+            ),
+            _record(
+                timestamp="2026-05-02T06:00:49+00:00",
+                detail=(
+                    "existing_id=bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb; "
+                    "Slug 'paper-b' already in use"
+                ),
+            ),
+        ]
+        result = _extract(records)
+        assert set(result.keys()) == {
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        }
+
+    def test_handles_double_squatter_detail_after_issue_32(self) -> None:
+        """Forward-compat: when #32 lands and a single WARNING enumerates
+        both the unsuffixed and suffix-retry squatters, both ids must be
+        captured from one record.
+        """
+        records = [
+            _record(
+                timestamp="2026-05-02T06:00:48+00:00",
+                detail=(
+                    "first_existing_id=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa; "
+                    "Slug 'omnirobothome' already in use; "
+                    "retry_existing_id=bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb; "
+                    "Slug 'omnirobothome-arxiv-260428197' already in use"
+                ),
+            ),
+        ]
+        result = _extract(records)
+        assert len(result) == 2
+        a = result["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]
+        b = result["bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"]
+        assert a["slugs"] == ["omnirobothome"]
+        assert b["slugs"] == ["omnirobothome-arxiv-260428197"]
+
+    def test_falls_back_to_message_when_detail_absent(self) -> None:
+        # Records without a ``detail`` extra still surface squatters
+        # if the message itself contains the diagnostic.  Robustness
+        # against future log-shape tweaks.
+        rec = _record(
+            timestamp="2026-05-02T06:00:48+00:00",
+            detail="",
+            message=(
+                "slug_collision: existing_id=cccccccc-cccc-cccc-cccc-cccccccccccc; "
+                "Slug 'paper-c' already in use"
+            ),
+        )
+        rec.pop("detail")
+        result = _extract([rec])
+        assert "cccccccc-cccc-cccc-cccc-cccccccccccc" in result


### PR DESCRIPTION
## Summary

Two related changes to ``scripts/`` motivated by the 2026-05-02 staging incident where arXiv paper ``2604.28197`` (``OmniRobotHome…``) keeps getting silently dropped on every sweep because two existing Lithos notes squat both the unsuffixed and the suffix-retry slugs.

### 1. New ``squatters`` subcommand on ``influx-diagnose.py``

Default mode is a pure log scan (no Lithos connection): walks ``docker logs`` for influx-staging slug_collision WARNINGs (per #30's enriched ``detail`` field), parses out the squatting doc id and slug, deduplicates across runs, and prints first/last/total seen counts plus the colliding ``source_url`` + ``title``.

```
$ ./scripts/influx-diagnose.py squatters --since 24h
1 squatter(s) found in container 'influx-staging' (window: --since 24h --tail 50000):

SQUATTER doc_id=006bbcb8-ee01-4616-aa43-473f292eba0e
   slug='omnirobothome-…-arxiv-260428197'
   seen 1x  first=2026-05-02T06:00:48+00:00  last=2026-05-02T06:00:48+00:00
   colliding source_url=https://arxiv.org/abs/2604.28197
   colliding title='OmniRobotHome: A Multi-Camera Platform for …'
```

``--apply`` enables deletion via ``lithos_delete``, gated by:

* ``--yes <doc-id>`` per-id confirmation (repeatable), **or**
* ``--yes-to-all`` for bulk cleanup (use with care).

Pre-delete safety: each candidate is fetched via ``lithos_read`` and refused unless its tags carry ``ingested-by:influx``.  Override with ``--no-require-influx-authored`` after manual review.

The squatter regex tolerates today's bare ``existing_id=<uuid>`` shape **and** the forward-compat ``*_existing_id=<uuid>`` shape that #32 will introduce when both colliding slugs are surfaced together.

### 2. ``--env <name>`` parity across both scripts

Per operator confirmation that back-compat cruft is unwanted, ``influx-report.py`` is converged onto ``--env <name>`` to match ``influx-diagnose.py``.  No positional alias.  Both scripts now default to ``staging``.

Before:
```bash
./scripts/influx-report.py staging --limit 10            # positional, default=dev
./scripts/influx-diagnose.py --env staging recent        # flag,       default=staging
```

After:
```bash
./scripts/influx-report.py   --env staging --limit 10
./scripts/influx-diagnose.py --env staging recent
```

## Why

* The current behaviour silently drops new papers whenever both slug variants are squatted, with no recovery and no operator-actionable backlog (issue #31).  Until #31's self-healing repair-tag path ships, operators need a fast, safe cleanup loop — that is what this script gives.
* Cross-script env-arg inconsistency was a small papercut that operators (the maintainer, currently the only user) had to remember.

## Test plan

- [x] ``uv run pytest tests/unit/test_diagnose_squatters.py`` — 7/7 pass (new file; covers regex, dedup, multi-squatter aggregation, and the forward-compat #32 detail shape).
- [x] ``uv run pytest`` (full suite) — 1507/1507 pass.
- [x] ``uv run ruff check`` and ``ruff format --check`` clean across ``src/``, ``tests/``, and ``scripts/``.
- [x] **Live read-only smoke against staging**: ``./scripts/influx-diagnose.py squatters --since 24h`` correctly identified ``006bbcb8-ee01-4616-aa43-473f292eba0e`` as the squatter for the OmniRobotHome paper.
- [x] CLI smoke for ``influx-report.py``: ``--env staging``, ``--env dev``, default ``--env staging``, and rejection of stray positional arg all behave correctly.

## Refs

* #31 — planned self-healing repair-tag path; this script is the manual-cleanup bridge until that ships.
* #32 — surface both colliding slugs in a single WARNING; the regex here is forward-compatible so the script needs no change when #32 lands.
* PR #30 — enriched ``detail`` field that this script depends on (already merged).