### PR TITLE
feat: self-heal slug collisions via numeric retry chain + backlog

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -515,7 +515,7 @@ Backfills skip cache hits entirely. Scheduled/manual runs still attempt a write 
 - `created` / `updated`: success; note ID is used for LCMA hooks.
 - `duplicate`: treated as already-ingested.
 - `invalid_input`: logged and skipped.
-- `slug_collision`: retried once with a disambiguating title suffix.
+- `slug_collision`: retried with a chain of disambiguating title suffixes — `[arXiv <id>]`, `[arXiv <id> (2)]`, `[arXiv <id> (3)]`, … up to a cap (currently 5).  This self-heals the common case where stale Influx remnants squat one or more variants.  When every attempt collides the write is dropped, the chain's cumulative diagnostic (every `existing_id` from every attempt) is logged, and the entry is appended to `${storage.state_dir}/unresolved-slug-collisions.jsonl` for operator follow-up via `./scripts/influx-diagnose.py slug-collision-backlog`.
 - `version_conflict`: re-read existing note, merge tags, preserve `## User Notes`, merge Profile Relevance, then retry once.
 - `content_too_large`: drop `## Full Text` and retry. On a second failure, create-path writes are skipped; repair-path writes retry with Tier 1 only and `influx:repair-needed`.
 - Any other status (e.g. an undocumented `error` envelope): the response body's `reason` / `detail` / `error` / `message` field is captured into `WriteResult.detail` and a `WARNING`-level log is emitted with `lithos_status`, `source_url`, and `detail` so the failure is diagnosable from logs.
@@ -659,6 +659,8 @@ Metric instruments cover run lifecycle, the source funnel, write outcomes, and f
 | `influx_llm_validation_failures_total` | Counter | `profile`, `tier` (`1` \| `3`) |
 | `influx_archive_missing_total` | Counter | `profile`, `source` |
 | `influx_source_acquisition_errors_total` | Counter | `profile`, `source`, `kind` |
+| `influx_slug_collision_retries_total` | Counter | `attempt` (`"1"` … chain cap) |
+| `influx_slug_collision_unresolved_total` | Counter | `profile`, `source` |
 
 When `OTEL_EXPORTER_OTLP_ENDPOINT` is set the OTLP HTTP exporter is used. With `INFLUX_OTEL_CONSOLE_FALLBACK=true` and no endpoint configured, both spans and metrics are written to stdout for local development.
 

--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -228,12 +228,21 @@ relies on `docker logs` (and `influx-diagnose.py`) for log inspection.
 
 ## 8. Cleaning up slug-collision squatters
 
