### PR TITLE
fix(diagnose): make squatters --apply usable end-to-end from the host

### DIFF
--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -571,6 +571,32 @@ def _read_lithos_url(args: argparse.Namespace, env: dict[str, str]) -> str:
     )
 
 
+def _summarise_doc_for_refusal(doc: dict[str, Any]) -> str:
+    """Concise one-line preview of a Lithos doc for the safety-check refusal.
+
+    The operator needs four signals to triage a non-Influx-authored
+    squatter without a separate ``lithos_read`` round trip: the
+    title, the source URL (if any), the ingester / author tag, and
+    the full tag list.  Render those compactly on a single message.
+    """
+    title = str(doc.get("title") or "(no title)")[:80]
+    source_url = str(doc.get("source_url") or "")
+    tags = list(doc.get("tags") or [])
+    author = str(doc.get("author") or "")
+    ingester = next(
+        (t.split(":", 1)[1] for t in tags if t.startswith("ingested-by:")),
+        "(no ingested-by tag)",
+    )
+    parts = [
+        f"title={title!r}",
+        f"author={author!r}" if author else None,
+        f"ingested_by={ingester}",
+        f"source_url={source_url}" if source_url else None,
+        f"tags={tags}",
+    ]
+    return " ".join(p for p in parts if p)
+
+
 def _format_exception_chain(exc: BaseException) -> str:
     """Render an exception (and its causes / sub-exceptions) compactly.
 
@@ -679,11 +705,18 @@ async def _delete_squatter(
 
         tags = list(doc.get("tags") or [])
         if require_influx_authored and "ingested-by:influx" not in tags:
+            # Surface enough of the doc to let the operator decide
+            # whether the squatter is an old Influx note that just lost
+            # its tag (safe to delete after manual review) or a genuine
+            # user/other-agent note (must NOT be deleted).
+            preview = _summarise_doc_for_refusal(doc)
             return (
                 False,
                 "refused: doc is not influx-authored "
-                "(missing 'ingested-by:influx' tag); "
-                "pass --no-require-influx-authored to override",
+                "(missing 'ingested-by:influx' tag).  "
+                f"Preview: {preview}  "
+                "If safe to delete after review, re-run with "
+                "--no-require-influx-authored.",
             )
 
         try:

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -680,19 +680,38 @@ def _ensure_project_runtime_or_reexec() -> None:
     )
 
 
+# Outcomes for ``_delete_squatter``.  Distinguishing ``already_gone``
+# from ``refused`` matters: a doc that vanished between scan and delete
+# (e.g. cleaned up by a parallel run, or by the operator outside this
+# script) is effectively the success state for our caller, not a fault
+# requiring intervention.
+DELETE_OK = "deleted"
+DELETE_ALREADY_GONE = "already_gone"
+DELETE_REFUSED = "refused"
+
+
+def _is_doc_not_found(message: str) -> bool:
+    """Match Lithos's ``doc_not_found`` shapes from delete + read paths."""
+    if not message:
+        return False
+    needle = message.lower()
+    return "document not found" in needle or "doc_not_found" in needle
+
+
 async def _delete_squatter(
     *,
     lithos_url: str,
     doc_id: str,
     agent: str,
     require_influx_authored: bool,
-) -> tuple[bool, str]:
-    """Read-then-delete one squatter.  Returns ``(deleted, reason)``.
+) -> tuple[str, str]:
+    """Read-then-delete one squatter.
 
