### PR TITLE
refactor: extract LcmaWiring module (#54)

### DIFF
--- a/src/influx/lcma_wiring.py
+++ b/src/influx/lcma_wiring.py
@@ -1,0 +1,184 @@
+"""Post-write LCMA wiring (CONTEXT.md ``LcmaWiring``).
+
+The LcmaWiring module owns the post-``lithos_write`` graph-edge dispatch
+the scheduler used to inline:
+
+- Calling ``lithos_retrieve`` with the title-plus-contributions query
+  (FR-LCMA-2) and scoring results against ``thresholds.lcma_edge_score``
+  to upsert ``related_to`` edges (FR-LCMA-3, AC-M2-5/6).
+- Resolving Tier 3 ``builds_on`` entries via ``lithos_cache_lookup`` and
+  upserting ``builds_on`` edges only on exact ``source_url`` match
+  (FR-LCMA-4, AC-M2-7/8).
+- Latching the ``lcma_unknown_tool_failure`` probe flag (FR-LCMA-6) when
+  Lithos returns ``unknown_tool`` for any of those calls.
+
+The actual retrieve / cache-lookup / edge-upsert primitives still live
+in :mod:`influx.lcma`.  This module is the seam the scheduler (and,
+later, the ``Run`` module) calls into after each successful write.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from influx.errors import LCMAError
+from influx.lcma import after_write, resolve_builds_on
+
+if TYPE_CHECKING:
+    from influx.lithos_client import LithosClient
+
+__all__ = [
+    "CascadeOutput",
+    "LcmaUnknownToolLatch",
+    "LcmaWiringDeps",
+    "wire",
+]
+
+logger = logging.getLogger(__name__)
+
+
+# Latch callback shape — typically ``ProbeLoop.mark_lcma_unknown_tool_failure``
+# (kwargs: ``profile``, ``detail``).  Any callable accepting those kwargs
+# is acceptable so unit tests can pass a plain capturing fake.
+LcmaUnknownToolLatch = Callable[..., None]
+
+
+@dataclass(frozen=True, slots=True)
+class CascadeOutput:
+    """Subset of one item's enrichment output the LCMA wiring consumes.
+
+    The fields mirror the cascade keys ``build_*_note_item`` populate on
+    the ``ProfileItem`` dict today.  When the Cascade module lands the
+    real ``EnrichedSections`` value (CONTEXT.md), its public reading
+    helpers will return this same shape so callers do not need to
+    re-thread fields by hand.
+    """
+
+    title: str
+    contributions: list[str] | None = None
+    builds_on: list[str] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LcmaWiringDeps:
+    """Per-run dependencies the LCMA wiring needs to dispatch.
+
+    Bundled into one value so the scheduler can build the deps once per
+    profile run and pass them to :func:`wire` for every written note.
+    """
+
+    client: LithosClient
+    profile: str
+    run_task_id: str
+    lcma_edge_score: float
+    on_unknown_tool: LcmaUnknownToolLatch | None = field(default=None)
+
+
+# ── Entry point ─────────────────────────────────────────────────────
+
+
+async def wire(
+    *,
+    written_note_id: str,
+    cascade: CascadeOutput,
+    deps: LcmaWiringDeps,
+) -> list[dict[str, Any]]:
+    """Run the post-write LCMA wiring for one just-written note.
+
+    Parameters
+    ----------
+    written_note_id:
+        The ``note_id`` returned by the successful ``lithos_write`` —
+        becomes the ``source_note_id`` on every edge_upsert.
+    cascade:
+        Title plus the Tier 1 ``contributions`` and Tier 3 ``builds_on``
+        from the cascade output for this item.
+    deps:
+        Per-run wiring dependencies (Lithos client, profile, run task,
+        edge-score threshold, optional unknown-tool latch).
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        The high-scoring ``lithos_retrieve`` results for the webhook
+        digest's ``related_in_lithos`` field — see
+        :func:`influx.lcma.after_write` for the dict shape.
+
+    Raises
+    ------
+    LCMAError
+        Propagated verbatim after latching ``lcma_unknown_tool_failure``
+        on ``unknown_tool``; other errors propagate unchanged.
+    """
+    related: list[dict[str, Any]] = []
+    try:
+        related = await after_write(
+            client=deps.client,
+            title=cascade.title,
+            contributions=cascade.contributions,
+            run_task_id=deps.run_task_id,
+            profile=deps.profile,
+            lcma_edge_score=deps.lcma_edge_score,
+            source_note_id=written_note_id,
+        )
+    except LCMAError as exc:
+        _maybe_latch_unknown_tool(
+            exc=exc,
+            profile=deps.profile,
+            fallback_tool="lithos_retrieve",
+            on_unknown_tool=deps.on_unknown_tool,
+        )
+        raise
+
+    try:
+        await resolve_builds_on(
+            client=deps.client,
+            builds_on=cascade.builds_on,
+            source_note_id=written_note_id,
+        )
+    except LCMAError as exc:
+        _maybe_latch_unknown_tool(
+            exc=exc,
+            profile=deps.profile,
+            fallback_tool="lithos_cache_lookup",
+            on_unknown_tool=deps.on_unknown_tool,
+        )
+        raise
+
+    return related
+
+
+# ── Unknown-tool latch helper ──────────────────────────────────────
+
+
+def _maybe_latch_unknown_tool(
+    *,
+    exc: LCMAError,
+    profile: str,
+    fallback_tool: str,
+    on_unknown_tool: LcmaUnknownToolLatch | None,
+) -> None:
+    """Log + latch readiness when *exc* is an LCMA ``unknown_tool`` failure.
+
+    Mirrors the original ``_handle_lcma_unknown_tool`` behaviour from the
+    scheduler: an ERROR log line names the offending tool, and the
+    optional latch callback flips the probe flag so ``/ready`` reports
+    degraded.  Other LCMAError values are no-ops here so the caller can
+    re-raise unchanged.
+    """
+    if str(exc) != "unknown_tool":
+        return
+
+    tool = getattr(exc, "stage", "") or fallback_tool
+    logger.error(
+        "LCMA deployment error: unknown_tool for %s during profile %r run "
+        "— aborting run. Check that the connected Lithos deployment "
+        "supports the required LCMA tools.",
+        tool,
+        profile,
+    )
+    if on_unknown_tool is not None:
+        on_unknown_tool(profile=profile, detail=f"tool={tool!r}")

--- a/src/influx/scheduler.py
+++ b/src/influx/scheduler.py
@@ -39,8 +39,8 @@ from influx.config import AppConfig
 from influx.coordinator import Coordinator, ProfileBusyError, RunKind
 from influx.errors import LCMAError
 from influx.feedback import build_negative_examples_block
-from influx.lcma import after_write as lcma_after_write
-from influx.lcma import resolve_builds_on as lcma_resolve_builds_on
+from influx.lcma_wiring import CascadeOutput, LcmaWiringDeps
+from influx.lcma_wiring import wire as lcma_wire
 from influx.lithos_client import LithosClient
 from influx.notifications import HighlightItem, ProfileRunResult, RunStats
 from influx.rejection_rate import on_run_complete as rejection_rate_on_run_complete
@@ -394,7 +394,24 @@ async def _run_profile_body(
         task_body = json.loads(
             task_result.content[0].text  # type: ignore[union-attr]
         )
-        run_task_id = task_body["task_id"]
+        run_task_id = str(task_body["task_id"])
+
+        # ── Build LCMA wiring deps once per run (issue #54) ─────────
+        lcma_unknown_tool_latch = (
+            probe_loop.mark_lcma_unknown_tool_failure
+            if probe_loop is not None
+            and hasattr(probe_loop, "mark_lcma_unknown_tool_failure")
+            else None
+        )
+        lcma_deps = LcmaWiringDeps(
+            client=client,
+            profile=profile,
+            run_task_id=run_task_id,
+            lcma_edge_score=(
+                profile_cfg.thresholds.lcma_edge_score if profile_cfg else 0.75
+            ),
+            on_unknown_tool=lcma_unknown_tool_latch,
+        )
 
         outcome = "success"
         body_failed = False
@@ -563,22 +580,14 @@ async def _run_profile_body(
                         )
                         related_in_lithos: list[dict[str, Any]] = []
                         if run_task_id is not None:
-                            source_note_id = write_result.note_id
-                            related_in_lithos = await lcma_after_write(
-                                client=client,
-                                title=title,
-                                contributions=item.get("contributions"),
-                                run_task_id=run_task_id,
-                                profile=profile,
-                                lcma_edge_score=profile_cfg.thresholds.lcma_edge_score
-                                if profile_cfg
-                                else 0.75,
-                                source_note_id=source_note_id,
-                            )
-                            await lcma_resolve_builds_on(
-                                client=client,
-                                builds_on=item.get("builds_on"),
-                                source_note_id=source_note_id,
+                            related_in_lithos = await lcma_wire(
+                                written_note_id=write_result.note_id,
+                                cascade=CascadeOutput(
+                                    title=title,
+                                    contributions=item.get("contributions"),
+                                    builds_on=item.get("builds_on"),
+                                ),
+                                deps=lcma_deps,
                             )
                         ingested.append(
                             HighlightItem(
@@ -627,30 +636,17 @@ async def _run_profile_body(
                         write_result.status,
                         write_result.note_id,
                     )
-                    # ── LCMA post-write hook (FR-LCMA-2/3, AC-M2-5/6) ──
+                    # ── LCMA post-write hook (FR-LCMA-2/3/4, AC-M2-5..8) ──
                     related_in_lithos: list[dict[str, Any]] = []
                     if run_task_id is not None:
-                        # The just-written note's id is plumbed through
-                        # so LCMA edges carry a real source endpoint
-                        # rather than an empty string (PRD 08 graph
-                        # wiring; see finding 1).
-                        source_note_id = write_result.note_id
-                        related_in_lithos = await lcma_after_write(
-                            client=client,
-                            title=title,
-                            contributions=item.get("contributions"),
-                            run_task_id=run_task_id,
-                            profile=profile,
-                            lcma_edge_score=profile_cfg.thresholds.lcma_edge_score
-                            if profile_cfg
-                            else 0.75,
-                            source_note_id=source_note_id,
-                        )
-                        # ── Tier 3 builds_on resolver (FR-LCMA-4, AC-M2-7/8) ──
-                        await lcma_resolve_builds_on(
-                            client=client,
-                            builds_on=item.get("builds_on"),
-                            source_note_id=source_note_id,
+                        related_in_lithos = await lcma_wire(
+                            written_note_id=write_result.note_id,
+                            cascade=CascadeOutput(
+                                title=title,
+                                contributions=item.get("contributions"),
+                                builds_on=item.get("builds_on"),
+                            ),
+                            deps=lcma_deps,
                         )
 
                     ingested.append(

--- a/tests/unit/test_lcma_wiring.py
+++ b/tests/unit/test_lcma_wiring.py
@@ -1,0 +1,357 @@
+"""Unit tests for the post-write LCMA wiring entry point (issue #54).
+
+Covers the three issue acceptance areas:
+
+- ``related_to`` edge_score threshold honoured by ``lithos_retrieve``
+  scoring (FR-LCMA-3, AC-M2-5/6).
+- Tier 3 ``builds_on`` resolution path via ``lithos_cache_lookup``
+  (FR-LCMA-4, AC-M2-7/8).
+- Unknown LCMA tool latches the ``lcma_unknown_tool_failure`` flag
+  (FR-LCMA-6) and re-raises so the run aborts.
+
+Lower-level retrieve / cache-lookup primitives are exercised in
+``influx.lcma`` tests; these tests focus on the wiring seam.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from influx.errors import LCMAError
+from influx.lcma_wiring import CascadeOutput, LcmaWiringDeps, wire
+
+
+def _mcp_text_result(payload: dict[str, Any]) -> MagicMock:
+    """Build a fake MCP-style result whose ``content[0].text`` is JSON."""
+    text_content = MagicMock()
+    text_content.text = json.dumps(payload)
+    result = MagicMock()
+    result.content = [text_content]
+    return result
+
+
+def _make_client(
+    *,
+    retrieve_payload: dict[str, Any] | None = None,
+    cache_lookup_payload: dict[str, Any] | None = None,
+) -> AsyncMock:
+    """Build an AsyncMock LithosClient with the listed call returns."""
+    client = AsyncMock()
+    client.retrieve = AsyncMock(
+        return_value=_mcp_text_result(retrieve_payload or {"results": []})
+    )
+    client.cache_lookup = AsyncMock(
+        return_value=_mcp_text_result(cache_lookup_payload or {"hit": False})
+    )
+    client.edge_upsert = AsyncMock()
+    return client
+
+
+def _make_deps(
+    client: AsyncMock,
+    *,
+    lcma_edge_score: float = 0.75,
+    on_unknown_tool: Any = None,
+) -> LcmaWiringDeps:
+    return LcmaWiringDeps(
+        client=client,
+        profile="research",
+        run_task_id="task-1",
+        lcma_edge_score=lcma_edge_score,
+        on_unknown_tool=on_unknown_tool,
+    )
+
+
+# ── related_to edge-score threshold ────────────────────────────────
+
+
+class TestRelatedToEdgeScoreThreshold:
+    """Results scoring at or above ``lcma_edge_score`` upsert ``related_to``."""
+
+    @pytest.mark.asyncio
+    async def test_above_threshold_upserts_edge(self) -> None:
+        client = _make_client(
+            retrieve_payload={
+                "results": [
+                    {
+                        "title": "Prior",
+                        "score": 0.9,
+                        "note_id": "note-prior",
+                        "receipt_id": "rcpt-1",
+                    }
+                ]
+            }
+        )
+        deps = _make_deps(client, lcma_edge_score=0.75)
+
+        related = await wire(
+            written_note_id="note-new",
+            cascade=CascadeOutput(title="A Paper", contributions=["c1"]),
+            deps=deps,
+        )
+
+        assert related == [{"title": "Prior", "score": 0.9}]
+        client.edge_upsert.assert_awaited_once()
+        call = client.edge_upsert.await_args
+        assert call.kwargs["type"] == "related_to"
+        assert call.kwargs["source_note_id"] == "note-new"
+        assert call.kwargs["target_note_id"] == "note-prior"
+        assert call.kwargs["evidence"]["score"] == 0.9
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_skips_edge(self) -> None:
+        client = _make_client(
+            retrieve_payload={
+                "results": [
+                    {"title": "Weak match", "score": 0.5, "note_id": "note-weak"},
+                ]
+            }
+        )
+        deps = _make_deps(client, lcma_edge_score=0.75)
+
+        related = await wire(
+            written_note_id="note-new",
+            cascade=CascadeOutput(title="A Paper"),
+            deps=deps,
+        )
+
+        assert related == []
+        client.edge_upsert.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_threshold_boundary_is_inclusive(self) -> None:
+        """A result scoring exactly at the threshold is kept (>=, not >)."""
+        client = _make_client(
+            retrieve_payload={
+                "results": [
+                    {"title": "Edge", "score": 0.75, "note_id": "note-edge"},
+                ]
+            }
+        )
+        deps = _make_deps(client, lcma_edge_score=0.75)
+
+        related = await wire(
+            written_note_id="note-new",
+            cascade=CascadeOutput(title="A Paper"),
+            deps=deps,
+        )
+
+        assert related == [{"title": "Edge", "score": 0.75}]
+        client.edge_upsert.assert_awaited_once()
+
+
+# ── Tier 3 builds_on resolution ────────────────────────────────────
+
+
+class TestBuildsOnResolution:
+    """Tier 3 ``builds_on`` items resolve via ``lithos_cache_lookup``."""
+
+    @pytest.mark.asyncio
+    async def test_arxiv_match_upserts_builds_on_edge(self) -> None:
+        client = _make_client(
+            cache_lookup_payload={
+                "hit": True,
+                "source_url": "https://arxiv.org/abs/2412.12345",
+                "note_id": "note-prior",
+            }
+        )
+        deps = _make_deps(client)
+
+        await wire(
+            written_note_id="note-new",
+            cascade=CascadeOutput(
+                title="A Paper",
+                builds_on=["FooNet (arXiv:2412.12345)"],
+            ),
+            deps=deps,
+        )
+
+        client.cache_lookup.assert_awaited_once()
+        # Find the builds_on edge among the upsert calls.
+        upserts = [
+            call.kwargs
+            for call in client.edge_upsert.await_args_list
+            if call.kwargs.get("type") == "builds_on"
+        ]
+        assert len(upserts) == 1
+        assert upserts[0]["source_note_id"] == "note-new"
+        assert upserts[0]["target_note_id"] == "note-prior"
+
+    @pytest.mark.asyncio
+    async def test_no_arxiv_id_skips_lookup(self) -> None:
+        client = _make_client()
+        deps = _make_deps(client)
+
+        await wire(
+            written_note_id="note-new",
+            cascade=CascadeOutput(
+                title="A Paper",
+                builds_on=["A handwave reference with no id"],
+            ),
+            deps=deps,
+        )
+
+        client.cache_lookup.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_skips_edge(self) -> None:
+        client = _make_client(cache_lookup_payload={"hit": False})
+        deps = _make_deps(client)
+
+        await wire(
+            written_note_id="note-new",
+            cascade=CascadeOutput(
+                title="A Paper",
+                builds_on=["FooNet (arXiv:2412.12345)"],
+            ),
+            deps=deps,
+        )
+
+        client.cache_lookup.assert_awaited_once()
+        builds_on_upserts = [
+            call.kwargs
+            for call in client.edge_upsert.await_args_list
+            if call.kwargs.get("type") == "builds_on"
+        ]
+        assert builds_on_upserts == []
+
+    @pytest.mark.asyncio
+    async def test_source_url_mismatch_skips_edge(self) -> None:
+        """AC-M2-8: cache hit with a different source_url is treated as miss."""
+        client = _make_client(
+            cache_lookup_payload={
+                "hit": True,
+                "source_url": "https://arxiv.org/abs/9999.99999",  # different paper
+                "note_id": "note-other",
+            }
+        )
+        deps = _make_deps(client)
+
+        await wire(
+            written_note_id="note-new",
+            cascade=CascadeOutput(
+                title="A Paper",
+                builds_on=["FooNet (arXiv:2412.12345)"],
+            ),
+            deps=deps,
+        )
+
+        builds_on_upserts = [
+            call.kwargs
+            for call in client.edge_upsert.await_args_list
+            if call.kwargs.get("type") == "builds_on"
+        ]
+        assert builds_on_upserts == []
+
+    @pytest.mark.asyncio
+    async def test_empty_builds_on_is_noop(self) -> None:
+        client = _make_client()
+        deps = _make_deps(client)
+
+        await wire(
+            written_note_id="note-new",
+            cascade=CascadeOutput(title="A Paper", builds_on=None),
+            deps=deps,
+        )
+
+        client.cache_lookup.assert_not_awaited()
+
+
+# ── Unknown LCMA tool latch ────────────────────────────────────────
+
+
+class TestUnknownToolLatch:
+    """Unknown LCMA tools latch the readiness flag and re-raise."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_on_retrieve_latches(self) -> None:
+        client = _make_client()
+        client.retrieve = AsyncMock(
+            side_effect=LCMAError("unknown_tool", stage="lithos_retrieve")
+        )
+        latched: list[dict[str, str]] = []
+
+        def fake_latch(*, profile: str, detail: str) -> None:
+            latched.append({"profile": profile, "detail": detail})
+
+        deps = _make_deps(client, on_unknown_tool=fake_latch)
+
+        with pytest.raises(LCMAError):
+            await wire(
+                written_note_id="note-new",
+                cascade=CascadeOutput(title="A Paper"),
+                deps=deps,
+            )
+
+        assert latched == [
+            {"profile": "research", "detail": "tool='lithos_retrieve'"},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_on_cache_lookup_latches(self) -> None:
+        client = _make_client()
+        client.cache_lookup = AsyncMock(
+            side_effect=LCMAError("unknown_tool", stage="lithos_cache_lookup")
+        )
+        latched: list[dict[str, str]] = []
+
+        def fake_latch(*, profile: str, detail: str) -> None:
+            latched.append({"profile": profile, "detail": detail})
+
+        deps = _make_deps(client, on_unknown_tool=fake_latch)
+
+        with pytest.raises(LCMAError):
+            await wire(
+                written_note_id="note-new",
+                cascade=CascadeOutput(
+                    title="A Paper",
+                    builds_on=["FooNet (arXiv:2412.12345)"],
+                ),
+                deps=deps,
+            )
+
+        assert latched == [
+            {"profile": "research", "detail": "tool='lithos_cache_lookup'"},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_other_lcma_error_is_not_latched(self) -> None:
+        """Non-unknown_tool LCMA errors propagate without latching."""
+        client = _make_client()
+        client.retrieve = AsyncMock(
+            side_effect=LCMAError("transport refused", stage="http")
+        )
+        latched: list[dict[str, str]] = []
+
+        def fake_latch(*, profile: str, detail: str) -> None:
+            latched.append({"profile": profile, "detail": detail})
+
+        deps = _make_deps(client, on_unknown_tool=fake_latch)
+
+        with pytest.raises(LCMAError):
+            await wire(
+                written_note_id="note-new",
+                cascade=CascadeOutput(title="A Paper"),
+                deps=deps,
+            )
+
+        assert latched == []  # no latch for non-unknown_tool error
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_without_latch_callback_still_reraises(self) -> None:
+        """The latch callback is optional; absence does not swallow the error."""
+        client = _make_client()
+        client.retrieve = AsyncMock(side_effect=LCMAError("unknown_tool"))
+
+        deps = _make_deps(client, on_unknown_tool=None)
+
+        with pytest.raises(LCMAError):
+            await wire(
+                written_note_id="note-new",
+                cascade=CascadeOutput(title="A Paper"),
+                deps=deps,
+            )

--- a/tests/unit/test_telemetry_wiring.py
+++ b/tests/unit/test_telemetry_wiring.py
@@ -1146,13 +1146,9 @@ class TestInfluxLithosWriteSpan:
                     new_callable=AsyncMock,
                 ),
                 patch(
-                    "influx.scheduler.lcma_after_write",
+                    "influx.scheduler.lcma_wire",
                     new_callable=AsyncMock,
                     return_value=[],
-                ),
-                patch(
-                    "influx.scheduler.lcma_resolve_builds_on",
-                    new_callable=AsyncMock,
                 ),
                 patch("influx.service.post_run_webhook_hook"),
             ):
@@ -1227,11 +1223,10 @@ class TestInfluxLithosWriteSpan:
             ),
             patch("influx.scheduler.repair_sweep", new_callable=AsyncMock),
             patch(
-                "influx.scheduler.lcma_after_write",
+                "influx.scheduler.lcma_wire",
                 new_callable=AsyncMock,
                 return_value=[],
             ),
-            patch("influx.scheduler.lcma_resolve_builds_on", new_callable=AsyncMock),
             patch("influx.service.post_run_webhook_hook"),
         ):
             mock_client = AsyncMock()


### PR DESCRIPTION
## Summary

- Introduces \`src/influx/lcma_wiring.py\` with a single \`wire(...)\` entry point taking the written-note id, the cascade output, and a \`LcmaWiringDeps\` bundle.
- The module owns the post-write retrieve + \`related_to\` edge upsert (scored against \`thresholds.lcma_edge_score\`), Tier 3 \`builds_on\` resolution via \`lithos_cache_lookup\` with exact source_url match (AC-M2-7/8), and the unknown-tool latch (FR-LCMA-6) for any LCMAError(\"unknown_tool\") from those calls — a path the scheduler previously left uncaught.
- \`_run_profile_body\` now builds \`LcmaWiringDeps\` once after \`task_create\` and dispatches both LCMA call sites through \`lcma_wire(...)\`, collapsing duplicated cache-hit/cache-miss inline logic. Retrieve / cache-lookup / edge-upsert primitives still live in \`influx.lcma\`.
- Adds \`tests/unit/test_lcma_wiring.py\` (12 tests) covering edge-score threshold (with boundary inclusivity), builds_on resolution across hit / miss / mismatch / no-arxiv-id, and unknown-tool latch on both retrieve and cache_lookup.

Closes #54.

## Test plan

- [x] \`uv run ruff check .\`
- [x] \`uv run ruff format --check .\`
- [x] \`uv run pyright src/\` (0 errors)
- [x] \`uv run pytest tests/ -q\` (1623 passed)