### PR TITLE
feat: self-heal slug collisions via squatter-shape dispatch

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -515,7 +515,11 @@ Backfills skip cache hits entirely. Scheduled/manual runs still attempt a write 
 - `created` / `updated`: success; note ID is used for LCMA hooks.
 - `duplicate`: treated as already-ingested.
 - `invalid_input`: logged and skipped.
-- `slug_collision`: retried once with a disambiguating title suffix.
+- `slug_collision`: recovered via squatter-shape dispatch.  When Lithos returns the colliding `existing_id`, Influx reads that doc and routes:
+  - **duplicate** — squatter carries matching `arxiv-id:<id>` tag or matching `source_url` → treat as `duplicate` outcome (the URL/cache dedup missed; metric `influx_slug_collision_dedup_recovery_total` ticks).
+  - **reclaimable** — squatter is empty residue (no tags, no `source_url`, empty body, typically a stale aborted-write artefact) → `lithos_delete(existing_id)` then re-issue the original write (metric `influx_slug_collision_reclaimed_total`).
+  - **distinct** — genuinely different paper that slugifies the same → fall back to the AC-05-D `[arXiv <id>]` (or `[<host>]`) suffix retry.  If THAT also collides and the suffixed-slug squatter is itself reclaimable, delete-and-retry once more.
+  Anything still `slug_collision` after the chain is appended to `${storage.state_dir}/unresolved-slug-collisions.jsonl` and `influx_slug_collision_unresolved_total` ticks; operators inspect via `./scripts/influx-diagnose.py slug-collision-backlog`.
 - `version_conflict`: re-read existing note, merge tags, preserve `## User Notes`, merge Profile Relevance, then retry once.
 - `content_too_large`: drop `## Full Text` and retry. On a second failure, create-path writes are skipped; repair-path writes retry with Tier 1 only and `influx:repair-needed`.
 - Any other status (e.g. an undocumented `error` envelope): the response body's `reason` / `detail` / `error` / `message` field is captured into `WriteResult.detail` and a `WARNING`-level log is emitted with `lithos_status`, `source_url`, and `detail` so the failure is diagnosable from logs.
@@ -659,6 +663,9 @@ Metric instruments cover run lifecycle, the source funnel, write outcomes, and f
 | `influx_llm_validation_failures_total` | Counter | `profile`, `tier` (`1` \| `3`) |
 | `influx_archive_missing_total` | Counter | `profile`, `source` |
 | `influx_source_acquisition_errors_total` | Counter | `profile`, `source`, `kind` |
+| `influx_slug_collision_dedup_recovery_total` | Counter | _(no labels)_ |
+| `influx_slug_collision_reclaimed_total` | Counter | _(no labels)_ |
+| `influx_slug_collision_unresolved_total` | Counter | `profile`, `source` |
 
 When `OTEL_EXPORTER_OTLP_ENDPOINT` is set the OTLP HTTP exporter is used. With `INFLUX_OTEL_CONSOLE_FALLBACK=true` and no endpoint configured, both spans and metrics are written to stdout for local development.
 

--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -228,12 +228,28 @@ relies on `docker logs` (and `influx-diagnose.py`) for log inspection.
 
 ## 8. Cleaning up slug-collision squatters
 