-    Caller is responsible for invoking
-    :func:`_ensure_project_runtime_or_reexec` before calling this — see
-    ``cmd_squatters``.  We don't re-check here because the import would
-    have already succeeded (or re-execed) at that point.
+    Returns ``(outcome, reason)`` where ``outcome`` is one of
+    :data:`DELETE_OK`, :data:`DELETE_ALREADY_GONE`, or
+    :data:`DELETE_REFUSED`.  The caller is responsible for invoking
+    :func:`_ensure_project_runtime_or_reexec` first — see
+    ``cmd_squatters``.
     """
     from influx.lithos_client import LithosClient
 
@@ -701,7 +720,13 @@ async def _delete_squatter(
         try:
             doc = await client.read_note(note_id=doc_id)
         except BaseException as exc:  # noqa: BLE001
-            return False, f"read failed: {_format_exception_chain(exc)}"
+            chain = _format_exception_chain(exc)
+            if _is_doc_not_found(chain):
+                # The doc vanished before we could even read it — most
+                # likely a parallel cleanup or out-of-band delete.
+                # Effective success for our caller.
+                return DELETE_ALREADY_GONE, "doc not found at read time"
+            return DELETE_REFUSED, f"read failed: {chain}"
 
         tags = list(doc.get("tags") or [])
         if require_influx_authored and "ingested-by:influx" not in tags:
@@ -711,8 +736,8 @@ async def _delete_squatter(
             # user/other-agent note (must NOT be deleted).
             preview = _summarise_doc_for_refusal(doc)
             return (
-                False,
-                "refused: doc is not influx-authored "
+                DELETE_REFUSED,
+                "doc is not influx-authored "
                 "(missing 'ingested-by:influx' tag).  "
                 f"Preview: {preview}  "
                 "If safe to delete after review, re-run with "
@@ -725,18 +750,24 @@ async def _delete_squatter(
                 {"id": doc_id, "agent": agent},
             )
         except BaseException as exc:  # noqa: BLE001
-            return False, f"delete failed: {_format_exception_chain(exc)}"
+            return DELETE_REFUSED, f"delete failed: {_format_exception_chain(exc)}"
 
-        # Lithos returns either the bare success envelope or an error
-        # envelope with ``status="error"``; surface either back to the
-        # caller for printing.
+        # Lithos returns either a success envelope or an error envelope
+        # with ``status="error"`` (and ``code`` / ``message``).  The
+        # ``doc_not_found`` shape happens when the read succeeded but
+        # the doc was deleted between the read and the delete — treat
+        # that as ``already_gone`` rather than ``refused``.
         try:
             body = json.loads(result.content[0].text)  # type: ignore[union-attr]
         except (AttributeError, IndexError, TypeError, json.JSONDecodeError):
             body = {"status": "deleted"}
         if body.get("status") == "error":
-            return False, f"lithos_delete error: {body.get('message', body)}"
-        return True, "deleted"
+            code = body.get("code", "")
+            message = body.get("message", body)
+            if code == "doc_not_found" or _is_doc_not_found(str(message)):
+                return DELETE_ALREADY_GONE, "doc not found at delete time"
+            return DELETE_REFUSED, f"lithos_delete error: {message}"
+        return DELETE_OK, "deleted"
     finally:
         await client.close()
 
@@ -817,9 +848,10 @@ def cmd_squatters(args: argparse.Namespace) -> int:
     import asyncio
 
     deleted = 0
+    already_gone = 0
     refused = 0
     for doc_id in sorted(confirmed):
-        deleted_ok, reason = asyncio.run(
+        outcome, reason = asyncio.run(
             _delete_squatter(
                 lithos_url=lithos_url,
                 doc_id=doc_id,
@@ -827,15 +859,28 @@ def cmd_squatters(args: argparse.Namespace) -> int:
                 require_influx_authored=not args.no_require_influx_authored,
             )
         )
-        if deleted_ok:
-            print(f"DELETED  doc_id={doc_id}  ({reason})")
+        if outcome == DELETE_OK:
+            print(f"DELETED      doc_id={doc_id}  ({reason})")
             deleted += 1
+        elif outcome == DELETE_ALREADY_GONE:
+            # Effective success — the squatter is no longer in Lithos.
+            # Logged separately so a parallel cleanup is observable.
+            print(f"ALREADY GONE doc_id={doc_id}  ({reason})")
+            already_gone += 1
         else:
-            print(f"REFUSED  doc_id={doc_id}  reason={reason}")
+            print(f"REFUSED      doc_id={doc_id}  reason={reason}")
             refused += 1
 
     print()
-    print(f"Summary: deleted={deleted} refused={refused}")
+    print(f"Summary: deleted={deleted} already_gone={already_gone} refused={refused}")
+    if already_gone:
+        print(
+            "Note: 'already gone' squatters are still surfacing because the "
+            "log scan reads historical WARNINGs from the docker buffer; the "
+            "doc itself has been removed from Lithos.  The next sweep will "
+            "either succeed cleanly or surface a fresh squatter."
+        )
+    # Exit non-zero only on genuine refusals; ``already_gone`` is success.
     return 0 if refused == 0 else 1
 
 

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -537,6 +538,56 @@ def _read_lithos_url(args: argparse.Namespace, env: dict[str, str]) -> str:
     )
 
 
+def _ensure_project_runtime_or_reexec() -> None:
+    """Re-exec the script under ``uv run`` if project deps are missing.
+
+    The script is operator-facing and meant to be invoked as
+    ``./scripts/influx-diagnose.py …`` rather than
+    ``uv run scripts/influx-diagnose.py …``.  Read-only subcommands do
+    not import any project module, so the bare invocation works under
+    the system Python.  ``squatters --apply`` does need
+    ``influx.lithos_client``, which transitively pulls in ``mcp`` from
+    the project venv.
+
+    Detect the gap by attempting an import inside this current
+    interpreter.  If it fails, ``os.execvp`` ourselves under
+    ``uv run`` so the operator's argv reaches the venv-backed
+    interpreter unchanged.  No-op when the imports already succeed
+    (``uv run …`` invocation, or ``PYTHONPATH`` already set).
+    """
+    src_path = str(_repo_root() / "src")
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
+    try:
+        import influx.lithos_client  # noqa: F401
+
+        return  # already runnable
+    except ImportError:
+        pass
+
+    if not shutil.which("uv"):
+        sys.exit(
+            "Project dependencies are not importable and 'uv' is not on "
+            "PATH.  Install uv (https://docs.astral.sh/uv/) or run the "
+            f"script as: uv run {sys.argv[0]} {' '.join(sys.argv[1:])}"
+        )
+
+    if os.environ.get("INFLUX_DIAGNOSE_REEXECED") == "1":
+        # Defensive: avoid an infinite re-exec loop if uv run somehow
+        # still produces an environment without the project deps.
+        sys.exit(
+            "uv run did not provide importable project dependencies.  "
+            "Check that this directory contains a valid pyproject.toml + "
+            "uv.lock and that 'uv sync' has been run."
+        )
+
+    os.environ["INFLUX_DIAGNOSE_REEXECED"] = "1"
+    os.execvp(
+        "uv",
+        ["uv", "run", "--project", str(_repo_root()), sys.argv[0], *sys.argv[1:]],
+    )
+
+
 async def _delete_squatter(
     *,
     lithos_url: str,
@@ -544,8 +595,13 @@ async def _delete_squatter(
     agent: str,
     require_influx_authored: bool,
 ) -> tuple[bool, str]:
-    """Read-then-delete one squatter.  Returns ``(deleted, reason)``."""
-    # Imported lazily so the read-only invocation never pays the cost.
+    """Read-then-delete one squatter.  Returns ``(deleted, reason)``.
+
+    Caller is responsible for invoking
+    :func:`_ensure_project_runtime_or_reexec` before calling this — see
+    ``cmd_squatters``.  We don't re-check here because the import would
+    have already succeeded (or re-execed) at that point.
+    """
     from influx.lithos_client import LithosClient
 
     client = LithosClient(url=lithos_url)
@@ -629,6 +685,12 @@ def cmd_squatters(args: argparse.Namespace) -> int:
             "ensure it carries 'ingested-by:influx' before deletion."
         )
         return 0
+
+    # ``--apply`` needs the project deps (LithosClient → mcp).  Re-exec
+    # under ``uv run`` if we are not already in the project venv so the
+    # operator can keep using the bare ``./scripts/influx-diagnose.py``
+    # invocation without thinking about the runtime.
+    _ensure_project_runtime_or_reexec()
 
     confirmed: set[str] = set(args.yes or [])
     if args.yes_to_all:

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -505,20 +505,46 @@ def _print_squatter(entry: dict[str, Any]) -> None:
         print(f"   colliding title={title!r}")
 
 
+def _running_inside_docker() -> bool:
+    """Detect whether we're inside a docker container.
+
+    The ``[lithos] url`` in ``influx.toml`` resolves
+    ``host.docker.internal`` to the docker host from inside the influx
+    container, but that hostname is not resolvable on the host.  When
+    the script is invoked from the host we have to swap in the
+    loopback address that the docker port mapping exposes.
+    """
+    return Path("/.dockerenv").exists()
+
+
+def _rewrite_url_for_host(url: str) -> str:
+    """Substitute ``host.docker.internal`` → ``127.0.0.1`` when on the host.
+
+    Operator-friendly default: the staging / dev influx.toml stores the
+    URL the **container** uses (``host.docker.internal:<port>``), so the
+    bare diagnose script invoked from the host would otherwise fail with
+    a DNS error.  Pass ``--lithos-url`` to override this rewrite.
+    """
+    if _running_inside_docker():
+        return url
+    if "host.docker.internal" not in url:
+        return url
+    return url.replace("host.docker.internal", "127.0.0.1")
+
+
 def _read_lithos_url(args: argparse.Namespace, env: dict[str, str]) -> str:
     """Resolve the Lithos MCP/SSE URL for ``--apply`` mode.
 
     Resolution order:
