### PR TITLE
refactor: extract Renderer module from source builders (#52)

### DIFF
--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -29,16 +29,18 @@ from influx.dedup import compose_dedup_query
 from influx.errors import ConfigError, LCMAError, LithosError
 from influx.notes import (
     NoteParseError,
-    ProfileRelevanceEntry,
-    merge_profile_relevance_union,
     parse_note,
     parse_profile_relevance,
 )
 from influx.notes import (
-    _render_profile_relevance_body as _render_pr_body,
-)
-from influx.notes import (
     merge_tags as _canonical_merge_tags,
+)
+from influx.renderer import (
+    ProfileRelevanceEntry,
+    merge_profile_relevance_union,
+)
+from influx.renderer import (
+    _render_profile_relevance_body as _render_pr_body,
 )
 
 __all__ = ["LithosClient", "WriteResult"]

--- a/src/influx/notes.py
+++ b/src/influx/notes.py
@@ -1,6 +1,6 @@
-"""Canonical Lithos note parser and renderer (FR-NOTE-1..9).
+"""Canonical Lithos note parser and rewrite-merge helpers (FR-NOTE-1..9).
 
-Parses and renders the canonical note format used by Influx:
+Parses the canonical note format used by Influx:
 
     ---
     <YAML frontmatter>
@@ -17,6 +17,8 @@ Parses and renders the canonical note format used by Influx:
 The ``## User Notes`` region is everything from the ``## User Notes``
 heading to end-of-file, preserved byte-exactly across parse/rewrite
 cycles (FR-NOTE-4, R-5).
+
+Rendering of canonical notes lives in :mod:`influx.renderer`.
 """
 
 from __future__ import annotations
@@ -25,27 +27,18 @@ import re
 from dataclasses import dataclass, field
 
 from influx.errors import InfluxError
-from influx.schemas import Tier1Enrichment, Tier3Extraction
-from influx.urls import normalise_url
+from influx.renderer import ProfileRelevanceEntry
 
 __all__ = [
-    "ArchiveInvariantError",
     "ArchiveParseError",
-    "MissingIngestedByTagError",
     "NoteParseError",
     "ParsedNote",
     "ParsedSection",
-    "ProfileRelevanceEntry",
-    "build_profile_relevance_for_rewrite",
-    "merge_profile_relevance_union",
     "merge_tags",
     "parse_archive_path",
     "parse_note",
     "parse_profile_relevance",
     "recompute_confidence",
-    "render_archive_section",
-    "render_note",
-    "validate_archive_tag_invariant",
 ]
 
 # ── Exceptions ───────────────────────────────────────────────────────
@@ -57,14 +50,6 @@ class NoteParseError(InfluxError):
 
 class ArchiveParseError(NoteParseError):
     """Raised when the ``## Archive`` section body is malformed."""
-
-
-class ArchiveInvariantError(InfluxError):
-    """Raised when a path: line and influx:archive-missing co-exist."""
-
-
-class MissingIngestedByTagError(InfluxError):
-    """Raised when an Influx-authored note lacks ``ingested-by:influx`` (FR-RES-6)."""
 
 
 # ── Data structures ──────────────────────────────────────────────────
@@ -363,28 +348,9 @@ def recompute_confidence(
     return max(existing_confidence, current_max_score / 10.0)
 
 
-# ── Archive section render / parse (FR-NOTE-9) ──────────────────────
+# ── Archive section parser (FR-NOTE-9) ──────────────────────────────
 
 _ARCHIVE_PATH_RE = re.compile(r"^path:\s*(.+)$")
-
-
-def render_archive_section(archive_path: str | None) -> str:
-    """Render the ``## Archive`` section body.
-
-    Parameters
-    ----------
-    archive_path:
-        A POSIX-separator relative path for the ``path:`` line, or
-        ``None`` for the empty-body (failure-path) form.
-
-    Returns
-    -------
-    str
-        The rendered section text starting with ``## Archive\\n``.
-    """
-    if archive_path is not None:
-        return f"## Archive\npath: {archive_path}\n"
-    return "## Archive\n"
 
 
 def parse_archive_path(note: ParsedNote) -> str | None:
@@ -438,231 +404,7 @@ def parse_archive_path(note: ParsedNote) -> str | None:
     return m.group(1).strip()
 
 
-def validate_archive_tag_invariant(
-    *,
-    archive_path: str | None,
-    tags: list[str],
-) -> None:
-    """Enforce: never write both a path: line AND influx:archive-missing.
-
-    Parameters
-    ----------
-    archive_path:
-        The archive path that will be rendered (or ``None``).
-    tags:
-        The tag list that will be written to frontmatter.
-
-    Raises
-    ------
-    ArchiveInvariantError
-        When *archive_path* is not ``None`` and *tags* contains
-        ``influx:archive-missing``.
-    """
-    if archive_path is not None and "influx:archive-missing" in tags:
-        raise ArchiveInvariantError(
-            "Cannot write both a path: line and influx:archive-missing "
-            "tag on the same note"
-        )
-
-
-# ── Full canonical renderer (FR-NOTE-1..8, US-007) ──────────────────
-
-
-@dataclass(frozen=True)
-class ProfileRelevanceEntry:
-    """One profile's relevance data for the ``## Profile Relevance`` section."""
-
-    profile_name: str
-    score: int
-    reason: str
-
-
-def _format_confidence(confidence: float) -> str:
-    """Format confidence as a clean decimal string for frontmatter."""
-    val = round(confidence, 4)
-    if val == int(val):
-        return f"{int(val)}.0"
-    return str(val)
-
-
-def _render_frontmatter(
-    *,
-    source_url: str,
-    tags: list[str],
-    confidence: float,
-) -> str:
-    """Render the YAML frontmatter content (between ``---`` fences).
-
-    ``source_url`` is normalised via :func:`influx.urls.normalise_url`
-    so that frontmatter always carries the canonical form (FR-MCP-4).
-    """
-    lines = [
-        "note_type: summary",
-        "namespace: influx",
-        f"source_url: {normalise_url(source_url)}",
-    ]
-    if tags:
-        lines.append("tags:")
-        for tag in tags:
-            lines.append(f"  - {tag}")
-    else:
-        lines.append("tags: []")
-    lines.append(f"confidence: {_format_confidence(confidence)}")
-    return "\n".join(lines)
-
-
-def _render_profile_relevance_body(
-    entries: list[ProfileRelevanceEntry],
-) -> str:
-    """Render the body of the ``## Profile Relevance`` section."""
-    parts: list[str] = []
-    for entry in entries:
-        parts.append(
-            f"### {entry.profile_name}\nScore: {entry.score}/10\n{entry.reason}"
-        )
-    return "\n\n".join(parts)
-
-
-def render_note(
-    *,
-    title: str,
-    source_url: str,
-    tags: list[str],
-    confidence: float,
-    archive_path: str | None,
-    summary: str,
-    keywords: list[str],
-    profile_entries: list[ProfileRelevanceEntry],
-    tier1_enrichment: Tier1Enrichment | None = None,
-    full_text: str | None = None,
-    tier3_extraction: Tier3Extraction | None = None,
-    user_notes: str | None = None,
-) -> str:
-    """Render a full canonical Lithos note (FR-NOTE-1..8).
-
-    Parameters
-    ----------
-    title:
-        The ``# <Title>`` text (without the ``# `` prefix).
-    source_url:
-        Normalised canonical URL for frontmatter.
-    tags:
-        The final merged tag list (from :func:`merge_tags`).
-    confidence:
-        The confidence value for frontmatter.
-    archive_path:
-        POSIX-separator relative path or ``None`` for empty Archive.
-    summary:
-        The Tier-1 summary text for the ``## Summary`` section.
-    keywords:
-        Keywords from Tier-1 enrichment (may be empty).
-    profile_entries:
-        Profile relevance entries to render. For rewrites, use
-        :func:`build_profile_relevance_for_rewrite` to resolve
-        entries that honour the rejection guard.
-    tier1_enrichment:
-        Tier-1 structured enrichment result. When provided, emits ``## Summary``
-        containing ``### Contributions``, ``### Method``, ``### Result``,
-        ``### Relevance`` sub-blocks. When ``None`` falls back to the plain
-        *summary* string; when both are absent the section is omitted (FR-ENR-6).
-    full_text:
-        Tier-2 extracted plain text for the ``## Full Text`` section.
-        When ``None`` or empty the section is omitted entirely (FR-ENR-6).
-    tier3_extraction:
-        Tier-3 deep extraction result. When provided, emits ``## Claims``,
-        ``## Datasets & Benchmarks``, ``## Builds On``, ``## Open Questions``
-        sections. ``potential_connections`` is NOT rendered (consumed by
-        PRD 08 LCMA only). When ``None`` all four sections are omitted
-        (FR-ENR-6).
-    user_notes:
-        Byte-exact ``## User Notes`` region from a previous parse,
-        or ``None`` to append an empty ``## User Notes`` heading.
-
-    Returns
-    -------
-    str
-        The complete canonical note text.
-
-    Raises
-    ------
-    ArchiveInvariantError
-        When *archive_path* is not ``None`` and *tags* contains
-        ``influx:archive-missing``.
-    MissingIngestedByTagError
-        When *tags* does not contain ``ingested-by:influx`` (FR-RES-6).
-    """
-    if "ingested-by:influx" not in tags:
-        raise MissingIngestedByTagError(
-            "Influx-authored notes must carry the 'ingested-by:influx' tag (FR-RES-6)"
-        )
-    validate_archive_tag_invariant(archive_path=archive_path, tags=tags)
-
-    frontmatter = _render_frontmatter(
-        source_url=source_url,
-        tags=tags,
-        confidence=confidence,
-    )
-    archive_section = render_archive_section(archive_path)
-
-    # Compose note
-    output = f"---\n{frontmatter}\n---\n"
-    output += f"# {title}\n\n"
-    output += archive_section + "\n"
-
-    # Summary section: structured Tier1Enrichment → plain summary → omit
-    if tier1_enrichment is not None:
-        output += "## Summary\n"
-        output += "### Contributions\n"
-        for contrib in tier1_enrichment.contributions:
-            output += f"- {contrib}\n"
-        output += f"\n### Method\n{tier1_enrichment.method}\n"
-        output += f"\n### Result\n{tier1_enrichment.result}\n"
-        output += f"\n### Relevance\n{tier1_enrichment.relevance}\n"
-    elif summary:
-        summary_body = summary
-        if keywords:
-            summary_body += f"\n\nKeywords: {', '.join(keywords)}"
-        output += f"## Summary\n{summary_body}\n"
-
-    # Full Text section (Tier 2) — omitted when absent/empty (FR-ENR-6, US-011)
-    if full_text:
-        output += f"\n## Full Text\n{full_text}\n"
-
-    # Tier 3 sections (US-012) — omitted entirely when absent (FR-ENR-6)
-    if tier3_extraction is not None:
-        output += "\n## Claims\n"
-        for claim in tier3_extraction.claims:
-            output += f"- {claim}\n"
-        output += "\n## Datasets & Benchmarks\n"
-        for ds in tier3_extraction.datasets:
-            output += f"- {ds}\n"
-        output += "\n## Builds On\n"
-        for item in tier3_extraction.builds_on:
-            output += f"- {item}\n"
-        output += "\n## Open Questions\n"
-        for q in tier3_extraction.open_questions:
-            output += f"- {q}\n"
-
-    # Profile Relevance section — always emitted to keep the canonical
-    # note shape stable (US-007); body is empty when no entries are given.
-    output += "\n"
-    pr_body = _render_profile_relevance_body(profile_entries)
-    if pr_body:
-        output += f"## Profile Relevance\n{pr_body}\n"
-    else:
-        output += "## Profile Relevance\n"
-
-    # User Notes — preserved byte-exactly or empty heading appended
-    output += "\n"
-    if user_notes is not None:
-        output += user_notes
-    else:
-        output += "## User Notes\n"
-
-    return output
-
-
-# ── Profile relevance parse / rewrite helpers ────────────────────────
+# ── Profile relevance parser (FR-NOTE-6) ────────────────────────────
 
 # Heading and score regexes are CRLF-tolerant: H3 captures stop before
 # CR/LF (lookahead, not $) and score matches accept ``\r?\n`` after the
@@ -733,106 +475,3 @@ def parse_profile_relevance(
         )
 
     return entries
-
-
-def build_profile_relevance_for_rewrite(
-    *,
-    old_entries: list[ProfileRelevanceEntry],
-    new_entries: list[ProfileRelevanceEntry],
-    tags: list[str],
-) -> list[ProfileRelevanceEntry]:
-    """Resolve profile relevance entries for a rewrite (FR-NOTE-6).
-
-    Rejected profiles (``influx:rejected:<profile>`` in *tags*) keep
-    their old entries unchanged.  Non-rejected profiles use new entries.
-
-    Parameters
-    ----------
-    old_entries:
-        Entries from the previously parsed note.
-    new_entries:
-        Freshly computed entries for the current rewrite cycle.
-    tags:
-        The final merged tag list (used to detect rejection guards).
-
-    Returns
-    -------
-    list[ProfileRelevanceEntry]
-        The resolved entries to pass to :func:`render_note`.
-    """
-    rejected = {
-        t[len("influx:rejected:") :] for t in tags if t.startswith("influx:rejected:")
-    }
-
-    result: list[ProfileRelevanceEntry] = []
-    seen: set[str] = set()
-
-    # Non-rejected profiles use new entries
-    for entry in new_entries:
-        if entry.profile_name not in rejected:
-            result.append(entry)
-            seen.add(entry.profile_name)
-
-    # Rejected profiles keep old entries
-    for entry in old_entries:
-        if entry.profile_name in rejected and entry.profile_name not in seen:
-            result.append(entry)
-            seen.add(entry.profile_name)
-
-    return result
-
-
-def merge_profile_relevance_union(
-    *,
-    old_entries: list[ProfileRelevanceEntry],
-    new_entries: list[ProfileRelevanceEntry],
-    tags: list[str],
-) -> list[ProfileRelevanceEntry]:
-    """Union-merge profile relevance entries for multi-profile merging (FR-NOTE-6).
-
-    Unlike :func:`build_profile_relevance_for_rewrite` — which drops
-    old entries for non-rejected, non-new profiles (correct for
-    single-profile rewrites and repair sweeps) — this function
-    preserves old entries for ALL profiles not superseded by new
-    entries, enabling multi-profile tag merging on shared notes.
-
-    Rejected profiles (``influx:rejected:<profile>`` in *tags*) always
-    keep their old entries; new entries for rejected profiles are
-    dropped.
-
-    Parameters
-    ----------
-    old_entries:
-        Entries from the previously existing note.
-    new_entries:
-        Entries from the incoming write (typically one profile).
-    tags:
-        The final merged tag list (used to detect rejection guards).
-
-    Returns
-    -------
-    list[ProfileRelevanceEntry]
-        The merged entries to render.
-    """
-    rejected = {
-        t[len("influx:rejected:") :] for t in tags if t.startswith("influx:rejected:")
-    }
-
-    result: list[ProfileRelevanceEntry] = []
-    seen: set[str] = set()
-
-    # Non-rejected profiles use new entries
-    for entry in new_entries:
-        if entry.profile_name not in rejected:
-            result.append(entry)
-            seen.add(entry.profile_name)
-
-    # ALL old entries for profiles not yet in result (union semantics):
-    # - Rejected profiles: keep old entry (rejection authority)
-    # - Non-current profiles: keep old entry (multi-profile preservation)
-    for entry in old_entries:
-        if entry.profile_name not in seen:
-            result.append(entry)
-            seen.add(entry.profile_name)
-
-    return result

--- a/src/influx/renderer.py
+++ b/src/influx/renderer.py
@@ -1,0 +1,473 @@
+"""Canonical Lithos note renderer (CONTEXT.md Renderer module).
+
+The Renderer produces a CanonicalNote from one Acquired item plus its
+EnrichedSections plus the score/reason. It owns the canonical Markdown
+shape from spec §9 (frontmatter, section ordering, omitted-section
+rules) and the byte-exact ``## User Notes`` preservation rule (R-5).
+
+Public surface:
+
+- :func:`render` — high-level facade for source builders. Wraps a
+  single-profile :class:`ProfileRelevanceEntry` and delegates to
+  :func:`render_note`.
+- :func:`render_note` — full renderer used directly by repair / rewrite
+  paths that need to control profile-relevance composition.
+- :func:`render_archive_section`, :func:`validate_archive_tag_invariant`
+  — Archive-section helpers (FR-NOTE-9).
+- :func:`build_profile_relevance_for_rewrite`,
+  :func:`merge_profile_relevance_union` — profile-relevance merge
+  helpers used during rewrites (FR-NOTE-6).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from influx.errors import InfluxError
+from influx.schemas import Tier1Enrichment, Tier3Extraction
+from influx.urls import normalise_url
+
+__all__ = [
+    "ArchiveInvariantError",
+    "MissingIngestedByTagError",
+    "ProfileRelevanceEntry",
+    "build_profile_relevance_for_rewrite",
+    "merge_profile_relevance_union",
+    "render",
+    "render_archive_section",
+    "render_note",
+    "validate_archive_tag_invariant",
+]
+
+
+# ── Exceptions ───────────────────────────────────────────────────────
+
+
+class ArchiveInvariantError(InfluxError):
+    """Raised when a path: line and influx:archive-missing co-exist."""
+
+
+class MissingIngestedByTagError(InfluxError):
+    """Raised when an Influx-authored note lacks ``ingested-by:influx`` (FR-RES-6)."""
+
+
+# ── Profile relevance entry ─────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ProfileRelevanceEntry:
+    """One profile's relevance data for the ``## Profile Relevance`` section."""
+
+    profile_name: str
+    score: int
+    reason: str
+
+
+# ── Archive section render / invariant (FR-NOTE-9) ──────────────────
+
+
+def render_archive_section(archive_path: str | None) -> str:
+    """Render the ``## Archive`` section body.
+
+    Parameters
+    ----------
+    archive_path:
+        A POSIX-separator relative path for the ``path:`` line, or
+        ``None`` for the empty-body (failure-path) form.
+
+    Returns
+    -------
+    str
+        The rendered section text starting with ``## Archive\\n``.
+    """
+    if archive_path is not None:
+        return f"## Archive\npath: {archive_path}\n"
+    return "## Archive\n"
+
+
+def validate_archive_tag_invariant(
+    *,
+    archive_path: str | None,
+    tags: list[str],
+) -> None:
+    """Enforce: never write both a path: line AND influx:archive-missing.
+
+    Parameters
+    ----------
+    archive_path:
+        The archive path that will be rendered (or ``None``).
+    tags:
+        The tag list that will be written to frontmatter.
+
+    Raises
+    ------
+    ArchiveInvariantError
+        When *archive_path* is not ``None`` and *tags* contains
+        ``influx:archive-missing``.
+    """
+    if archive_path is not None and "influx:archive-missing" in tags:
+        raise ArchiveInvariantError(
+            "Cannot write both a path: line and influx:archive-missing "
+            "tag on the same note"
+        )
+
+
+# ── Frontmatter / profile-relevance body helpers ────────────────────
+
+
+def _format_confidence(confidence: float) -> str:
+    """Format confidence as a clean decimal string for frontmatter."""
+    val = round(confidence, 4)
+    if val == int(val):
+        return f"{int(val)}.0"
+    return str(val)
+
+
+def _render_frontmatter(
+    *,
+    source_url: str,
+    tags: list[str],
+    confidence: float,
+) -> str:
+    """Render the YAML frontmatter content (between ``---`` fences).
+
+    ``source_url`` is normalised via :func:`influx.urls.normalise_url`
+    so that frontmatter always carries the canonical form (FR-MCP-4).
+    """
+    lines = [
+        "note_type: summary",
+        "namespace: influx",
+        f"source_url: {normalise_url(source_url)}",
+    ]
+    if tags:
+        lines.append("tags:")
+        for tag in tags:
+            lines.append(f"  - {tag}")
+    else:
+        lines.append("tags: []")
+    lines.append(f"confidence: {_format_confidence(confidence)}")
+    return "\n".join(lines)
+
+
+def _render_profile_relevance_body(
+    entries: list[ProfileRelevanceEntry],
+) -> str:
+    """Render the body of the ``## Profile Relevance`` section."""
+    parts: list[str] = []
+    for entry in entries:
+        parts.append(
+            f"### {entry.profile_name}\nScore: {entry.score}/10\n{entry.reason}"
+        )
+    return "\n\n".join(parts)
+
+
+# ── Full canonical renderer (FR-NOTE-1..8, US-007) ──────────────────
+
+
+def render_note(
+    *,
+    title: str,
+    source_url: str,
+    tags: list[str],
+    confidence: float,
+    archive_path: str | None,
+    summary: str,
+    keywords: list[str],
+    profile_entries: list[ProfileRelevanceEntry],
+    tier1_enrichment: Tier1Enrichment | None = None,
+    full_text: str | None = None,
+    tier3_extraction: Tier3Extraction | None = None,
+    user_notes: str | None = None,
+) -> str:
+    """Render a full canonical Lithos note (FR-NOTE-1..8).
+
+    Parameters
+    ----------
+    title:
+        The ``# <Title>`` text (without the ``# `` prefix).
+    source_url:
+        Normalised canonical URL for frontmatter.
+    tags:
+        The final merged tag list (from ``influx.notes.merge_tags``).
+    confidence:
+        The confidence value for frontmatter.
+    archive_path:
+        POSIX-separator relative path or ``None`` for empty Archive.
+    summary:
+        The Tier-1 summary text for the ``## Summary`` section.
+    keywords:
+        Keywords from Tier-1 enrichment (may be empty).
+    profile_entries:
+        Profile relevance entries to render. For rewrites, use
+        :func:`build_profile_relevance_for_rewrite` to resolve
+        entries that honour the rejection guard.
+    tier1_enrichment:
+        Tier-1 structured enrichment result. When provided, emits ``## Summary``
+        containing ``### Contributions``, ``### Method``, ``### Result``,
+        ``### Relevance`` sub-blocks. When ``None`` falls back to the plain
+        *summary* string; when both are absent the section is omitted (FR-ENR-6).
+    full_text:
+        Tier-2 extracted plain text for the ``## Full Text`` section.
+        When ``None`` or empty the section is omitted entirely (FR-ENR-6).
+    tier3_extraction:
+        Tier-3 deep extraction result. When provided, emits ``## Claims``,
+        ``## Datasets & Benchmarks``, ``## Builds On``, ``## Open Questions``
+        sections. ``potential_connections`` is NOT rendered (consumed by
+        PRD 08 LCMA only). When ``None`` all four sections are omitted
+        (FR-ENR-6).
+    user_notes:
+        Byte-exact ``## User Notes`` region from a previous parse,
+        or ``None`` to append an empty ``## User Notes`` heading.
+
+    Returns
+    -------
+    str
+        The complete canonical note text.
+
+    Raises
+    ------
+    ArchiveInvariantError
+        When *archive_path* is not ``None`` and *tags* contains
+        ``influx:archive-missing``.
+    MissingIngestedByTagError
+        When *tags* does not contain ``ingested-by:influx`` (FR-RES-6).
+    """
+    if "ingested-by:influx" not in tags:
+        raise MissingIngestedByTagError(
+            "Influx-authored notes must carry the 'ingested-by:influx' tag (FR-RES-6)"
+        )
+    validate_archive_tag_invariant(archive_path=archive_path, tags=tags)
+
+    frontmatter = _render_frontmatter(
+        source_url=source_url,
+        tags=tags,
+        confidence=confidence,
+    )
+    archive_section = render_archive_section(archive_path)
+
+    # Compose note
+    output = f"---\n{frontmatter}\n---\n"
+    output += f"# {title}\n\n"
+    output += archive_section + "\n"
+
+    # Summary section: structured Tier1Enrichment → plain summary → omit
+    if tier1_enrichment is not None:
+        output += "## Summary\n"
+        output += "### Contributions\n"
+        for contrib in tier1_enrichment.contributions:
+            output += f"- {contrib}\n"
+        output += f"\n### Method\n{tier1_enrichment.method}\n"
+        output += f"\n### Result\n{tier1_enrichment.result}\n"
+        output += f"\n### Relevance\n{tier1_enrichment.relevance}\n"
+    elif summary:
+        summary_body = summary
+        if keywords:
+            summary_body += f"\n\nKeywords: {', '.join(keywords)}"
+        output += f"## Summary\n{summary_body}\n"
+
+    # Full Text section (Tier 2) — omitted when absent/empty (FR-ENR-6, US-011)
+    if full_text:
+        output += f"\n## Full Text\n{full_text}\n"
+
+    # Tier 3 sections (US-012) — omitted entirely when absent (FR-ENR-6)
+    if tier3_extraction is not None:
+        output += "\n## Claims\n"
+        for claim in tier3_extraction.claims:
+            output += f"- {claim}\n"
+        output += "\n## Datasets & Benchmarks\n"
+        for ds in tier3_extraction.datasets:
+            output += f"- {ds}\n"
+        output += "\n## Builds On\n"
+        for item in tier3_extraction.builds_on:
+            output += f"- {item}\n"
+        output += "\n## Open Questions\n"
+        for q in tier3_extraction.open_questions:
+            output += f"- {q}\n"
+
+    # Profile Relevance section — always emitted to keep the canonical
+    # note shape stable (US-007); body is empty when no entries are given.
+    output += "\n"
+    pr_body = _render_profile_relevance_body(profile_entries)
+    if pr_body:
+        output += f"## Profile Relevance\n{pr_body}\n"
+    else:
+        output += "## Profile Relevance\n"
+
+    # User Notes — preserved byte-exactly or empty heading appended
+    output += "\n"
+    if user_notes is not None:
+        output += user_notes
+    else:
+        output += "## User Notes\n"
+
+    return output
+
+
+# ── High-level facade for source builders ──────────────────────────
+
+
+def render(
+    *,
+    title: str,
+    source_url: str,
+    tags: list[str],
+    confidence: float,
+    archive_path: str | None,
+    summary: str,
+    profile_name: str,
+    score: int,
+    reason: str,
+    keywords: list[str] | None = None,
+    tier1_enrichment: Tier1Enrichment | None = None,
+    full_text: str | None = None,
+    tier3_extraction: Tier3Extraction | None = None,
+    user_notes: str | None = None,
+) -> str:
+    """Render a CanonicalNote for one Acquired item from a single Source.
+
+    The Source-builder facade that wraps a single-profile relevance
+    entry and delegates to :func:`render_note`. Source builders that
+    have applied their own summary-suppression rule (e.g. AC-07-A:
+    suppress fallback summary when Tier 1 was attempted but failed)
+    pass an empty *summary* string here.
+
+    Parameters
+    ----------
+    title, source_url, tags, confidence, archive_path, summary,
+    keywords, tier1_enrichment, full_text, tier3_extraction, user_notes:
+        Forwarded to :func:`render_note`.
+    profile_name, score, reason:
+        Used to construct a single-entry profile relevance list.
+
+    Returns
+    -------
+    str
+        The complete canonical note text.
+    """
+    profile_entries = [
+        ProfileRelevanceEntry(
+            profile_name=profile_name,
+            score=score,
+            reason=reason,
+        ),
+    ]
+    return render_note(
+        title=title,
+        source_url=source_url,
+        tags=tags,
+        confidence=confidence,
+        archive_path=archive_path,
+        summary=summary,
+        keywords=keywords if keywords is not None else [],
+        profile_entries=profile_entries,
+        tier1_enrichment=tier1_enrichment,
+        full_text=full_text,
+        tier3_extraction=tier3_extraction,
+        user_notes=user_notes,
+    )
+
+
+# ── Profile relevance merge helpers (FR-NOTE-6) ─────────────────────
+
+
+def build_profile_relevance_for_rewrite(
+    *,
+    old_entries: list[ProfileRelevanceEntry],
+    new_entries: list[ProfileRelevanceEntry],
+    tags: list[str],
+) -> list[ProfileRelevanceEntry]:
+    """Resolve profile relevance entries for a rewrite (FR-NOTE-6).
+
+    Rejected profiles (``influx:rejected:<profile>`` in *tags*) keep
+    their old entries unchanged.  Non-rejected profiles use new entries.
+
+    Parameters
+    ----------
+    old_entries:
+        Entries from the previously parsed note.
+    new_entries:
+        Freshly computed entries for the current rewrite cycle.
+    tags:
+        The final merged tag list (used to detect rejection guards).
+
+    Returns
+    -------
+    list[ProfileRelevanceEntry]
+        The resolved entries to pass to :func:`render_note`.
+    """
+    rejected = {
+        t[len("influx:rejected:") :] for t in tags if t.startswith("influx:rejected:")
+    }
+
+    result: list[ProfileRelevanceEntry] = []
+    seen: set[str] = set()
+
+    # Non-rejected profiles use new entries
+    for entry in new_entries:
+        if entry.profile_name not in rejected:
+            result.append(entry)
+            seen.add(entry.profile_name)
+
+    # Rejected profiles keep old entries
+    for entry in old_entries:
+        if entry.profile_name in rejected and entry.profile_name not in seen:
+            result.append(entry)
+            seen.add(entry.profile_name)
+
+    return result
+
+
+def merge_profile_relevance_union(
+    *,
+    old_entries: list[ProfileRelevanceEntry],
+    new_entries: list[ProfileRelevanceEntry],
+    tags: list[str],
+) -> list[ProfileRelevanceEntry]:
+    """Union-merge profile relevance entries for multi-profile merging (FR-NOTE-6).
+
+    Unlike :func:`build_profile_relevance_for_rewrite` — which drops
+    old entries for non-rejected, non-new profiles (correct for
+    single-profile rewrites and repair sweeps) — this function
+    preserves old entries for ALL profiles not superseded by new
+    entries, enabling multi-profile tag merging on shared notes.
+
+    Rejected profiles (``influx:rejected:<profile>`` in *tags*) always
+    keep their old entries; new entries for rejected profiles are
+    dropped.
+
+    Parameters
+    ----------
+    old_entries:
+        Entries from the previously existing note.
+    new_entries:
+        Entries from the incoming write (typically one profile).
+    tags:
+        The final merged tag list (used to detect rejection guards).
+
+    Returns
+    -------
+    list[ProfileRelevanceEntry]
+        The merged entries to render.
+    """
+    rejected = {
+        t[len("influx:rejected:") :] for t in tags if t.startswith("influx:rejected:")
+    }
+
+    result: list[ProfileRelevanceEntry] = []
+    seen: set[str] = set()
+
+    # Non-rejected profiles use new entries
+    for entry in new_entries:
+        if entry.profile_name not in rejected:
+            result.append(entry)
+            seen.add(entry.profile_name)
+
+    # ALL old entries for profiles not yet in result (union semantics):
+    # - Rejected profiles: keep old entry (rejection authority)
+    # - Non-current profiles: keep old entry (multi-profile preservation)
+    for entry in old_entries:
+        if entry.profile_name not in seen:
+            result.append(entry)
+            seen.add(entry.profile_name)
+
+    return result

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -41,7 +41,7 @@ from influx.errors import ExtractionError, LCMAError, NetworkError
 from influx.extraction.pipeline import extract_arxiv_text
 from influx.filter import FilterScorerError
 from influx.http_client import guarded_fetch
-from influx.notes import ProfileRelevanceEntry, render_note
+from influx.renderer import render
 from influx.schemas import Tier1Enrichment, Tier3Extraction
 from influx.storage import download_archive
 from influx.telemetry import (
@@ -550,7 +550,7 @@ def build_arxiv_note_item(
     Runs the HTML → PDF → abstract-only extraction cascade when the
     candidate's *score* crosses the ``full_text`` threshold, sets the
     appropriate ``text:*`` tier tag, and renders the canonical note via
-    :func:`~influx.notes.render_note`.
+    :func:`~influx.renderer.render`.
 
     Parameters
     ----------
@@ -777,23 +777,16 @@ def build_arxiv_note_item(
     if tier1_attempted and tier1_result is None:
         summary_text = ""
 
-    profile_entries = [
-        ProfileRelevanceEntry(
-            profile_name=profile_name,
-            score=score,
-            reason=reason,
-        ),
-    ]
-
-    content = render_note(
+    content = render(
         title=item.title,
         source_url=source_url,
         tags=tags,
         confidence=confidence,
         archive_path=archive_path,
         summary=summary_text,
-        keywords=[],
-        profile_entries=profile_entries,
+        profile_name=profile_name,
+        score=score,
+        reason=reason,
         full_text=full_text_for_note,
         tier1_enrichment=tier1_result,
         tier3_extraction=tier3_result,

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -38,7 +38,7 @@ from influx.extraction.article import extract_article
 from influx.filter import FilterScorerError
 from influx.http_client import guarded_fetch as _guarded_fetch
 from influx.http_client import guarded_post_json_fetch
-from influx.notes import ProfileRelevanceEntry, render_note
+from influx.renderer import render
 from influx.schemas import FilterResponse, Tier1Enrichment, Tier3Extraction
 from influx.slugs import slugify_feed_name
 from influx.storage import download_archive
@@ -308,23 +308,16 @@ def build_rss_note_item(
 
     summary_for_note = "" if score and tier1_result is None else summary
 
-    profile_entries = [
-        ProfileRelevanceEntry(
-            profile_name=profile_name,
-            score=score,
-            reason=reason,
-        ),
-    ]
-
-    content = render_note(
+    content = render(
         title=item.title,
         source_url=source_url,
         tags=tags,
         confidence=confidence,
         archive_path=archive_path,
         summary=summary_for_note,
-        keywords=[],
-        profile_entries=profile_entries,
+        profile_name=profile_name,
+        score=score,
+        reason=reason,
         tier1_enrichment=tier1_result,
         full_text=full_text_for_note,
         tier3_extraction=tier3_result,

--- a/tests/integration/test_multi_profile_shared_source.py
+++ b/tests/integration/test_multi_profile_shared_source.py
@@ -35,8 +35,8 @@ from influx.config import (
 )
 from influx.coordinator import Coordinator, RunKind
 from influx.http_api import router
-from influx.notes import ProfileRelevanceEntry, render_note
 from influx.probes import ProbeLoop
+from influx.renderer import ProfileRelevanceEntry, render_note
 from influx.scheduler import InfluxScheduler
 from tests.contract.test_lithos_client import FakeLithosServer
 

--- a/tests/integration/test_profile_rejection_authority.py
+++ b/tests/integration/test_profile_rejection_authority.py
@@ -36,8 +36,8 @@ from influx.config import (
 )
 from influx.coordinator import Coordinator, RunKind
 from influx.http_api import router
-from influx.notes import ProfileRelevanceEntry, render_note
 from influx.probes import ProbeLoop
+from influx.renderer import ProfileRelevanceEntry, render_note
 from influx.scheduler import InfluxScheduler
 from tests.contract.test_lithos_client import FakeLithosServer
 

--- a/tests/unit/test_full_text_render.py
+++ b/tests/unit/test_full_text_render.py
@@ -9,7 +9,7 @@ Covers:
 
 from __future__ import annotations
 
-from influx.notes import render_note
+from influx.renderer import render_note
 
 _BASE_TAGS = ["source:arxiv", "ingested-by:influx", "schema:1"]
 _BASE_KWARGS = {

--- a/tests/unit/test_multi_profile_merge.py
+++ b/tests/unit/test_multi_profile_merge.py
@@ -13,11 +13,13 @@ from influx.lithos_client import (
     _replace_profile_relevance_section,
 )
 from influx.notes import (
-    ProfileRelevanceEntry,
-    merge_profile_relevance_union,
     merge_tags,
     parse_note,
     parse_profile_relevance,
+)
+from influx.renderer import (
+    ProfileRelevanceEntry,
+    merge_profile_relevance_union,
     render_note,
 )
 

--- a/tests/unit/test_notes_render.py
+++ b/tests/unit/test_notes_render.py
@@ -8,10 +8,9 @@ from __future__ import annotations
 
 import pytest
 
-from influx.notes import (
+from influx.notes import merge_tags, recompute_confidence
+from influx.renderer import (
     ArchiveInvariantError,
-    merge_tags,
-    recompute_confidence,
     render_archive_section,
     validate_archive_tag_invariant,
 )

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -1,0 +1,314 @@
+"""Unit tests for the high-level Renderer facade (issue #52).
+
+The Renderer module owns the canonical Markdown shape from spec §9.
+``render(...)`` is the high-level entry point used by Source builders;
+it wraps a single-profile :class:`ProfileRelevanceEntry` and delegates
+to :func:`render_note`. These tests cover:
+
+- Frontmatter shape (note_type, namespace, source_url, tags, confidence)
+- Section ordering: ``## Archive``, ``## Summary``, ``## Full Text``,
+  ``## Claims``, ``## Datasets & Benchmarks``, ``## Builds On``,
+  ``## Open Questions``, ``## Profile Relevance``, ``## User Notes``
+- Omitted-section rules (FR-ENR-6) for missing Tier 1 / Tier 2 / Tier 3
+- Profile-relevance merge across rewrites (single-profile authority +
+  multi-profile union)
+- Byte-exact ``## User Notes`` preservation across parse/render cycles
+"""
+
+from __future__ import annotations
+
+from influx.notes import parse_note
+from influx.renderer import (
+    ProfileRelevanceEntry,
+    build_profile_relevance_for_rewrite,
+    merge_profile_relevance_union,
+    render,
+    render_note,
+)
+from influx.schemas import Tier1Enrichment, Tier3Extraction
+
+_BASE_TAGS = ["source:arxiv", "ingested-by:influx", "schema:1"]
+
+
+def _render_minimal(**overrides: object) -> str:
+    """Render a minimal note with sensible defaults; *overrides* override kwargs."""
+    kwargs: dict[str, object] = {
+        "title": "A Paper About Things",
+        "source_url": "https://arxiv.org/abs/2601.00001",
+        "tags": list(_BASE_TAGS),
+        "confidence": 0.8,
+        "archive_path": "papers/arxiv/2026/01/2601.00001.pdf",
+        "summary": "An abstract.",
+        "profile_name": "research",
+        "score": 8,
+        "reason": "Directly relevant.",
+    }
+    kwargs.update(overrides)
+    return render(**kwargs)  # type: ignore[arg-type]
+
+
+# ── Frontmatter ─────────────────────────────────────────────────────
+
+
+class TestFrontmatter:
+    """``render`` produces well-formed YAML frontmatter."""
+
+    def test_frontmatter_fences(self) -> None:
+        text = _render_minimal()
+        assert text.startswith("---\n")
+        assert "\n---\n" in text
+
+    def test_frontmatter_fields_present(self) -> None:
+        text = _render_minimal()
+        head = text.split("\n---\n", 1)[0]
+        assert "note_type: summary" in head
+        assert "namespace: influx" in head
+        assert "source_url: https://arxiv.org/abs/2601.00001" in head
+        assert "confidence: 0.8" in head
+
+    def test_frontmatter_tags_listed(self) -> None:
+        text = _render_minimal(tags=["source:arxiv", "ingested-by:influx", "favourite"])
+        head = text.split("\n---\n", 1)[0]
+        assert "  - source:arxiv" in head
+        assert "  - ingested-by:influx" in head
+        assert "  - favourite" in head
+
+    def test_confidence_normalised_to_decimal(self) -> None:
+        text = _render_minimal(confidence=1.0)
+        assert "confidence: 1.0" in text
+
+
+# ── Section ordering ────────────────────────────────────────────────
+
+
+class TestSectionOrdering:
+    """Sections appear in the canonical order from spec §9."""
+
+    def test_full_pipeline_order(self) -> None:
+        tier1 = Tier1Enrichment(
+            contributions=["c1"],
+            method="m",
+            result="r",
+            relevance="rel",
+        )
+        tier3 = Tier3Extraction(
+            claims=["claim"],
+            datasets=["dataset"],
+            builds_on=["prior"],
+            open_questions=["q"],
+            potential_connections=[],
+        )
+        text = _render_minimal(
+            tier1_enrichment=tier1,
+            full_text="extracted body",
+            tier3_extraction=tier3,
+        )
+
+        headings = [
+            "## Archive",
+            "## Summary",
+            "## Full Text",
+            "## Claims",
+            "## Datasets & Benchmarks",
+            "## Builds On",
+            "## Open Questions",
+            "## Profile Relevance",
+            "## User Notes",
+        ]
+        positions = [text.index(h) for h in headings]
+        assert positions == sorted(positions), (
+            f"Section ordering violated: {list(zip(headings, positions, strict=True))}"
+        )
+
+    def test_archive_path_rendered_in_section(self) -> None:
+        text = _render_minimal(archive_path="papers/arxiv/2026/01/foo.pdf")
+        assert "## Archive\npath: papers/arxiv/2026/01/foo.pdf\n" in text
+
+    def test_archive_empty_body_when_no_path(self) -> None:
+        text = _render_minimal(archive_path=None)
+        # Empty Archive body: heading followed by blank line
+        assert "## Archive\n\n" in text
+
+
+# ── Omitted-section rules (FR-ENR-6) ────────────────────────────────
+
+
+class TestOmittedSections:
+    """Optional sections are omitted entirely when their data is absent."""
+
+    def test_summary_omitted_when_blank_and_no_tier1(self) -> None:
+        text = _render_minimal(summary="", tier1_enrichment=None)
+        assert "## Summary" not in text
+
+    def test_summary_present_when_summary_provided(self) -> None:
+        text = _render_minimal(summary="A short abstract.")
+        assert "## Summary\nA short abstract.\n" in text
+
+    def test_full_text_omitted_when_none(self) -> None:
+        text = _render_minimal(full_text=None)
+        assert "## Full Text" not in text
+
+    def test_full_text_omitted_when_empty(self) -> None:
+        text = _render_minimal(full_text="")
+        assert "## Full Text" not in text
+
+    def test_full_text_present_when_provided(self) -> None:
+        text = _render_minimal(full_text="extracted body")
+        assert "## Full Text\nextracted body\n" in text
+
+    def test_tier3_sections_all_omitted_when_none(self) -> None:
+        text = _render_minimal(tier3_extraction=None)
+        for heading in (
+            "## Claims",
+            "## Datasets & Benchmarks",
+            "## Builds On",
+            "## Open Questions",
+        ):
+            assert heading not in text
+
+    def test_profile_relevance_always_present(self) -> None:
+        text = _render_minimal()
+        assert "## Profile Relevance" in text
+
+
+# ── Profile relevance ───────────────────────────────────────────────
+
+
+class TestProfileRelevance:
+    """``render`` builds a single-profile entry from name/score/reason."""
+
+    def test_single_profile_entry_rendered(self) -> None:
+        text = _render_minimal(
+            profile_name="ai-robotics", score=9, reason="Builds on attention."
+        )
+        expected = (
+            "## Profile Relevance\n### ai-robotics\nScore: 9/10\nBuilds on attention."
+        )
+        assert expected in text
+
+
+# ── Profile-relevance merge across rewrites ─────────────────────────
+
+
+class TestProfileRelevanceMergeForRewrite:
+    """build_profile_relevance_for_rewrite resolves new-vs-old entries (FR-NOTE-6)."""
+
+    def test_new_entry_replaces_old_for_same_profile(self) -> None:
+        old = [ProfileRelevanceEntry("research", 5, "old reason")]
+        new = [ProfileRelevanceEntry("research", 8, "new reason")]
+        resolved = build_profile_relevance_for_rewrite(
+            old_entries=old,
+            new_entries=new,
+            tags=["profile:research"],
+        )
+        assert resolved == [ProfileRelevanceEntry("research", 8, "new reason")]
+
+    def test_rejected_profile_keeps_old_entry(self) -> None:
+        old = [ProfileRelevanceEntry("research", 5, "kept")]
+        new = [ProfileRelevanceEntry("research", 8, "ignored")]
+        resolved = build_profile_relevance_for_rewrite(
+            old_entries=old,
+            new_entries=new,
+            tags=["profile:research", "influx:rejected:research"],
+        )
+        assert resolved == [ProfileRelevanceEntry("research", 5, "kept")]
+
+    def test_old_entry_for_non_current_profile_dropped(self) -> None:
+        """Single-profile rewrite drops entries not in new and not rejected."""
+        old = [ProfileRelevanceEntry("other", 7, "drop me")]
+        new = [ProfileRelevanceEntry("research", 8, "keep")]
+        resolved = build_profile_relevance_for_rewrite(
+            old_entries=old,
+            new_entries=new,
+            tags=["profile:research"],
+        )
+        assert resolved == [ProfileRelevanceEntry("research", 8, "keep")]
+
+
+class TestProfileRelevanceMergeUnion:
+    """merge_profile_relevance_union preserves old entries on shared notes."""
+
+    def test_old_entry_for_other_profile_preserved(self) -> None:
+        old = [ProfileRelevanceEntry("other", 7, "shared note")]
+        new = [ProfileRelevanceEntry("research", 8, "incoming")]
+        merged = merge_profile_relevance_union(
+            old_entries=old,
+            new_entries=new,
+            tags=["profile:research", "profile:other"],
+        )
+        names = [e.profile_name for e in merged]
+        assert names == ["research", "other"]
+
+    def test_rejected_profile_keeps_old_entry(self) -> None:
+        old = [ProfileRelevanceEntry("research", 5, "kept")]
+        new = [ProfileRelevanceEntry("research", 8, "ignored")]
+        merged = merge_profile_relevance_union(
+            old_entries=old,
+            new_entries=new,
+            tags=["profile:research", "influx:rejected:research"],
+        )
+        assert merged == [ProfileRelevanceEntry("research", 5, "kept")]
+
+
+# ── Byte-exact ## User Notes preservation ──────────────────────────
+
+
+class TestUserNotesPreservation:
+    """The ``## User Notes`` region is preserved byte-exactly across rewrites."""
+
+    def test_user_notes_passed_through_byte_exactly(self) -> None:
+        user_notes = "## User Notes\n  Hand-written: keep me!  \n\nstill mine\n"
+        text = _render_minimal(user_notes=user_notes)
+        assert text.endswith(user_notes)
+
+    def test_user_notes_with_crlf_preserved(self) -> None:
+        user_notes = "## User Notes\r\nCRLF body\r\n"
+        text = _render_minimal(user_notes=user_notes)
+        assert text.endswith(user_notes)
+
+    def test_empty_user_notes_heading_appended_when_missing(self) -> None:
+        text = _render_minimal()  # user_notes=None default
+        assert text.endswith("## User Notes\n")
+
+    def test_round_trip_through_parse_preserves_user_notes(self) -> None:
+        original_user_notes = (
+            "## User Notes\n- bullet kept verbatim\n\n  trailing whitespace  \n"
+        )
+        first = _render_minimal(user_notes=original_user_notes)
+        parsed = parse_note(first)
+        assert parsed.user_notes == original_user_notes
+        # Re-render with the parsed user_notes — bytes should match
+        rerendered = _render_minimal(user_notes=parsed.user_notes)
+        assert rerendered.endswith(original_user_notes)
+
+
+# ── render(...) parity with render_note(...) ───────────────────────
+
+
+class TestRenderFacadeParity:
+    """render(...) produces the same bytes as a manual render_note call."""
+
+    def test_render_matches_manual_render_note(self) -> None:
+        kwargs = {
+            "title": "Parity Paper",
+            "source_url": "https://arxiv.org/abs/2601.00099",
+            "tags": list(_BASE_TAGS),
+            "confidence": 0.7,
+            "archive_path": None,
+            "summary": "An abstract.",
+            "profile_name": "research",
+            "score": 7,
+            "reason": "Worth a look.",
+        }
+        via_facade = render(**kwargs)  # type: ignore[arg-type]
+        via_render_note = render_note(
+            title="Parity Paper",
+            source_url="https://arxiv.org/abs/2601.00099",
+            tags=list(_BASE_TAGS),
+            confidence=0.7,
+            archive_path=None,
+            summary="An abstract.",
+            keywords=[],
+            profile_entries=[ProfileRelevanceEntry("research", 7, "Worth a look.")],
+        )
+        assert via_facade == via_render_note

--- a/tests/unit/test_repair_rejection_authority.py
+++ b/tests/unit/test_repair_rejection_authority.py
@@ -8,10 +8,10 @@ Relevance`` section is not created or refreshed for rejected profiles.
 
 from __future__ import annotations
 
-from influx.notes import (
+from influx.notes import merge_tags
+from influx.renderer import (
     ProfileRelevanceEntry,
     build_profile_relevance_for_rewrite,
-    merge_tags,
 )
 
 # ── Shared fixtures ──────────────────────────────────────────────────

--- a/tests/unit/test_summary_render.py
+++ b/tests/unit/test_summary_render.py
@@ -9,7 +9,7 @@ Covers:
 
 from __future__ import annotations
 
-from influx.notes import render_note
+from influx.renderer import render_note
 from influx.schemas import Tier1Enrichment
 
 _BASE_TAGS = ["source:arxiv", "ingested-by:influx", "schema:1"]

--- a/tests/unit/test_tier3_render.py
+++ b/tests/unit/test_tier3_render.py
@@ -9,7 +9,7 @@ Covers:
 
 from __future__ import annotations
 
-from influx.notes import render_note
+from influx.renderer import render_note
 from influx.schemas import Tier3Extraction
 
 _BASE_TAGS = ["source:arxiv", "ingested-by:influx", "schema:1"]

--- a/tests/unit/test_user_notes_roundtrip.py
+++ b/tests/unit/test_user_notes_roundtrip.py
@@ -15,13 +15,15 @@ from pathlib import Path
 import pytest
 
 from influx.notes import (
+    parse_note,
+    parse_profile_relevance,
+    recompute_confidence,
+)
+from influx.renderer import (
     ArchiveInvariantError,
     MissingIngestedByTagError,
     ProfileRelevanceEntry,
     build_profile_relevance_for_rewrite,
-    parse_note,
-    parse_profile_relevance,
-    recompute_confidence,
     render_note,
 )
 


### PR DESCRIPTION
## Summary

- Introduces `src/influx/renderer.py` as the canonical-note rendering seam from CONTEXT.md. Owns frontmatter, section ordering, omitted-section rules, profile-relevance merging across rewrites, and byte-exact `## User Notes` preservation.
- `build_arxiv_note_item` and `build_rss_note_item` now delegate note assembly to a new `render(...)` facade that wraps a single-profile `ProfileRelevanceEntry`. `notes.py` is slimmed to parsing plus tag/confidence merge utilities.
- Adds `tests/unit/test_renderer.py` (25 tests) covering frontmatter, section ordering, omitted sections, profile-relevance merge across rewrites, and `## User Notes` byte-exact preservation.
- No change to canonical note output bytes — existing fixtures and golden-file round-trips remain identical.

Closes #52.

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright src/`
- [x] `uv run pytest tests/ -q` (1594 passed)