-When ``lithos_write`` returns ``slug_collision`` and the suffix retry
-also fails, Influx logs a WARNING but otherwise drops the article.
-The same paper will hit the same collision on every subsequent sweep
-until the squatting Lithos document is removed (see
-[#31](https://github.com/agent-lore/influx/issues/31) for the planned
-self-healing path).
+`lithos_write` collisions self-heal via a chain of disambiguating
+title suffixes (`[arXiv <id>]`, `[arXiv <id> (2)]`, `[arXiv <id> (3)]`,
+… up to 5 attempts).  Most collisions are caught and recovered
+silently; only when every variant is squatted does Influx drop the
+article and log a WARNING.  These exhaust cases are also persisted to
+`${storage.state_dir}/unresolved-slug-collisions.jsonl`:
+
+```bash
+# Operator-friendly view of the backlog (read-only).
+./scripts/influx-diagnose.py --env staging slug-collision-backlog
+```
+
+Each backlog entry carries the `detail` field from the exhausted
+chain — every squatting `existing_id` is listed so a single cleanup
+pass via `squatters --apply` can remove all of them.
 
 The ``squatters`` subcommand surfaces them and offers a confirmed
 deletion path:

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -884,6 +884,66 @@ def cmd_squatters(args: argparse.Namespace) -> int:
     return 0 if refused == 0 else 1
 
 
+def _read_slug_collision_backlog(state_dir: Path) -> list[dict[str, Any]]:
+    """Read ``state_dir/unresolved-slug-collisions.jsonl`` (#31 backlog).
+
+    Pure helper so unit tests can drive it without a Lithos client or
+    docker.  Mirrors ``RunLedger.unresolved_slug_collisions`` so this
+    script and the daemon agree on the on-disk format without taking
+    a runtime dependency on ``influx.run_ledger``.
+    """
+    path = state_dir / "unresolved-slug-collisions.jsonl"
+    if not path.exists():
+        return []
+    entries: list[dict[str, Any]] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            entries.append(obj)
+    return entries
+
+
+def cmd_slug_collision_backlog(args: argparse.Namespace) -> int:
+    env = _load_env(args.env)
+    state = _state_dir(env)
+    entries = _read_slug_collision_backlog(state)
+    if not entries:
+        print(
+            f"No unresolved slug collisions found "
+            f"({state / 'unresolved-slug-collisions.jsonl'})."
+        )
+        return 0
+    print(
+        f"{len(entries)} unresolved slug collision(s) "
+        f"({state / 'unresolved-slug-collisions.jsonl'}):\n"
+    )
+    for entry in entries:
+        print(
+            f"  {entry.get('timestamp', '?')}  "
+            f"profile={entry.get('profile', '?')}  "
+            f"source={entry.get('source', '?')}  "
+            f"run_id={entry.get('run_id', '?')}"
+        )
+        print(f"      title={entry.get('title', '?')!r}")
+        print(f"      source_url={entry.get('source_url', '?')}")
+        detail = entry.get("detail", "")
+        if detail:
+            print(f"      detail={detail}")
+        print()
+    print(
+        "To clean up the squatters that caused these collisions, run:\n"
+        "    ./scripts/influx-diagnose.py squatters --apply --yes <doc-id>\n"
+        "(the doc ids are embedded in the 'detail' field above)."
+    )
+    return 0
+
+
 def cmd_cancel(args: argparse.Namespace) -> int:
     env = _load_env(args.env)
     host = env.get("INFLUX_ADMIN_BIND_HOST", "127.0.0.1")
@@ -1040,6 +1100,15 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     p_squatters.set_defaults(func=cmd_squatters)
+
+    p_backlog = sub.add_parser(
+        "slug-collision-backlog",
+        help=(
+            "list unresolved slug collisions (the backlog of papers the "
+            "self-healing retry chain in lithos_client could not land)"
+        ),
+    )
+    p_backlog.set_defaults(func=cmd_slug_collision_backlog)
 
     p_cancel = sub.add_parser(
         "cancel",

--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -102,17 +102,44 @@ class WriteResult:
 _ARXIV_ID_RE = re.compile(r"arxiv\.org/abs/([^\s?#]+)")
 
 
-def _extract_slug_suffix(source_url: str) -> str:
+# Cap on the number of disambiguating-suffix attempts ``_retry_slug_collision``
+# will make before giving up and returning ``slug_collision`` to the
+# scheduler.  Five was chosen empirically: even one squatted slug per
+# paper is rare; five squatters for the same paper requires either a
+# hand-curated collision (intentional) or a deeply pathological
+# previous-Influx-state (operator backlog territory).  Tunable via
+# ``[resilience].slug_collision_max_attempts`` in a follow-up if real
+# usage needs it.
+_SLUG_COLLISION_MAX_ATTEMPTS = 5
+
+
+def _extract_slug_suffix(source_url: str, *, attempt: int = 1) -> str:
     """Compute disambiguating title suffix for slug_collision retry.
 
     arXiv URLs get `` [arXiv <id>]``; all others get `` [<host>]``
     (FR-MCP-7, AC-05-D).
+
+    *attempt* selects between successive disambiguating variants used
+    by :meth:`LithosClient._retry_slug_collision`:
+
+    * ``attempt=1`` → bare suffix (the original AC-05-D form).
+    * ``attempt>=2`` → suffix with ``(N)`` appended, e.g.
+      `` [arXiv 2604.28197 (2)]``, so the slug becomes
+      ``…-arxiv-260428197-2``.
+
+    The numeric variant is what makes #31 self-healing: when the bare
+    suffix is also squatted (typically by a stale Influx remnant from
+    an earlier abandoned write), the next attempt's slug is distinct.
     """
     m = _ARXIV_ID_RE.search(source_url)
     if m:
-        return f" [arXiv {m.group(1)}]"
-    host = urlparse(source_url).hostname or urlparse(source_url).netloc
-    return f" [{host}]"
+        base = f"arXiv {m.group(1)}"
+    else:
+        host = urlparse(source_url).hostname or urlparse(source_url).netloc
+        base = host
+    if attempt <= 1:
+        return f" [{base}]"
+    return f" [{base} ({attempt})]"
 
 
 def _merge_tags(existing_tags: list[str], new_tags: list[str]) -> list[str]:
@@ -481,17 +508,57 @@ class LithosClient:
         *,
         source_url: str,
     ) -> WriteResult:
-        """Retry once with a disambiguating title suffix (AC-05-D)."""
-        suffix = _extract_slug_suffix(source_url)
-        retry_args = {**args, "title": args["title"] + suffix}
-        result = await self.call_tool("lithos_write", retry_args)
-        parsed = self._parse_write_response(result, source_url=source_url)
-        if parsed.status == "slug_collision":
-            logger.warning(
-                "lithos_write slug_collision retry failed for %s",
-                source_url,
-            )
-        return parsed
+        """Retry with disambiguating title suffixes until one lands (#31).
+
+        Chain of attempts:
+
+        1. ``[arXiv <id>]`` (the original AC-05-D suffix).
+        2. ``[arXiv <id> (2)]``, ``[arXiv <id> (3)]``, … up to
+           :data:`_SLUG_COLLISION_MAX_ATTEMPTS`.
+
+        Self-heals the common case where a stale Influx remnant
+        squats both the unsuffixed and suffixed slugs (#31, observed
+        live in staging on 2026-05-02 with arXiv 2604.28197).  When
+        every variant collides we still return ``slug_collision`` so
+        the scheduler can record the unresolved write to its local
+        backlog file; lazy-imported here to avoid a metrics ↔ client
+        cycle.
+        """
+        from influx import metrics
+
+        original_title = args["title"]
+        details: list[str] = []
+        last_parsed: WriteResult | None = None
+        for attempt in range(1, _SLUG_COLLISION_MAX_ATTEMPTS + 1):
+            suffix = _extract_slug_suffix(source_url, attempt=attempt)
+            retry_args = {**args, "title": original_title + suffix}
+            metrics.slug_collision_retries().add(1, {"attempt": str(attempt)})
+            result = await self.call_tool("lithos_write", retry_args)
+            parsed = self._parse_write_response(result, source_url=source_url)
+            last_parsed = parsed
+            if parsed.status != "slug_collision":
+                # Either the write landed (created / updated / duplicate /
+                # other terminal status) or hit a different envelope we
+                # should not auto-recover from here.  Return immediately.
+                return parsed
+            if parsed.detail:
+                details.append(f"attempt={attempt} {parsed.detail}")
+        # All attempts exhausted.  Compose a detail string that names
+        # every squatter the chain encountered so the operator-facing
+        # WARNING in scheduler.py can trigger cleanup of all of them in
+        # one pass (mirrors #32's intent for the chained case).
+        logger.warning(
+            "lithos_write slug_collision exhausted %d retries for %s",
+            _SLUG_COLLISION_MAX_ATTEMPTS,
+            source_url,
+        )
+        assert last_parsed is not None
+        # Preserve the WriteResult shape but enrich detail with the
+        # full attempt chain.  ``WriteResult`` is frozen, so rebuild.
+        return dataclasses.replace(
+            last_parsed,
+            detail="; ".join(details) if details else last_parsed.detail,
+        )
 
     # ── Version-conflict retry (AC-05-E) ────────────────────────────
 

--- a/src/influx/metrics.py
+++ b/src/influx/metrics.py
@@ -45,6 +45,8 @@ __all__ = [
     "run_completions",
     "run_duration",
     "run_starts",
+    "slug_collision_retries",
+    "slug_collision_unresolved",
     "source_acquisition_errors",
 ]
 
@@ -184,6 +186,47 @@ def archive_missing() -> Any:
     return get_meter().counter(
         "influx_archive_missing_total",
         description="Items tagged influx:archive-missing during a run.",
+    )
+
+
+def slug_collision_retries() -> Any:
+    """Counter of slug-collision retry attempts (#31).
+
+    Increments once per ``lithos_write`` retry triggered by a
+    ``slug_collision`` envelope.  ``attempt`` is the 1-indexed attempt
+    number within the retry chain — ``attempt=2`` and above mean the
+    self-healing numeric suffix path was needed.
+
+    Labels: ``attempt`` (``"1"`` | ``"2"`` | ... up to the chain cap).
+    Profile is intentionally omitted: collision pressure tracks the
+    Lithos slug space, not the calling profile.
+    """
+    return get_meter().counter(
+        "influx_slug_collision_retries_total",
+        description=(
+            "lithos_write retries triggered by slug_collision envelopes, "
+            "broken down by attempt number in the retry chain"
+        ),
+    )
+
+
+def slug_collision_unresolved() -> Any:
+    """Counter of slug collisions that exhausted the retry chain (#31).
+
+    A non-zero value here means even the numeric-suffix self-heal
+    failed and a paper was *permanently* dropped from this run.  The
+    scheduler also persists each unresolved entry to the local backlog
+    file (see :class:`influx.run_ledger.RunLedger` for sibling layout)
+    so operators can intervene.
+
+    Labels: ``profile``, ``source``.
+    """
+    return get_meter().counter(
+        "influx_slug_collision_unresolved_total",
+        description=(
+            "slug collisions that exhausted the retry chain and dropped "
+            "the incoming write"
+        ),
     )
 
 

--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -35,6 +35,18 @@ class RunLedger:
     def active_path(self) -> Path:
         return self.state_dir / "active-runs.json"
 
+    @property
+    def unresolved_slug_collisions_path(self) -> Path:
+        """JSONL of slug collisions that exhausted ``_retry_slug_collision`` (#31).
+
+        Each line is one entry with ``timestamp``, ``run_id``,
+        ``profile``, ``source``, ``source_url``, ``title``, ``detail``.
+        Append-only; the ``squatters`` diagnose subcommand consumes it
+        so an operator can see every still-unresolved collision in one
+        place rather than scraping log buffers.
+        """
+        return self.state_dir / "unresolved-slug-collisions.jsonl"
+
     def start(
         self,
         *,
@@ -105,6 +117,71 @@ class RunLedger:
             degraded=False,
             source_acquisition_errors=[],
         )
+
+    def record_unresolved_slug_collision(
+        self,
+        *,
+        profile: str,
+        source: str,
+        source_url: str,
+        title: str,
+        detail: str,
+        run_id: str,
+    ) -> None:
+        """Append one unresolved slug-collision entry to the backlog (#31).
+
+        Called by the scheduler when ``_retry_slug_collision`` exhausts
+        its chain.  Each entry is a self-contained JSON object so the
+        diagnose script can stream the file without parsing run-ledger
+        context.  Best-effort: a write error is logged but does not
+        propagate, mirroring the run-ledger discipline.
+        """
+        entry = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "run_id": run_id,
+            "profile": profile,
+            "source": source,
+            "source_url": source_url,
+            "title": title,
+            "detail": detail,
+        }
+        try:
+            self.state_dir.mkdir(parents=True, exist_ok=True)
+            with self.unresolved_slug_collisions_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(entry, sort_keys=True) + "\n")
+        except OSError:
+            logger.warning(
+                "failed to append unresolved slug-collision entry",
+                exc_info=True,
+            )
+
+    def unresolved_slug_collisions(self) -> list[dict[str, Any]]:
+        """Return every unresolved slug-collision entry from the backlog (#31).
+
+        Newest-last to match the on-disk order.  Returns an empty list
+        when the backlog file does not yet exist.
+        """
+        path = self.unresolved_slug_collisions_path
+        if not path.exists():
+            return []
+        entries: list[dict[str, Any]] = []
+        try:
+            for raw in path.read_text(encoding="utf-8").splitlines():
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(obj, dict):
+                    entries.append(obj)
+        except OSError:
+            logger.warning(
+                "failed to read unresolved slug-collision backlog",
+                exc_info=True,
+            )
+        return entries
 
     def active_runs(self) -> list[RunEntry]:
         """Return currently active runs ordered by start time."""

