### PR TITLE
feat: broaden 'degraded' to cover ingestion stalls

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -642,6 +642,13 @@ Readiness is degraded when:
 
 When the Lithos probe has been ``degraded`` for **3 consecutive cycles** (default; see `ProbeLoop.lithos_circuit_open`), `run_profile` short-circuits — the run is recorded as ``status="skipped", error="lithos_unhealthy"`` in the run ledger, the `influx_runs_skipped_total{profile, reason="lithos_unhealthy"}` metric ticks, and no source-fetch / LLM-filter / write work is performed.  The breaker closes automatically on the first ``ok`` probe; subsequent runs proceed normally.  This prevents an extended Lithos outage from burning LLM tokens against a write path that will fail (#40).
 
+Run-ledger entries carry a structured `degraded_reasons` field listing why a completed run was marked `degraded=True`.  Today the values are:
+
+- `"source_acquisition"` — at least one source-fetch failure was swallowed during the run (issue #20).
+- `"ingestion_stall"` — this and the immediately prior scheduled run for the same profile both saw `ingested == 0` despite `sources_checked > 0` (issue #36).  Typical causes: every candidate hit `slug_collision`/`duplicate`, the LLM filter rejected everything, or upstream sources started returning content the profile no longer accepts.  Backfills are excluded from this check (their ingest pattern is fundamentally different — they legitimately ingest 0 when every candidate is a cache hit).
+
+Both reasons can apply to a single run.  `influx_ingestion_stall_runs_total{profile}` ticks once per stall-flagged run so dashboards have an alertable counter independent of source-fetch errors.
+
 ### 13.2 Telemetry
 
 When telemetry is enabled (`INFLUX_OTEL_ENABLED=true`), Influx exports OTEL traces and metrics. Both signals share the same toggle, the same OTLP endpoint configuration (`OTEL_EXPORTER_OTLP_ENDPOINT`), and the same resource attributes (`service.name=influx`, `deployment.environment=<INFLUX_ENVIRONMENT>`).
@@ -669,6 +676,7 @@ Metric instruments cover run lifecycle, the source funnel, write outcomes, and f
 | `influx_slug_collision_reclaimed_total` | Counter | _(no labels)_ |
 | `influx_slug_collision_unresolved_total` | Counter | `profile`, `source` |
 | `influx_runs_skipped_total` | Counter | `profile`, `reason` |
+| `influx_ingestion_stall_runs_total` | Counter | `profile` |
 
 When `OTEL_EXPORTER_OTLP_ENDPOINT` is set the OTLP HTTP exporter is used. With `INFLUX_OTEL_CONSOLE_FALLBACK=true` and no endpoint configured, both spans and metrics are written to stdout for local development.
 

--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -39,8 +39,16 @@ Three quick signals, all read-only:
   duration, and source-acquisition errors. Active runs (if any) appear
   above the list.
 - **`failures`** filters to `failed`, `abandoned`, and `degraded` runs
-  in one go. A `degraded` run completed but had at least one swallowed
-  source-fetch failure (issue #20); the body of the run still landed.
+  in one go. A `degraded` run completed but is flagged for at least
+  one structured reason in `degraded_reasons`:
+  - `source_acquisition` (issue #20) — at least one source-fetch
+    failure was swallowed; the body of the run still landed.
+  - `ingestion_stall` (issue #36) — this and the prior scheduled
+    run for the same profile both inspected items but ingested
+    zero; typical cause is every candidate hitting `slug_collision`
+    / `duplicate`, the LLM filter rejecting everything, or an
+    upstream content shift.  The diagnose row prints the reason
+    list so you can triage without parsing the JSON.
   A `skipped` run (#40) means the Lithos circuit breaker fired:
   ProbeLoop saw 3+ consecutive `degraded` Lithos probes, so the
   scheduler short-circuited to avoid burning LLM tokens against a

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -134,7 +134,14 @@ def _filter_runs(
 def _print_run_row(run: dict[str, Any]) -> None:
     status = run.get("status", "?")
     if run.get("degraded"):
-        status = f"{status} (degraded)"
+        # #36: surface the structured degraded_reasons so an operator
+        # immediately sees WHY a run was flagged (source_acquisition vs
+        # ingestion_stall vs both) rather than just ``(degraded)``.
+        reasons = run.get("degraded_reasons") or []
+        if reasons:
+            status = f"{status} (degraded: {','.join(str(r) for r in reasons)})"
+        else:
+            status = f"{status} (degraded)"
     print(
         f"  {run.get('completed_at') or run.get('started_at')} "
         f"{run.get('profile')} {run.get('kind')} "

--- a/src/influx/metrics.py
+++ b/src/influx/metrics.py
@@ -44,6 +44,7 @@ __all__ = [
     "repair_candidates",
     "run_completions",
     "run_duration",
+    "ingestion_stalls",
     "run_starts",
     "runs_skipped",
     "slug_collision_dedup_recovery",
@@ -188,6 +189,32 @@ def archive_missing() -> Any:
     return get_meter().counter(
         "influx_archive_missing_total",
         description="Items tagged influx:archive-missing during a run.",
+    )
+
+
+def ingestion_stalls() -> Any:
+    """Counter of runs flagged ``degraded_reasons=['ingestion_stall']`` (#36).
+
+    Increments once per scheduled run that completes with
+    ``ingested == 0 AND sources_checked > 0`` AND the immediately
+    prior scheduled run for the same profile also matched that
+    shape — i.e. a profile has now seen TWO consecutive
+    inspect-something-but-write-nothing sweeps.
+
+    Typical causes: every candidate hits ``slug_collision`` /
+    ``duplicate``, or the LLM filter is rejecting everything.
+    Sustained non-zero rate is the early-warning signal that
+    ``degraded`` (which today only fires for source-acquisition
+    errors) was missing.
+
+    Labels: ``profile``.
+    """
+    return get_meter().counter(
+        "influx_ingestion_stall_runs_total",
+        description=(
+            "scheduled runs flagged ingestion_stall (this and the prior "
+            "scheduled run both inspected items but ingested zero)"
+        ),
     )
 
 

--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -70,6 +70,7 @@ class RunLedger:
             "ingested": None,
             "error": None,
             "degraded": False,
+            "degraded_reasons": [],
             "source_acquisition_errors": [],
         }
         try:
@@ -86,25 +87,94 @@ class RunLedger:
         sources_checked: int | None,
         ingested: int | None,
         source_acquisition_errors: list[dict[str, str]] | None = None,
-    ) -> None:
+    ) -> list[str]:
         """Mark an active run as completed and append it to history.
 
-        *source_acquisition_errors* records source-fetch failures that
-        were swallowed during the run (e.g. arxiv HTTP 5xx, RSS
-        timeout).  When non-empty the run is flagged ``degraded=True``
-        in the ledger so dashboards can distinguish a partial-failure
-        run from a genuinely quiet window (issue #20).
+        Returns the structured ``degraded_reasons`` list that was
+        recorded — one of: ``[]`` (clean run), ``["source_acquisition"]``
+        (issue #20: swallowed source-fetch failures), or
+        ``["ingestion_stall"]`` (issue #36: this and the immediately
+        prior scheduled run for the same profile both saw
+        ``ingested == 0`` despite ``sources_checked > 0`` — typically a
+        slug-collision squatter, all-duplicate writes, etc.).  When
+        both apply the list contains both reasons.
+
+        Returning the reasons lets the caller (the scheduler) emit
+        per-reason metrics without re-deriving the logic.
         """
         errors = list(source_acquisition_errors or [])
+        reasons: list[str] = []
+        if errors:
+            reasons.append("source_acquisition")
+
+        # #36 ingestion-stall detection: only meaningful when the run
+        # actually inspected something.  Backfills are excluded — they
+        # legitimately ingest 0 when every candidate is a cache hit.
+        if (
+            isinstance(ingested, int)
+            and ingested == 0
+            and isinstance(sources_checked, int)
+            and sources_checked > 0
+        ):
+            # Look up the *currently-active* entry to learn this run's
+            # profile + kind, then count consecutive prior scheduled runs
+            # for the same profile that match the stall shape.  We add
+            # 1 for *this* run since it hasn't been written yet.
+            active = self._read_active()
+            entry = active.get(run_id, {})
+            profile = entry.get("profile")
+            kind = entry.get("kind")
+            if isinstance(profile, str) and kind == "scheduled":
+                consecutive = 1 + self._consecutive_zero_ingestion_runs(
+                    profile=profile, exclude_run_id=run_id
+                )
+                if consecutive >= 2:
+                    reasons.append("ingestion_stall")
+
         self._finish(
             run_id=run_id,
             status="completed",
             sources_checked=sources_checked,
             ingested=ingested,
             error=None,
-            degraded=bool(errors),
+            degraded=bool(reasons),
             source_acquisition_errors=errors,
+            degraded_reasons=reasons,
         )
+        return reasons
+
+    def _consecutive_zero_ingestion_runs(
+        self, *, profile: str, exclude_run_id: str
+    ) -> int:
+        """Count consecutive prior scheduled runs that match the stall shape.
+
+        Walks ``recent()`` newest-first, counting runs where
+        ``ingested == 0 AND sources_checked > 0`` for *profile* of kind
+        ``scheduled``.  Stops at the first run that doesn't match.  Used
+        by :meth:`complete` to compute the ``ingestion_stall`` degraded
+        reason (#36).
+        """
+        count = 0
+        for prior in self.recent(limit=20, profile=profile):
+            if prior.get("run_id") == exclude_run_id:
+                continue
+            if prior.get("kind") != "scheduled":
+                # Backfills don't count — their ingest pattern is
+                # different.  But they shouldn't break the streak
+                # either; skip silently.
+                continue
+            ingested = prior.get("ingested")
+            sources_checked = prior.get("sources_checked")
+            if (
+                isinstance(ingested, int)
+                and ingested == 0
+                and isinstance(sources_checked, int)
+                and sources_checked > 0
+            ):
+                count += 1
+                continue
+            break
+        return count
 
     def fail(self, *, run_id: str, error: str) -> None:
         """Mark an active run as failed and append it to history."""
@@ -230,6 +300,7 @@ class RunLedger:
                         ),
                         "error": reason,
                         "degraded": entry.get("degraded", False),
+                        "degraded_reasons": list(entry.get("degraded_reasons") or []),
                         "source_acquisition_errors": list(
                             entry.get("source_acquisition_errors") or []
                         ),
@@ -289,6 +360,7 @@ class RunLedger:
         error: str | None,
         degraded: bool = False,
         source_acquisition_errors: list[dict[str, str]] | None = None,
+        degraded_reasons: list[str] | None = None,
     ) -> None:
         try:
             active = self._read_active()
@@ -317,6 +389,7 @@ class RunLedger:
                     "ingested": ingested,
                     "error": error,
                     "degraded": degraded,
+                    "degraded_reasons": list(degraded_reasons or []),
                     "source_acquisition_errors": list(source_acquisition_errors or []),
                 }
             )

--- a/src/influx/scheduler.py
+++ b/src/influx/scheduler.py
@@ -267,7 +267,7 @@ async def run_profile(
                     run_id,
                     elapsed,
                 )
-                ledger.complete(
+                degraded_reasons = ledger.complete(
                     run_id=run_id,
                     sources_checked=None,
                     ingested=None,
@@ -285,11 +285,29 @@ async def run_profile(
                     result.stats.ingested,
                     bool(source_errors),
                 )
-                ledger.complete(
+                degraded_reasons = ledger.complete(
                     run_id=run_id,
                     sources_checked=result.stats.sources_checked,
                     ingested=result.stats.ingested,
                     source_acquisition_errors=source_errors,
+                )
+            # #36: when the ledger flagged this run as ingestion-stalled
+            # (this and the prior scheduled run both inspected items but
+            # ingested zero), tick the per-profile counter so dashboards
+            # have an early-warning signal independent of source-fetch
+            # errors.  Update the run-completions outcome to ``degraded``
+            # in this case too, so the existing alerting paths see it.
+            if "ingestion_stall" in degraded_reasons:
+                metrics.ingestion_stalls().add(1, {"profile": profile})
+                if outcome == "success":
+                    outcome = "degraded"
+                logger.warning(
+                    "run flagged ingestion_stall profile=%s kind=%s run_id=%s "
+                    "(this + prior scheduled run both ingested 0 with "
+                    "sources_checked > 0)",
+                    profile,
+                    kind.value,
+                    run_id,
                 )
             metrics.run_duration().record(elapsed, run_metric_attrs)
             metrics.run_completions().add(1, {**run_metric_attrs, "outcome": outcome})

--- a/tests/unit/test_run_ledger.py
+++ b/tests/unit/test_run_ledger.py
@@ -219,3 +219,170 @@ def test_skip_records_skipped_status_with_reason(tmp_path: Path) -> None:
     assert entry["degraded"] is False
     assert entry["sources_checked"] is None
     assert entry["ingested"] is None
+
+
+# ── #36: ingestion-stall detection ──────────────────────────────────
+
+
+def _start_complete(
+    ledger: RunLedger,
+    *,
+    run_id: str,
+    profile: str,
+    kind: str = "scheduled",
+    sources_checked: int | None,
+    ingested: int | None,
+    source_acquisition_errors: list[dict[str, str]] | None = None,
+) -> list[str]:
+    """Helper: start + complete a run, return the degraded_reasons list."""
+    ledger.start(run_id=run_id, profile=profile, kind=kind, run_range=None)
+    return ledger.complete(
+        run_id=run_id,
+        sources_checked=sources_checked,
+        ingested=ingested,
+        source_acquisition_errors=source_acquisition_errors,
+    )
+
+
+def test_complete_returns_empty_reasons_for_clean_run(tmp_path: Path) -> None:
+    """A clean run has no degraded_reasons and degraded=False."""
+    ledger = RunLedger(tmp_path / "state")
+    reasons = _start_complete(
+        ledger,
+        run_id="r-1",
+        profile="p",
+        sources_checked=5,
+        ingested=3,
+    )
+    assert reasons == []
+    entry = ledger.recent()[0]
+    assert entry["degraded"] is False
+    assert entry["degraded_reasons"] == []
+
+
+def test_complete_returns_source_acquisition_reason(tmp_path: Path) -> None:
+    """source_acquisition_errors → degraded_reasons=['source_acquisition']."""
+    ledger = RunLedger(tmp_path / "state")
+    reasons = _start_complete(
+        ledger,
+        run_id="r-1",
+        profile="p",
+        sources_checked=5,
+        ingested=2,
+        source_acquisition_errors=[
+            {"source": "arxiv", "kind": "timeout", "detail": "x"}
+        ],
+    )
+    assert reasons == ["source_acquisition"]
+    entry = ledger.recent()[0]
+    assert entry["degraded"] is True
+    assert entry["degraded_reasons"] == ["source_acquisition"]
+
+
+def test_single_zero_ingestion_run_is_not_yet_a_stall(tmp_path: Path) -> None:
+    """One zero-ingestion run alone doesn't trigger the stall flag.
+
+    The signal must require TWO consecutive matching runs so a single
+    quiet sweep doesn't generate noise.
+    """
+    ledger = RunLedger(tmp_path / "state")
+    reasons = _start_complete(
+        ledger,
+        run_id="r-1",
+        profile="p",
+        sources_checked=5,
+        ingested=0,
+    )
+    assert reasons == []
+    entry = ledger.recent()[0]
+    assert entry["degraded"] is False
+
+
+def test_two_consecutive_zero_ingestion_runs_flag_stall(tmp_path: Path) -> None:
+    """Second consecutive zero-ingest scheduled run flips degraded=True."""
+    ledger = RunLedger(tmp_path / "state")
+    _start_complete(ledger, run_id="r-1", profile="p", sources_checked=5, ingested=0)
+    reasons = _start_complete(
+        ledger, run_id="r-2", profile="p", sources_checked=4, ingested=0
+    )
+    assert reasons == ["ingestion_stall"]
+    entry = ledger.recent()[0]
+    assert entry["degraded"] is True
+    assert entry["degraded_reasons"] == ["ingestion_stall"]
+
+
+def test_zero_sources_checked_does_not_count_as_stall(tmp_path: Path) -> None:
+    """sources_checked=0 means a quiet window, not a stall — don't flag."""
+    ledger = RunLedger(tmp_path / "state")
+    _start_complete(ledger, run_id="r-1", profile="p", sources_checked=0, ingested=0)
+    reasons = _start_complete(
+        ledger, run_id="r-2", profile="p", sources_checked=0, ingested=0
+    )
+    assert reasons == []
+
+
+def test_successful_ingest_resets_the_stall_streak(tmp_path: Path) -> None:
+    """A run that ingested anything resets the streak."""
+    ledger = RunLedger(tmp_path / "state")
+    _start_complete(ledger, run_id="r-1", profile="p", sources_checked=5, ingested=0)
+    _start_complete(ledger, run_id="r-2", profile="p", sources_checked=5, ingested=2)
+    reasons = _start_complete(
+        ledger, run_id="r-3", profile="p", sources_checked=5, ingested=0
+    )
+    # r-3 is the first zero-run after a successful one; not yet a stall.
+    assert reasons == []
+
+
+def test_stall_is_per_profile(tmp_path: Path) -> None:
+    """Different profiles don't share a stall streak."""
+    ledger = RunLedger(tmp_path / "state")
+    _start_complete(ledger, run_id="r-1", profile="ai", sources_checked=5, ingested=0)
+    # Different profile zero-runs in between don't count toward 'ai'.
+    _start_complete(
+        ledger,
+        run_id="r-2",
+        profile="robotics",
+        sources_checked=5,
+        ingested=0,
+    )
+    reasons = _start_complete(
+        ledger, run_id="r-3", profile="ai", sources_checked=5, ingested=0
+    )
+    assert reasons == ["ingestion_stall"]
+
+
+def test_backfill_kind_does_not_trigger_stall(tmp_path: Path) -> None:
+    """Backfills legitimately ingest 0 (cache hits) — never flag stall."""
+    ledger = RunLedger(tmp_path / "state")
+    _start_complete(
+        ledger,
+        run_id="r-1",
+        profile="p",
+        kind="backfill",
+        sources_checked=10,
+        ingested=0,
+    )
+    reasons = _start_complete(
+        ledger,
+        run_id="r-2",
+        profile="p",
+        kind="backfill",
+        sources_checked=10,
+        ingested=0,
+    )
+    assert reasons == []
+
+
+def test_combined_source_acquisition_and_stall(tmp_path: Path) -> None:
+    """Both reasons can apply at once — both must appear in the list."""
+    ledger = RunLedger(tmp_path / "state")
+    _start_complete(ledger, run_id="r-1", profile="p", sources_checked=5, ingested=0)
+    reasons = _start_complete(
+        ledger,
+        run_id="r-2",
+        profile="p",
+        sources_checked=4,
+        ingested=0,
+        source_acquisition_errors=[{"source": "arxiv", "kind": "x", "detail": "y"}],
+    )
+    assert reasons == ["source_acquisition", "ingestion_stall"]


### PR DESCRIPTION
Closes #36.

## Summary

Today the ``degraded`` flag fires only when a swallowed source-fetch failure is recorded.  But a run that reaches every source cleanly and then ingests **zero** notes (every candidate hit ``slug_collision`` / ``duplicate``, or the LLM filter rejected everything) is reported as ``degraded=False, ingested=0`` — operationally a stall, but invisible to existing alerting.

## Detection

A scheduled run is flagged ``degraded_reasons += [""ingestion_stall""]`` when **it AND the immediately prior scheduled run for the same profile** both saw ``ingested == 0 AND sources_checked > 0``.  Two-consecutive threshold avoids noise from a single quiet sweep; per-profile so a quiet ``ai`` profile doesn't mask a stall in ``robotics``; only ``scheduled`` runs participate (backfills legitimately ingest 0 when every candidate is a cache hit).

## Behaviour

| Layer | Change |
|---|---|
| ``RunLedger`` | Entries gain a structured ``degraded_reasons: list[str]`` enum field.  Today's values: ``""source_acquisition""`` (#20), ``""ingestion_stall""`` (#36).  Both can apply to one run.  ``complete()`` returns the computed list. |
| Existing ``degraded: bool`` | Semantics preserved — ``True`` whenever the reasons list is non-empty.  Dashboards keyed on the bool keep working. |
| Metric | New ``influx_ingestion_stall_runs_total{profile}`` Counter ticks once per stall-flagged run.  Used a Counter rather than the issue's proposed Gauge — ``rate()`` / ``sum_over_time()`` give the same alerting power and the metric set composes more naturally. |
| Scheduler | Reads ``complete()``'s return, bumps the metric, escalates the run-completion ``outcome`` from ``success`` to ``degraded``, logs a WARNING. |
| ``influx-diagnose.py failures`` | Run rows now print ``(degraded: ingestion_stall)`` (or ``source_acquisition,ingestion_stall``) instead of just ``(degraded)`` so operators triage without parsing JSON. |

## Test plan

- [x] ``make check`` — **1567 tests pass**, ruff + format + pyright clean.
- [x] **9 new ledger tests** in ``tests/unit/test_run_ledger.py`` covering every triage path: clean run, source_acquisition, single zero (no stall), two-consecutive (stall), zero sources_checked (not stall), successful ingest resets streak, per-profile isolation, backfills excluded, both reasons combined.
- [x] Diagnose row format updated and verified locally.

## Why a Counter (not a Gauge)

The original issue text proposed an ``influx_profile_ingestion_stall_consecutive_runs{profile}`` Gauge.  I chose a Counter (``influx_ingestion_stall_runs_total``) because:

* OTEL synchronous Gauges need a callback shim to back them by ledger state, which adds a runtime path purely for the gauge.
* For alerting (the issue's stated goal — operators noticing the stall) ``rate(influx_ingestion_stall_runs_total[1h]) > 0`` is equally clear and more idiomatic.
* The full ledger ``degraded_reasons`` field already gives dashboards the per-run shape if they want richer queries.

If a Gauge turns out to add value, it's an additive follow-up.

## Refs

- 2026-05-02 OmniRobotHome incident — exactly this signal would have caught it.  ``staging-robotics`` reported ``degraded=False, ingested=0`` on two consecutive sweeps while permanently dropping the paper.  PR #46's slug-collision self-heal fixes the root cause; this PR ensures any future class of similar silent failures is visible.
- Companion alerting issue #37 — when alerts ship, an ``InfluxIngestionStall`` rule on ``rate(influx_ingestion_stall_runs_total[1h]) > 0`` will page when the new signal fires.