### PR TITLE
refactor: extract RepairCounters module (#53)

### DIFF
--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -17,13 +17,16 @@ import copy
 import enum
 import json
 import logging
-import re
-from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any, Literal, Protocol
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
 
 from influx import metrics
 from influx.errors import ExtractionError, LCMAError, LithosError
 from influx.notes import merge_tags
+from influx.repair_counters import (
+    classify_failure,
+    record_counted_failure,
+)
 from influx.telemetry import current_run_id, get_tracer
 
 if TYPE_CHECKING:
@@ -37,7 +40,6 @@ __all__ = [
     "ExtractionOutcome",
     "ReExtractionResult",
     "ReExtractArchiveHook",
-    "RepairCounters",
     "StageSelection",
     "SweepHooks",
     "SweepWriteError",
@@ -45,19 +47,10 @@ __all__ = [
     "Tier2EnrichHook",
     "Tier3ExtractHook",
     "apply_abstract_only_reextraction",
-    "classify_failure",
     "compute_clearing",
-    "parse_repair_section",
-    "render_repair_section",
     "select_stages",
     "sweep",
-    "upsert_repair_section",
 ]
-
-# Per-stage cap on counted failures before flipping influx:tier{2,3}-terminal.
-# Tunable via influx.toml in a follow-up; hardcoded for the initial roll-out
-# (plan: 3 mirrors the abstract-only re-extraction TERMINAL outcome cadence).
-REPAIR_COUNTED_CAP = 3
 
 logger = logging.getLogger(__name__)
 
@@ -452,223 +445,13 @@ def _restore_note(note: dict[str, Any], snapshot: dict[str, Any]) -> None:
     note.update(snapshot)
 
 
-# ── ## Repair section: per-stage attempt counters (Layer 2) ─────────
-
-
-@dataclass(frozen=True, slots=True)
-class RepairCounters:
-    """Per-stage attempt counters tracked in the note's ``## Repair`` section.
-
-    ``{archive,tier2,tier3}_attempts`` count *counted-toward-cap*
-    failures only — transient HTTP / network failures are not bumped
-    (see :func:`classify_failure`).  When ``<stage>_attempts`` reaches
-    the configured cap, the sweep adds the ``influx:<stage>-terminal``
-    tag and stops re-running that stage on subsequent passes.
-    """
-
-    tier2_attempts: int = 0
-    tier2_last_stage: str = ""
-    tier2_last_error: str = ""
-    tier3_attempts: int = 0
-    tier3_last_stage: str = ""
-    tier3_last_error: str = ""
-    archive_attempts: int = 0
-    archive_last_kind: str = ""
-    archive_last_error: str = ""
-
-    def bump_tier2(self, *, stage: str, error: str) -> RepairCounters:
-        """Return a new counters value with Tier 2 attempts incremented."""
-        return replace(
-            self,
-            tier2_attempts=self.tier2_attempts + 1,
-            tier2_last_stage=stage,
-            tier2_last_error=_collapse_to_single_line(error),
-        )
-
-    def bump_tier3(self, *, stage: str, error: str) -> RepairCounters:
-        """Return a new counters value with Tier 3 attempts incremented."""
-        return replace(
-            self,
-            tier3_attempts=self.tier3_attempts + 1,
-            tier3_last_stage=stage,
-            tier3_last_error=_collapse_to_single_line(error),
-        )
-
-    def bump_archive(self, *, kind: str, error: str) -> RepairCounters:
-        """Return a new counters value with archive attempts incremented.
-
-        *kind* is the underlying failure classifier — typically the
-        ``stage`` from ``ExtractionError`` or the ``kind`` from
-        ``NetworkError`` (e.g. ``"oversize"``).  Stored verbatim so an
-        operator inspecting the note can tell at a glance whether the
-        archive is being terminated for size, content-type mismatch,
-        or some other persistent reason.
-        """
-        return replace(
-            self,
-            archive_attempts=self.archive_attempts + 1,
-            archive_last_kind=kind,
-            archive_last_error=_collapse_to_single_line(error),
-        )
-
-
-_REPAIR_HEADING_RE = re.compile(r"^## Repair[ \t]*\n", re.MULTILINE)
-_REPAIR_BULLET_RE = re.compile(r"^[ \t]*-\s*(\w+)\s*:\s*(.*)$")
-_QUOTED_RE = re.compile(r'^"(.*)"$')
-_NEXT_HEADING_RE = re.compile(r"^## ", re.MULTILINE)
-_REPAIR_PROFILE_RELEVANCE_RE = re.compile(r"^## Profile Relevance\b", re.MULTILINE)
-_REPAIR_USER_NOTES_RE = re.compile(r"^## User Notes\b", re.MULTILINE)
-
-
-def _collapse_to_single_line(value: str) -> str:
-    """Flatten *value* to a single line (caps at 300 chars).
-
-    The ``## Repair`` section uses one bullet per key, so multi-line
-    values would corrupt round-tripping.  Truncating long error strings
-    also keeps notes from ballooning when the same provider message
-    repeats every sweep.
-    """
-    return " ".join(value.replace("\r", " ").split())[:300]
-
-
-def _find_repair_section_span(content: str) -> tuple[int, int] | None:
-    """Return (start, end) of the existing ``## Repair`` section, or None."""
-    m = _REPAIR_HEADING_RE.search(content)
-    if not m:
-        return None
-    body_start = m.end()
-    next_h = _NEXT_HEADING_RE.search(content, body_start)
-    end = next_h.start() if next_h else len(content)
-    return m.start(), end
-
-
-def parse_repair_section(content: str) -> RepairCounters:
-    """Parse the ``## Repair`` section of *content* into :class:`RepairCounters`.
-
-    Returns zero-defaults when the section is absent.  Unknown bullets
-    are ignored; malformed integer counts default to zero so a hand-edit
-    cannot break the sweep.
-    """
-    span = _find_repair_section_span(content)
-    if span is None:
-        return RepairCounters()
-    start, end = span
-    # Skip past the heading line we already matched.
-    body_start = content.find("\n", start)
-    if body_start < 0 or body_start >= end:
-        return RepairCounters()
-    body = content[body_start + 1 : end]
-
-    fields: dict[str, Any] = {}
-    int_keys = {"tier2_attempts", "tier3_attempts", "archive_attempts"}
-    str_keys = {
-        "tier2_last_stage",
-        "tier2_last_error",
-        "tier3_last_stage",
-        "tier3_last_error",
-        "archive_last_kind",
-        "archive_last_error",
-    }
-    for line in body.splitlines():
-        bm = _REPAIR_BULLET_RE.match(line)
-        if not bm:
-            continue
-        key = bm.group(1)
-        raw = bm.group(2).strip()
-        qm = _QUOTED_RE.match(raw)
-        value: Any = qm.group(1) if qm else raw
-        if key in int_keys:
-            try:
-                fields[key] = int(value)
-            except (TypeError, ValueError):
-                fields[key] = 0
-        elif key in str_keys:
-            fields[key] = value
-    return RepairCounters(**fields)
-
-
-def render_repair_section(counters: RepairCounters) -> str:
-    """Serialise *counters* as a ``## Repair`` section (trailing newline)."""
-    lines = [
-        "## Repair",
-        f"- tier2_attempts: {counters.tier2_attempts}",
-        f'- tier2_last_stage: "{counters.tier2_last_stage}"',
-        f'- tier2_last_error: "{_collapse_to_single_line(counters.tier2_last_error)}"',
-        f"- tier3_attempts: {counters.tier3_attempts}",
-        f'- tier3_last_stage: "{counters.tier3_last_stage}"',
-        f'- tier3_last_error: "{_collapse_to_single_line(counters.tier3_last_error)}"',
-        f"- archive_attempts: {counters.archive_attempts}",
-        f'- archive_last_kind: "{counters.archive_last_kind}"',
-        (
-            "- archive_last_error: "
-            f'"{_collapse_to_single_line(counters.archive_last_error)}"'
-        ),
-    ]
-    return "\n".join(lines) + "\n"
-
-
-def upsert_repair_section(content: str, counters: RepairCounters) -> str:
-    """Return *content* with the ``## Repair`` section set to *counters*.
-
-    Replaces an existing section in place; otherwise inserts the new
-    section before ``## Profile Relevance`` (canonical placement,
-    matching ``repair_hooks._find_insertion_point``), or before
-    ``## User Notes``, or at end of content when neither is present.
-    """
-    rendered = render_repair_section(counters)
-    span = _find_repair_section_span(content)
-    if span is not None:
-        start, end = span
-        # Trim leading whitespace from the post-section so we don't
-        # accumulate blank lines on every re-render.
-        tail = content[end:].lstrip("\n")
-        if tail:
-            tail = "\n" + tail
-        head = content[:start].rstrip("\n")
-        separator = "\n\n" if head.strip() else ""
-        return head + separator + rendered + tail
-
-    pr = _REPAIR_PROFILE_RELEVANCE_RE.search(content)
-    if pr:
-        ins = pr.start()
-        return content[:ins] + rendered + "\n" + content[ins:]
-    un = _REPAIR_USER_NOTES_RE.search(content)
-    if un:
-        ins = un.start()
-        return content[:ins] + rendered + "\n" + content[ins:]
-    if content and not content.endswith("\n"):
-        content += "\n"
-    return content + ("\n" if content else "") + rendered
-
-
-# ── Failure classification (Layer 2) ────────────────────────────────
-
-
-def classify_failure(exc: BaseException) -> Literal["transient", "counted"]:
-    """Partition a sweep stage failure into transient vs counted.
-
-    *Counted* failures advance the per-stage attempt counter and
-    eventually flip the stage to terminal — these are exceptions whose
-    ``stage`` indicates the model output itself was malformed (``parse``,
-    ``validate``).  Re-running the same prompt on the same input will
-    almost certainly keep failing.
-
-    *Transient* failures (HTTP, transport, resolve, archive_read, or
-    anything we don't specifically recognise) leave the counter alone.
-    The next sweep retries them indefinitely.
-    """
-    if isinstance(exc, (LCMAError, ExtractionError)):
-        stage = getattr(exc, "stage", "") or ""
-        if stage in _COUNTED_STAGES:
-            return "counted"
-    return "transient"
-
-
-# Stage / kind discriminators that mean "rerunning will almost certainly
-# fail the same way" — bump the attempt counter toward the cap.  Includes
-# both LCMA-side schema failures (parse, validate) and archive-side
-# size violations (oversize) which won't shrink on retry.
-_COUNTED_STAGES: frozenset[str] = frozenset({"parse", "validate", "oversize"})
+# ── ## Repair section / counter helpers (re-exported) ───────────────
+#
+# ``RepairCounters``, ``parse_repair_section``, ``render_repair_section``,
+# ``upsert_repair_section``, ``classify_failure``, and
+# :data:`REPAIR_COUNTED_CAP` now live in :mod:`influx.repair_counters`
+# (issue #53) and are imported above so the sweep code below can use
+# them unchanged.
 
 
 def _log_stage_failure(
@@ -1189,32 +972,32 @@ async def _process_sweep_note(
             # the failing hook are NOT persisted (finding #1).
             _restore_note(note, snapshot)
             if classify_failure(exc) == "counted":
-                counters = parse_repair_section(str(note.get("content", "")))
                 kind = (
                     getattr(exc, "stage", "")
                     or getattr(exc, "kind", "")
                     or "archive_failed"
                 )
-                counters = counters.bump_archive(kind=kind, error=str(exc))
-                note["content"] = upsert_repair_section(
-                    str(note.get("content", "")), counters
+                advance = record_counted_failure(
+                    content=str(note.get("content", "")),
+                    tags=current_tags,
+                    stage="archive",
+                    failure_stage=kind,
+                    failure_error=str(exc),
                 )
-                if (
-                    counters.archive_attempts >= REPAIR_COUNTED_CAP
-                    and "influx:archive-terminal" not in current_tags
-                ):
-                    current_tags.append("influx:archive-terminal")
+                note["content"] = advance.new_content
+                current_tags = advance.new_tags
+                if advance.terminal_tag_added:
                     note["tags"] = list(current_tags)
                     logger.warning(
                         "sweep: archive marked terminal after %d failures for %s",
-                        counters.archive_attempts,
+                        advance.attempts,
                         note.get("id", "?"),
                         extra={
                             "sweep_stage": "archive_terminal_flip",
                             "note_id": note.get("id"),
                             "profile": profile,
                             "run_id": current_run_id.get() or "",
-                            "archive_attempts": counters.archive_attempts,
+                            "archive_attempts": advance.attempts,
                             "exc_type": type(exc).__name__,
                             "kind": kind,
                             "detail": getattr(exc, "detail", None),
@@ -1316,30 +1099,27 @@ async def _process_sweep_note(
             # sync hook mutations into ``current_tags``.
             _restore_note(note, snapshot)
             if classify_failure(exc) == "counted":
-                counters = parse_repair_section(str(note.get("content", "")))
-                counters = counters.bump_tier2(
-                    stage=getattr(exc, "stage", "") or "",
-                    error=str(exc),
+                advance = record_counted_failure(
+                    content=str(note.get("content", "")),
+                    tags=current_tags,
+                    stage="tier2",
+                    failure_stage=getattr(exc, "stage", "") or "",
+                    failure_error=str(exc),
                 )
-                note["content"] = upsert_repair_section(
-                    str(note.get("content", "")), counters
-                )
-                if (
-                    counters.tier2_attempts >= REPAIR_COUNTED_CAP
-                    and "influx:tier2-terminal" not in current_tags
-                ):
-                    current_tags.append("influx:tier2-terminal")
+                note["content"] = advance.new_content
+                current_tags = advance.new_tags
+                if advance.terminal_tag_added:
                     note["tags"] = list(current_tags)
                     logger.warning(
                         "sweep: tier2 marked terminal after %d counted failures for %s",
-                        counters.tier2_attempts,
+                        advance.attempts,
                         note.get("id", "?"),
                         extra={
                             "sweep_stage": "tier2_terminal_flip",
                             "note_id": note.get("id"),
                             "profile": profile,
                             "run_id": current_run_id.get() or "",
-                            "tier2_attempts": counters.tier2_attempts,
+                            "tier2_attempts": advance.attempts,
                             "exc_type": type(exc).__name__,
                             "stage": getattr(exc, "stage", None),
                             "detail": getattr(exc, "detail", None),
@@ -1372,30 +1152,27 @@ async def _process_sweep_note(
         except (ExtractionError, LCMAError, LithosError) as exc:
             _restore_note(note, snapshot)
             if classify_failure(exc) == "counted":
-                counters = parse_repair_section(str(note.get("content", "")))
-                counters = counters.bump_tier3(
-                    stage=getattr(exc, "stage", "") or "",
-                    error=str(exc),
+                advance = record_counted_failure(
+                    content=str(note.get("content", "")),
+                    tags=current_tags,
+                    stage="tier3",
+                    failure_stage=getattr(exc, "stage", "") or "",
+                    failure_error=str(exc),
                 )
-                note["content"] = upsert_repair_section(
-                    str(note.get("content", "")), counters
-                )
-                if (
-                    counters.tier3_attempts >= REPAIR_COUNTED_CAP
-                    and "influx:tier3-terminal" not in current_tags
-                ):
-                    current_tags.append("influx:tier3-terminal")
+                note["content"] = advance.new_content
+                current_tags = advance.new_tags
+                if advance.terminal_tag_added:
                     note["tags"] = list(current_tags)
                     logger.warning(
                         "sweep: tier3 marked terminal after %d counted failures for %s",
-                        counters.tier3_attempts,
+                        advance.attempts,
                         note.get("id", "?"),
                         extra={
                             "sweep_stage": "tier3_terminal_flip",
                             "note_id": note.get("id"),
                             "profile": profile,
                             "run_id": current_run_id.get() or "",
-                            "tier3_attempts": counters.tier3_attempts,
+                            "tier3_attempts": advance.attempts,
                             "exc_type": type(exc).__name__,
                             "stage": getattr(exc, "stage", None),
                             "detail": getattr(exc, "detail", None),

--- a/src/influx/repair_counters.py
+++ b/src/influx/repair_counters.py
@@ -1,0 +1,401 @@
+"""Per-stage repair counters parsed from the note's ``## Repair`` section.
+
+The ``RepairCounters`` module owns the read / advance / cap-check
+contract for the per-stage Layer-2 attempt counters Influx persists in
+each note (CONTEXT.md ``RepairCounters``):
+
+- :func:`parse_repair_section` reads existing
+  ``tier{N}_attempts``/``tier{N}_last_stage``/``tier{N}_last_error``
+  bullets from a note body.
+- :func:`render_repair_section` / :func:`upsert_repair_section`
+  serialise the counters back into the note before its rewrite.
+- :func:`classify_failure` partitions sweep-stage failures into
+  ``"transient"`` vs ``"counted"``.  Transient failures (HTTP, transport,
+  resolve, archive_read, etc.) do **not** advance the counter — that
+  partition stays in callers via the ``classify_failure`` check.
+- :func:`record_counted_failure` performs the canonical
+  parse → bump → upsert → cap-check sequence and emits the
+  ``influx:<stage>-terminal`` tag when the cap is reached.
+
+The cap (:data:`REPAIR_COUNTED_CAP`) is hardcoded to 3 to mirror the
+abstract-only re-extraction TERMINAL outcome cadence; tunability is a
+follow-up.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, replace
+from typing import Any, Literal
+
+from influx.errors import ExtractionError, LCMAError
+
+__all__ = [
+    "REPAIR_COUNTED_CAP",
+    "CountedFailureResult",
+    "CountedStage",
+    "RepairCounters",
+    "classify_failure",
+    "parse_repair_section",
+    "record_counted_failure",
+    "render_repair_section",
+    "terminal_tag_for",
+    "upsert_repair_section",
+]
+
+# Per-stage cap on counted failures before flipping
+# influx:tier{2,3}-terminal / influx:archive-terminal.  Tunable via
+# influx.toml in a follow-up; hardcoded for the initial roll-out (plan:
+# 3 mirrors the abstract-only re-extraction TERMINAL outcome cadence).
+REPAIR_COUNTED_CAP = 3
+
+
+CountedStage = Literal["tier2", "tier3", "archive"]
+
+
+# ── Counters dataclass ──────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class RepairCounters:
+    """Per-stage attempt counters tracked in the note's ``## Repair`` section.
+
+    ``{archive,tier2,tier3}_attempts`` count *counted-toward-cap*
+    failures only — transient HTTP / network failures are not bumped
+    (see :func:`classify_failure`).  When ``<stage>_attempts`` reaches
+    the configured cap, the sweep adds the ``influx:<stage>-terminal``
+    tag and stops re-running that stage on subsequent passes.
+    """
+
+    tier2_attempts: int = 0
+    tier2_last_stage: str = ""
+    tier2_last_error: str = ""
+    tier3_attempts: int = 0
+    tier3_last_stage: str = ""
+    tier3_last_error: str = ""
+    archive_attempts: int = 0
+    archive_last_kind: str = ""
+    archive_last_error: str = ""
+
+    def bump_tier2(self, *, stage: str, error: str) -> RepairCounters:
+        """Return a new counters value with Tier 2 attempts incremented."""
+        return replace(
+            self,
+            tier2_attempts=self.tier2_attempts + 1,
+            tier2_last_stage=stage,
+            tier2_last_error=_collapse_to_single_line(error),
+        )
+
+    def bump_tier3(self, *, stage: str, error: str) -> RepairCounters:
+        """Return a new counters value with Tier 3 attempts incremented."""
+        return replace(
+            self,
+            tier3_attempts=self.tier3_attempts + 1,
+            tier3_last_stage=stage,
+            tier3_last_error=_collapse_to_single_line(error),
+        )
+
+    def bump_archive(self, *, kind: str, error: str) -> RepairCounters:
+        """Return a new counters value with archive attempts incremented.
+
+        *kind* is the underlying failure classifier — typically the
+        ``stage`` from ``ExtractionError`` or the ``kind`` from
+        ``NetworkError`` (e.g. ``"oversize"``).  Stored verbatim so an
+        operator inspecting the note can tell at a glance whether the
+        archive is being terminated for size, content-type mismatch,
+        or some other persistent reason.
+        """
+        return replace(
+            self,
+            archive_attempts=self.archive_attempts + 1,
+            archive_last_kind=kind,
+            archive_last_error=_collapse_to_single_line(error),
+        )
+
+    def attempts_for(self, stage: CountedStage) -> int:
+        """Return the per-stage counter for *stage*."""
+        if stage == "tier2":
+            return self.tier2_attempts
+        if stage == "tier3":
+            return self.tier3_attempts
+        return self.archive_attempts
+
+
+# ── Section parser / serializer ─────────────────────────────────────
+
+
+_REPAIR_HEADING_RE = re.compile(r"^## Repair[ \t]*\n", re.MULTILINE)
+_REPAIR_BULLET_RE = re.compile(r"^[ \t]*-\s*(\w+)\s*:\s*(.*)$")
+_QUOTED_RE = re.compile(r'^"(.*)"$')
+_NEXT_HEADING_RE = re.compile(r"^## ", re.MULTILINE)
+_REPAIR_PROFILE_RELEVANCE_RE = re.compile(r"^## Profile Relevance\b", re.MULTILINE)
+_REPAIR_USER_NOTES_RE = re.compile(r"^## User Notes\b", re.MULTILINE)
+
+
+def _collapse_to_single_line(value: str) -> str:
+    """Flatten *value* to a single line (caps at 300 chars).
+
+    The ``## Repair`` section uses one bullet per key, so multi-line
+    values would corrupt round-tripping.  Truncating long error strings
+    also keeps notes from ballooning when the same provider message
+    repeats every sweep.
+    """
+    return " ".join(value.replace("\r", " ").split())[:300]
+
+
+def _find_repair_section_span(content: str) -> tuple[int, int] | None:
+    """Return (start, end) of the existing ``## Repair`` section, or None."""
+    m = _REPAIR_HEADING_RE.search(content)
+    if not m:
+        return None
+    body_start = m.end()
+    next_h = _NEXT_HEADING_RE.search(content, body_start)
+    end = next_h.start() if next_h else len(content)
+    return m.start(), end
+
+
+def parse_repair_section(content: str) -> RepairCounters:
+    """Parse the ``## Repair`` section of *content* into :class:`RepairCounters`.
+
+    Returns zero-defaults when the section is absent.  Unknown bullets
+    are ignored; malformed integer counts default to zero so a hand-edit
+    cannot break the sweep.
+    """
+    span = _find_repair_section_span(content)
+    if span is None:
+        return RepairCounters()
+    start, end = span
+    # Skip past the heading line we already matched.
+    body_start = content.find("\n", start)
+    if body_start < 0 or body_start >= end:
+        return RepairCounters()
+    body = content[body_start + 1 : end]
+
+    fields: dict[str, Any] = {}
+    int_keys = {"tier2_attempts", "tier3_attempts", "archive_attempts"}
+    str_keys = {
+        "tier2_last_stage",
+        "tier2_last_error",
+        "tier3_last_stage",
+        "tier3_last_error",
+        "archive_last_kind",
+        "archive_last_error",
+    }
+    for line in body.splitlines():
+        bm = _REPAIR_BULLET_RE.match(line)
+        if not bm:
+            continue
+        key = bm.group(1)
+        raw = bm.group(2).strip()
+        qm = _QUOTED_RE.match(raw)
+        value: Any = qm.group(1) if qm else raw
+        if key in int_keys:
+            try:
+                fields[key] = int(value)
+            except (TypeError, ValueError):
+                fields[key] = 0
+        elif key in str_keys:
+            fields[key] = value
+    return RepairCounters(**fields)
+
+
+def render_repair_section(counters: RepairCounters) -> str:
+    """Serialise *counters* as a ``## Repair`` section (trailing newline)."""
+    lines = [
+        "## Repair",
+        f"- tier2_attempts: {counters.tier2_attempts}",
+        f'- tier2_last_stage: "{counters.tier2_last_stage}"',
+        f'- tier2_last_error: "{_collapse_to_single_line(counters.tier2_last_error)}"',
+        f"- tier3_attempts: {counters.tier3_attempts}",
+        f'- tier3_last_stage: "{counters.tier3_last_stage}"',
+        f'- tier3_last_error: "{_collapse_to_single_line(counters.tier3_last_error)}"',
+        f"- archive_attempts: {counters.archive_attempts}",
+        f'- archive_last_kind: "{counters.archive_last_kind}"',
+        (
+            "- archive_last_error: "
+            f'"{_collapse_to_single_line(counters.archive_last_error)}"'
+        ),
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def upsert_repair_section(content: str, counters: RepairCounters) -> str:
+    """Return *content* with the ``## Repair`` section set to *counters*.
+
+    Replaces an existing section in place; otherwise inserts the new
+    section before ``## Profile Relevance`` (canonical placement,
+    matching ``repair_hooks._find_insertion_point``), or before
+    ``## User Notes``, or at end of content when neither is present.
+    """
+    rendered = render_repair_section(counters)
+    span = _find_repair_section_span(content)
+    if span is not None:
+        start, end = span
+        # Trim leading whitespace from the post-section so we don't
+        # accumulate blank lines on every re-render.
+        tail = content[end:].lstrip("\n")
+        if tail:
+            tail = "\n" + tail
+        head = content[:start].rstrip("\n")
+        separator = "\n\n" if head.strip() else ""
+        return head + separator + rendered + tail
+
+    pr = _REPAIR_PROFILE_RELEVANCE_RE.search(content)
+    if pr:
+        ins = pr.start()
+        return content[:ins] + rendered + "\n" + content[ins:]
+    un = _REPAIR_USER_NOTES_RE.search(content)
+    if un:
+        ins = un.start()
+        return content[:ins] + rendered + "\n" + content[ins:]
+    if content and not content.endswith("\n"):
+        content += "\n"
+    return content + ("\n" if content else "") + rendered
+
+
+# ── Failure classification ──────────────────────────────────────────
+
+
+# Stage / kind discriminators that mean "rerunning will almost certainly
+# fail the same way" — bump the attempt counter toward the cap.  Includes
+# both LCMA-side schema failures (parse, validate) and archive-side
+# size violations (oversize) which won't shrink on retry.
+_COUNTED_STAGES: frozenset[str] = frozenset({"parse", "validate", "oversize"})
+
+
+def classify_failure(exc: BaseException) -> Literal["transient", "counted"]:
+    """Partition a sweep stage failure into transient vs counted.
+
+    *Counted* failures advance the per-stage attempt counter and
+    eventually flip the stage to terminal — these are exceptions whose
+    ``stage`` indicates the model output itself was malformed (``parse``,
+    ``validate``).  Re-running the same prompt on the same input will
+    almost certainly keep failing.
+
+    *Transient* failures (HTTP, transport, resolve, archive_read, or
+    anything we don't specifically recognise) leave the counter alone.
+    The next sweep retries them indefinitely.
+    """
+    if isinstance(exc, (LCMAError, ExtractionError)):
+        stage = getattr(exc, "stage", "") or ""
+        if stage in _COUNTED_STAGES:
+            return "counted"
+    return "transient"
+
+
+# ── Combined record-counted-failure operation ──────────────────────
+
+
+def terminal_tag_for(stage: CountedStage) -> str:
+    """Return the ``influx:<stage>-terminal`` tag for *stage*."""
+    return f"influx:{stage}-terminal"
+
+
+@dataclass(frozen=True, slots=True)
+class CountedFailureResult:
+    """Outcome of recording one counted failure for a stage.
+
+    Attributes
+    ----------
+    counters:
+        The post-bump :class:`RepairCounters` value (already serialised
+        into ``new_content``).
+    new_content:
+        The note body with the updated ``## Repair`` section upserted.
+    new_tags:
+        The tag list with ``influx:<stage>-terminal`` appended when the
+        cap was just crossed.  Existing tags are preserved verbatim.
+    attempts:
+        The post-bump per-stage counter.
+    cap_reached:
+        ``True`` when ``attempts >= REPAIR_COUNTED_CAP``.
+    terminal_tag:
+        The ``influx:<stage>-terminal`` literal for *stage*.
+    terminal_tag_added:
+        ``True`` when the terminal tag was *newly* appended on this
+        record (i.e. cap reached AND tag was not already present).
+        Callers use this as the trigger for the "stage marked terminal"
+        warning so the log fires exactly once per stage flip.
+    """
+
+    counters: RepairCounters
+    new_content: str
+    new_tags: list[str]
+    attempts: int
+    cap_reached: bool
+    terminal_tag: str
+    terminal_tag_added: bool
+
+
+def record_counted_failure(
+    *,
+    content: str,
+    tags: list[str],
+    stage: CountedStage,
+    failure_stage: str,
+    failure_error: str,
+) -> CountedFailureResult:
+    """Advance the per-stage counter, upsert ``## Repair``, check cap.
+
+    Performs the canonical four-step pattern that the repair sweep
+    repeats for every counted-class failure on tier 2, tier 3, and
+    archive download:
+
+    1. Parse the existing ``## Repair`` section from *content*.
+    2. Bump the per-stage counter (``bump_tier2`` /
+       ``bump_tier3`` / ``bump_archive``) with *failure_stage* and
+       *failure_error* attribution.
+    3. Upsert the new counters into the note body.
+    4. Compare against :data:`REPAIR_COUNTED_CAP`; when reached, append
+       ``influx:<stage>-terminal`` to *tags* (idempotent).
+
+    Parameters
+    ----------
+    content:
+        The note's current Markdown body.
+    tags:
+        The current tag list. Not mutated; the returned ``new_tags`` is
+        a fresh list with the terminal tag appended on cap.
+    stage:
+        Which counter to bump (``"tier2"``, ``"tier3"``, ``"archive"``).
+    failure_stage:
+        Stage attribution for the bump — typically
+        ``LCMAError.stage`` or ``ExtractionError.stage``.  For archive
+        failures pass the ``kind`` (e.g. ``"oversize"``).
+    failure_error:
+        Stringified exception for the ``last_error`` field.
+
+    Returns
+    -------
+    CountedFailureResult
+        Post-bump counters, updated content, updated tags, plus
+        cap-check signals callers use to drive structured logging.
+    """
+    counters = parse_repair_section(content)
+    if stage == "tier2":
+        counters = counters.bump_tier2(stage=failure_stage, error=failure_error)
+    elif stage == "tier3":
+        counters = counters.bump_tier3(stage=failure_stage, error=failure_error)
+    else:  # "archive"
+        counters = counters.bump_archive(kind=failure_stage, error=failure_error)
+
+    new_content = upsert_repair_section(content, counters)
+    attempts = counters.attempts_for(stage)
+    cap_reached = attempts >= REPAIR_COUNTED_CAP
+    terminal_tag = terminal_tag_for(stage)
+
+    new_tags = list(tags)
+    terminal_tag_added = False
+    if cap_reached and terminal_tag not in new_tags:
+        new_tags.append(terminal_tag)
+        terminal_tag_added = True
+
+    return CountedFailureResult(
+        counters=counters,
+        new_content=new_content,
+        new_tags=new_tags,
+        attempts=attempts,
+        cap_reached=cap_reached,
+        terminal_tag=terminal_tag,
+        terminal_tag_added=terminal_tag_added,
+    )

--- a/tests/unit/test_repair_counters.py
+++ b/tests/unit/test_repair_counters.py
@@ -1,0 +1,307 @@
+"""Unit tests for the ``record_counted_failure`` operation (issue #53).
+
+The repair_counters module owns the canonical four-step pattern that
+the repair sweep repeats for tier 2, tier 3, and archive download:
+
+1. parse the existing ``## Repair`` section
+2. bump the per-stage counter
+3. upsert the new counters back into the note body
+4. add ``influx:<stage>-terminal`` when the cap is reached (idempotent)
+
+These tests cover the combined ``record_counted_failure`` API plus the
+read/advance/cap-check contract. Lower-level parse / render / upsert
+behaviour is exercised in ``test_repair_self_repair.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from influx.errors import ExtractionError, InfluxError, LCMAError, LithosError
+from influx.repair_counters import (
+    REPAIR_COUNTED_CAP,
+    CountedFailureResult,
+    RepairCounters,
+    classify_failure,
+    parse_repair_section,
+    record_counted_failure,
+    terminal_tag_for,
+)
+
+# A minimal note body with the placement landmarks ``upsert_repair_section``
+# uses to insert the ``## Repair`` section in canonical position.
+_BASE_NOTE = (
+    "# Paper\n\n"
+    "## Summary\nA paper.\n\n"
+    "## Profile Relevance\n### research\nScore: 9/10\nReason\n\n"
+    "## User Notes\n"
+)
+_BASE_TAGS = ["source:arxiv", "ingested-by:influx", "schema:1"]
+
+
+# ── terminal_tag_for ───────────────────────────────────────────────
+
+
+class TestTerminalTagFor:
+    """``terminal_tag_for`` returns the canonical ``influx:<stage>-terminal``."""
+
+    @pytest.mark.parametrize(
+        ("stage", "expected"),
+        [
+            ("tier2", "influx:tier2-terminal"),
+            ("tier3", "influx:tier3-terminal"),
+            ("archive", "influx:archive-terminal"),
+        ],
+    )
+    def test_canonical_tag(self, stage: str, expected: str) -> None:
+        # ``stage`` is typed as ``CountedStage`` but pytest parametrise
+        # passes plain strings — cast at the call site.
+        from influx.repair_counters import CountedStage
+
+        cs: CountedStage = stage  # type: ignore[assignment]
+        assert terminal_tag_for(cs) == expected
+
+
+# ── attempts_for ───────────────────────────────────────────────────
+
+
+class TestAttemptsFor:
+    """``RepairCounters.attempts_for`` reads per-stage counter values."""
+
+    def test_tier2_counter(self) -> None:
+        c = RepairCounters(tier2_attempts=2, tier3_attempts=5, archive_attempts=1)
+        assert c.attempts_for("tier2") == 2
+
+    def test_tier3_counter(self) -> None:
+        c = RepairCounters(tier2_attempts=2, tier3_attempts=5, archive_attempts=1)
+        assert c.attempts_for("tier3") == 5
+
+    def test_archive_counter(self) -> None:
+        c = RepairCounters(tier2_attempts=2, tier3_attempts=5, archive_attempts=1)
+        assert c.attempts_for("archive") == 1
+
+
+# ── record_counted_failure: cap not reached ───────────────────────
+
+
+class TestRecordCountedFailureBelowCap:
+    """First counted failure: counter advances; no terminal tag added."""
+
+    def test_first_tier2_failure_advances_counter(self) -> None:
+        result = record_counted_failure(
+            content=_BASE_NOTE,
+            tags=list(_BASE_TAGS),
+            stage="tier2",
+            failure_stage="parse",
+            failure_error="bad json",
+        )
+        assert result.attempts == 1
+        assert result.cap_reached is False
+        assert result.terminal_tag_added is False
+        assert "influx:tier2-terminal" not in result.new_tags
+        # Tags preserved verbatim
+        assert result.new_tags == _BASE_TAGS
+        assert result.counters.tier2_attempts == 1
+        assert result.counters.tier2_last_stage == "parse"
+        assert result.counters.tier2_last_error == "bad json"
+
+    def test_repair_section_inserted_in_content(self) -> None:
+        result = record_counted_failure(
+            content=_BASE_NOTE,
+            tags=list(_BASE_TAGS),
+            stage="tier3",
+            failure_stage="validate",
+            failure_error="schema mismatch",
+        )
+        assert "## Repair\n" in result.new_content
+        assert "tier3_attempts: 1" in result.new_content
+        assert '- tier3_last_stage: "validate"' in result.new_content
+        # Round-trips through parse
+        roundtrip = parse_repair_section(result.new_content)
+        assert roundtrip.tier3_attempts == 1
+        assert roundtrip.tier3_last_stage == "validate"
+
+    def test_existing_counter_advances_from_existing_state(self) -> None:
+        content_with_two = (
+            "# Paper\n\n## Repair\n"
+            "- tier2_attempts: 2\n"
+            '- tier2_last_stage: "parse"\n'
+            "- tier3_attempts: 0\n"
+            "- archive_attempts: 0\n\n"
+            "## Profile Relevance\n### r\nScore: 9/10\nReason\n\n"
+            "## User Notes\n"
+        )
+        result = record_counted_failure(
+            content=content_with_two,
+            tags=list(_BASE_TAGS),
+            stage="tier2",
+            failure_stage="validate",
+            failure_error="oops",
+        )
+        # 2 + 1 = 3 → cap reached on this single advance
+        assert result.attempts == 3
+        assert result.cap_reached is True
+        assert result.terminal_tag_added is True
+        assert "influx:tier2-terminal" in result.new_tags
+
+
+# ── record_counted_failure: cap-reach and idempotence ──────────────
+
+
+class TestRecordCountedFailureAtCap:
+    """Cap-reach flips the terminal tag exactly once."""
+
+    def test_cap_reach_adds_terminal_tag(self) -> None:
+        content = (
+            "# Paper\n\n## Repair\n"
+            f"- tier3_attempts: {REPAIR_COUNTED_CAP - 1}\n\n"
+            "## User Notes\n"
+        )
+        result = record_counted_failure(
+            content=content,
+            tags=list(_BASE_TAGS),
+            stage="tier3",
+            failure_stage="parse",
+            failure_error="boom",
+        )
+        assert result.cap_reached is True
+        assert result.terminal_tag_added is True
+        assert result.new_tags[-1] == "influx:tier3-terminal"
+
+    def test_already_terminal_does_not_re_add(self) -> None:
+        """Idempotence: if ``influx:<stage>-terminal`` is already present,
+        a subsequent counted failure does not duplicate the tag, and
+        ``terminal_tag_added`` is False."""
+        content = (
+            "# Paper\n\n## Repair\n"
+            f"- tier3_attempts: {REPAIR_COUNTED_CAP}\n\n"
+            "## User Notes\n"
+        )
+        tags = [*_BASE_TAGS, "influx:tier3-terminal"]
+        result = record_counted_failure(
+            content=content,
+            tags=tags,
+            stage="tier3",
+            failure_stage="parse",
+            failure_error="still bad",
+        )
+        assert result.cap_reached is True
+        assert result.terminal_tag_added is False  # NOT newly added
+        assert result.new_tags.count("influx:tier3-terminal") == 1
+
+    def test_archive_cap_uses_archive_terminal_tag(self) -> None:
+        content = (
+            "# Paper\n\n## Repair\n"
+            f"- archive_attempts: {REPAIR_COUNTED_CAP - 1}\n\n"
+            "## User Notes\n"
+        )
+        result = record_counted_failure(
+            content=content,
+            tags=list(_BASE_TAGS),
+            stage="archive",
+            failure_stage="oversize",
+            failure_error="exceeds 100MB",
+        )
+        assert result.cap_reached is True
+        assert result.terminal_tag_added is True
+        assert "influx:archive-terminal" in result.new_tags
+        # tier-specific terminal tags must NOT leak across stages
+        assert "influx:tier2-terminal" not in result.new_tags
+        assert "influx:tier3-terminal" not in result.new_tags
+
+    def test_input_tags_not_mutated(self) -> None:
+        """The input *tags* list is treated immutably."""
+        original_tags = list(_BASE_TAGS)
+        before = list(original_tags)
+        content = (
+            "# Paper\n\n## Repair\n"
+            f"- tier2_attempts: {REPAIR_COUNTED_CAP - 1}\n\n"
+            "## User Notes\n"
+        )
+        result = record_counted_failure(
+            content=content,
+            tags=original_tags,
+            stage="tier2",
+            failure_stage="parse",
+            failure_error="boom",
+        )
+        assert original_tags == before
+        # And the returned list is a fresh object
+        assert result.new_tags is not original_tags
+
+
+# ── record_counted_failure: stage isolation ────────────────────────
+
+
+class TestStageIsolation:
+    """Bumping one stage does not leak counters into the other stages."""
+
+    def test_tier2_bump_does_not_advance_tier3_or_archive(self) -> None:
+        result = record_counted_failure(
+            content=_BASE_NOTE,
+            tags=list(_BASE_TAGS),
+            stage="tier2",
+            failure_stage="parse",
+            failure_error="boom",
+        )
+        assert result.counters.tier2_attempts == 1
+        assert result.counters.tier3_attempts == 0
+        assert result.counters.archive_attempts == 0
+
+
+# ── classify_failure partition contract ────────────────────────────
+
+
+class TestTransientCountedPartition:
+    """Callers consult ``classify_failure`` BEFORE calling
+    ``record_counted_failure`` — transient failures must not enter
+    the counted path. These tests document the partition contract."""
+
+    def test_transient_failures(self) -> None:
+        transients: list[BaseException] = [
+            LithosError("connection refused", operation="write"),
+            LCMAError("timeout", model="extract", stage="http"),
+            LCMAError("model slot missing", stage="resolve"),
+            LCMAError("opaque failure"),  # no stage
+            ExtractionError("io error", url="http://x", stage="archive_read"),
+            InfluxError("generic"),
+            ValueError("oops"),
+        ]
+        for exc in transients:
+            assert classify_failure(exc) == "transient", (
+                f"expected transient for {exc!r}"
+            )
+
+    def test_counted_failures(self) -> None:
+        counted: list[BaseException] = [
+            LCMAError("bad json", model="extract", stage="parse"),
+            LCMAError("schema validation failed", stage="validate"),
+            ExtractionError("no full text", url="http://x", stage="parse"),
+            ExtractionError("too big", url="http://x", stage="oversize"),
+        ]
+        for exc in counted:
+            assert classify_failure(exc) == "counted", f"expected counted for {exc!r}"
+
+
+# ── Result dataclass shape ─────────────────────────────────────────
+
+
+class TestCountedFailureResultShape:
+    """``CountedFailureResult`` exposes the fields the sweep needs."""
+
+    def test_has_expected_fields(self) -> None:
+        result = record_counted_failure(
+            content=_BASE_NOTE,
+            tags=list(_BASE_TAGS),
+            stage="tier2",
+            failure_stage="parse",
+            failure_error="boom",
+        )
+        assert isinstance(result, CountedFailureResult)
+        assert isinstance(result.counters, RepairCounters)
+        assert isinstance(result.new_content, str)
+        assert isinstance(result.new_tags, list)
+        assert isinstance(result.attempts, int)
+        assert isinstance(result.cap_reached, bool)
+        assert result.terminal_tag == "influx:tier2-terminal"
+        assert isinstance(result.terminal_tag_added, bool)

--- a/tests/unit/test_repair_hooks_production.py
+++ b/tests/unit/test_repair_hooks_production.py
@@ -619,7 +619,7 @@ class TestArchiveDownloadHookFailures:
         self, tmp_path: Path
     ) -> None:
         """Oversize is a counted failure — the stage must round-trip."""
-        from influx.repair import classify_failure
+        from influx.repair_counters import classify_failure
         from influx.storage import ArchiveResult
 
         config = _make_config(tmp_path)
@@ -641,7 +641,7 @@ class TestArchiveDownloadHookFailures:
 
     def test_http_error_raises_transient(self, tmp_path: Path) -> None:
         """HTTP 4xx/5xx is currently transient — the note retries next sweep."""
-        from influx.repair import classify_failure
+        from influx.repair_counters import classify_failure
         from influx.storage import ArchiveResult
 
         config = _make_config(tmp_path)
@@ -662,7 +662,7 @@ class TestArchiveDownloadHookFailures:
         assert classify_failure(exc_info.value) == "transient"
 
     def test_timeout_is_transient(self, tmp_path: Path) -> None:
-        from influx.repair import classify_failure
+        from influx.repair_counters import classify_failure
         from influx.storage import ArchiveResult
 
         config = _make_config(tmp_path)
@@ -685,7 +685,7 @@ class TestArchiveDownloadHookFailures:
 
 class TestArchiveDownloadHookMetadataRecovery:
     def test_missing_arxiv_id_tag_raises_resolve(self, tmp_path: Path) -> None:
-        from influx.repair import classify_failure
+        from influx.repair_counters import classify_failure
 
         config = _make_config(tmp_path)
         hooks = make_default_sweep_hooks(config)
@@ -709,7 +709,7 @@ class TestArchiveDownloadHookMetadataRecovery:
         assert exc_info.value.stage == "resolve"
 
     def test_unsupported_source_raises_unsupported_source(self, tmp_path: Path) -> None:
-        from influx.repair import classify_failure
+        from influx.repair_counters import classify_failure
 
         config = _make_config(tmp_path)
         hooks = make_default_sweep_hooks(config)
@@ -790,7 +790,7 @@ class TestTextExtractionHookSuccess:
 
 class TestTextExtractionHookFailures:
     def test_cascade_failure_propagates_extraction_error(self, tmp_path: Path) -> None:
-        from influx.repair import classify_failure
+        from influx.repair_counters import classify_failure
 
         config = _make_config(tmp_path)
         hooks = make_default_sweep_hooks(config)
@@ -833,7 +833,7 @@ class TestTextExtractionHookFailures:
 
 class TestTextExtractionHookMetadataRecovery:
     def test_missing_arxiv_id_raises_resolve(self, tmp_path: Path) -> None:
-        from influx.repair import classify_failure
+        from influx.repair_counters import classify_failure
 
         config = _make_config(tmp_path)
         hooks = make_default_sweep_hooks(config)
@@ -847,7 +847,7 @@ class TestTextExtractionHookMetadataRecovery:
         assert classify_failure(exc_info.value) == "transient"
 
     def test_unsupported_source_raises_unsupported_source(self, tmp_path: Path) -> None:
-        from influx.repair import classify_failure
+        from influx.repair_counters import classify_failure
 
         config = _make_config(tmp_path)
         hooks = make_default_sweep_hooks(config)

--- a/tests/unit/test_repair_self_repair.py
+++ b/tests/unit/test_repair_self_repair.py
@@ -15,7 +15,7 @@ tag) is exercised in ``test_repair_sweep.py``.
 from __future__ import annotations
 
 from influx.errors import ExtractionError, InfluxError, LCMAError, LithosError
-from influx.repair import (
+from influx.repair_counters import (
     RepairCounters,
     classify_failure,
     parse_repair_section,


### PR DESCRIPTION
## Summary

- Introduces \`src/influx/repair_counters.py\` owning the per-stage \`## Repair\` section parse/render/upsert helpers, the \`classify_failure\` transient-vs-counted partition, and a new \`record_counted_failure(...)\` operation that performs the canonical parse → bump → upsert → cap-check sequence and emits \`influx:<stage>-terminal\` idempotently when the cap is reached.
- Repair sweep's three duplicated tier2 / tier3 / archive counted-failure handlers in \`src/influx/repair.py\` now delegate to \`record_counted_failure\`, collapsing ~40 lines of inline counter logic per stage into a single call.
- Public symbols (\`RepairCounters\`, \`classify_failure\`, \`parse/render/upsert_repair_section\`) move to the new module; test import paths follow the move.
- Adds \`tests/unit/test_repair_counters.py\` (17 tests) covering cap-not-reached, cap-reached, idempotent-terminal, stage-isolation, and transient-vs-counted partition contracts.

Closes #53.

## Test plan

- [x] \`uv run ruff check .\`
- [x] \`uv run ruff format --check .\`
- [x] \`uv run pyright src/\`
- [x] \`uv run pytest tests/ -q\` (1611 passed)