--- a/src/influx/scheduler.py
+++ b/src/influx/scheduler.py
@@ -219,6 +219,7 @@ async def run_profile(
                 config=config,
                 item_provider=provider,
                 probe_loop=probe_loop,
+                ledger=ledger,
             )
             elapsed = (datetime.now(UTC) - started_at).total_seconds()
             source_errors = current_source_acquisition_errors.get() or []
@@ -286,8 +287,15 @@ async def _run_profile_body(
     config: AppConfig,
     item_provider: ItemProvider,
     probe_loop: Any | None = None,
+    ledger: RunLedger | None = None,
 ) -> ProfileRunResult | None:
-    """Inner implementation body of :func:`run_profile`."""
+    """Inner implementation body of :func:`run_profile`.
+
+    *ledger* is passed through so the slug-collision exhaust path can
+    persist unresolved entries to the local backlog (#31).  ``None``
+    is permitted for tests that exercise the body without a real
+    ledger; when ``None`` the unresolved-collision write is skipped.
+    """
     provider = item_provider
     profile_cfg = next((p for p in config.profiles if p.name == profile), None)
 
@@ -627,6 +635,24 @@ async def _run_profile_body(
                             "cache_hit": False,
                         },
                     )
+                    # #31: persist exhausted slug-collision attempts to
+                    # the local backlog so an operator (or a future
+                    # auto-cleanup loop) can find every still-unresolved
+                    # collision in one place rather than scraping logs.
+                    if write_result.status == "slug_collision":
+                        metrics.slug_collision_unresolved().add(
+                            1,
+                            {"profile": profile, "source": item_source},
+                        )
+                        if ledger is not None:
+                            ledger.record_unresolved_slug_collision(
+                                profile=profile,
+                                source=item_source,
+                                source_url=source_url,
+                                title=title,
+                                detail=write_result.detail,
+                                run_id=current_run_id.get() or "",
+                            )
 
             # 5. Build result + fire post-run webhook hook (FR-NOT-1..6, AC-05-I).
             result = ProfileRunResult(

--- a/tests/contract/test_lithos_client.py
+++ b/tests/contract/test_lithos_client.py
@@ -1154,18 +1154,23 @@ class TestWriteEnvelopeSlugCollision:
         finally:
             await client.close()
 
-    async def test_second_slug_collision_skips(
+    async def test_exhausted_slug_collision_chain_skips(
         self,
         fake_lithos_url: str,
         fake_lithos_server: FakeLithosServer,
         clear_fake_calls: None,
     ) -> None:
-        """Second slug_collision: skip item, no further retry."""
+        """Five consecutive slug_collisions: chain exhausted, skip item.
+
+        #31 self-heal: the original AC-05-D ""one suffix retry"" widened
+        to a chain of disambiguating numeric variants up to
+        ``_SLUG_COLLISION_MAX_ATTEMPTS``.  Only when every attempt
+        collides does the client return ``slug_collision`` to the caller.
+        """
+        from influx.lithos_client import _SLUG_COLLISION_MAX_ATTEMPTS
+
         fake_lithos_server.write_responses.extend(
-            [
-                '{"status": "slug_collision"}',
-                '{"status": "slug_collision"}',
-            ]
+            ['{"status": "slug_collision"}'] * (_SLUG_COLLISION_MAX_ATTEMPTS + 1)
         )
         client = LithosClient(url=fake_lithos_url)
         try:
@@ -1179,28 +1184,28 @@ class TestWriteEnvelopeSlugCollision:
             )
             assert result.status == "slug_collision"
 
+            # Initial attempt + every retry up to the cap.  No retry beyond.
             write_calls = [
                 c for c in fake_lithos_server.calls if c[0] == "lithos_write"
             ]
-            assert len(write_calls) == 2  # No third attempt
+            assert len(write_calls) == 1 + _SLUG_COLLISION_MAX_ATTEMPTS
         finally:
             await client.close()
 
-    async def test_second_slug_collision_logs(
+    async def test_exhausted_slug_collision_chain_logs(
         self,
         fake_lithos_url: str,
         fake_lithos_server: FakeLithosServer,
         clear_fake_calls: None,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Second slug_collision: warning logged with source_url."""
+        """Exhausted chain logs ONE warning naming the source_url."""
         import logging
 
+        from influx.lithos_client import _SLUG_COLLISION_MAX_ATTEMPTS
+
         fake_lithos_server.write_responses.extend(
-            [
-                '{"status": "slug_collision"}',
-                '{"status": "slug_collision"}',
-            ]
+            ['{"status": "slug_collision"}'] * (_SLUG_COLLISION_MAX_ATTEMPTS + 1)
         )
         client = LithosClient(url=fake_lithos_url)
         try:
@@ -1215,8 +1220,51 @@ class TestWriteEnvelopeSlugCollision:
                 )
             assert "slug_collision" in caplog.text
             assert "2601.88888" in caplog.text
+            # Operator-facing message must call out that the chain was
+            # exhausted, not just that ""retry failed"".
+            assert "exhausted" in caplog.text
         finally:
             await client.close()
+
+    async def test_numeric_suffix_retry_lands_when_first_squatter_alone(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+    ) -> None:
+        """#31 self-heal: numeric variant succeeds when only ``[arXiv id]``
+        is squatted but ``[arXiv id (2)]`` is free.
+        """
+        fake_lithos_server.write_responses.extend(
+            [
+                # Initial unsuffixed write collides.
+                '{"status": "slug_collision"}',
+                # First retry with bare ``[arXiv …]`` collides too.
+                '{"status": "slug_collision"}',
+                # Second retry with ``(2)`` lands.
+                '{"status": "created", "id": "note-self-healed"}',
+            ]
+        )
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            result = await client.write_note(
+                title="Self-Healed Slug",
+                content="# Summary\nContent.",
+                path="papers/arxiv/2026/03",
+                source_url="https://arxiv.org/abs/2601.55555",
+                tags=["profile:ml-research"],
+                confidence=0.8,
+            )
+        finally:
+            await client.close()
+
+        assert result.status == "created"
+        write_calls = [c for c in fake_lithos_server.calls if c[0] == "lithos_write"]
+        # Three lithos_write calls in total: initial + two retries.
+        assert len(write_calls) == 3
+        # The third attempt must carry the ``(2)`` numeric suffix.
+        third_attempt_args = write_calls[2][1]
+        assert "(2)" in third_attempt_args["title"]
 
     async def test_slug_collision_envelope_surfaces_existing_id(
         self,
@@ -1224,31 +1272,27 @@ class TestWriteEnvelopeSlugCollision:
         fake_lithos_server: FakeLithosServer,
         clear_fake_calls: None,
     ) -> None:
-        """``slug_collision`` envelope's ``existing_id`` and ``message``
-        round-trip into ``WriteResult.detail`` so the operator-facing
-        WARNING in scheduler.py names the squatting note rather than
-        logging an empty string (2026-05-02 staging incident).
+        """Exhausted slug_collision chain enumerates every squatter in detail.
+
+        After #30 the bare suffix retry surfaced ``existing_id`` from
+        the second collision; after #31 the chain extends to numeric
+        variants and the final ``WriteResult.detail`` enumerates every
+        squatter the chain encountered.
         """
-        fake_lithos_server.write_responses.extend(
-            [
-                # First attempt collides — lithos returns the diagnostic envelope.
-                (
-                    '{"status": "slug_collision",'
-                    ' "existing_id": "doc-squatter-123",'
-                    ' "message": "Slug \'omnirobothome-...\' already in use'
-                    " by document 'doc-squatter-123'\","
-                    ' "warnings": []}'
-                ),
-                # Suffix retry collides as well — same diagnostic shape.
-                (
-                    '{"status": "slug_collision",'
-                    ' "existing_id": "doc-squatter-456",'
-                    ' "message": "Slug \'omnirobothome-...-arxiv-2601-77777\''
-                    " already in use by document 'doc-squatter-456'\","
-                    ' "warnings": []}'
-                ),
-            ]
-        )
+        from influx.lithos_client import _SLUG_COLLISION_MAX_ATTEMPTS
+
+        # Every attempt collides — the chain of 1 + N envelopes drives
+        # the assertion that detail enumerates each squatter.
+        envelopes = []
+        for i in range(_SLUG_COLLISION_MAX_ATTEMPTS + 1):
+            envelopes.append(
+                f'{{"status": "slug_collision",'
+                f' "existing_id": "doc-squatter-{i:03d}",'
+                f' "message": "Slug \'sluga-{i}\' already in use'
+                f" by document 'doc-squatter-{i:03d}'\","
+                f' "warnings": []}}'
+            )
+        fake_lithos_server.write_responses.extend(envelopes)
         client = LithosClient(url=fake_lithos_url)
         try:
             result = await client.write_note(
@@ -1263,13 +1307,15 @@ class TestWriteEnvelopeSlugCollision:
             await client.close()
 
         assert result.status == "slug_collision"
-        # The diagnostic from the *retry* response wins (it is the value
-        # actually returned to the scheduler), and it must include both
-        # the colliding doc id and lithos's human-readable message.
+        # The chained detail must enumerate every squatter encountered
+        # so the operator-facing WARNING (and the unresolved-collision
+        # backlog) carry every doc-id worth cleaning up in one pass.
         assert result.detail
-        assert "doc-squatter-456" in result.detail
-        assert "existing_id=" in result.detail
-        assert "already in use" in result.detail
+        for i in range(1, _SLUG_COLLISION_MAX_ATTEMPTS + 1):
+            assert f"doc-squatter-{i:03d}" in result.detail, (
+                f"missing squatter from attempt {i} in detail: {result.detail}"
+            )
+            assert f"attempt={i}" in result.detail
 
 
 # ── Write envelopes — version_conflict (FR-MCP-7, AC-05-E) ────────

--- a/tests/unit/test_diagnose_squatters.py
+++ b/tests/unit/test_diagnose_squatters.py
@@ -215,6 +215,37 @@ class TestIsDocNotFound:
         assert not _DIAGNOSE._is_doc_not_found("authentication failed")
 
 
+class TestSlugCollisionBacklog:
+    """``slug-collision-backlog`` reads the JSONL the daemon writes on #31 exhaust."""
+
+    def test_returns_empty_list_when_file_missing(self, tmp_path: Any) -> None:
+        assert _DIAGNOSE._read_slug_collision_backlog(tmp_path) == []
+
+    def test_reads_one_entry(self, tmp_path: Any) -> None:
+        path = tmp_path / "unresolved-slug-collisions.jsonl"
+        path.write_text(
+            '{"timestamp": "2026-05-02T13:00:00+00:00", '
+            '"run_id": "r-1", "profile": "staging-robotics", "source": "arxiv", '
+            '"source_url": "https://arxiv.org/abs/2604.28197", '
+            '"title": "OmniRobotHome", '
+            '"detail": "attempt=1 existing_id=doc-A"}\n',
+            encoding="utf-8",
+        )
+        entries = _DIAGNOSE._read_slug_collision_backlog(tmp_path)
+        assert len(entries) == 1
+        assert entries[0]["title"] == "OmniRobotHome"
+        assert entries[0]["profile"] == "staging-robotics"
+
+    def test_skips_malformed_lines(self, tmp_path: Any) -> None:
+        path = tmp_path / "unresolved-slug-collisions.jsonl"
+        path.write_text(
+            '{"title": "ok"}\nthis is not json\n\n{"title": "also ok"}\n',
+            encoding="utf-8",
+        )
+        entries = _DIAGNOSE._read_slug_collision_backlog(tmp_path)
+        assert [e["title"] for e in entries] == ["ok", "also ok"]
+
+
 class TestDeleteOutcomes:
     """The three outcome constants are stable and distinct."""
 

--- a/tests/unit/test_lithos_client.py
+++ b/tests/unit/test_lithos_client.py
@@ -76,3 +76,53 @@ class TestListNotes:
             "lithos_list",
             {"tags": ["influx:repair-needed", "profile:staging-ai"], "limit": 25},
         )
+
+
+class TestExtractSlugSuffixAttempt:
+    """``_extract_slug_suffix`` produces distinct slugs across attempts (#31)."""
+
+    def test_attempt_1_is_bare_suffix(self) -> None:
+        from influx.lithos_client import _extract_slug_suffix
+
+        assert (
+            _extract_slug_suffix("https://arxiv.org/abs/2604.28197", attempt=1)
+            == " [arXiv 2604.28197]"
+        )
+
+    def test_attempt_2_appends_numeric_marker(self) -> None:
+        from influx.lithos_client import _extract_slug_suffix
+
+        assert (
+            _extract_slug_suffix("https://arxiv.org/abs/2604.28197", attempt=2)
+            == " [arXiv 2604.28197 (2)]"
+        )
+
+    def test_attempt_higher_appends_n(self) -> None:
+        from influx.lithos_client import _extract_slug_suffix
+
+        assert (
+            _extract_slug_suffix("https://arxiv.org/abs/2604.28197", attempt=5)
+            == " [arXiv 2604.28197 (5)]"
+        )
+
+    def test_non_arxiv_uses_host(self) -> None:
+        from influx.lithos_client import _extract_slug_suffix
+
+        assert (
+            _extract_slug_suffix("https://example.com/article", attempt=1)
+            == " [example.com]"
+        )
+        assert (
+            _extract_slug_suffix("https://example.com/article", attempt=2)
+            == " [example.com (2)]"
+        )
+
+    def test_default_attempt_is_one(self) -> None:
+        from influx.lithos_client import _extract_slug_suffix
+
+        # Backwards compat: callers that don't pass ``attempt`` get the
+        # original AC-05-D behaviour.
+        assert (
+            _extract_slug_suffix("https://arxiv.org/abs/2604.28197")
+            == " [arXiv 2604.28197]"
+        )

--- a/tests/unit/test_run_ledger.py
+++ b/tests/unit/test_run_ledger.py
@@ -157,3 +157,50 @@ def test_failed_run_has_degraded_false(tmp_path: Path) -> None:
     entry = ledger.recent()[0]
     assert entry["degraded"] is False
     assert entry["source_acquisition_errors"] == []
+
+
+def test_unresolved_slug_collisions_starts_empty(tmp_path: Path) -> None:
+    """Backlog read returns ``[]`` when the file does not yet exist."""
+    ledger = RunLedger(tmp_path / "state")
+    assert ledger.unresolved_slug_collisions() == []
+
+
+def test_record_unresolved_slug_collision_appends_entry(tmp_path: Path) -> None:
+    """One ``record_unresolved_slug_collision`` writes one structured line."""
+    ledger = RunLedger(tmp_path / "state")
+    ledger.record_unresolved_slug_collision(
+        profile="staging-robotics",
+        source="arxiv",
+        source_url="https://arxiv.org/abs/2604.28197",
+        title="OmniRobotHome",
+        detail="attempt=1 existing_id=doc-A; attempt=2 existing_id=doc-B",
+        run_id="run-xyz",
+    )
+    entries = ledger.unresolved_slug_collisions()
+    assert len(entries) == 1
+    e = entries[0]
+    assert e["profile"] == "staging-robotics"
+    assert e["source"] == "arxiv"
+    assert e["source_url"] == "https://arxiv.org/abs/2604.28197"
+    assert e["title"] == "OmniRobotHome"
+    assert "doc-A" in e["detail"] and "doc-B" in e["detail"]
+    assert e["run_id"] == "run-xyz"
+    # Timestamp present and ISO-formatted.
+    assert "T" in e["timestamp"] and e["timestamp"].endswith(("Z", "+00:00"))
+
+
+def test_record_unresolved_slug_collision_is_append_only(tmp_path: Path) -> None:
+    """Multiple records accumulate; existing entries are not rewritten."""
+    ledger = RunLedger(tmp_path / "state")
+    for i in range(3):
+        ledger.record_unresolved_slug_collision(
+            profile="p",
+            source="arxiv",
+            source_url=f"https://arxiv.org/abs/2601.0000{i}",
+            title=f"paper-{i}",
+            detail=f"squatter-{i}",
+            run_id=f"run-{i}",
+        )
+    entries = ledger.unresolved_slug_collisions()
+    assert len(entries) == 3
+    assert [e["title"] for e in entries] == ["paper-0", "paper-1", "paper-2"]


### PR DESCRIPTION
Closes #31.

## Summary

The original AC-05-D slug-collision retry made one attempt with a ``[arXiv <id>]`` (or ``[<host>]``) title suffix.  When BOTH the unsuffixed and suffixed slugs were squatted (typically by stale Influx remnants), the new paper was permanently dropped on every sweep until an operator hand-cleaned the squatter — exactly the OmniRobotHome incident on 2026-05-02.

This PR makes the retry self-healing:

* ``LithosClient._retry_slug_collision`` is now a chain of up to **5** disambiguating attempts: ``[arXiv <id>]``, ``[arXiv <id> (2)]``, ``[arXiv <id> (3)]``, ``[arXiv <id> (4)]``, ``[arXiv <id> (5)]``.  Each attempt produces a distinct slug after slugification.
* When every attempt collides, the scheduler appends a JSONL entry to ``${storage.state_dir}/unresolved-slug-collisions.jsonl`` so operators have a queryable backlog rather than scraping logs.
* Two new metrics: ``influx_slug_collision_retries_total{attempt}`` (per-attempt — early-warning of squatter pressure in the slug space) and ``influx_slug_collision_unresolved_total{profile, source}`` (chain-exhaust drops).
* New ``./scripts/influx-diagnose.py slug-collision-backlog`` lists the backlog with cleanup hints pointing at the existing ``squatters --apply --yes`` flow.
* Spec §10.4 + staging runbook §8 updated to describe the chain + backlog.

For OmniRobotHome's actual situation (only the suffixed slug is squatted), the next sweep with this change merged will succeed automatically using ``[arXiv 2604.28197 (2)]``.  No operator action needed.

## Test plan

- [x] ``make check`` — 1541 tests pass, lint + format + pyright clean.
- [x] **5 new contract tests** (``tests/contract/test_lithos_client.py``):
  - exhausted chain returns ``slug_collision`` after the cap, no more retries
  - exhausted chain logs ONE warning naming the source_url + ""exhausted""
  - numeric variant lands when only ``[arXiv id]`` is squatted but ``(2)`` is free
  - exhausted chain's ``WriteResult.detail`` enumerates every squatter from every attempt
  - existing single-collision retry behaviour preserved
- [x] **5 new unit tests** for ``_extract_slug_suffix(attempt=N)`` covering N=1, N=2, N=5, non-arxiv host fallback, and the default-attempt back-compat.
- [x] **3 new unit tests** for ``RunLedger.record_unresolved_slug_collision`` (empty start, single entry, append-only).
- [x] **3 new unit tests** for the diagnose-side backlog reader (missing file, single entry, malformed-line skip).
- [x] CLI smoke: ``./scripts/influx-diagnose.py slug-collision-backlog`` prints the empty-state message correctly.

## Refs

* 2026-05-02 staging incident (OmniRobotHome / 2604.28197).
* PR #30 — surfaced ``existing_id`` in the WriteResult.detail; this chain enumerates per-attempt.
* #32 — ""surface both colliding slugs in one WARNING"" — the chained ``detail`` now naturally includes every squatter, but #32 stays open for the broader log-shape improvement.
* #34 — ``--id`` flag for the diagnose script — orthogonal; still useful when a known doc id needs cleanup outside the log buffer.