### PR TITLE
fix(diagnose): translate Nd day units in --since for docker logs

### DIFF
--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -154,6 +154,26 @@ def _have_docker() -> bool:
     return shutil.which("docker") is not None
 
 
+_SINCE_DAYS_RE = re.compile(r"^\s*(\d+)\s*d\s*$", re.IGNORECASE)
+
+
+def _normalise_since(since: str | None) -> str | None:
+    """Translate ``Nd`` (days) into ``(N*24)h`` for ``docker logs --since``.
+
+    Docker's duration parser only understands Go's ``time.ParseDuration``
+    units (``s``/``m``/``h``), so a friendly ``--since 7d`` produces
+    ``invalid value for "since"``.  We translate at the boundary so the
+    operator-facing CLI can keep using day units.  Mixed-unit strings
+    (``2d12h``) are out of scope; pass them as ``60h`` directly.
+    """
+    if not since:
+        return since
+    m = _SINCE_DAYS_RE.match(since)
+    if not m:
+        return since
+    return f"{int(m.group(1)) * 24}h"
+
+
 def _docker_logs_iter(
     container: str,
     *,
@@ -169,6 +189,7 @@ def _docker_logs_iter(
     if not _have_docker():
         sys.exit("'docker' not on PATH; cannot read container logs")
     cmd = ["docker", "logs"]
+    since = _normalise_since(since)
     if since:
         cmd += ["--since", since]
     if tail is not None:

--- a/tests/unit/test_diagnose_squatters.py
+++ b/tests/unit/test_diagnose_squatters.py
@@ -29,6 +29,33 @@ def _load_script() -> Any:
 
 _DIAGNOSE = _load_script()
 _extract = _DIAGNOSE._extract_squatters_from_logs
+_normalise_since = _DIAGNOSE._normalise_since
+
+
+class TestNormaliseSince:
+    """Docker rejects day units in ``--since``; we translate at the boundary."""
+
+    def test_days_translated_to_hours(self) -> None:
+        assert _normalise_since("7d") == "168h"
+        assert _normalise_since("1d") == "24h"
+        assert _normalise_since("30d") == "720h"
+
+    def test_passes_through_native_docker_units(self) -> None:
+        assert _normalise_since("24h") == "24h"
+        assert _normalise_since("90m") == "90m"
+        assert _normalise_since("45s") == "45s"
+
+    def test_passes_through_absolute_timestamp(self) -> None:
+        # docker accepts RFC3339 / unix-epoch timestamps too — leave alone.
+        assert _normalise_since("2026-04-25T00:00:00") == "2026-04-25T00:00:00"
+
+    def test_handles_none_and_empty(self) -> None:
+        assert _normalise_since(None) is None
+        assert _normalise_since("") == ""
+
+    def test_tolerates_whitespace_and_case(self) -> None:
+        assert _normalise_since(" 7d ") == "168h"
+        assert _normalise_since("7D") == "168h"
 
 
 def _record(


### PR DESCRIPTION
## Summary

Reported live: ``./scripts/influx-diagnose.py --env staging squatters`` failed with

```
docker logs failed (exit=1):
  invalid value for "since": failed to parse value as time or duration: "7d"
```

Docker's ``--since`` parser only understands Go ``time.ParseDuration`` units (``s`` / ``m`` / ``h``), so the operator-friendly ``--since 7d`` (the default for both ``squatters`` and ``terminal-flips``) was rejected.

This PR adds a one-line translator at the docker boundary that converts ``Nd`` → ``(N*24)h`` so the CLI keeps using day units. ``Nh`` / ``Nm`` / ``Ns`` and RFC3339 timestamps pass through untouched.

Also fixes the latent equivalent in the pre-existing ``terminal-flips`` subcommand, which has carried a broken ``--since 7d`` default since #27 — it just hadn't been exercised against day units yet.

## Test plan

- [x] ``uv run pytest tests/unit/test_diagnose_squatters.py`` — 12 pass (5 new ``TestNormaliseSince`` cases: day → hours, native units pass-through, RFC3339 pass-through, None / empty handling, whitespace + case tolerance).
- [x] ``uv run ruff check`` and ``ruff format --check`` clean across ``scripts/``, ``src/``, ``tests/``.
- [x] **Live verification** against staging: ``./scripts/influx-diagnose.py --env staging squatters --since 7d --tail 5000`` now executes cleanly (returns ""no squatters"" because the influx-staging container had been restarted minutes earlier and the previous WARNING was lost from the buffer — separate issue tracked in #34).

## Refs

- Reported during 2026-05-02 staging session.
- PR #33 — original ``squatters`` subcommand.
- #34 — follow-up for ``--id <doc-id>`` to clean known squatters without depending on the log buffer.