-      1. ``--lithos-url`` CLI flag (explicit override).
-      2. ``LITHOS_URL`` env var on the host.
-      3. ``[lithos] url`` in ``${INFLUX_DATA_PATH}/influx.toml``.
+      1. ``--lithos-url`` CLI flag (explicit override; never rewritten).
+      2. ``LITHOS_URL`` env var on the host (rewritten if needed).
+      3. ``[lithos] url`` in ``${INFLUX_DATA_PATH}/influx.toml``
+         (rewritten if needed — see :func:`_rewrite_url_for_host`).
     """
     if getattr(args, "lithos_url", None):
         return str(args.lithos_url)
-    import os
-
     if "LITHOS_URL" in os.environ:
-        return os.environ["LITHOS_URL"]
+        return _rewrite_url_for_host(os.environ["LITHOS_URL"])
     data_path = env.get("INFLUX_DATA_PATH")
     if data_path:
         toml_path = Path(data_path) / "influx.toml"
@@ -531,11 +557,51 @@ def _read_lithos_url(args: argparse.Namespace, env: dict[str, str]) -> str:
                 cfg = tomllib.load(fh)
             url = cfg.get("lithos", {}).get("url")
             if isinstance(url, str) and url:
-                return url
+                rewritten = _rewrite_url_for_host(url)
+                if rewritten != url:
+                    print(
+                        f"note: rewrote container-only host "
+                        f"{url!r} -> {rewritten!r} for host invocation; "
+                        "pass --lithos-url to override"
+                    )
+                return rewritten
     sys.exit(
         "Lithos URL not resolved.  Pass --lithos-url, set $LITHOS_URL, "
         "or ensure [lithos] url is set in $INFLUX_DATA_PATH/influx.toml."
     )
+
+
+def _format_exception_chain(exc: BaseException) -> str:
+    """Render an exception (and its causes / sub-exceptions) compactly.
+
+    The MCP client uses ``anyio`` task groups under the hood, so a
+    transport-level failure surfaces as
+    ``ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)``
+    by default — the actual diagnostic (DNS error, connection refused)
+    lives inside ``exc.exceptions[0]``.  Walk the chain and surface
+    every distinct ``type(exc).__name__: <str>`` so the operator can
+    diagnose without re-running with ``--verbose``.
+    """
+    seen: list[str] = []
+
+    def _walk(e: BaseException) -> None:
+        rendered = f"{type(e).__name__}: {e}"
+        if rendered not in seen:
+            seen.append(rendered)
+        # ExceptionGroup (PEP 654) carries siblings on .exceptions
+        sub = getattr(e, "exceptions", None)
+        if isinstance(sub, (list, tuple)):
+            for child in sub:
+                if isinstance(child, BaseException):
+                    _walk(child)
+        # Regular cause / context chain
+        for nxt in (e.__cause__, e.__context__):
+            if isinstance(nxt, BaseException):
+                _walk(nxt)
+
+    _walk(exc)
+    # Cap the rendered chain so a deep cause stack stays readable.
+    return " | ".join(seen[:6])
 
 
 def _ensure_project_runtime_or_reexec() -> None:
@@ -608,8 +674,8 @@ async def _delete_squatter(
     try:
         try:
             doc = await client.read_note(note_id=doc_id)
-        except Exception as exc:  # noqa: BLE001
-            return False, f"read failed: {type(exc).__name__}: {exc}"
+        except BaseException as exc:  # noqa: BLE001
+            return False, f"read failed: {_format_exception_chain(exc)}"
 
         tags = list(doc.get("tags") or [])
         if require_influx_authored and "ingested-by:influx" not in tags:
@@ -625,8 +691,8 @@ async def _delete_squatter(
                 "lithos_delete",
                 {"id": doc_id, "agent": agent},
             )
-        except Exception as exc:  # noqa: BLE001
-            return False, f"delete failed: {type(exc).__name__}: {exc}"
+        except BaseException as exc:  # noqa: BLE001
+            return False, f"delete failed: {_format_exception_chain(exc)}"
 
         # Lithos returns either the bare success envelope or an error
         # envelope with ``status="error"``; surface either back to the

--- a/tests/unit/test_diagnose_squatters.py
+++ b/tests/unit/test_diagnose_squatters.py
@@ -197,6 +197,40 @@ class TestFormatExceptionChain:
         assert "(no title)" in rendered
         assert "(no ingested-by tag)" in rendered
 
+
+class TestIsDocNotFound:
+    """Match Lithos's ``doc_not_found`` message variants."""
+
+    def test_matches_lithos_message(self) -> None:
+        assert _DIAGNOSE._is_doc_not_found(
+            "Document not found: 006bbcb8-ee01-4616-aa43-473f292eba0e"
+        )
+
+    def test_matches_envelope_code(self) -> None:
+        assert _DIAGNOSE._is_doc_not_found("error code=doc_not_found")
+
+    def test_negative_cases(self) -> None:
+        assert not _DIAGNOSE._is_doc_not_found("")
+        assert not _DIAGNOSE._is_doc_not_found("connection refused")
+        assert not _DIAGNOSE._is_doc_not_found("authentication failed")
+
+
+class TestDeleteOutcomes:
+    """The three outcome constants are stable and distinct."""
+
+    def test_outcome_constants_distinct(self) -> None:
+        outcomes = {
+            _DIAGNOSE.DELETE_OK,
+            _DIAGNOSE.DELETE_ALREADY_GONE,
+            _DIAGNOSE.DELETE_REFUSED,
+        }
+        # Three distinct string values; no accidental aliasing.
+        assert len(outcomes) == 3
+        # Operator-facing labels — guard the wire format.
+        assert _DIAGNOSE.DELETE_OK == "deleted"
+        assert _DIAGNOSE.DELETE_ALREADY_GONE == "already_gone"
+        assert _DIAGNOSE.DELETE_REFUSED == "refused"
+
     def test_caps_long_chains(self) -> None:
         # Ten nested causes — output must stay readable.
         excs: list[BaseException] = [ValueError(f"layer-{i}") for i in range(10)]