-When ``lithos_write`` returns ``slug_collision`` and the suffix retry
-also fails, Influx logs a WARNING but otherwise drops the article.
-The same paper will hit the same collision on every subsequent sweep
-until the squatting Lithos document is removed (see
-[#31](https://github.com/agent-lore/influx/issues/31) for the planned
-self-healing path).
+Influx now self-heals most slug collisions automatically.  When
+``lithos_write`` returns ``slug_collision``, the client reads the
+squatting doc and dispatches:
+
+| Squatter shape | Action | Metric |
+|---|---|---|
+| Same paper (matching `arxiv-id` or `source_url`) | Treat as `duplicate` (Lithos's URL-dedup missed it) | `influx_slug_collision_dedup_recovery_total` |
+| Empty residue (no tags, no `source_url`, empty body) | Delete + re-issue original write | `influx_slug_collision_reclaimed_total` |
+| Different paper, same slug | Fall back to AC-05-D `[arXiv <id>]` suffix retry; if that also collides and the suffixed-slug squatter is also reclaimable, delete + retry once more | (no metric on the retry itself) |
+
+Anything still `slug_collision` after the chain is appended to
+`${INFLUX_STATE_PATH}/unresolved-slug-collisions.jsonl` and surfaced
+via:
+
+```bash
+./scripts/influx-diagnose.py --env staging slug-collision-backlog
+```
+
+For the small minority of collisions that still need manual cleanup
+(e.g. an operator must decide whether to delete a non-Influx note
+that happens to share a slug), the existing `squatters` subcommand
+still applies:
 
 The ``squatters`` subcommand surfaces them and offers a confirmed
 deletion path:

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -18,6 +18,11 @@ Subcommands
     terminal-flips  Per-stage terminal-flip log events with note IDs
     squatters       Find Lithos docs squatting slugs that block Influx
                     writes; optionally delete them with --apply --yes
+    slug-collision-backlog
+                    List slug collisions that survived the in-client
+                    recovery chain (squatter-shape dispatch + suffix
+                    retry); read from
+                    ${INFLUX_STATE_PATH}/unresolved-slug-collisions.jsonl
     cancel          Print the curl line for cancelling an in-flight run
                     (this script never sends destructive HTTP itself)
 
@@ -884,6 +889,66 @@ def cmd_squatters(args: argparse.Namespace) -> int:
     return 0 if refused == 0 else 1
 
 
+def _read_slug_collision_backlog(state_dir: Path) -> list[dict[str, Any]]:
+    """Read ``state_dir/unresolved-slug-collisions.jsonl`` (#31 backlog).
+
+    Pure helper so unit tests can drive it without a live state dir.
+    Mirrors ``RunLedger.unresolved_slug_collisions`` so this script and
+    the daemon agree on the on-disk format without taking a runtime
+    dependency on ``influx.run_ledger``.
+    """
+    path = state_dir / "unresolved-slug-collisions.jsonl"
+    if not path.exists():
+        return []
+    entries: list[dict[str, Any]] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            entries.append(obj)
+    return entries
+
+
+def cmd_slug_collision_backlog(args: argparse.Namespace) -> int:
+    env = _load_env(args.env)
+    state = _state_dir(env)
+    entries = _read_slug_collision_backlog(state)
+    if not entries:
+        print(
+            f"No unresolved slug collisions found "
+            f"({state / 'unresolved-slug-collisions.jsonl'})."
+        )
+        return 0
+    print(
+        f"{len(entries)} unresolved slug collision(s) "
+        f"({state / 'unresolved-slug-collisions.jsonl'}):\n"
+    )
+    for entry in entries:
+        print(
+            f"  {entry.get('timestamp', '?')}  "
+            f"profile={entry.get('profile', '?')}  "
+            f"source={entry.get('source', '?')}  "
+            f"run_id={entry.get('run_id', '?')}"
+        )
+        print(f"      title={entry.get('title', '?')!r}")
+        print(f"      source_url={entry.get('source_url', '?')}")
+        detail = entry.get("detail", "")
+        if detail:
+            print(f"      detail={detail}")
+        print()
+    print(
+        "To clean up the squatters that caused these collisions, run:\n"
+        "    ./scripts/influx-diagnose.py squatters --apply --yes <doc-id>\n"
+        "(the doc ids are embedded in the 'detail' field above)."
+    )
+    return 0
+
+
 def cmd_cancel(args: argparse.Namespace) -> int:
     env = _load_env(args.env)
     host = env.get("INFLUX_ADMIN_BIND_HOST", "127.0.0.1")
@@ -1040,6 +1105,15 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     p_squatters.set_defaults(func=cmd_squatters)
+
+    p_backlog = sub.add_parser(
+        "slug-collision-backlog",
+        help=(
+            "list unresolved slug collisions (papers the squatter-shape "
+            "recovery chain in lithos_client could not land)"
+        ),
+    )
+    p_backlog.set_defaults(func=cmd_slug_collision_backlog)
 
     p_cancel = sub.add_parser(
         "cancel",

--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -100,6 +100,11 @@ class WriteResult:
 # ── Pure helpers ────────────────────────────────────────────────────
 
 _ARXIV_ID_RE = re.compile(r"arxiv\.org/abs/([^\s?#]+)")
+# Matcher for parsing ``existing_id=<id>`` out of the slug_collision
+# diagnostic.  Lithos returns UUIDs in production (``[0-9a-f-]+``) but
+# tests use friendlier ids like ``doc-dup-1``; accept anything up to a
+# whitespace, semicolon, or comma terminator.
+_EXISTING_ID_RE = re.compile(r"existing_id=([^\s;,]+)")
 
 
 def _extract_slug_suffix(source_url: str) -> str:
@@ -113,6 +118,137 @@ def _extract_slug_suffix(source_url: str) -> str:
         return f" [arXiv {m.group(1)}]"
     host = urlparse(source_url).hostname or urlparse(source_url).netloc
     return f" [{host}]"
+
+
+def _arxiv_id_from_url(source_url: str) -> str | None:
+    """Return the arxiv id from a URL like ``https://arxiv.org/abs/2604.28197``."""
+    m = _ARXIV_ID_RE.search(source_url)
+    return m.group(1) if m else None
+
+
+def _existing_id_from_detail(detail: str) -> str | None:
+    """Parse ``existing_id=<uuid>`` out of a slug_collision detail string (#30)."""
+    if not detail:
+        return None
+    m = _EXISTING_ID_RE.search(detail)
+    return m.group(1) if m else None
+
+
+def _doc_tags(doc: dict[str, Any]) -> list[str]:
+    """Extract the tag list from a ``lithos_read`` response.
+
+    Tags live under ``metadata`` in the canonical envelope but some
+    code paths (and the diagnose-script preview) read them at the top
+    level — be tolerant of both shapes.
+    """
+    direct = doc.get("tags")
+    if isinstance(direct, list):
+        return [str(t) for t in direct]
+    meta = doc.get("metadata")
+    if isinstance(meta, dict):
+        nested = meta.get("tags")
+        if isinstance(nested, list):
+            return [str(t) for t in nested]
+    return []
+
+
+def _doc_source_url(doc: dict[str, Any]) -> str | None:
+    """Extract source_url from a ``lithos_read`` response (top-level or metadata)."""
+    direct = doc.get("source_url")
+    if isinstance(direct, str) and direct:
+        return direct
+    meta = doc.get("metadata")
+    if isinstance(meta, dict):
+        nested = meta.get("source_url")
+        if isinstance(nested, str) and nested:
+            return nested
+    return None
+
+
+@dataclasses.dataclass(frozen=True)
+class SquatterClassification:
+    """Outcome of inspecting the doc that owns a colliding slug (#31)."""
+
+    kind: str  # "duplicate" | "reclaimable" | "distinct"
+    squatter_id: str
+    reason: str  # human-readable explanation, surfaced in detail / logs
+
+
+def _classify_squatter(
+    doc: dict[str, Any],
+    *,
+    squatter_id: str,
+    incoming_source_url: str,
+) -> SquatterClassification:
+    """Classify a slug-squatting Lithos doc against an incoming write (#31).
+
+    Returns one of three outcomes:
+
+    * ``"duplicate"`` — the squatter already represents the same paper
+      as the incoming write (matching ``arxiv-id:<id>`` tag, or
+      matching ``source_url``).  Lithos's URL/cache dedup should have
+      caught this; surfacing it here recovers from that miss.
+    * ``"reclaimable"`` — the squatter is an empty residue from an
+      aborted prior write (no tags AND no source_url AND no body).
+      Safe to delete and retry the original write.
+    * ``"distinct"`` — the squatter is a real, distinct doc that
+      happens to slugify the same.  The caller should fall back to
+      the suffix-retry path; if THAT also collides, the entry goes
+      to the unresolved-collisions backlog.
+
+    This function is pure: I/O lives in :meth:`LithosClient._retry_slug_collision`.
+    """
+    tags = _doc_tags(doc)
+    sq_source_url = _doc_source_url(doc)
+    body = str(doc.get("content") or "").strip()
+
+    incoming_arxiv_id = _arxiv_id_from_url(incoming_source_url)
+
+    # Match #1: explicit arxiv-id tag equality.
+    if incoming_arxiv_id:
+        for tag in tags:
+            if tag == f"arxiv-id:{incoming_arxiv_id}":
+                return SquatterClassification(
+                    kind="duplicate",
+                    squatter_id=squatter_id,
+                    reason=(
+                        f"squatter carries arxiv-id:{incoming_arxiv_id} — "
+                        "treat as duplicate of the same paper"
+                    ),
+                )
+
+    # Match #2: source_url equality.
+    if sq_source_url and sq_source_url == incoming_source_url:
+        return SquatterClassification(
+            kind="duplicate",
+            squatter_id=squatter_id,
+            reason=(
+                f"squatter source_url matches incoming ({sq_source_url}) — "
+                "treat as duplicate of the same paper"
+            ),
+        )
+
+    # Reclaim path: empty residue.  Conservative: ALL of the following
+    # must hold so we never delete a real note that just shares a slug.
+    if not tags and not sq_source_url and not body:
+        return SquatterClassification(
+            kind="reclaimable",
+            squatter_id=squatter_id,
+            reason=(
+                "squatter has no tags, no source_url, and empty body — "
+                "stale residue from an aborted prior write"
+            ),
+        )
+
+    # Genuinely-distinct paper that happens to slugify the same.
+    return SquatterClassification(
+        kind="distinct",
+        squatter_id=squatter_id,
+        reason=(
+            f"squatter has its own metadata "
+            f"(tags={len(tags)}, source_url={sq_source_url!r}, body_len={len(body)})"
+        ),
+    )
 
 
 def _merge_tags(existing_tags: list[str], new_tags: list[str]) -> list[str]:
@@ -454,7 +590,9 @@ class LithosClient:
         parsed = self._parse_write_response(result, source_url=source_url)
 
         if parsed.status == "slug_collision":
-            return await self._retry_slug_collision(args, source_url=source_url)
+            return await self._retry_slug_collision(
+                args, source_url=source_url, initial_collision=parsed
+            )
 
         if parsed.status == "version_conflict":
             return await self._retry_version_conflict(
@@ -480,18 +618,144 @@ class LithosClient:
         args: dict[str, Any],
         *,
         source_url: str,
+        initial_collision: WriteResult,
     ) -> WriteResult:
-        """Retry once with a disambiguating title suffix (AC-05-D)."""
+        """Recover from slug_collision by inspecting the squatter (#31).
+
+        Strategy (replaces the original AC-05-D ""one suffix retry"" form):
+
+        1. Read the squatter via the ``existing_id`` lithos returned in
+           the initial collision envelope.
+        2. Classify (:func:`_classify_squatter`):
+
+           * ``duplicate`` — squatter shares the incoming write's
+             ``arxiv-id`` or ``source_url``.  Return as ``duplicate``.
+           * ``reclaimable`` — squatter is empty residue (no tags, no
+             source_url, no body).  Delete it then re-issue the original
+             write.
+           * ``distinct`` — squatter is a real, different doc that
+             happens to slugify the same.  Try the AC-05-D suffix once.
+             If THAT also collides, recurse the inspection (in case the
+             suffixed slug is itself residue) — once.
+
+        Anything still ``slug_collision`` after the recovery chain is
+        returned to the caller, which (in the scheduler) appends to the
+        unresolved-collisions backlog file.
+        """
+        from influx import metrics
+
+        # Round 1: inspect the squatter named in the initial collision.
+        recovered = await self._try_recover_collision(
+            args,
+            source_url=source_url,
+            collision=initial_collision,
+            metrics_module=metrics,
+        )
+
+        if recovered.status != "slug_collision":
+            return recovered
+
+        # Round 2: the suffix retry collided too.  One more inspection in
+        # case the suffixed-slug squatter is itself a reclaimable residue.
+        suffix = _extract_slug_suffix(source_url)
+        suffixed_args = {**args, "title": args["title"] + suffix}
+        recovered = await self._try_recover_collision(
+            suffixed_args,
+            source_url=source_url,
+            collision=recovered,
+            metrics_module=metrics,
+            allow_suffix_retry=False,
+        )
+
+        if recovered.status == "slug_collision":
+            logger.warning(
+                "lithos_write slug_collision unresolved after recovery for %s",
+                source_url,
+            )
+        return recovered
+
+    async def _try_recover_collision(
+        self,
+        args: dict[str, Any],
+        *,
+        source_url: str,
+        collision: WriteResult,
+        metrics_module: Any,
+        allow_suffix_retry: bool = True,
+    ) -> WriteResult:
+        """Single recovery round.  Returns the ``WriteResult`` to surface.
+
+        When ``allow_suffix_retry=True`` (round 1) and the squatter is
+        ``distinct``, this method issues the AC-05-D suffix retry and
+        returns its result (which may itself be a ``slug_collision``
+        for the outer to handle in round 2).
+        """
+        squatter_id = _existing_id_from_detail(collision.detail)
+        if not squatter_id:
+            # No squatter id to inspect (e.g. older lithos response shape).
+            # Fall through to the conservative AC-05-D suffix retry.
+            if allow_suffix_retry:
+                return await self._suffix_retry(args, source_url=source_url)
+            return collision
+
+        try:
+            doc = await self.read_note(note_id=squatter_id)
+        except Exception:  # noqa: BLE001 — read failure shouldn't crash the write loop
+            logger.warning(
+                "slug_collision squatter inspection failed for %s id=%s; "
+                "falling back to suffix retry",
+                source_url,
+                squatter_id,
+            )
+            if allow_suffix_retry:
+                return await self._suffix_retry(args, source_url=source_url)
+            return collision
+
+        classification = _classify_squatter(
+            doc, squatter_id=squatter_id, incoming_source_url=source_url
+        )
+
+        if classification.kind == "duplicate":
+            metrics_module.slug_collision_dedup_recovery().add(1)
+            logger.info(
+                "slug_collision recovered as duplicate for %s: %s",
+                source_url,
+                classification.reason,
+            )
+            return WriteResult(
+                status="duplicate",
+                source_url=source_url,
+                detail=f"recovered: {classification.reason}",
+            )
+
+        if classification.kind == "reclaimable":
+            metrics_module.slug_collision_reclaimed().add(1)
+            logger.warning(
+                "slug_collision reclaimed empty squatter for %s id=%s: %s",
+                source_url,
+                squatter_id,
+                classification.reason,
+            )
+            await self.call_tool(
+                "lithos_delete", {"id": squatter_id, "agent": "influx"}
+            )
+            # Re-issue the original write — the slug is now free.
+            result = await self.call_tool("lithos_write", args)
+            return self._parse_write_response(result, source_url=source_url)
+
+        # 'distinct' — fall back to the AC-05-D suffix retry.
+        if not allow_suffix_retry:
+            return collision
+        return await self._suffix_retry(args, source_url=source_url)
+
+    async def _suffix_retry(
+        self, args: dict[str, Any], *, source_url: str
+    ) -> WriteResult:
+        """Single AC-05-D suffix retry for the genuinely-distinct case."""
         suffix = _extract_slug_suffix(source_url)
         retry_args = {**args, "title": args["title"] + suffix}
         result = await self.call_tool("lithos_write", retry_args)
-        parsed = self._parse_write_response(result, source_url=source_url)
-        if parsed.status == "slug_collision":
-            logger.warning(
-                "lithos_write slug_collision retry failed for %s",
-                source_url,
-            )
-        return parsed
+        return self._parse_write_response(result, source_url=source_url)
 
     # ── Version-conflict retry (AC-05-E) ────────────────────────────
 

--- a/src/influx/metrics.py
+++ b/src/influx/metrics.py
@@ -45,6 +45,9 @@ __all__ = [
     "run_completions",
     "run_duration",
     "run_starts",
+    "slug_collision_dedup_recovery",
+    "slug_collision_reclaimed",
+    "slug_collision_unresolved",
     "source_acquisition_errors",
 ]
 
@@ -184,6 +187,72 @@ def archive_missing() -> Any:
     return get_meter().counter(
         "influx_archive_missing_total",
         description="Items tagged influx:archive-missing during a run.",
+    )
+
+
+def slug_collision_dedup_recovery() -> Any:
+    """Counter of slug collisions recovered as duplicates (#31).
+
+    Increments when a ``slug_collision`` envelope's squatter doc was
+    actually the same paper as the incoming write — Lithos's URL or
+    cache dedup missed it (typically because the squatter lacks a
+    matching ``source_url`` or ``arxiv-id`` tag), and Influx routed
+    the write through the ``duplicate`` path instead of creating a
+    near-duplicate note.
+
+    No labels: this is a low-volume signal that mostly tracks the
+    quality of upstream dedup.  When non-zero in steady state, file
+    a Lithos-side issue (see agent-lore/lithos#222).
+    """
+    return get_meter().counter(
+        "influx_slug_collision_dedup_recovery_total",
+        description=(
+            "slug_collision events recovered as duplicates after squatter "
+            "inspection (the squatter shares arxiv-id or source_url with "
+            "the incoming write)"
+        ),
+    )
+
+
+def slug_collision_reclaimed() -> Any:
+    """Counter of slug collisions resolved by reclaiming an empty squatter (#31).
+
+    Increments when ``slug_collision`` was caused by a stale residue
+    (no tags, no source_url, empty body — typically an aborted prior
+    write that committed a slug but never landed metadata).  Influx
+    deletes the residue and re-issues the write.
+
+    No labels: low-volume operational signal.  Sustained non-zero
+    means there's a write-path bug somewhere upstream that's
+    repeatedly leaving residues; investigate.
+    """
+    return get_meter().counter(
+        "influx_slug_collision_reclaimed_total",
+        description=(
+            "slug_collision events resolved by deleting an empty stale "
+            "squatter and re-issuing the write"
+        ),
+    )
+
+
+def slug_collision_unresolved() -> Any:
+    """Counter of slug collisions that exhausted the recovery chain (#31).
+
+    A non-zero value here means even after squatter inspection +
+    suffix retry the write was permanently dropped from this run.
+    The scheduler also persists each unresolved entry to the local
+    backlog file (``${state_dir}/unresolved-slug-collisions.jsonl``)
+    so operators can intervene via
+    ``./scripts/influx-diagnose.py slug-collision-backlog``.
+
+    Labels: ``profile``, ``source``.
+    """
+    return get_meter().counter(
+        "influx_slug_collision_unresolved_total",
+        description=(
+            "slug collisions that exhausted the recovery chain "
+            "(inspect + reclaim + suffix retry) and dropped the write"
+        ),
     )
 
 

--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -35,6 +35,18 @@ class RunLedger:
     def active_path(self) -> Path:
         return self.state_dir / "active-runs.json"
 
+    @property
+    def unresolved_slug_collisions_path(self) -> Path:
+        """JSONL of slug collisions that exhausted the recovery chain (#31).
+
+        Each line is one entry with ``timestamp``, ``run_id``,
+        ``profile``, ``source``, ``source_url``, ``title``, ``detail``.
+        Append-only; the ``slug-collision-backlog`` diagnose subcommand
+        consumes it so an operator can see every still-unresolved
+        collision in one place rather than scraping log buffers.
+        """
+        return self.state_dir / "unresolved-slug-collisions.jsonl"
+
     def start(
         self,
         *,
@@ -105,6 +117,72 @@ class RunLedger:
             degraded=False,
             source_acquisition_errors=[],
         )
+
+    def record_unresolved_slug_collision(
+        self,
+        *,
+        profile: str,
+        source: str,
+        source_url: str,
+        title: str,
+        detail: str,
+        run_id: str,
+    ) -> None:
+        """Append one unresolved slug-collision entry to the backlog (#31).
+
+        Called by the scheduler when ``LithosClient._retry_slug_collision``
+        cannot recover the write (squatter is genuinely-distinct AND the
+        suffix retry also collides).  Each entry is a self-contained JSON
+        object so the diagnose script can stream the file without parsing
+        run-ledger context.  Best-effort: a write error is logged but
+        does not propagate, mirroring the run-ledger discipline.
+        """
+        entry = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "run_id": run_id,
+            "profile": profile,
+            "source": source,
+            "source_url": source_url,
+            "title": title,
+            "detail": detail,
+        }
+        try:
+            self.state_dir.mkdir(parents=True, exist_ok=True)
+            with self.unresolved_slug_collisions_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(entry, sort_keys=True) + "\n")
+        except OSError:
+            logger.warning(
+                "failed to append unresolved slug-collision entry",
+                exc_info=True,
+            )
+
+    def unresolved_slug_collisions(self) -> list[dict[str, Any]]:
+        """Return every unresolved slug-collision entry from the backlog (#31).
+
+        Newest-last to match the on-disk order.  Returns an empty list
+        when the backlog file does not yet exist.
+        """
+        path = self.unresolved_slug_collisions_path
+        if not path.exists():
+            return []
+        entries: list[dict[str, Any]] = []
+        try:
+            for raw in path.read_text(encoding="utf-8").splitlines():
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(obj, dict):
+                    entries.append(obj)
+        except OSError:
+            logger.warning(
+                "failed to read unresolved slug-collision backlog",
+                exc_info=True,
+            )
+        return entries
 
     def active_runs(self) -> list[RunEntry]:
         """Return currently active runs ordered by start time."""

--- a/src/influx/scheduler.py
+++ b/src/influx/scheduler.py
@@ -219,6 +219,7 @@ async def run_profile(
                 config=config,
                 item_provider=provider,
                 probe_loop=probe_loop,
+                ledger=ledger,
             )
             elapsed = (datetime.now(UTC) - started_at).total_seconds()
             source_errors = current_source_acquisition_errors.get() or []
@@ -286,8 +287,16 @@ async def _run_profile_body(
     config: AppConfig,
     item_provider: ItemProvider,
     probe_loop: Any | None = None,
+    ledger: RunLedger | None = None,
 ) -> ProfileRunResult | None:
-    """Inner implementation body of :func:`run_profile`."""
+    """Inner implementation body of :func:`run_profile`.
+
+    *ledger* is passed through so the slug-collision recovery exhaust
+    path can persist unresolved entries to the local backlog (#31).
+    ``None`` is permitted for tests that exercise the body without a
+    real ledger; when ``None`` the unresolved-collision write is
+    skipped (the metric still fires).
+    """
     provider = item_provider
     profile_cfg = next((p for p in config.profiles if p.name == profile), None)
 
@@ -627,6 +636,27 @@ async def _run_profile_body(
                             "cache_hit": False,
                         },
                     )
