### PR TITLE
ci: lint and format-check scripts/ alongside src/ and tests/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ install:
 	uv sync
 
 fmt:
-	uv run ruff format src/ tests/
+	uv run ruff format src/ tests/ scripts/
 
 lint:
-	uv run ruff check src/ tests/
-	uv run ruff format --check src/ tests/
+	uv run ruff check src/ tests/ scripts/
+	uv run ruff format --check src/ tests/ scripts/
 
 typecheck:
 	uv run pyright


### PR DESCRIPTION
## Summary

``make lint`` and ``make fmt`` only walked ``src/`` and ``tests/``.  That gap is exactly how the broken ``--since 7d`` default in ``influx-diagnose.py`` shipped:

* Ruff would have rejected the existing ``yield`` over a ``for`` loop in ``_docker_logs_iter`` (``UP028``).
* The operator script went un-linted otherwise — including any new code added under PRs #27 / #33 / #35.

This PR adds ``scripts/`` to both targets:

```diff
 fmt:
-	uv run ruff format src/ tests/
+	uv run ruff format src/ tests/ scripts/

 lint:
-	uv run ruff check src/ tests/
-	uv run ruff format --check src/ tests/
+	uv run ruff check src/ tests/ scripts/
+	uv run ruff format --check src/ tests/ scripts/
```

Pyright already covers the whole project (``[tool.pyright]`` carries no include / exclude restriction), so no typecheck change is needed; ``make typecheck`` already exercises ``scripts/``.

## Test plan

- [x] ``make lint`` clean against the expanded surface.
- [x] ``make typecheck`` clean (already covered).
- [x] Both ``influx-diagnose.py`` and ``influx-report.py`` pass ``ruff check`` + ``ruff format --check`` under the new gate.

## Why now

Operator confirmed (this session) that back-compat cruft is unwanted and that script bugs hurt the only operator running them.  Closing the CI gap stops new bugs of the ``--since 7d`` shape from shipping unobserved.