--- a/tests/unit/test_diagnose_squatters.py
+++ b/tests/unit/test_diagnose_squatters.py
@@ -179,6 +179,24 @@ class TestFormatExceptionChain:
         assert "RuntimeError: transport setup failed" in rendered
         assert "OSError: dns lookup failed: host.docker.internal" in rendered
 
+    def test_summarise_doc_for_refusal_renders_useful_signals(self) -> None:
+        doc = {
+            "title": "OmniRobotHome: A Multi-Camera Platform",
+            "source_url": "https://arxiv.org/abs/2604.28197",
+            "author": "operator@example.com",
+            "tags": ["profile:staging-robotics", "source:arxiv", "ingested-by:loom"],
+        }
+        rendered = _DIAGNOSE._summarise_doc_for_refusal(doc)
+        assert "OmniRobotHome" in rendered
+        assert "operator@example.com" in rendered
+        assert "ingested_by=loom" in rendered
+        assert "https://arxiv.org/abs/2604.28197" in rendered
+
+    def test_summarise_doc_for_refusal_handles_missing_fields(self) -> None:
+        rendered = _DIAGNOSE._summarise_doc_for_refusal({})
+        assert "(no title)" in rendered
+        assert "(no ingested-by tag)" in rendered
+
     def test_caps_long_chains(self) -> None:
         # Ten nested causes — output must stay readable.
         excs: list[BaseException] = [ValueError(f"layer-{i}") for i in range(10)]

