### PR TITLE
feat: bump default arxiv lookback_days from 1 to 3

### DIFF
--- a/influx.example.toml
+++ b/influx.example.toml
@@ -114,7 +114,10 @@ lcma_edge_score = 0.75
 enabled = true
 categories = ["cs.AI", "cs.RO", "cs.MA", "cs.NE", "cs.CL", "cs.LO"]
 max_results_per_category = 200
-lookback_days = 1
+# 3 days tolerates arxiv's natural release gaps (weekends, holidays).
+# Set narrower (e.g. 1) only when the cron interval is short enough
+# that you don't need same-paper overlap across sweeps.
+lookback_days = 3
 
 [[profiles.sources.rss]]
 name = "Andrej Karpathy"

--- a/src/influx/config.py
+++ b/src/influx/config.py
@@ -261,7 +261,14 @@ class ArxivSourceConfig(BaseModel):
         ]
     )
     max_results_per_category: int = 200
-    lookback_days: int = 1
+    # Default 3 (not 1): arxiv has natural release gaps (weekends,
+    # holidays, low-activity days).  A 1-day window returns zero
+    # candidates for ~2 days every week which is rarely intended; a
+    # 3-day window tolerates that without changing the throttling
+    # story for the deep-extract path (cache-dedup catches re-fetched
+    # items so the LLM cost is paid once per item).  See #49 / the
+    # 2026-05-02 staging investigation.
+    lookback_days: int = 3
 
 
 class RssSourceEntry(BaseModel):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1103,3 +1103,33 @@ class TestConftestFixture:
         assert "enrich" in cfg.models
         assert "extract" in cfg.models
         assert cfg.repair.max_items_per_run == 100
+
+
+class TestArxivSourceConfigDefaults:
+    """#49: defaults must tolerate arxiv's natural release gaps."""
+
+    def test_lookback_days_default_is_three(self) -> None:
+        """``lookback_days`` defaults to 3, not 1.
+
+        With 1 day, profiles that omit ``[profiles.sources.arxiv]`` go
+        silent across arxiv's weekend / holiday gaps (no new papers
+        for 24-48h is normal).  3 days covers the common gap shape
+        without changing per-item LLM cost (cache-dedup catches re-fetched
+        items).  See #49 / 2026-05-02 staging investigation.
+        """
+        from influx.config import ArxivSourceConfig
+
+        cfg = ArxivSourceConfig()
+        assert cfg.lookback_days == 3, (
+            "default lookback_days must be 3 to tolerate arxiv release gaps; "
+            "narrower defaults silently dropped staging-ai for entire weekends"
+        )
+
+    def test_other_arxiv_defaults_unchanged(self) -> None:
+        """Pin the rest of the default surface so this PR's intent is clear."""
+        from influx.config import ArxivSourceConfig
+
+        cfg = ArxivSourceConfig()
+        assert cfg.enabled is True
+        assert cfg.max_results_per_category == 200
+        assert "cs.AI" in cfg.categories


### PR DESCRIPTION
Closes #49.

## Summary

``ArxivSourceConfig.lookback_days`` defaulted to ``1``.  When a profile omits its ``[profiles.sources.arxiv]`` block in ``influx.toml``, Pydantic supplies that default silently.  arxiv has natural release gaps (weekends, holidays, low-activity days), so a 1-day lookback returns zero candidates for ~2 days every week — even when the profile is correctly configured otherwise.

Surfaced during the #38 investigation: ``staging-ai`` was silently using ``lookback_days=1`` and returned zero candidates across **4 consecutive scheduled sweeps** over the 2026-05-02 weekend, while ``staging-robotics`` (with explicit ``lookback_days=3``) kept re-fetching the 2026-04-30 batch the whole time.

This PR bumps the default to **3**.

## Cost / behaviour

- Profiles that *explicitly* set ``lookback_days`` are unaffected.
- Profiles inheriting the default now scan a 3× larger window per fetch — expect a small uptick in arxiv API call volume per sweep tick.
- Per-item **LLM cost is unchanged**: the Lithos cache catches re-fetched items as ``duplicate`` before any tier-1 / tier-3 enrichment runs.

## Test plan

- [x] ``make check`` — **1569 tests pass**, ruff + format + pyright clean.
- [x] **2 new pin tests** in ``test_config.py`` (one for the new default, one pinning the rest of ``ArxivSourceConfig`` defaults so future changes are intentional).
- [x] All existing ``test_arxiv_fetcher.py`` tests pass — they use explicit ``lookback_days`` values, unaffected by the default change.

## Refs

- #49 — this issue.
- #38 — staging-ai investigation that surfaced the failure mode.
- 2026-05-02 staging logs (4 consecutive weekend sweeps with 0 candidates).