### PR TITLE
feat: add Lithos extended-outage circuit breaker

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -640,6 +640,8 @@ Readiness is degraded when:
 - Repair sweep terminal write failure is latched.
 - LCMA unknown-tool failure is latched.
 
+When the Lithos probe has been ``degraded`` for **3 consecutive cycles** (default; see `ProbeLoop.lithos_circuit_open`), `run_profile` short-circuits — the run is recorded as ``status="skipped", error="lithos_unhealthy"`` in the run ledger, the `influx_runs_skipped_total{profile, reason="lithos_unhealthy"}` metric ticks, and no source-fetch / LLM-filter / write work is performed.  The breaker closes automatically on the first ``ok`` probe; subsequent runs proceed normally.  This prevents an extended Lithos outage from burning LLM tokens against a write path that will fail (#40).
+
 ### 13.2 Telemetry
 
 When telemetry is enabled (`INFLUX_OTEL_ENABLED=true`), Influx exports OTEL traces and metrics. Both signals share the same toggle, the same OTLP endpoint configuration (`OTEL_EXPORTER_OTLP_ENDPOINT`), and the same resource attributes (`service.name=influx`, `deployment.environment=<INFLUX_ENVIRONMENT>`).
@@ -666,6 +668,7 @@ Metric instruments cover run lifecycle, the source funnel, write outcomes, and f
 | `influx_slug_collision_dedup_recovery_total` | Counter | _(no labels)_ |
 | `influx_slug_collision_reclaimed_total` | Counter | _(no labels)_ |
 | `influx_slug_collision_unresolved_total` | Counter | `profile`, `source` |
+| `influx_runs_skipped_total` | Counter | `profile`, `reason` |
 
 When `OTEL_EXPORTER_OTLP_ENDPOINT` is set the OTLP HTTP exporter is used. With `INFLUX_OTEL_CONSOLE_FALLBACK=true` and no endpoint configured, both spans and metrics are written to stdout for local development.
 

--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -41,6 +41,12 @@ Three quick signals, all read-only:
 - **`failures`** filters to `failed`, `abandoned`, and `degraded` runs
   in one go. A `degraded` run completed but had at least one swallowed
   source-fetch failure (issue #20); the body of the run still landed.
+  A `skipped` run (#40) means the Lithos circuit breaker fired:
+  ProbeLoop saw 3+ consecutive `degraded` Lithos probes, so the
+  scheduler short-circuited to avoid burning LLM tokens against a
+  write path that would fail.  Look at `/ready` and `/status` to
+  confirm Lithos health; the breaker closes automatically on the
+  first `ok` probe.
 - **`influx-report.py`** queries `/status` + `/runs/recent` over HTTP
   for an at-a-glance view; useful when the container is unreachable
   from the ledger path (e.g. running on a remote host).

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -313,12 +313,20 @@ def cmd_failures(args: argparse.Namespace) -> int:
         profile=args.profile,
         statuses={"failed", "abandoned"},
     )
+    skipped = _filter_runs(runs, profile=args.profile, statuses={"skipped"})
     degraded = _filter_runs(runs, profile=args.profile, degraded_only=True)
 
     print(f"Failed/abandoned runs ({len(failed)}):")
     for run in failed[-args.limit :]:
         _print_run_row(run)
     if not failed:
+        print("  (none)")
+
+    print()
+    print(f"Skipped runs ({len(skipped)}):  # circuit-breaker short-circuit (#40)")
+    for run in skipped[-args.limit :]:
+        _print_run_row(run)
+    if not skipped:
         print("  (none)")
 
     print()

--- a/src/influx/metrics.py
+++ b/src/influx/metrics.py
@@ -45,6 +45,7 @@ __all__ = [
     "run_completions",
     "run_duration",
     "run_starts",
+    "runs_skipped",
     "slug_collision_dedup_recovery",
     "slug_collision_reclaimed",
     "slug_collision_unresolved",
@@ -187,6 +188,26 @@ def archive_missing() -> Any:
     return get_meter().counter(
         "influx_archive_missing_total",
         description="Items tagged influx:archive-missing during a run.",
+    )
+
+
+def runs_skipped() -> Any:
+    """Counter of runs short-circuited before any work was done (#40).
+
+    Increments once per cron-tick run that the Lithos circuit breaker
+    refused.  ``reason`` distinguishes skip causes so future short-
+    circuit paths (e.g. provider-credential outage) can share the
+    metric without label collisions.
+
+    Labels: ``profile``, ``reason`` (``"lithos_unhealthy"`` today; new
+    values added under-test only when the breaker grows new arms).
+    """
+    return get_meter().counter(
+        "influx_runs_skipped_total",
+        description=(
+            "runs short-circuited before any source-fetch / LLM / write "
+            "work was done, broken down by reason"
+        ),
     )
 
 

--- a/src/influx/probes.py
+++ b/src/influx/probes.py
@@ -237,6 +237,12 @@ class ProbeLoop:
         # LCMA unknown_tool failure latch (PRD 08 FR-LCMA-6).
         self._lcma_unknown_tool_failure = False
         self._lcma_unknown_tool_failure_detail = ""
+        # Consecutive count of degraded Lithos probes (#40 circuit breaker).
+        # Reset to 0 on the first ``ok`` probe; ``lithos_circuit_open``
+        # returns True once it crosses the configured threshold so the
+        # scheduler can short-circuit further runs and stop burning LLM
+        # tokens against a write path that will fail.
+        self._lithos_unhealthy_consecutive = 0
         self._state = ProbeState(max_age=self._max_age)
         self._task: asyncio.Task[None] | None = None
 
@@ -251,8 +257,16 @@ class ProbeLoop:
         Useful for tests and for running an initial probe before the
         background loop starts.
         """
+        lithos_result = _probe_lithos(self._config.lithos.url)
+        # Update the consecutive-degraded counter (#40 circuit breaker).
+        # Reset to 0 on the first ``ok`` so the breaker closes
+        # automatically the moment Lithos is reachable again.
+        if lithos_result.status == "ok":
+            self._lithos_unhealthy_consecutive = 0
+        else:
+            self._lithos_unhealthy_consecutive += 1
         self._state = ProbeState(
-            lithos=_probe_lithos(self._config.lithos.url),
+            lithos=lithos_result,
             llm_credentials=_probe_llm_credentials(self._config.providers),
             max_age=self._max_age,
             repair_write_failure=self._repair_write_failure,
@@ -260,6 +274,27 @@ class ProbeLoop:
             lcma_unknown_tool_failure=self._lcma_unknown_tool_failure,
             lcma_unknown_tool_failure_detail=self._lcma_unknown_tool_failure_detail,
         )
+
+    @property
+    def lithos_unhealthy_consecutive(self) -> int:
+        """Consecutive ``degraded`` Lithos probes since the last ``ok`` (#40)."""
+        return self._lithos_unhealthy_consecutive
+
+    def lithos_circuit_open(self, *, threshold: int = 3) -> bool:
+        """Return ``True`` when Lithos has been unhealthy for ``threshold+`` probes.
+
+        The scheduler consults this before kicking off ``_run_profile_body``;
+        when the breaker is open, the run is recorded as ``skipped`` with
+        ``reason="lithos_unhealthy"`` and no source-fetch / LLM-filter /
+        write work is done.  As soon as a probe returns ``ok`` the
+        counter resets and the breaker closes automatically.
+
+        ``threshold=3`` with the default 30-second probe interval gives
+        ~90 seconds of sustained Lithos failure before the breaker
+        opens — long enough to weather a Lithos restart or transient
+        network blip without spuriously skipping a sweep.
+        """
+        return self._lithos_unhealthy_consecutive >= threshold
 
     def mark_repair_write_failure(
         self,

--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -118,6 +118,25 @@ class RunLedger:
             source_acquisition_errors=[],
         )
 
+    def skip(self, *, run_id: str, reason: str) -> None:
+        """Mark an active run as ``skipped`` and append it to history (#40).
+
+        Distinct from ``fail``: ``failed`` means the run started and
+        crashed; ``skipped`` means the run never started any
+        source-fetch / LLM / write work because a circuit breaker (e.g.
+        Lithos extended outage) opened first.  ``reason`` is recorded
+        so dashboards can distinguish skip causes.
+        """
+        self._finish(
+            run_id=run_id,
+            status="skipped",
+            sources_checked=None,
+            ingested=None,
+            error=reason,
+            degraded=False,
+            source_acquisition_errors=[],
+        )
+
     def record_unresolved_slug_collision(
         self,
         *,

--- a/src/influx/scheduler.py
+++ b/src/influx/scheduler.py
@@ -175,6 +175,40 @@ async def run_profile(
     provider = item_provider if item_provider is not None else default_item_provider
     run_id = run_id or str(uuid.uuid4())
     ledger = run_ledger or RunLedger(Path(config.storage.state_dir))
+
+    # #40 circuit breaker: when Lithos has been unhealthy for
+    # ``threshold`` consecutive probes, short-circuit the run before
+    # any source-fetch / LLM-filter / write work happens.  Burning
+    # tokens against a write path that will fail is worse than a
+    # skipped sweep.  The breaker closes automatically as soon as
+    # ProbeLoop reports ``ok`` again.
+    if (
+        probe_loop is not None
+        and hasattr(probe_loop, "lithos_circuit_open")
+        and probe_loop.lithos_circuit_open()
+    ):
+        ledger.start(
+            run_id=run_id,
+            profile=profile,
+            kind=kind.value,
+            run_range=run_range,
+        )
+        ledger.skip(run_id=run_id, reason="lithos_unhealthy")
+        metrics.runs_skipped().add(
+            1,
+            {"profile": profile, "reason": "lithos_unhealthy"},
+        )
+        consecutive = getattr(probe_loop, "lithos_unhealthy_consecutive", "?")
+        logger.warning(
+            "run skipped profile=%s kind=%s run_id=%s "
+            "reason=lithos_unhealthy lithos_unhealthy_consecutive=%s",
+            profile,
+            kind.value,
+            run_id,
+            consecutive,
+        )
+        return None
+
     ledger.start(
         run_id=run_id,
         profile=profile,

--- a/tests/unit/test_probes.py
+++ b/tests/unit/test_probes.py
@@ -516,3 +516,89 @@ class TestRepairWriteFailureLatch:
 
         loop.clear_repair_write_failure()
         assert loop.state.repair_write_failure is False
+
+
+# ── #40: Lithos circuit breaker ──────────────────────────────────────
+
+
+class TestLithosCircuitBreaker:
+    """ProbeLoop tracks consecutive degraded Lithos probes (#40)."""
+
+    def test_starts_closed(self, fake_lithos_sse_url: str) -> None:
+        cfg = _make_config(lithos_url=fake_lithos_sse_url)
+        loop = ProbeLoop(cfg, interval=30.0)
+        assert loop.lithos_unhealthy_consecutive == 0
+        assert loop.lithos_circuit_open() is False
+
+    def test_increments_on_degraded_probe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Each degraded probe bumps the consecutive counter."""
+        from influx import probes as _probes
+
+        cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")  # unreachable
+        # Stub the lithos probe so we don't pay an actual TCP timeout.
+        monkeypatch.setattr(
+            _probes,
+            "_probe_lithos",
+            lambda url: ProbeResult(status="degraded", detail="stub", timestamp=1.0),
+        )
+        loop = ProbeLoop(cfg, interval=30.0)
+        for expected in (1, 2, 3):
+            loop.run_once()
+            assert loop.lithos_unhealthy_consecutive == expected
+
+    def test_opens_at_threshold(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Default threshold of 3 — breaker stays closed at 2, opens at 3."""
+        from influx import probes as _probes
+
+        cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")
+        monkeypatch.setattr(
+            _probes,
+            "_probe_lithos",
+            lambda url: ProbeResult(status="degraded", detail="stub", timestamp=1.0),
+        )
+        loop = ProbeLoop(cfg, interval=30.0)
+        loop.run_once()
+        loop.run_once()
+        assert loop.lithos_circuit_open() is False
+        loop.run_once()
+        assert loop.lithos_circuit_open() is True
+
+    def test_threshold_is_configurable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from influx import probes as _probes
+
+        cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")
+        monkeypatch.setattr(
+            _probes,
+            "_probe_lithos",
+            lambda url: ProbeResult(status="degraded", detail="stub", timestamp=1.0),
+        )
+        loop = ProbeLoop(cfg, interval=30.0)
+        loop.run_once()
+        assert loop.lithos_circuit_open(threshold=1) is True
+        assert loop.lithos_circuit_open(threshold=2) is False
+
+    def test_resets_on_first_ok_probe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Breaker closes automatically on the first ``ok`` probe."""
+        from influx import probes as _probes
+
+        cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")
+        # Three degraded probes, then one ok — counter must reset.
+        responses = iter(
+            [
+                ProbeResult(status="degraded", detail="x", timestamp=1.0),
+                ProbeResult(status="degraded", detail="x", timestamp=2.0),
+                ProbeResult(status="degraded", detail="x", timestamp=3.0),
+                ProbeResult(status="ok", detail="", timestamp=4.0),
+            ]
+        )
+        monkeypatch.setattr(_probes, "_probe_lithos", lambda url: next(responses))
+        loop = ProbeLoop(cfg, interval=30.0)
+        loop.run_once()
+        loop.run_once()
+        loop.run_once()
+        assert loop.lithos_circuit_open() is True
+        loop.run_once()
+        assert loop.lithos_unhealthy_consecutive == 0
+        assert loop.lithos_circuit_open() is False

--- a/tests/unit/test_run_ledger.py
+++ b/tests/unit/test_run_ledger.py
@@ -200,3 +200,22 @@ def test_record_unresolved_slug_collision_is_append_only(tmp_path: Path) -> None
         )
     entries = ledger.unresolved_slug_collisions()
     assert [e["title"] for e in entries] == ["paper-0", "paper-1", "paper-2"]
+
+
+def test_skip_records_skipped_status_with_reason(tmp_path: Path) -> None:
+    """``skip`` produces a ``skipped`` ledger entry with the reason captured."""
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(
+        run_id="run-1",
+        profile="staging-robotics",
+        kind="scheduled",
+        run_range=None,
+    )
+    ledger.skip(run_id="run-1", reason="lithos_unhealthy")
+
+    entry = ledger.recent()[0]
+    assert entry["status"] == "skipped"
+    assert entry["error"] == "lithos_unhealthy"
+    assert entry["degraded"] is False
+    assert entry["sources_checked"] is None
+    assert entry["ingested"] is None

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -824,3 +824,127 @@ class TestNegativeExampleMaxTitleCharsWired:
 
         assert captured_kwargs, "build_negative_examples_block was not called"
         assert captured_kwargs[0]["max_title_chars"] == 42
+
+
+# ── #40: Lithos circuit breaker short-circuit ─────────────────────────
+
+
+class TestLithosCircuitBreakerShortCircuit:
+    """``run_profile`` short-circuits when ``probe_loop.lithos_circuit_open()``."""
+
+    async def test_short_circuits_without_calling_provider(self, tmp_path: Any) -> None:
+        """Open breaker → no provider invocation, ledger entry is ``skipped``."""
+        from influx.run_ledger import RunLedger
+
+        config = _make_config(profiles=["staging-robotics"])
+        # Override storage so the ledger writes under tmp_path.
+        config = config.model_copy(
+            update={
+                "storage": config.storage.model_copy(
+                    update={"state_dir": str(tmp_path)}
+                )
+            }
+        )
+
+        provider_called = False
+
+        async def spy_provider(
+            profile: str,
+            kind: RunKind,
+            run_range: dict[str, str | int] | None,
+            filter_prompt: str,
+        ) -> list[dict[str, Any]]:
+            nonlocal provider_called
+            provider_called = True
+            return []
+
+        # Stub probe loop reporting the breaker open.
+        class StubProbeLoop:
+            lithos_unhealthy_consecutive = 5
+
+            def lithos_circuit_open(self, *, threshold: int = 3) -> bool:
+                return True
+
+        ledger = RunLedger(tmp_path)
+        result = await run_profile(
+            "staging-robotics",
+            RunKind.SCHEDULED,
+            config=config,
+            item_provider=spy_provider,
+            probe_loop=StubProbeLoop(),
+            run_ledger=ledger,
+        )
+
+        assert result is None
+        assert provider_called is False, (
+            "Lithos circuit breaker must short-circuit BEFORE the item "
+            "provider runs — otherwise we burn LLM tokens against a "
+            "write path that will fail"
+        )
+        # The ledger entry must reflect the skip.
+        entries = ledger.recent()
+        assert len(entries) == 1
+        assert entries[0]["status"] == "skipped"
+        assert entries[0]["error"] == "lithos_unhealthy"
+
+    async def test_breaker_closed_proceeds_normally(self, tmp_path: Any) -> None:
+        """Closed breaker → provider IS called (existing path unchanged)."""
+        from influx.run_ledger import RunLedger
+
+        config = _make_config(profiles=["staging-robotics"])
+        config = config.model_copy(
+            update={
+                "storage": config.storage.model_copy(
+                    update={"state_dir": str(tmp_path)}
+                )
+            }
+        )
+
+        provider_called = False
+
+        async def spy_provider(
+            profile: str,
+            kind: RunKind,
+            run_range: dict[str, str | int] | None,
+            filter_prompt: str,
+        ) -> list[dict[str, Any]]:
+            nonlocal provider_called
+            provider_called = True
+            return []
+
+        class StubProbeLoop:
+            lithos_unhealthy_consecutive = 0
+
+            def lithos_circuit_open(self, *, threshold: int = 3) -> bool:
+                return False
+
+        ledger = RunLedger(tmp_path)
+        # The body still calls into LithosClient; the test would need
+        # full mocking to run end-to-end.  Here we only assert the
+        # short-circuit DOES NOT fire — the body's normal failure path
+        # is exercised in the fuller integration tests.
+        import contextlib
+
+        from influx.errors import ConfigError, LCMAError, LithosError
+
+        # Expected: the body tries to connect to a real Lithos URL which
+        # isn't available in this unit test.  Either of the raised types
+        # is acceptable; what matters is that we got past the breaker.
+        with contextlib.suppress(
+            ConfigError, LCMAError, LithosError, ConnectionError, OSError
+        ):
+            await run_profile(
+                "staging-robotics",
+                RunKind.SCHEDULED,
+                config=config,
+                item_provider=spy_provider,
+                probe_loop=StubProbeLoop(),
+                run_ledger=ledger,
+            )
+
+        # The ledger entry exists and is NOT skipped (the short-circuit
+        # would have written a ``skipped`` row before any error).
+        entries = ledger.recent()
+        # Either a failed entry or no terminal entry yet — neither
+        # should be ``skipped``.
+        assert all(e.get("status") != "skipped" for e in entries)


### PR DESCRIPTION
Closes #40.

## Summary

When Lithos has been unhealthy for ``threshold`` consecutive ProbeLoop cycles (default 3 ≈ 90s with the 30s probe interval), ``run_profile`` short-circuits before any source-fetch / LLM-filter / write work.  Burning LLM tokens against a write path that will fail is worse than a skipped sweep.  The breaker closes automatically as soon as Lithos returns ``ok``.

## Behaviour

| Component | Change |
|---|---|
| ``ProbeLoop`` | New ``lithos_unhealthy_consecutive`` property and ``lithos_circuit_open(threshold=3)`` method.  The counter resets to ``0`` on the first ``ok`` probe — no manual reset needed. |
| ``run_profile`` | When the breaker is open, the run is recorded as ``ledger.skip(reason=""lithos_unhealthy"")``, ``influx_runs_skipped_total{profile, reason}`` ticks, and the function returns ``None`` immediately.  No provider call, no LLM spend, no LCMA hooks. |
| ``RunLedger.skip()`` | New method, distinct from ``fail()``: ``skipped`` means the run never started any work because a breaker opened first; ``failed`` means the run started and crashed. |
| Metric | ``influx_runs_skipped_total{profile, reason}`` — today the only reason is ``""lithos_unhealthy""``; new short-circuit paths can extend without label collisions. |
| ``influx-diagnose.py failures`` | New ""Skipped runs"" section surfaces breaker-fired runs separately. |

The 3-cycle default × 30s probe interval = ~90s of sustained Lithos failure before the breaker opens.  Long enough to weather a Lithos restart or transient blip without spuriously skipping a sweep; short enough that operators don't waste an hour of LLM tokens during a real outage.  Threshold is parameterised on ``lithos_circuit_open(threshold=N)`` so we can tune later from real-world data.

## Test plan

- [x] ``make check`` — **1558 tests pass**, ruff + format + pyright clean.
- [x] **5 new ProbeLoop tests**: starts closed, increments on degraded, opens at threshold, threshold is configurable, resets on first ``ok`` probe.
- [x] **1 new RunLedger test**: ``skip(run_id, reason)`` produces a ``skipped`` entry with the reason captured.
- [x] **2 new scheduler integration tests**: open breaker → provider NOT called + ledger entry is ``skipped``; closed breaker → existing path proceeds (no new short-circuit).

## Refs

- 2026-05-02 production-readiness review.
- Companion alerting issue (#37) — when alerts ship, an ``InfluxBreakerOpen`` rule on ``rate(influx_runs_skipped_total{reason=""lithos_unhealthy""}[15m])`` will page on sustained breaker activity.