--- a/tests/unit/test_diagnose_squatters.py
+++ b/tests/unit/test_diagnose_squatters.py
@@ -115,6 +115,80 @@ class TestDirectInvocationImports:
         from influx.lithos_client import LithosClient  # noqa: F401
 
 
+class TestRewriteUrlForHost:
+    """``host.docker.internal`` is unresolvable from the host."""
+
+    def test_rewrites_host_docker_internal_when_not_in_docker(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.setattr(_DIAGNOSE, "_running_inside_docker", lambda: False)
+        assert (
+            _DIAGNOSE._rewrite_url_for_host("http://host.docker.internal:8766/sse")
+            == "http://127.0.0.1:8766/sse"
+        )
+
+    def test_no_rewrite_when_inside_docker(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(_DIAGNOSE, "_running_inside_docker", lambda: True)
+        assert (
+            _DIAGNOSE._rewrite_url_for_host("http://host.docker.internal:8766/sse")
+            == "http://host.docker.internal:8766/sse"
+        )
+
+    def test_no_rewrite_for_unrelated_urls(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(_DIAGNOSE, "_running_inside_docker", lambda: False)
+        assert (
+            _DIAGNOSE._rewrite_url_for_host("http://lithos.internal:8765/sse")
+            == "http://lithos.internal:8765/sse"
+        )
+        assert (
+            _DIAGNOSE._rewrite_url_for_host("http://127.0.0.1:8766/sse")
+            == "http://127.0.0.1:8766/sse"
+        )
+
+
+class TestFormatExceptionChain:
+    """Anyio TaskGroup exceptions hide the actual cause; we unwrap them."""
+
+    def test_plain_exception(self) -> None:
+        try:
+            raise ValueError("nope")
+        except ValueError as exc:
+            rendered = _DIAGNOSE._format_exception_chain(exc)
+        assert rendered == "ValueError: nope"
+
+    def test_unwraps_exception_group(self) -> None:
+        # Mimic the anyio TaskGroup wrap shape:
+        #   ExceptionGroup(..., [ConnectionRefusedError(...), ...])
+        cause = ConnectionRefusedError("connect failed: 111")
+        group = BaseExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [cause],
+        )
+        rendered = _DIAGNOSE._format_exception_chain(group)
+        assert "ConnectionRefusedError" in rendered
+        assert "connect failed: 111" in rendered
+
+    def test_unwraps_chained_cause(self) -> None:
+        try:
+            try:
+                raise OSError("dns lookup failed: host.docker.internal")
+            except OSError as inner:
+                raise RuntimeError("transport setup failed") from inner
+        except RuntimeError as exc:
+            rendered = _DIAGNOSE._format_exception_chain(exc)
+        assert "RuntimeError: transport setup failed" in rendered
+        assert "OSError: dns lookup failed: host.docker.internal" in rendered
+
+    def test_caps_long_chains(self) -> None:
+        # Ten nested causes — output must stay readable.
+        excs: list[BaseException] = [ValueError(f"layer-{i}") for i in range(10)]
+        for i in range(1, len(excs)):
+            excs[i].__cause__ = excs[i - 1]
+        rendered = _DIAGNOSE._format_exception_chain(excs[-1])
+        # Capped at 6 distinct entries by ``_format_exception_chain``.
+        assert rendered.count("|") <= 5
+
+
 def _record(
     *,
     timestamp: str,

--- a/tests/unit/test_diagnose_squatters.py
+++ b/tests/unit/test_diagnose_squatters.py
@@ -58,6 +58,63 @@ class TestNormaliseSince:
         assert _normalise_since("7D") == "168h"
 
 
+class TestDirectInvocationImports:
+    """``./scripts/influx-diagnose.py --apply`` must work without uv run.
+
+    The squatter delete path imports ``influx.lithos_client``, which
+    transitively pulls in ``mcp`` from the project venv.  When the
+    script is invoked as ``./scripts/influx-diagnose.py …`` (system
+    Python, no venv on sys.path), neither symbol is importable.
+
+    ``_ensure_project_runtime_or_reexec`` detects the gap and
+    ``os.execvp``-replaces this process under ``uv run`` so the
+    operator's argv reaches the venv-backed interpreter unchanged.
+    These tests pin the helper's contract so a future refactor cannot
+    silently regress to the original ``ModuleNotFoundError`` shape that
+    bit the 2026-05-02 incident.
+    """
+
+    def test_helper_exists_and_attempts_import_then_reexec(self) -> None:
+        import inspect
+
+        assert hasattr(_DIAGNOSE, "_ensure_project_runtime_or_reexec")
+        source = inspect.getsource(_DIAGNOSE._ensure_project_runtime_or_reexec)
+        # Must try the import first ...
+        assert "import influx.lithos_client" in source
+        # ... and re-exec via uv run when it fails.
+        assert "os.execvp" in source
+        assert '"uv"' in source and '"run"' in source
+
+    def test_helper_is_called_from_apply_path_in_cmd_squatters(self) -> None:
+        import inspect
+
+        source = inspect.getsource(_DIAGNOSE.cmd_squatters)
+        # The call must live AFTER the read-only return so dry-run
+        # invocations never trigger a ``uv run`` re-exec.
+        assert "_ensure_project_runtime_or_reexec" in source
+        idx_dry_return = source.index("return 0")
+        idx_reexec = source.index("_ensure_project_runtime_or_reexec")
+        assert idx_reexec > idx_dry_return, (
+            "_ensure_project_runtime_or_reexec must be called only on "
+            "the --apply path, not for read-only scans"
+        )
+
+    def test_helper_avoids_infinite_reexec_loop(self) -> None:
+        import inspect
+
+        source = inspect.getsource(_DIAGNOSE._ensure_project_runtime_or_reexec)
+        assert "INFLUX_DIAGNOSE_REEXECED" in source, (
+            "the helper must guard against an infinite re-exec loop "
+            "if uv run somehow yields an environment without the deps"
+        )
+
+    def test_lithos_client_importable_under_uv_run(self) -> None:
+        # Sanity check that the import chain still works under the test
+        # runner (``uv run pytest``).  Catches a future ``src/`` rename
+        # or ``LithosClient`` symbol move that would defeat the re-exec.
+        from influx.lithos_client import LithosClient  # noqa: F401
+
+
 def _record(
     *,
     timestamp: str,


### PR DESCRIPTION
## Summary

Four serially-discovered fixes from a live debugging session against staging.  Each commit fixes a distinct failure mode the operator hit when running

```
./scripts/influx-diagnose.py --env staging squatters --apply --yes-to-all
```

against the actual ``influx-staging`` / ``lithos-staging`` containers.

| # | Commit | Surface symptom |
|---|---|---|
| 1 | ``b39ae5d`` re-exec under ``uv run`` | ``ModuleNotFoundError: No module named 'influx'`` — system Python (from the script's ``#!/usr/bin/env python3`` shebang) does not have the project venv on ``sys.path``. |
| 2 | ``61e7fae`` rewrite host + unwrap ExceptionGroup | ``read failed: ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)`` — the configured ``[lithos] url`` is ``host.docker.internal:8766`` (in-container address); from the host this is unresolvable, and the underlying error was buried inside the anyio TaskGroup. |
| 3 | ``a7373b5`` preview on safety refusal | ``REFUSED  reason=doc is not influx-authored`` — operator had no way to know whether the squatter was a stale Influx remnant (safe) or a genuine user note (must NOT delete) without a separate ``lithos_read``. |
| 4 | ``aeece66`` distinguish ``already_gone`` from ``refused`` | ``REFUSED  reason=lithos_delete error: Document not found`` — the squatter was *successfully* gone (parallel cleanup or prior partial success), but the script labelled it as a fault and exited non-zero. |

After all four, the same operator command now reads:

```
note: rewrote container-only host 'http://host.docker.internal:8766/sse' -> 'http://127.0.0.1:8766/sse' for host invocation; pass --lithos-url to override
Apply mode: deleting 1 squatter(s) via lithos_delete on http://127.0.0.1:8766/sse

ALREADY GONE doc_id=006bbcb8-…  (doc not found at delete time)

Summary: deleted=0 already_gone=1 refused=0
Note: 'already gone' squatters are still surfacing because the log scan
reads historical WARNINGs from the docker buffer; the doc itself has been
removed from Lithos.  The next sweep will either succeed cleanly or
surface a fresh squatter.
```

Exit code 0.  No more spurious failures.  No more buried ExceptionGroup.

## Detail per commit

**1. Re-exec under ``uv run`` (``b39ae5d``)** — new ``_ensure_project_runtime_or_reexec`` attempts the import in the current interpreter; if missing, ``os.execvp``s the same argv under ``uv run --project <repo>`` so the operator's command line still works.  Guarded against an infinite re-exec loop via the ``INFLUX_DIAGNOSE_REEXECED`` env-var sentinel.  Only invoked from the ``--apply`` path so dry-run scans never trigger a re-exec.

**2. Rewrite host + unwrap (``61e7fae``)** — new ``_rewrite_url_for_host`` substitutes ``host.docker.internal`` → ``127.0.0.1`` when ``/.dockerenv`` is absent, with a friendly note line.  ``--lithos-url`` is never rewritten.  New ``_format_exception_chain`` walks ``ExceptionGroup.exceptions`` + ``__cause__`` / ``__context__``, dedupes rendered strings, caps at 6 entries.

**3. Preview on refusal (``a7373b5``)** — new ``_summarise_doc_for_refusal`` renders ``title=… author=… ingested_by=… source_url=… tags=…`` directly inside the refusal message so the operator can triage without a separate ``lithos_read``.

**4. Already-gone outcome (``aeece66``)** — switch ``_delete_squatter`` from ``(bool, str)`` to ``(outcome, str)`` with three states (``DELETE_OK`` / ``DELETE_ALREADY_GONE`` / ``DELETE_REFUSED``).  ``doc_not_found`` from either the read or the delete envelope is treated as ``ALREADY_GONE`` — effective success.  Exit code 0 unless there's a genuine ``REFUSED``.

## Test plan

- [x] ``uv run pytest tests/unit/test_diagnose_squatters.py`` — 29 tests pass (16 new across the four commits).
- [x] ``make check`` — ruff + format + pyright clean.
- [x] **Live verification** against staging through every error path:
  - Direct invocation succeeded (re-exec triggered transparently).
  - Host-side URL rewrite logged and connection succeeded.
  - Safety check refusal surfaced the empty-tag preview that revealed the squatter's nature.
  - Already-gone outcome correctly identified the doc as cleaned up rather than failed.

## Refs

- 2026-05-02 staging session — single-thread debugging of operator workflow.
- PR #33 — original ``squatters`` subcommand this fixes the rough edges of.
- PR #35 — ``--since 7d`` translator (already merged).