+                    # #31: a slug_collision that survives the recovery
+                    # chain (squatter-shape dispatch + suffix retry)
+                    # means the write was permanently dropped.  Persist
+                    # the entry to the backlog and bump the metric so
+                    # the operator has both a queryable file and an
+                    # alertable counter — instead of just a WARNING
+                    # buried in the docker log buffer.
+                    if write_result.status == "slug_collision":
+                        metrics.slug_collision_unresolved().add(
+                            1,
+                            {"profile": profile, "source": item_source},
+                        )
+                        if ledger is not None:
+                            ledger.record_unresolved_slug_collision(
+                                profile=profile,
+                                source=item_source,
+                                source_url=source_url,
+                                title=title,
+                                detail=write_result.detail,
+                                run_id=current_run_id.get() or "",
+                            )
 
             # 5. Build result + fire post-run webhook hook (FR-NOT-1..6, AC-05-I).
             result = ProfileRunResult(

--- a/tests/contract/test_lithos_client.py
+++ b/tests/contract/test_lithos_client.py
@@ -145,6 +145,11 @@ class FakeLithosServer:
                 return read_responses.pop(0)
             return '{"id": "", "content": "", "tags": [], "version": 1}'
 
+        @self._mcp.tool(name="lithos_delete")
+        async def lithos_delete(id: str = "", agent: str = "") -> str:
+            calls.append(("lithos_delete", {"id": id, "agent": agent}))
+            return '{"status": "deleted"}'
+
         @self._mcp.tool(name="lithos_list")
         async def lithos_list(
             tags: list[str] | None = None,
@@ -1228,6 +1233,11 @@ class TestWriteEnvelopeSlugCollision:
         round-trip into ``WriteResult.detail`` so the operator-facing
         WARNING in scheduler.py names the squatting note rather than
         logging an empty string (2026-05-02 staging incident).
+
+        Both squatters here are distinct real notes (own ``arxiv-id``
+        and ``source_url``), so the recovery chain falls through to the
+        AC-05-D suffix retry; the suffixed write also collides; the
+        final ``detail`` carries the second squatter's id.
         """
         fake_lithos_server.write_responses.extend(
             [
@@ -1247,6 +1257,17 @@ class TestWriteEnvelopeSlugCollision:
                     " already in use by document 'doc-squatter-456'\","
                     ' "warnings": []}'
                 ),
+            ]
+        )
+        # Both squatters look like genuinely-distinct papers so the
+        # recovery dispatch falls through to the suffix retry rather
+        # than reclaiming or treating as duplicate.
+        fake_lithos_server.read_responses.extend(
+            [
+                '{"id": "doc-squatter-123", "title": "Other A",'
+                ' "content": "real body", "tags": ["arxiv-id:9999.11111"]}',
+                '{"id": "doc-squatter-456", "title": "Other B",'
+                ' "content": "real body", "tags": ["arxiv-id:9999.22222"]}',
             ]
         )
         client = LithosClient(url=fake_lithos_url)
@@ -1270,6 +1291,246 @@ class TestWriteEnvelopeSlugCollision:
         assert "doc-squatter-456" in result.detail
         assert "existing_id=" in result.detail
         assert "already in use" in result.detail
+
+
+class TestWriteSlugCollisionRecovery:
+    """#31: squatter-shape dispatch (duplicate / reclaim / distinct)."""
+
+    async def test_recovers_as_duplicate_when_squatter_has_matching_arxiv_id(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+    ) -> None:
+        """If the squatter carries ``arxiv-id:<id>`` matching the incoming
+        write, treat as ``duplicate`` (Lithos's URL-dedup missed it).
+        """
+        fake_lithos_server.write_responses.append(
+            '{"status": "slug_collision",'
+            ' "existing_id": "doc-dup-1",'
+            ' "message": "Slug already in use",'
+            ' "warnings": []}'
+        )
+        # Squatter carries the same arxiv-id, no source_url.
+        fake_lithos_server.read_responses.append(
+            '{"id": "doc-dup-1", "title": "Different Title",'
+            ' "content": "real content here",'
+            ' "tags": ["arxiv-id:2604.28197", "source:arxiv"]}'
+        )
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            result = await client.write_note(
+                title="OmniRobotHome",
+                content="# Summary\nContent.",
+                path="papers/arxiv/2026/04",
+                source_url="https://arxiv.org/abs/2604.28197",
+                tags=["profile:staging-robotics"],
+                confidence=0.8,
+            )
+        finally:
+            await client.close()
+
+        assert result.status == "duplicate"
+        assert "arxiv-id:2604.28197" in result.detail
+        # Only ONE lithos_write — no suffix retry was needed because
+        # the duplicate path returns immediately.
+        write_calls = [c for c in fake_lithos_server.calls if c[0] == "lithos_write"]
+        assert len(write_calls) == 1
+
+    async def test_reclaims_empty_squatter_then_retries_original_slug(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+    ) -> None:
+        """If the squatter is an empty residue (no tags, no source_url,
+        empty body) — like the OmniRobotHome ``006bbcb8-…`` case — delete
+        it and re-issue the original write with the same slug.
+        """
+        fake_lithos_server.write_responses.extend(
+            [
+                # Initial collision.
+                '{"status": "slug_collision", "existing_id": "doc-stale-1",'
+                ' "message": "Slug already in use", "warnings": []}',
+                # Re-issue after reclaim succeeds.
+                '{"status": "created", "note_id": "note-reclaimed"}',
+            ]
+        )
+        fake_lithos_server.read_responses.append(
+            '{"id": "doc-stale-1", "title": "OmniRobotHome", "content": "", "tags": []}'
+        )
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            result = await client.write_note(
+                title="OmniRobotHome",
+                content="# Summary\nContent.",
+                path="papers/arxiv/2026/04",
+                source_url="https://arxiv.org/abs/2604.28197",
+                tags=["profile:staging-robotics"],
+                confidence=0.8,
+            )
+        finally:
+            await client.close()
+
+        assert result.status == "created"
+        assert result.note_id == "note-reclaimed"
+        # Two writes (initial + reclaim retry) plus one delete in between.
+        tools_called = [c[0] for c in fake_lithos_server.calls]
+        assert tools_called.count("lithos_write") == 2
+        assert tools_called.count("lithos_delete") == 1
+        # The delete must target the squatter id.
+        delete_call = next(
+            c for c in fake_lithos_server.calls if c[0] == "lithos_delete"
+        )
+        assert delete_call[1]["id"] == "doc-stale-1"
+
+    async def test_distinct_squatter_falls_back_to_suffix_retry(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+    ) -> None:
+        """If the squatter is a real, different doc — same slugified title
+        but different paper — fall back to the AC-05-D suffix retry.
+        """
+        fake_lithos_server.write_responses.extend(
+            [
+                # Initial collision.
+                '{"status": "slug_collision", "existing_id": "doc-other-1",'
+                ' "message": "Slug already in use", "warnings": []}',
+                # Suffixed retry succeeds.
+                '{"status": "created", "note_id": "note-suffixed"}',
+            ]
+        )
+        # Squatter has its own metadata — different paper, same slug.
+        fake_lithos_server.read_responses.append(
+            '{"id": "doc-other-1", "title": "Some Other Paper",'
+            ' "content": "real body text", "tags": ["arxiv-id:9999.99999"],'
+            ' "source_url": "https://arxiv.org/abs/9999.99999"}'
+        )
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            result = await client.write_note(
+                title="OmniRobotHome",
+                content="# Summary\nContent.",
+                path="papers/arxiv/2026/04",
+                source_url="https://arxiv.org/abs/2604.28197",
+                tags=["profile:staging-robotics"],
+                confidence=0.8,
+            )
+        finally:
+            await client.close()
+
+        assert result.status == "created"
+        assert result.note_id == "note-suffixed"
+        write_calls = [c for c in fake_lithos_server.calls if c[0] == "lithos_write"]
+        # Initial + suffix retry; no delete.
+        assert len(write_calls) == 2
+        assert all(c[0] != "lithos_delete" for c in fake_lithos_server.calls)
+        # Suffixed write must carry the ``[arXiv …]`` suffix.
+        assert "[arXiv 2604.28197]" in write_calls[1][1]["title"]
+
+    async def test_stacked_residues_recovered_in_round_two(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+    ) -> None:
+        """Squatter A is distinct → suffix retry; suffixed slug is itself a
+        reclaimable residue → delete B, re-issue suffixed write.
+
+        This is the worst real-world case for the OmniRobotHome shape:
+        residues at both the natural and suffixed slugs.
+        """
+        fake_lithos_server.write_responses.extend(
+            [
+                # Initial collision (squatter A — distinct).
+                '{"status": "slug_collision", "existing_id": "doc-a",'
+                ' "message": "Slug already in use", "warnings": []}',
+                # Suffix retry collides (squatter B — reclaimable).
+                '{"status": "slug_collision", "existing_id": "doc-b-residue",'
+                ' "message": "Slug already in use", "warnings": []}',
+                # After reclaiming B, the suffixed write succeeds.
+                '{"status": "created", "note_id": "note-after-reclaim"}',
+            ]
+        )
+        fake_lithos_server.read_responses.extend(
+            [
+                # Squatter A — real distinct paper.
+                '{"id": "doc-a", "title": "Other Paper", "content": "real",'
+                ' "tags": ["arxiv-id:9999.99999"]}',
+                # Squatter B — empty residue.
+                '{"id": "doc-b-residue", "title": "OmniRobotHome",'
+                ' "content": "", "tags": []}',
+            ]
+        )
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            result = await client.write_note(
+                title="OmniRobotHome",
+                content="# Summary\nContent.",
+                path="papers/arxiv/2026/04",
+                source_url="https://arxiv.org/abs/2604.28197",
+                tags=["profile:staging-robotics"],
+                confidence=0.8,
+            )
+        finally:
+            await client.close()
+
+        assert result.status == "created"
+        assert result.note_id == "note-after-reclaim"
+        tools_called = [c[0] for c in fake_lithos_server.calls]
+        # Initial + suffix + reclaim-retry = 3 writes; 1 delete (of B only).
+        assert tools_called.count("lithos_write") == 3
+        assert tools_called.count("lithos_delete") == 1
+        delete_call = next(
+            c for c in fake_lithos_server.calls if c[0] == "lithos_delete"
+        )
+        assert delete_call[1]["id"] == "doc-b-residue"
+
+    async def test_unrecoverable_collision_returns_slug_collision(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+    ) -> None:
+        """Both attempts collide with distinct real notes — chain exhausted.
+
+        The result must remain ``slug_collision`` so the scheduler routes
+        the write to the unresolved-collisions backlog.
+        """
+        fake_lithos_server.write_responses.extend(
+            [
+                '{"status": "slug_collision", "existing_id": "doc-a",'
+                ' "message": "Slug A in use", "warnings": []}',
+                '{"status": "slug_collision", "existing_id": "doc-b",'
+                ' "message": "Slug B in use", "warnings": []}',
+            ]
+        )
+        fake_lithos_server.read_responses.extend(
+            [
+                '{"id": "doc-a", "title": "Real A", "content": "real",'
+                ' "tags": ["arxiv-id:9999.11111"]}',
+                '{"id": "doc-b", "title": "Real B", "content": "real",'
+                ' "tags": ["arxiv-id:9999.22222"]}',
+            ]
+        )
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            result = await client.write_note(
+                title="OmniRobotHome",
+                content="# Summary\nContent.",
+                path="papers/arxiv/2026/04",
+                source_url="https://arxiv.org/abs/2604.28197",
+                tags=["profile:staging-robotics"],
+                confidence=0.8,
+            )
+        finally:
+            await client.close()
+
+        assert result.status == "slug_collision"
+        # No deletes attempted (both squatters were 'distinct').
+        assert all(c[0] != "lithos_delete" for c in fake_lithos_server.calls)
 
 
 # ── Write envelopes — version_conflict (FR-MCP-7, AC-05-E) ────────

--- a/tests/unit/test_diagnose_squatters.py
+++ b/tests/unit/test_diagnose_squatters.py
@@ -390,3 +390,34 @@ class TestExtractSquatters:
         rec.pop("detail")
         result = _extract([rec])
         assert "cccccccc-cccc-cccc-cccc-cccccccccccc" in result
+
+
+class TestSlugCollisionBacklog:
+    """``slug-collision-backlog`` reads the JSONL the daemon writes on chain exhaust."""
+
+    def test_returns_empty_list_when_file_missing(self, tmp_path: Any) -> None:
+        assert _DIAGNOSE._read_slug_collision_backlog(tmp_path) == []
+
+    def test_reads_one_entry(self, tmp_path: Any) -> None:
+        path = tmp_path / "unresolved-slug-collisions.jsonl"
+        path.write_text(
+            '{"timestamp": "2026-05-02T13:00:00+00:00", '
+            '"run_id": "r-1", "profile": "staging-robotics", "source": "arxiv", '
+            '"source_url": "https://arxiv.org/abs/2604.28197", '
+            '"title": "OmniRobotHome", '
+            '"detail": "existing_id=doc-A"}\n',
+            encoding="utf-8",
+        )
+        entries = _DIAGNOSE._read_slug_collision_backlog(tmp_path)
+        assert len(entries) == 1
+        assert entries[0]["title"] == "OmniRobotHome"
+        assert entries[0]["profile"] == "staging-robotics"
+
+    def test_skips_malformed_lines(self, tmp_path: Any) -> None:
+        path = tmp_path / "unresolved-slug-collisions.jsonl"
+        path.write_text(
+            '{"title": "ok"}\nthis is not json\n\n{"title": "also ok"}\n',
+            encoding="utf-8",
+        )
+        entries = _DIAGNOSE._read_slug_collision_backlog(tmp_path)
+        assert [e["title"] for e in entries] == ["ok", "also ok"]

--- a/tests/unit/test_lithos_client.py
+++ b/tests/unit/test_lithos_client.py
@@ -76,3 +76,158 @@ class TestListNotes:
             "lithos_list",
             {"tags": ["influx:repair-needed", "profile:staging-ai"], "limit": 25},
         )
+
+
+class TestClassifySquatter:
+    """#31 squatter-shape dispatch is a pure function — exhaustively cover."""
+
+    def _make_doc(
+        self,
+        *,
+        tags: list[str] | None = None,
+        source_url: str | None = None,
+        content: str = "",
+        title: str = "Some Title",
+    ) -> dict[str, object]:
+        doc: dict[str, object] = {
+            "id": "doc-x",
+            "title": title,
+            "content": content,
+            "tags": list(tags or []),
+        }
+        if source_url is not None:
+            doc["source_url"] = source_url
+        return doc
+
+    def test_arxiv_id_match_classifies_as_duplicate(self) -> None:
+        from influx.lithos_client import _classify_squatter
+
+        doc = self._make_doc(
+            tags=["arxiv-id:2604.28197", "source:arxiv"],
+            content="real body text",
+        )
+        result = _classify_squatter(
+            doc,
+            squatter_id="doc-x",
+            incoming_source_url="https://arxiv.org/abs/2604.28197",
+        )
+        assert result.kind == "duplicate"
+        assert "arxiv-id:2604.28197" in result.reason
+
+    def test_source_url_match_classifies_as_duplicate(self) -> None:
+        from influx.lithos_client import _classify_squatter
+
+        doc = self._make_doc(
+            tags=["source:rss"],
+            source_url="https://example.com/article-x",
+            content="real body",
+        )
+        result = _classify_squatter(
+            doc,
+            squatter_id="doc-x",
+            incoming_source_url="https://example.com/article-x",
+        )
+        assert result.kind == "duplicate"
+        assert "source_url" in result.reason
+
+    def test_empty_residue_classifies_as_reclaimable(self) -> None:
+        from influx.lithos_client import _classify_squatter
+
+        doc = self._make_doc(tags=[], content="")
+        result = _classify_squatter(
+            doc,
+            squatter_id="doc-x",
+            incoming_source_url="https://arxiv.org/abs/2604.28197",
+        )
+        assert result.kind == "reclaimable"
+        assert "stale residue" in result.reason
+
+    def test_residue_with_any_tag_is_distinct_not_reclaimable(self) -> None:
+        """Conservative: a single tag (e.g. an operator-added one) is
+        enough to refuse reclaim, even with no source_url and empty body.
+        """
+        from influx.lithos_client import _classify_squatter
+
+        doc = self._make_doc(tags=["bookmark"], content="")
+        result = _classify_squatter(
+            doc,
+            squatter_id="doc-x",
+            incoming_source_url="https://arxiv.org/abs/2604.28197",
+        )
+        assert result.kind == "distinct"
+
+    def test_residue_with_body_is_distinct_not_reclaimable(self) -> None:
+        from influx.lithos_client import _classify_squatter
+
+        doc = self._make_doc(tags=[], content="user notes here")
+        result = _classify_squatter(
+            doc,
+            squatter_id="doc-x",
+            incoming_source_url="https://arxiv.org/abs/2604.28197",
+        )
+        assert result.kind == "distinct"
+
+    def test_different_arxiv_id_classifies_as_distinct(self) -> None:
+        """Same slug, different arxiv id = different paper that happens
+        to slugify the same.  Suffix retry territory.
+        """
+        from influx.lithos_client import _classify_squatter
+
+        doc = self._make_doc(
+            tags=["arxiv-id:9999.99999"],
+            content="real body",
+        )
+        result = _classify_squatter(
+            doc,
+            squatter_id="doc-x",
+            incoming_source_url="https://arxiv.org/abs/2604.28197",
+        )
+        assert result.kind == "distinct"
+
+    def test_metadata_nested_tags_are_recognised(self) -> None:
+        """Tags can live under ``metadata.tags`` per lithos_read shape;
+        the helper must read both top-level and nested.
+        """
+        from influx.lithos_client import _classify_squatter
+
+        doc = {
+            "id": "doc-x",
+            "title": "T",
+            "content": "real",
+            "metadata": {"tags": ["arxiv-id:2604.28197"]},
+        }
+        result = _classify_squatter(
+            doc,
+            squatter_id="doc-x",
+            incoming_source_url="https://arxiv.org/abs/2604.28197",
+        )
+        assert result.kind == "duplicate"
+
+
+class TestExistingIdParsing:
+    """``_existing_id_from_detail`` extracts the squatter id from PR-#30 detail."""
+
+    def test_parses_uuid_form(self) -> None:
+        from influx.lithos_client import _existing_id_from_detail
+
+        detail = (
+            "existing_id=006bbcb8-ee01-4616-aa43-473f292eba0e; "
+            "Slug 'omnirobothome-…' already in use"
+        )
+        assert (
+            _existing_id_from_detail(detail) == "006bbcb8-ee01-4616-aa43-473f292eba0e"
+        )
+
+    def test_parses_friendly_test_id(self) -> None:
+        from influx.lithos_client import _existing_id_from_detail
+
+        assert (
+            _existing_id_from_detail("existing_id=doc-test-1; Slug 'x' in use")
+            == "doc-test-1"
+        )
+
+    def test_returns_none_for_missing(self) -> None:
+        from influx.lithos_client import _existing_id_from_detail
+
+        assert _existing_id_from_detail("") is None
+        assert _existing_id_from_detail("no id here") is None

--- a/tests/unit/test_run_ledger.py
+++ b/tests/unit/test_run_ledger.py
@@ -157,3 +157,46 @@ def test_failed_run_has_degraded_false(tmp_path: Path) -> None:
     entry = ledger.recent()[0]
     assert entry["degraded"] is False
     assert entry["source_acquisition_errors"] == []
+
+
+def test_unresolved_slug_collisions_starts_empty(tmp_path: Path) -> None:
+    """Backlog read returns ``[]`` when the file does not yet exist."""
+    ledger = RunLedger(tmp_path / "state")
+    assert ledger.unresolved_slug_collisions() == []
+
+
+def test_record_unresolved_slug_collision_appends_entry(tmp_path: Path) -> None:
+    ledger = RunLedger(tmp_path / "state")
+    ledger.record_unresolved_slug_collision(
+        profile="staging-robotics",
+        source="arxiv",
+        source_url="https://arxiv.org/abs/2604.28197",
+        title="OmniRobotHome",
+        detail="existing_id=doc-A; existing_id=doc-B",
+        run_id="run-xyz",
+    )
+    entries = ledger.unresolved_slug_collisions()
+    assert len(entries) == 1
+    e = entries[0]
+    assert e["profile"] == "staging-robotics"
+    assert e["source"] == "arxiv"
+    assert e["source_url"] == "https://arxiv.org/abs/2604.28197"
+    assert e["title"] == "OmniRobotHome"
+    assert "doc-A" in e["detail"]
+    assert e["run_id"] == "run-xyz"
+    assert "T" in e["timestamp"] and e["timestamp"].endswith(("Z", "+00:00"))
+
+
+def test_record_unresolved_slug_collision_is_append_only(tmp_path: Path) -> None:
+    ledger = RunLedger(tmp_path / "state")
+    for i in range(3):
+        ledger.record_unresolved_slug_collision(
+            profile="p",
+            source="arxiv",
+            source_url=f"https://arxiv.org/abs/2601.0000{i}",
+            title=f"paper-{i}",
+            detail=f"squatter-{i}",
+            run_id=f"run-{i}",
+        )
+    entries = ledger.unresolved_slug_collisions()
+    assert [e["title"] for e in entries] == ["paper-0", "paper-1", "paper-2"]


### PR DESCRIPTION
Closes #31.

Replaces the abandoned PR #45 with the corrected design that came out of code review.

## Summary

The original AC-05-D behaviour did one ``[arXiv <id>]`` suffix retry on ``slug_collision`` and dropped the write if that also collided.  The 2026-05-02 OmniRobotHome incident showed why this was insufficient: a stale residue from an aborted prior write was squatting both the unsuffixed and the suffixed slug, so every sweep silently dropped the same paper.

This PR replaces the unconditional suffix retry with **squatter-shape dispatch**.  When Lithos returns ``existing_id``, ``LithosClient`` reads the squatter and routes on its shape:

| Squatter shape | Action | Metric |
|---|---|---|
| Same paper (matching ``arxiv-id`` tag or ``source_url``) | Treat as ``duplicate`` — Lithos's URL/cache dedup missed it | ``influx_slug_collision_dedup_recovery_total`` |
| Empty residue (no tags AND no ``source_url`` AND empty body) | ``lithos_delete(existing_id)`` then re-issue original write | ``influx_slug_collision_reclaimed_total`` |
| Distinct paper (any other shape) | Fall back to AC-05-D suffix retry; if THAT also collides and the suffixed-slug squatter is itself reclaimable, delete + retry once more | _(no per-attempt metric)_ |

Anything still ``slug_collision`` after the chain is appended to ``${storage.state_dir}/unresolved-slug-collisions.jsonl`` and surfaced via ``./scripts/influx-diagnose.py slug-collision-backlog``.  ``influx_slug_collision_unresolved_total{profile, source}`` ticks for each unresolved drop.

## Why this is the right design (and not PR #45's numeric chain)

For arxiv items, an id uniquely identifies a paper.  If two Lithos docs map to the same id they ARE the same paper, and the right fix is to recognise the duplicate (or reclaim a stale residue) — not to create a numeric variant.

PR #45 would have shipped ``[arXiv id (2)]``, ``(3)``, ``(4)``, … duplicates of the same paper while leaving original residues squatting earlier slots — strictly worse than today's behaviour.  This PR fixes the actual underlying bug.

The reclaim heuristic is conservative (no tags AND no source_url AND empty body, all three) so a real note that happens to share a slug never gets deleted.  The 2026-05-02 ``006bbcb8-…`` squatter matched this shape exactly.

## What this does for OmniRobotHome at the next sweep

Squatter ``006bbcb8-…`` matches the **reclaimable** shape.  Influx will ``lithos_delete`` it and re-issue the OmniRobotHome write — succeeds on the same slug, no numeric variant created, no operator action needed.

## Test plan

- [x] ``make check`` — **1550 tests pass**, ruff + format + pyright clean.
- [x] **5 new contract tests** in ``tests/contract/test_lithos_client.py``: one per dispatch path (duplicate / reclaim / distinct→suffix / stacked-residues / unrecoverable).
- [x] **7 new unit tests** for ``_classify_squatter`` covering arxiv-id match, source_url match, empty residue, single-tag → distinct, body → distinct, different arxiv-id → distinct, ``metadata.tags`` shape support.
- [x] **3 new unit tests** for ``_existing_id_from_detail`` (UUID, friendly id, missing).
- [x] **3 new unit tests** for ``RunLedger.record_unresolved_slug_collision``.
- [x] **3 new unit tests** for the diagnose-side backlog reader.
- [x] All existing slug_collision contract tests pass — the dispatch chain falls back to AC-05-D suffix retry when the squatter cannot be classified, so envelopes without ``existing_id`` keep their original behaviour (verified).

## Refs

- 2026-05-02 staging incident (OmniRobotHome / 2604.28197).
- PR #30 — surfaced ``existing_id`` in WriteResult.detail; this PR consumes that signal.
- PR #45 — closed without merging; numeric-suffix chain was the wrong fix.  Salvaged backlog file + diagnose subcommand + metrics shape brought forward here.
- agent-lore/lithos#222 — Lithos-side companion.  When that lands, ``lithos_write`` will dedup by identifier server-side and this Influx-side dispatch becomes a backstop rather than the primary path.