### PR TITLE
refactor: introduce Cascade module; migrate arXiv builder (#55)

### DIFF
--- a/src/influx/cascade.py
+++ b/src/influx/cascade.py
@@ -1,0 +1,346 @@
+"""Score-gated enrichment Cascade (CONTEXT.md ``Cascade``).
+
+The Cascade turns one :class:`Acquired` bundle into
+:class:`EnrichedSections` by running tier-gated enrichment:
+
+- **Tier 1** (``score >= thresholds.relevance``) — ``models.enrich``
+  summary via :func:`influx.enrich.tier1_enrich` (FR-ENR-4).
+- **Tier 2** (``score >= thresholds.full_text``) — full-text extraction
+  via the injected ``tier2_extractor``.  Source-agnostic: arXiv injects
+  :func:`influx.extraction.pipeline.extract_arxiv_text`; RSS pre-populates
+  ``Acquired.extracted_text`` and skips the extractor.
+- **Tier 3** (``score >= thresholds.deep_extract`` and full text
+  available) — ``models.extract`` via
+  :func:`influx.enrich.tier3_extract` (FR-ENR-5).
+
+The Cascade consults :class:`influx.repair_counters.RepairCounters`
+before each tier and emits ``influx:tier{2,3}-terminal`` flags when the
+cap has been reached, plus ``influx:repair-needed`` when a counted
+failure needs a repair-sweep retry.
+
+Tier-gating logic lives **only** here — Source builders that delegate
+to the Cascade should not duplicate the threshold checks.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Literal, NamedTuple
+
+from influx import metrics
+from influx.config import AppConfig, ProfileThresholds
+from influx.enrich import tier1_enrich, tier3_extract
+from influx.errors import ExtractionError, LCMAError
+from influx.repair_counters import REPAIR_COUNTED_CAP, RepairCounters
+from influx.schemas import Tier1Enrichment, Tier3Extraction
+from influx.telemetry import current_run_id, get_tracer
+
+__all__ = [
+    "Acquired",
+    "Cascade",
+    "EnrichedSections",
+    "TextFlavour",
+    "Tier2Extractor",
+    "Tier2Result",
+]
+
+logger = logging.getLogger(__name__)
+
+
+TextFlavour = Literal["html", "pdf", "summary-fallback"]
+
+
+# ── Acquired bundle ────────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class Acquired:
+    """A Source's acquired bundle for one Candidate (CONTEXT.md).
+
+    Carries everything the Cascade and Renderer need that does not
+    depend on the per-tier enrichment outcome:
+
+    - **Identity**: ``item_id``, ``source_url``, ``title``, ``abstract``
+      (the pre-Tier-1 candidate text).
+    - **Archive state**: ``archive_path`` (POSIX rel path or ``None``),
+      plus the ``archive_missing`` / ``archive_terminal`` repair-flag
+      booleans the source set during acquire.
+    - **Extracted text**: ``extracted_text`` and ``text_flavour`` (when
+      the source already has the body, e.g. RSS).  ``None`` when the
+      Cascade's Tier 2 step needs to populate them (e.g. arXiv).
+    - **Identity tags**: source-specific provenance tags (``arxiv-id:``,
+      ``cat:``, ``feed-slug:``…) that the builder will combine with
+      profile and schema tags before rendering.
+    """
+
+    item_id: str
+    source_url: str
+    title: str
+    abstract: str
+    identity_tags: tuple[str, ...] = ()
+    archive_path: str | None = None
+    archive_missing: bool = False
+    archive_terminal: bool = False
+    extracted_text: str | None = None
+    text_flavour: TextFlavour | None = None
+
+
+# ── Tier 2 extractor seam ──────────────────────────────────────────
+
+
+class Tier2Result(NamedTuple):
+    """The text + canonical text-tag a Tier-2 extractor returns."""
+
+    text: str
+    flavour: TextFlavour
+    text_tag: str  # ``text:html`` | ``text:pdf`` | ``text:abstract-only``
+
+
+# A Tier2Extractor takes the Acquired bundle and returns a Tier2Result
+# or raises :class:`ExtractionError`.  The Cascade calls it only when
+# ``score >= thresholds.full_text`` AND ``acquired.extracted_text is
+# None``.  Sources that pre-populate ``extracted_text`` (e.g. RSS) can
+# skip injecting an extractor entirely.
+Tier2Extractor = Callable[[Acquired], Tier2Result]
+
+
+# ── EnrichedSections ──────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class EnrichedSections:
+    """The Cascade's output for one Acquired (CONTEXT.md).
+
+    All tier results are optional — absent when the gate did not fire,
+    when the cascade short-circuited on a terminal flag, or when the
+    underlying call raised a counted-class failure.
+    """
+
+    tier1: Tier1Enrichment | None = None
+    tier1_attempted: bool = False
+    full_text: str | None = None
+    full_text_flavour: TextFlavour | None = None
+    text_tag: str = "text:abstract-only"
+    tier3: Tier3Extraction | None = None
+    repair_flags: tuple[str, ...] = field(default_factory=tuple)
+    terminal_flags: tuple[str, ...] = field(default_factory=tuple)
+
+
+# ── Cascade ───────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class Cascade:
+    """Score-gated enrichment cascade for one profile run.
+
+    Built once per profile run with the resolved config + thresholds +
+    optional Tier-2 extractor; reused for every Acquired the run produces.
+    """
+
+    config: AppConfig
+    profile_name: str
+    profile_summary: str
+    thresholds: ProfileThresholds
+    tier2_extractor: Tier2Extractor | None = None
+
+    def enrich(
+        self,
+        acquired: Acquired,
+        score: int,
+        *,
+        counters: RepairCounters | None = None,
+    ) -> EnrichedSections:
+        """Run the score-gated cascade for one Acquired.
+
+        Parameters
+        ----------
+        acquired:
+            The Source's acquired bundle.
+        score:
+            The 1–10 LLM-filter score for this Candidate.
+        counters:
+            Optional :class:`RepairCounters` to consult before each
+            tier.  When omitted, defaults to a zero-counter value
+            (initial-write path: counters live on existing notes only).
+
+        Returns
+        -------
+        EnrichedSections
+            The cascade output.  ``repair_flags`` carries
+            ``influx:repair-needed`` when any tier emitted a counted
+            failure; ``terminal_flags`` carries
+            ``influx:tier{2,3}-terminal`` when the cap had already been
+            reached on entry.
+        """
+        counters = counters or RepairCounters()
+        repair_flags: list[str] = []
+        terminal_flags: list[str] = []
+
+        # ── Tier 2 (full-text gate) ────────────────────────────────
+        extracted_text = acquired.extracted_text
+        text_flavour = acquired.text_flavour
+        text_tag = _text_tag_for(text_flavour)
+
+        if (
+            score >= self.thresholds.full_text
+            and extracted_text is None
+            and self.tier2_extractor is not None
+        ):
+            if counters.tier2_attempts >= REPAIR_COUNTED_CAP:
+                terminal_flags.append("influx:tier2-terminal")
+            else:
+                tier2 = self._run_tier2(acquired)
+                if tier2 is not None:
+                    extracted_text = tier2.text
+                    text_flavour = tier2.flavour
+                    text_tag = tier2.text_tag
+                else:
+                    repair_flags.append("influx:repair-needed")
+
+        # ``full_text`` for the renderer only when extraction succeeded
+        # AND the score crosses the gate (FR-ENR-6, US-011).
+        full_text: str | None = None
+        full_text_flavour: TextFlavour | None = None
+        if extracted_text is not None and score >= self.thresholds.full_text:
+            full_text = extracted_text
+            full_text_flavour = text_flavour
+
+        # ── Tier 1 (relevance gate) ────────────────────────────────
+        tier1: Tier1Enrichment | None = None
+        tier1_attempted = score >= self.thresholds.relevance
+        if tier1_attempted:
+            tier1 = self._run_tier1(acquired)
+            if tier1 is None:
+                repair_flags.append("influx:repair-needed")
+
+        # ── Tier 3 (deep-extract gate, requires extracted text) ─────
+        tier3: Tier3Extraction | None = None
+        if score >= self.thresholds.deep_extract and full_text is not None:
+            if counters.tier3_attempts >= REPAIR_COUNTED_CAP:
+                terminal_flags.append("influx:tier3-terminal")
+            else:
+                tier3 = self._run_tier3(acquired.title, full_text)
+                if tier3 is None:
+                    repair_flags.append("influx:repair-needed")
+
+        return EnrichedSections(
+            tier1=tier1,
+            tier1_attempted=tier1_attempted,
+            full_text=full_text,
+            full_text_flavour=full_text_flavour,
+            text_tag=text_tag,
+            tier3=tier3,
+            repair_flags=tuple(dict.fromkeys(repair_flags)),
+            terminal_flags=tuple(dict.fromkeys(terminal_flags)),
+        )
+
+    # ── Tier dispatchers ──────────────────────────────────────────
+
+    def _run_tier1(self, acquired: Acquired) -> Tier1Enrichment | None:
+        """Dispatch Tier 1 with telemetry + degrade-on-failure semantics."""
+        tracer = get_tracer()
+        with tracer.span(
+            "influx.enrich.tier1",
+            attributes={
+                "influx.profile": self.profile_name,
+                "influx.run_id": current_run_id.get() or "",
+                "influx.item_count": 1,
+            },
+        ):
+            try:
+                return tier1_enrich(
+                    title=acquired.title,
+                    abstract=acquired.abstract,
+                    profile_summary=self.profile_summary,
+                    config=self.config,
+                )
+            except LCMAError:
+                logger.warning("Tier 1 enrichment failed for %s", acquired.item_id)
+                metrics.llm_validation_failures().add(
+                    1, {"profile": self.profile_name, "tier": "1"}
+                )
+                return None
+            except Exception:
+                # Defensive: any unexpected failure during Tier 1 (e.g.
+                # an LLM response shape that bypasses the schema's
+                # validators with an AttributeError, per staging
+                # incident 2026-05-01) must degrade to a per-paper
+                # repair, not take the whole scheduler run down.
+                logger.warning(
+                    "Tier 1 enrichment crashed unexpectedly for %s",
+                    acquired.item_id,
+                    exc_info=True,
+                )
+                metrics.llm_validation_failures().add(
+                    1, {"profile": self.profile_name, "tier": "1"}
+                )
+                return None
+
+    def _run_tier2(self, acquired: Acquired) -> Tier2Result | None:
+        """Dispatch Tier 2 with telemetry + degrade-on-failure semantics."""
+        assert self.tier2_extractor is not None  # gate-checked by caller
+        tracer = get_tracer()
+        with tracer.span(
+            "influx.enrich.tier2",
+            attributes={
+                "influx.profile": self.profile_name,
+                "influx.run_id": current_run_id.get() or "",
+                "influx.item_count": 1,
+            },
+        ):
+            try:
+                return self.tier2_extractor(acquired)
+            except ExtractionError:
+                # Both HTML and PDF failed (or whatever stages the
+                # source-specific extractor walks).  Fall through to
+                # abstract-only + repair-needed.
+                return None
+
+    def _run_tier3(self, title: str, full_text: str) -> Tier3Extraction | None:
+        """Dispatch Tier 3 with telemetry + degrade-on-failure semantics."""
+        tracer = get_tracer()
+        with tracer.span(
+            "influx.enrich.tier3",
+            attributes={
+                "influx.profile": self.profile_name,
+                "influx.run_id": current_run_id.get() or "",
+                "influx.item_count": 1,
+            },
+        ):
+            try:
+                return tier3_extract(
+                    title=title,
+                    full_text=full_text,
+                    config=self.config,
+                )
+            except LCMAError:
+                logger.warning("Tier 3 extraction failed for %s", title)
+                metrics.llm_validation_failures().add(
+                    1, {"profile": self.profile_name, "tier": "3"}
+                )
+                return None
+            except Exception:
+                # Defensive: same rationale as the Tier 1 catch — a
+                # validator bug or unforeseen response shape must not
+                # turn a single bad paper into a run-level abort
+                # (staging incident 2026-05-01).
+                logger.warning(
+                    "Tier 3 extraction crashed unexpectedly for %s",
+                    title,
+                    exc_info=True,
+                )
+                metrics.llm_validation_failures().add(
+                    1, {"profile": self.profile_name, "tier": "3"}
+                )
+                return None
+
+
+def _text_tag_for(flavour: TextFlavour | None) -> str:
+    """Return the canonical ``text:*`` tag for *flavour*."""
+    if flavour == "html":
+        return "text:html"
+    if flavour == "pdf":
+        return "text:pdf"
+    return "text:abstract-only"

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from influx import metrics
+from influx.cascade import Acquired, Cascade, Tier2Result
 from influx.config import (
     AppConfig,
     ArxivSourceConfig,
@@ -36,13 +37,11 @@ from influx.config import (
     StorageConfig,
 )
 from influx.coordinator import RunKind
-from influx.enrich import tier1_enrich, tier3_extract
-from influx.errors import ExtractionError, LCMAError, NetworkError
+from influx.errors import NetworkError
 from influx.extraction.pipeline import extract_arxiv_text
 from influx.filter import FilterScorerError
 from influx.http_client import guarded_fetch
 from influx.renderer import render
-from influx.schemas import Tier1Enrichment, Tier3Extraction
 from influx.storage import download_archive
 from influx.telemetry import (
     current_archive_terminal_arxiv_ids,
@@ -583,30 +582,20 @@ def build_arxiv_note_item(
     source_url = f"https://arxiv.org/abs/{item.arxiv_id}"
     cat_tags = [f"cat:{c}" for c in item.categories]
 
-    tags: list[str] = [
-        f"profile:{profile_name}",
-        f"arxiv-id:{item.arxiv_id}",
-        "source:arxiv",
-        "ingested-by:influx",
-        f"schema:{config.influx.note_schema_version}",
-        *cat_tags,
-    ]
-
-    repair_needed = False
-    archive_path: str | None = None
-    pdf_url = f"https://arxiv.org/pdf/{item.arxiv_id}.pdf"
-    tracer = get_tracer()
+    # ── Acquire stage (arXiv-specific) ────────────────────────────
     archive_terminal_ids = current_archive_terminal_arxiv_ids.get()
     is_archive_terminal = item.arxiv_id in archive_terminal_ids
+    archive_path: str | None = None
+    archive_missing = False
+    pdf_url = f"https://arxiv.org/pdf/{item.arxiv_id}.pdf"
+    tracer = get_tracer()
 
     if is_archive_terminal:
         # Issue #14: this paper's archive download has been terminal-flipped
         # by an earlier repair sweep (or hand-set by an operator).  Skip the
         # download attempt entirely; the existing Lithos note's tags will
         # be preserved by the canonical merge_tags path on rewrite.
-        tags.append("influx:archive-missing")
-        tags.append("influx:archive-terminal")
-        repair_needed = True
+        archive_missing = True
         metrics.archive_missing().add(1, {"profile": profile_name, "source": "arxiv"})
         _log.info(
             "archive download skipped (terminal) profile=%s arxiv_id=%s",
@@ -638,143 +627,66 @@ def build_arxiv_note_item(
         if archive_result.ok:
             archive_path = archive_result.rel_posix_path
         else:
-            tags.append("influx:archive-missing")
-            repair_needed = True
+            archive_missing = True
             metrics.archive_missing().add(
                 1, {"profile": profile_name, "source": "arxiv"}
             )
 
-    # ── Extraction cascade ────────────────────────────────────────
-    extracted_text: str | None = None
-    text_tag = "text:abstract-only"
+    acquired = Acquired(
+        item_id=item.arxiv_id,
+        source_url=source_url,
+        title=item.title,
+        abstract=item.abstract,
+        identity_tags=tuple(cat_tags),
+        archive_path=archive_path,
+        archive_missing=archive_missing,
+        archive_terminal=is_archive_terminal,
+    )
 
-    if score >= thresholds.full_text:
-        # ── Telemetry: influx.enrich.tier2 span (FR-OBS-4) ──
-        _tracer = get_tracer()
-        with _tracer.span(
-            "influx.enrich.tier2",
-            attributes={
-                "influx.profile": profile_name,
-                "influx.run_id": current_run_id.get() or "",
-                "influx.item_count": 1,
-            },
-        ):
-            try:
-                result = extract_arxiv_text(item.arxiv_id, config)
-                extracted_text = result.text
-                text_tag = result.source_tag
-            except ExtractionError:
-                # Both HTML and PDF failed — abstract-only + repair-needed.
-                repair_needed = True
+    # ── Cascade ───────────────────────────────────────────────────
+    cascade = Cascade(
+        config=config,
+        profile_name=profile_name,
+        profile_summary=profile_cfg.description if profile_cfg else "",
+        thresholds=thresholds,
+        tier2_extractor=_make_arxiv_tier2_extractor(config),
+    )
+    sections = cascade.enrich(acquired, score)
 
-    tags.append(text_tag)
-
-    # full-text tag iff extraction succeeded AND above threshold.
-    full_text_for_note: str | None = None
-    if extracted_text is not None and score >= thresholds.full_text:
-        full_text_for_note = extracted_text
+    # ── Tag composition ───────────────────────────────────────────
+    tags: list[str] = [
+        f"profile:{profile_name}",
+        f"arxiv-id:{item.arxiv_id}",
+        "source:arxiv",
+        "ingested-by:influx",
+        f"schema:{config.influx.note_schema_version}",
+        *cat_tags,
+    ]
+    if archive_missing:
+        tags.append("influx:archive-missing")
+    if is_archive_terminal:
+        tags.append("influx:archive-terminal")
+    tags.append(sections.text_tag)
+    if sections.full_text is not None:
         tags.append("full-text")
-
-    if repair_needed:
+    # Archive-driven repair flag fires at the early position so a
+    # missing archive is visible in tags before the cascade's outcomes.
+    if archive_missing and "influx:repair-needed" not in tags:
         tags.append("influx:repair-needed")
-
-    # ── Tier 1 enrichment (FR-ENR-4) ─────────────────────────────
-    tier1_result: Tier1Enrichment | None = None
-    tier1_attempted = score >= thresholds.relevance
-    if tier1_attempted:
-        # ── Telemetry: influx.enrich.tier1 span (FR-OBS-4) ──
-        _tracer = get_tracer()
-        with _tracer.span(
-            "influx.enrich.tier1",
-            attributes={
-                "influx.profile": profile_name,
-                "influx.run_id": current_run_id.get() or "",
-                "influx.item_count": 1,
-            },
-        ):
-            profile_summary = profile_cfg.description if profile_cfg else ""
-            try:
-                tier1_result = tier1_enrich(
-                    title=item.title,
-                    abstract=item.abstract,
-                    profile_summary=profile_summary,
-                    config=config,
-                )
-            except LCMAError:
-                _log.warning("Tier 1 enrichment failed for %s", item.arxiv_id)
-                repair_needed = True
-                metrics.llm_validation_failures().add(
-                    1, {"profile": profile_name, "tier": "1"}
-                )
-            except Exception:
-                # Defensive: any unexpected failure during Tier 1
-                # (e.g. an LLM response shape that bypasses the schema's
-                # validators with an AttributeError, per staging incident
-                # 2026-05-01) must degrade to a per-paper repair, not
-                # take the whole scheduler run down.
-                _log.warning(
-                    "Tier 1 enrichment crashed unexpectedly for %s",
-                    item.arxiv_id,
-                    exc_info=True,
-                )
-                repair_needed = True
-                metrics.llm_validation_failures().add(
-                    1, {"profile": profile_name, "tier": "1"}
-                )
-
-    # ── Tier 3 deep extraction (FR-ENR-5) ─────────────────────────
-    tier3_result: Tier3Extraction | None = None
-    if score >= thresholds.deep_extract and extracted_text is not None:
-        # ── Telemetry: influx.enrich.tier3 span (FR-OBS-4) ──
-        _tracer = get_tracer()
-        with _tracer.span(
-            "influx.enrich.tier3",
-            attributes={
-                "influx.profile": profile_name,
-                "influx.run_id": current_run_id.get() or "",
-                "influx.item_count": 1,
-            },
-        ):
-            try:
-                tier3_result = tier3_extract(
-                    title=item.title,
-                    full_text=extracted_text,
-                    config=config,
-                )
-            except LCMAError:
-                _log.warning("Tier 3 extraction failed for %s", item.arxiv_id)
-                repair_needed = True
-                metrics.llm_validation_failures().add(
-                    1, {"profile": profile_name, "tier": "3"}
-                )
-            except Exception:
-                # Defensive: same rationale as the Tier 1 catch — a
-                # validator bug or unforeseen response shape must not
-                # turn a single bad paper into a run-level abort
-                # (staging incident 2026-05-01).
-                _log.warning(
-                    "Tier 3 extraction crashed unexpectedly for %s",
-                    item.arxiv_id,
-                    exc_info=True,
-                )
-                repair_needed = True
-                metrics.llm_validation_failures().add(
-                    1, {"profile": profile_name, "tier": "3"}
-                )
-
-    # influx:deep-extracted iff all four Tier 3 sections exist.
-    if tier3_result is not None:
+    if sections.tier3 is not None:
         tags.append("influx:deep-extracted")
-
-    # Ensure repair-needed is set exactly once.
-    if repair_needed and "influx:repair-needed" not in tags:
-        tags.append("influx:repair-needed")
+    for flag in sections.repair_flags:
+        if flag not in tags:
+            tags.append(flag)
+    for flag in sections.terminal_flags:
+        if flag not in tags:
+            tags.append(flag)
 
     # ── Render note ───────────────────────────────────────────────
     # When Tier 1 was attempted but failed, suppress the plain-text
     # summary so ## Summary is omitted entirely (AC-07-A / FR-ENR-6).
     summary_text = item.abstract
-    if tier1_attempted and tier1_result is None:
+    if sections.tier1_attempted and sections.tier1 is None:
         summary_text = ""
 
     content = render(
@@ -787,9 +699,9 @@ def build_arxiv_note_item(
         profile_name=profile_name,
         score=score,
         reason=reason,
-        full_text=full_text_for_note,
-        tier1_enrichment=tier1_result,
-        tier3_extraction=tier3_result,
+        full_text=sections.full_text,
+        tier1_enrichment=sections.tier1,
+        tier3_extraction=sections.tier3,
     )
 
     pub = item.published
@@ -808,9 +720,29 @@ def build_arxiv_note_item(
         "reason": reason,
         "path": path,
         "abstract_or_summary": item.abstract,
-        "contributions": tier1_result.contributions if tier1_result else None,
-        "builds_on": list(tier3_result.builds_on) if tier3_result else None,
+        "contributions": sections.tier1.contributions if sections.tier1 else None,
+        "builds_on": list(sections.tier3.builds_on) if sections.tier3 else None,
     }
+
+
+def _make_arxiv_tier2_extractor(
+    config: AppConfig,
+) -> Callable[[Acquired], Tier2Result]:
+    """Build a Tier-2 extractor closure for arXiv that the Cascade calls.
+
+    Wraps :func:`extract_arxiv_text` (HTML → PDF cascade) and adapts
+    its ``ArxivExtractionResult`` into the source-agnostic
+    :class:`Tier2Result` the Cascade consumes.
+    """
+
+    def _extractor(acquired: Acquired) -> Tier2Result:
+        result = extract_arxiv_text(acquired.item_id, config)
+        flavour = "html" if result.source_tag == "text:html" else "pdf"
+        return Tier2Result(
+            text=result.text, flavour=flavour, text_tag=result.source_tag
+        )
+
+    return _extractor
 
 
 # ── Production-default item provider (PRD 07 finding #1) ──────────────

--- a/tests/integration/test_arxiv_pipeline_end_to_end.py
+++ b/tests/integration/test_arxiv_pipeline_end_to_end.py
@@ -408,7 +408,7 @@ class TestRunProfileHonoursScoreGating:
                 return_value=_html_fetch_result(),
             ),
             patch(
-                "influx.sources.arxiv.tier3_extract",
+                "influx.cascade.tier3_extract",
                 return_value=tier3_stub,
             ) as mock_tier3,
         ):
@@ -664,7 +664,7 @@ class TestDefaultFilterScorerEndToEnd:
                 return_value=_filter_fetch_result(_filter_response(_ARXIV_ID, 9)),
             ) as mock_filter_post,
             patch(
-                "influx.sources.arxiv.tier3_extract",
+                "influx.cascade.tier3_extract",
                 return_value=tier3_stub,
             ) as mock_tier3,
         ):

--- a/tests/integration/test_otel_metrics.py
+++ b/tests/integration/test_otel_metrics.py
@@ -210,13 +210,13 @@ async def _run_arxiv_scenario(meter: InfluxMeter, config: Any) -> None:
             ),
         ),
         patch(
-            "influx.sources.arxiv.tier1_enrich",
+            "influx.cascade.tier1_enrich",
             return_value=Tier1Enrichment(
                 contributions=["c1"], method="m", result="r", relevance="rel"
             ),
         ),
         patch(
-            "influx.sources.arxiv.tier3_extract",
+            "influx.cascade.tier3_extract",
             return_value=Tier3Extraction(claims=["claim1"], builds_on=["b1"]),
         ),
         patch("influx.scheduler.LithosClient", return_value=mock_client),
@@ -386,7 +386,7 @@ class TestOtelDisabledZeroMetrics:
                 ),
             ),
             patch(
-                "influx.sources.arxiv.tier1_enrich",
+                "influx.cascade.tier1_enrich",
                 return_value=Tier1Enrichment(
                     contributions=["c1"],
                     method="m",
@@ -395,7 +395,7 @@ class TestOtelDisabledZeroMetrics:
                 ),
             ),
             patch(
-                "influx.sources.arxiv.tier3_extract",
+                "influx.cascade.tier3_extract",
                 return_value=Tier3Extraction(claims=["claim1"], builds_on=["b1"]),
             ),
             patch("influx.scheduler.LithosClient", return_value=mock_client),

--- a/tests/integration/test_otel_spans.py
+++ b/tests/integration/test_otel_spans.py
@@ -223,6 +223,7 @@ async def _run_arxiv_scenario(
         # Tracer patches — all modules see the collecting tracer
         patch("influx.scheduler.get_tracer", return_value=tracer),
         patch("influx.sources.arxiv.get_tracer", return_value=tracer),
+        patch("influx.cascade.get_tracer", return_value=tracer),
         patch("influx.lcma.get_tracer", return_value=tracer),
         # ArXiv mocks
         patch("influx.sources.arxiv.fetch_arxiv", return_value=arxiv_items),
@@ -233,13 +234,13 @@ async def _run_arxiv_scenario(
             ),
         ),
         patch(
-            "influx.sources.arxiv.tier1_enrich",
+            "influx.cascade.tier1_enrich",
             return_value=Tier1Enrichment(
                 contributions=["c1"], method="m", result="r", relevance="rel"
             ),
         ),
         patch(
-            "influx.sources.arxiv.tier3_extract",
+            "influx.cascade.tier3_extract",
             return_value=Tier3Extraction(claims=["claim1"], builds_on=["b1"]),
         ),
         # Scheduler infrastructure
@@ -455,7 +456,7 @@ class TestOtelDisabledZeroSpans:
                 ),
             ),
             patch(
-                "influx.sources.arxiv.tier1_enrich",
+                "influx.cascade.tier1_enrich",
                 return_value=Tier1Enrichment(
                     contributions=["c1"],
                     method="m",
@@ -464,7 +465,7 @@ class TestOtelDisabledZeroSpans:
                 ),
             ),
             patch(
-                "influx.sources.arxiv.tier3_extract",
+                "influx.cascade.tier3_extract",
                 return_value=Tier3Extraction(claims=["claim1"], builds_on=["b1"]),
             ),
             # Scheduler infrastructure

--- a/tests/unit/test_build_arxiv_note_item.py
+++ b/tests/unit/test_build_arxiv_note_item.py
@@ -484,7 +484,7 @@ def _make_tier3(**overrides: object) -> Tier3Extraction:
 class TestTier1EnrichmentSuccess:
     """Score >= relevance + tier1_enrich succeeds → structured ## Summary."""
 
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier1_enrich")
     def test_summary_section_rendered_from_tier1(self, mock_t1: object) -> None:
         mock_t1.return_value = _make_tier1()  # type: ignore[union-attr]
         config = _make_config(relevance=7, deep_extract=100)
@@ -505,7 +505,7 @@ class TestTier1EnrichmentSuccess:
         assert "### Relevance" in result["content"]
         assert "Novel approach to task X" in result["content"]
 
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier1_enrich")
     def test_tier1_called_with_profile_summary(self, mock_t1: object) -> None:
         mock_t1.return_value = _make_tier1()  # type: ignore[union-attr]
         config = _make_config(relevance=7, deep_extract=100)
@@ -525,7 +525,7 @@ class TestTier1EnrichmentSuccess:
         assert call_kwargs["abstract"] == "This is the abstract of the test paper."
         assert call_kwargs["profile_summary"] == "AI and robotics research"
 
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier1_enrich")
     def test_no_repair_needed_when_tier1_succeeds(self, mock_t1: object) -> None:
         mock_t1.return_value = _make_tier1()  # type: ignore[union-attr]
         config = _make_config(relevance=7, deep_extract=100)
@@ -541,7 +541,7 @@ class TestTier1EnrichmentSuccess:
 
         assert "influx:repair-needed" not in result["tags"]
 
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier1_enrich")
     def test_tier1_not_called_below_relevance(self, mock_t1: object) -> None:
         config = _make_config(relevance=7)
 
@@ -579,7 +579,7 @@ class TestTier1EnrichmentSuccess:
 class TestTier1EnrichmentFailure:
     """Score >= relevance + tier1_enrich fails → no ## Summary + repair-needed."""
 
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier1_enrich")
     def test_no_summary_on_tier1_failure(self, mock_t1: object) -> None:
         """AC-07-A: note written WITHOUT ## Summary on tier1 failure."""
         mock_t1.side_effect = LCMAError(  # type: ignore[union-attr]
@@ -598,7 +598,7 @@ class TestTier1EnrichmentFailure:
 
         assert "## Summary" not in result["content"]
 
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier1_enrich")
     def test_repair_needed_on_tier1_failure(self, mock_t1: object) -> None:
         mock_t1.side_effect = LCMAError(  # type: ignore[union-attr]
             "validation failed", model="enrich", stage="validate"
@@ -616,7 +616,7 @@ class TestTier1EnrichmentFailure:
 
         assert "influx:repair-needed" in result["tags"]
 
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier1_enrich")
     def test_no_placeholder_text_on_tier1_failure(self, mock_t1: object) -> None:
         """FR-ENR-6: no placeholder text inserted on failure."""
         mock_t1.side_effect = LCMAError(  # type: ignore[union-attr]
@@ -644,8 +644,8 @@ class TestTier1EnrichmentFailure:
 class TestTier3ExtractionSuccess:
     """Score >= deep_extract + extraction succeeds + tier3 succeeds."""
 
-    @patch("influx.sources.arxiv.tier3_extract")
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier3_extract")
+    @patch("influx.cascade.tier1_enrich")
     @patch("influx.sources.arxiv.extract_arxiv_text")
     def test_tier3_sections_rendered(
         self, mock_ext: object, mock_t1: object, mock_t3: object
@@ -671,8 +671,8 @@ class TestTier3ExtractionSuccess:
         assert "## Builds On" in result["content"]
         assert "## Open Questions" in result["content"]
 
-    @patch("influx.sources.arxiv.tier3_extract")
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier3_extract")
+    @patch("influx.cascade.tier1_enrich")
     @patch("influx.sources.arxiv.extract_arxiv_text")
     def test_deep_extracted_tag_on_tier3_success(
         self, mock_ext: object, mock_t1: object, mock_t3: object
@@ -695,8 +695,8 @@ class TestTier3ExtractionSuccess:
 
         assert "influx:deep-extracted" in result["tags"]
 
-    @patch("influx.sources.arxiv.tier3_extract")
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier3_extract")
+    @patch("influx.cascade.tier1_enrich")
     @patch("influx.sources.arxiv.extract_arxiv_text")
     def test_no_repair_needed_all_succeed(
         self, mock_ext: object, mock_t1: object, mock_t3: object
@@ -719,8 +719,8 @@ class TestTier3ExtractionSuccess:
 
         assert "influx:repair-needed" not in result["tags"]
 
-    @patch("influx.sources.arxiv.tier3_extract")
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier3_extract")
+    @patch("influx.cascade.tier1_enrich")
     @patch("influx.sources.arxiv.extract_arxiv_text")
     def test_tier3_not_called_without_extracted_text(
         self, mock_ext: object, mock_t1: object, mock_t3: object
@@ -745,7 +745,7 @@ class TestTier3ExtractionSuccess:
 
         mock_t3.assert_not_called()  # type: ignore[union-attr]
 
-    @patch("influx.sources.arxiv.tier3_extract")
+    @patch("influx.cascade.tier3_extract")
     @patch("influx.sources.arxiv.extract_arxiv_text")
     def test_tier3_not_called_below_deep_extract_threshold(
         self, mock_ext: object, mock_t3: object
@@ -773,8 +773,8 @@ class TestTier3ExtractionSuccess:
 class TestTier3ExtractionFailure:
     """Score >= deep_extract + tier3_extract fails → no Tier 3 + repair-needed."""
 
-    @patch("influx.sources.arxiv.tier3_extract")
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier3_extract")
+    @patch("influx.cascade.tier1_enrich")
     @patch("influx.sources.arxiv.extract_arxiv_text")
     def test_no_tier3_sections_on_failure(
         self, mock_ext: object, mock_t1: object, mock_t3: object
@@ -802,8 +802,8 @@ class TestTier3ExtractionFailure:
         assert "## Builds On" not in result["content"]
         assert "## Open Questions" not in result["content"]
 
-    @patch("influx.sources.arxiv.tier3_extract")
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier3_extract")
+    @patch("influx.cascade.tier1_enrich")
     @patch("influx.sources.arxiv.extract_arxiv_text")
     def test_no_deep_extracted_tag_on_tier3_failure(
         self, mock_ext: object, mock_t1: object, mock_t3: object
@@ -828,8 +828,8 @@ class TestTier3ExtractionFailure:
 
         assert "influx:deep-extracted" not in result["tags"]
 
-    @patch("influx.sources.arxiv.tier3_extract")
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier3_extract")
+    @patch("influx.cascade.tier1_enrich")
     @patch("influx.sources.arxiv.extract_arxiv_text")
     def test_repair_needed_on_tier3_failure(
         self, mock_ext: object, mock_t1: object, mock_t3: object
@@ -854,8 +854,8 @@ class TestTier3ExtractionFailure:
 
         assert "influx:repair-needed" in result["tags"]
 
-    @patch("influx.sources.arxiv.tier3_extract")
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier3_extract")
+    @patch("influx.cascade.tier1_enrich")
     @patch("influx.sources.arxiv.extract_arxiv_text")
     def test_unexpected_tier3_exception_degrades_to_repair(
         self, mock_ext: object, mock_t1: object, mock_t3: object
@@ -888,7 +888,7 @@ class TestTier3ExtractionFailure:
         assert "influx:deep-extracted" not in result["tags"]
         assert "## Claims" not in result["content"]
 
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier1_enrich")
     @patch("influx.sources.arxiv.extract_arxiv_text")
     def test_unexpected_tier1_exception_degrades_to_repair(
         self, mock_ext: object, mock_t1: object
@@ -921,8 +921,8 @@ class TestTier3ExtractionFailure:
 class TestPerTierFailureIndependence:
     """Tier 1 success + Tier 3 failure → ## Summary present, no Tier 3."""
 
-    @patch("influx.sources.arxiv.tier3_extract")
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier3_extract")
+    @patch("influx.cascade.tier1_enrich")
     @patch("influx.sources.arxiv.extract_arxiv_text")
     def test_tier1_success_tier3_failure(
         self, mock_ext: object, mock_t1: object, mock_t3: object
@@ -955,8 +955,8 @@ class TestPerTierFailureIndependence:
         # repair-needed from Tier 3 failure
         assert "influx:repair-needed" in result["tags"]
 
-    @patch("influx.sources.arxiv.tier3_extract")
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier3_extract")
+    @patch("influx.cascade.tier1_enrich")
     @patch("influx.sources.arxiv.extract_arxiv_text")
     def test_tier1_failure_tier3_success(
         self, mock_ext: object, mock_t1: object, mock_t3: object
@@ -988,8 +988,8 @@ class TestPerTierFailureIndependence:
         # repair-needed from Tier 1 failure
         assert "influx:repair-needed" in result["tags"]
 
-    @patch("influx.sources.arxiv.tier3_extract")
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier3_extract")
+    @patch("influx.cascade.tier1_enrich")
     @patch("influx.sources.arxiv.extract_arxiv_text")
     def test_extraction_fail_tier1_success(
         self, mock_ext: object, mock_t1: object, mock_t3: object
@@ -1028,8 +1028,8 @@ class TestPerTierFailureIndependence:
 class TestTagDerivationInvariants:
     """Section-iff-tag invariant on initial write."""
 
-    @patch("influx.sources.arxiv.tier3_extract")
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier3_extract")
+    @patch("influx.cascade.tier1_enrich")
     @patch("influx.sources.arxiv.extract_arxiv_text")
     def test_full_text_tag_iff_section(
         self, mock_ext: object, mock_t1: object, mock_t3: object
@@ -1055,8 +1055,8 @@ class TestTagDerivationInvariants:
         has_tag = "full-text" in result["tags"]
         assert has_section == has_tag
 
-    @patch("influx.sources.arxiv.tier3_extract")
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier3_extract")
+    @patch("influx.cascade.tier1_enrich")
     @patch("influx.sources.arxiv.extract_arxiv_text")
     def test_deep_extracted_tag_iff_tier3_sections(
         self, mock_ext: object, mock_t1: object, mock_t3: object
@@ -1090,7 +1090,7 @@ class TestTagDerivationInvariants:
         has_tag = "influx:deep-extracted" in result["tags"]
         assert has_sections == has_tag
 
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier1_enrich")
     @patch("influx.sources.arxiv.extract_arxiv_text")
     def test_no_deep_extracted_without_tier3(
         self, mock_ext: object, mock_t1: object
@@ -1115,7 +1115,7 @@ class TestTagDerivationInvariants:
         assert "influx:deep-extracted" not in result["tags"]
         assert "## Claims" not in result["content"]
 
-    @patch("influx.sources.arxiv.tier1_enrich")
+    @patch("influx.cascade.tier1_enrich")
     @patch("influx.sources.arxiv.extract_arxiv_text")
     def test_repair_needed_set_exactly_once(
         self, mock_ext: object, mock_t1: object

--- a/tests/unit/test_cascade.py
+++ b/tests/unit/test_cascade.py
@@ -1,0 +1,388 @@
+"""Unit tests for the score-gated enrichment Cascade (issue #55).
+
+Covers:
+
+- All three tier gates (relevance / full_text / deep_extract).
+- Tier-2 extractor injection seam.
+- Counted-failure → ``influx:repair-needed`` repair_flags.
+- :class:`RepairCounters` integration: ``influx:tier{2,3}-terminal``
+  flags surface when the cap has been reached on entry.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from influx.cascade import (
+    Acquired,
+    Cascade,
+    EnrichedSections,
+    Tier2Result,
+)
+from influx.errors import ExtractionError, LCMAError
+from influx.repair_counters import REPAIR_COUNTED_CAP, RepairCounters
+from influx.schemas import Tier1Enrichment, Tier3Extraction
+
+
+def _make_config() -> Any:
+    """Minimal AppConfig sufficient for Cascade construction."""
+    from influx.config import (
+        AppConfig,
+        ProfileConfig,
+        PromptEntryConfig,
+        PromptsConfig,
+        ScheduleConfig,
+    )
+
+    return AppConfig(
+        schedule=ScheduleConfig(cron="0 6 * * *", timezone="UTC"),
+        profiles=[ProfileConfig(name="research")],
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="filter"),
+            tier1_enrich=PromptEntryConfig(text="t1"),
+            tier3_extract=PromptEntryConfig(text="t3"),
+        ),
+    )
+
+
+def _make_acquired(**overrides: Any) -> Acquired:
+    """Build an Acquired with sane test defaults."""
+    base: dict[str, Any] = {
+        "item_id": "2601.00001",
+        "source_url": "https://arxiv.org/abs/2601.00001",
+        "title": "A Paper",
+        "abstract": "An abstract.",
+        "identity_tags": ("cat:cs.AI",),
+        "archive_path": "papers/arxiv/2026/01/2601.00001.pdf",
+    }
+    base.update(overrides)
+    return Acquired(**base)
+
+
+def _make_cascade(
+    *,
+    thresholds: Any = None,
+    tier2_extractor: Any = None,
+) -> Cascade:
+    from influx.config import ProfileThresholds
+
+    return Cascade(
+        config=_make_config(),
+        profile_name="research",
+        profile_summary="A research profile.",
+        thresholds=thresholds or ProfileThresholds(),
+        tier2_extractor=tier2_extractor,
+    )
+
+
+# ── Tier gate: below all thresholds ────────────────────────────────
+
+
+class TestBelowAllThresholds:
+    """Score below relevance / full_text / deep_extract: no tier fires."""
+
+    def test_no_tiers_run(self) -> None:
+        with (
+            patch("influx.cascade.tier1_enrich") as t1,
+            patch("influx.cascade.tier3_extract") as t3,
+        ):
+            sections = _make_cascade().enrich(_make_acquired(), score=3)
+
+        assert sections.tier1 is None
+        assert sections.tier1_attempted is False
+        assert sections.full_text is None
+        assert sections.tier3 is None
+        assert sections.text_tag == "text:abstract-only"
+        assert sections.repair_flags == ()
+        assert sections.terminal_flags == ()
+        t1.assert_not_called()
+        t3.assert_not_called()
+
+
+# ── Tier 1 (relevance gate) ────────────────────────────────────────
+
+
+class TestTier1RelevanceGate:
+    """Tier 1 fires iff score >= relevance."""
+
+    def test_below_relevance_skips_tier1(self) -> None:
+        with patch("influx.cascade.tier1_enrich") as t1:
+            sections = _make_cascade().enrich(_make_acquired(), score=6)
+        t1.assert_not_called()
+        assert sections.tier1 is None
+        assert sections.tier1_attempted is False
+
+    def test_above_relevance_runs_tier1(self) -> None:
+        tier1 = Tier1Enrichment(
+            contributions=["c"], method="m", result="r", relevance="rel"
+        )
+        with patch("influx.cascade.tier1_enrich", return_value=tier1) as t1:
+            sections = _make_cascade().enrich(_make_acquired(), score=7)
+        t1.assert_called_once()
+        assert sections.tier1 == tier1
+        assert sections.tier1_attempted is True
+        assert sections.repair_flags == ()
+
+    def test_tier1_lcma_failure_emits_repair_needed(self) -> None:
+        with patch(
+            "influx.cascade.tier1_enrich",
+            side_effect=LCMAError("schema fail", model="enrich", stage="validate"),
+        ):
+            sections = _make_cascade().enrich(_make_acquired(), score=7)
+        assert sections.tier1 is None
+        assert sections.tier1_attempted is True
+        assert sections.repair_flags == ("influx:repair-needed",)
+
+    def test_tier1_unexpected_exception_degrades_to_repair(self) -> None:
+        """Unexpected Tier-1 exceptions must not abort the run.
+
+        Mirrors the staging-2026-05-01 incident: a validator AttributeError
+        bypassed the LCMAError envelope and took the whole run down.
+        """
+        with patch(
+            "influx.cascade.tier1_enrich",
+            side_effect=AttributeError("validator bug"),
+        ):
+            sections = _make_cascade().enrich(_make_acquired(), score=7)
+        assert sections.tier1 is None
+        assert sections.repair_flags == ("influx:repair-needed",)
+
+
+# ── Tier 2 (full_text gate) ────────────────────────────────────────
+
+
+class TestTier2FullTextGate:
+    """Tier 2 fires iff score >= full_text AND no extracted text yet."""
+
+    def test_below_full_text_skips_tier2(self) -> None:
+        called: list[Acquired] = []
+
+        def extractor(acq: Acquired) -> Tier2Result:
+            called.append(acq)
+            raise AssertionError("must not be called")
+
+        cascade = _make_cascade(tier2_extractor=extractor)
+        sections = cascade.enrich(_make_acquired(), score=6)
+        assert called == []
+        assert sections.full_text is None
+        assert sections.text_tag == "text:abstract-only"
+
+    def test_above_full_text_runs_tier2_html(self) -> None:
+        def extractor(_acq: Acquired) -> Tier2Result:
+            return Tier2Result(text="full body", flavour="html", text_tag="text:html")
+
+        cascade = _make_cascade(tier2_extractor=extractor)
+        sections = cascade.enrich(_make_acquired(), score=8)
+        assert sections.full_text == "full body"
+        assert sections.full_text_flavour == "html"
+        assert sections.text_tag == "text:html"
+
+    def test_tier2_extraction_failure_emits_repair_needed(self) -> None:
+        def extractor(_acq: Acquired) -> Tier2Result:
+            raise ExtractionError("both html and pdf failed", url="x", stage="parse")
+
+        cascade = _make_cascade(tier2_extractor=extractor)
+        sections = cascade.enrich(_make_acquired(), score=8)
+        assert sections.full_text is None
+        assert sections.text_tag == "text:abstract-only"
+        assert "influx:repair-needed" in sections.repair_flags
+
+    def test_no_extractor_skips_tier2_silently(self) -> None:
+        """If no Tier-2 extractor is injected, the gate is a no-op."""
+        tier1 = Tier1Enrichment(
+            contributions=["c"], method="m", result="r", relevance="rel"
+        )
+        with patch("influx.cascade.tier1_enrich", return_value=tier1):
+            sections = _make_cascade(tier2_extractor=None).enrich(
+                _make_acquired(), score=8
+            )
+        assert sections.full_text is None
+        assert sections.text_tag == "text:abstract-only"
+        assert sections.repair_flags == ()
+
+    def test_pre_extracted_text_skips_tier2_call(self) -> None:
+        """When Acquired already has extracted_text (e.g. RSS), Tier 2 is a no-op."""
+        called: list[Acquired] = []
+
+        def extractor(acq: Acquired) -> Tier2Result:
+            called.append(acq)
+            raise AssertionError("must not be called")
+
+        cascade = _make_cascade(tier2_extractor=extractor)
+        sections = cascade.enrich(
+            _make_acquired(extracted_text="prepopulated", text_flavour="html"),
+            score=8,
+        )
+        assert called == []
+        assert sections.full_text == "prepopulated"
+        assert sections.full_text_flavour == "html"
+        assert sections.text_tag == "text:html"
+
+
+# ── Tier 3 (deep_extract gate) ────────────────────────────────────
+
+
+class TestTier3DeepExtractGate:
+    """Tier 3 fires iff score >= deep_extract AND full text is available."""
+
+    def _tier1(self) -> Tier1Enrichment:
+        return Tier1Enrichment(
+            contributions=["c"], method="m", result="r", relevance="rel"
+        )
+
+    def _tier3(self) -> Tier3Extraction:
+        return Tier3Extraction(claims=["claim"], builds_on=["b"])
+
+    def test_below_deep_extract_skips_tier3(self) -> None:
+        def extractor(_acq: Acquired) -> Tier2Result:
+            return Tier2Result(text="body", flavour="html", text_tag="text:html")
+
+        with (
+            patch("influx.cascade.tier1_enrich", return_value=self._tier1()),
+            patch("influx.cascade.tier3_extract") as t3,
+        ):
+            sections = _make_cascade(tier2_extractor=extractor).enrich(
+                _make_acquired(), score=8
+            )
+        t3.assert_not_called()
+        assert sections.tier3 is None
+
+    def test_above_deep_extract_runs_tier3_when_text_available(self) -> None:
+        def extractor(_acq: Acquired) -> Tier2Result:
+            return Tier2Result(text="body", flavour="html", text_tag="text:html")
+
+        tier3 = self._tier3()
+        with (
+            patch("influx.cascade.tier1_enrich", return_value=self._tier1()),
+            patch("influx.cascade.tier3_extract", return_value=tier3) as t3,
+        ):
+            sections = _make_cascade(tier2_extractor=extractor).enrich(
+                _make_acquired(), score=10
+            )
+        t3.assert_called_once()
+        assert sections.tier3 == tier3
+
+    def test_tier3_skipped_without_full_text_even_above_threshold(self) -> None:
+        """If Tier 2 produced no text, Tier 3 must skip even at deep_extract."""
+        with patch("influx.cascade.tier3_extract") as t3:
+            sections = _make_cascade(tier2_extractor=None).enrich(
+                _make_acquired(), score=10
+            )
+        t3.assert_not_called()
+        assert sections.tier3 is None
+
+    def test_tier3_lcma_failure_emits_repair_needed(self) -> None:
+        def extractor(_acq: Acquired) -> Tier2Result:
+            return Tier2Result(text="body", flavour="html", text_tag="text:html")
+
+        with (
+            patch("influx.cascade.tier1_enrich", return_value=self._tier1()),
+            patch(
+                "influx.cascade.tier3_extract",
+                side_effect=LCMAError("validate fail", stage="validate"),
+            ),
+        ):
+            sections = _make_cascade(tier2_extractor=extractor).enrich(
+                _make_acquired(), score=10
+            )
+        assert sections.tier3 is None
+        assert "influx:repair-needed" in sections.repair_flags
+
+
+# ── RepairCounters integration ────────────────────────────────────
+
+
+class TestRepairCountersIntegration:
+    """Cascade consults RepairCounters before each tier."""
+
+    def test_tier2_terminal_when_counter_at_cap(self) -> None:
+        called: list[Acquired] = []
+
+        def extractor(acq: Acquired) -> Tier2Result:
+            called.append(acq)
+            raise AssertionError("must not run when counter at cap")
+
+        counters = RepairCounters(tier2_attempts=REPAIR_COUNTED_CAP)
+        sections = _make_cascade(tier2_extractor=extractor).enrich(
+            _make_acquired(), score=8, counters=counters
+        )
+        assert called == []
+        assert "influx:tier2-terminal" in sections.terminal_flags
+        assert sections.full_text is None
+
+    def test_tier3_terminal_when_counter_at_cap(self) -> None:
+        def extractor(_acq: Acquired) -> Tier2Result:
+            return Tier2Result(text="body", flavour="html", text_tag="text:html")
+
+        counters = RepairCounters(tier3_attempts=REPAIR_COUNTED_CAP)
+        with (
+            patch("influx.cascade.tier1_enrich", return_value=None),
+            patch("influx.cascade.tier3_extract") as t3,
+        ):
+            sections = _make_cascade(tier2_extractor=extractor).enrich(
+                _make_acquired(), score=10, counters=counters
+            )
+        t3.assert_not_called()
+        assert "influx:tier3-terminal" in sections.terminal_flags
+        assert sections.tier3 is None
+
+    def test_below_cap_runs_tier2_normally(self) -> None:
+        def extractor(_acq: Acquired) -> Tier2Result:
+            return Tier2Result(text="body", flavour="html", text_tag="text:html")
+
+        counters = RepairCounters(tier2_attempts=REPAIR_COUNTED_CAP - 1)
+        sections = _make_cascade(tier2_extractor=extractor).enrich(
+            _make_acquired(), score=8, counters=counters
+        )
+        assert "influx:tier2-terminal" not in sections.terminal_flags
+        assert sections.full_text == "body"
+
+    def test_default_counters_means_no_terminal_flags(self) -> None:
+        """Initial-write path: no counters → no skips."""
+
+        def extractor(_acq: Acquired) -> Tier2Result:
+            return Tier2Result(text="body", flavour="html", text_tag="text:html")
+
+        sections = _make_cascade(tier2_extractor=extractor).enrich(
+            _make_acquired(), score=8
+        )
+        assert sections.terminal_flags == ()
+        assert sections.full_text == "body"
+
+
+# ── Result dataclass shape ─────────────────────────────────────────
+
+
+class TestEnrichedSectionsShape:
+    """``EnrichedSections`` exposes the fields the renderer consumes."""
+
+    def test_default_values(self) -> None:
+        sections = EnrichedSections()
+        assert sections.tier1 is None
+        assert sections.tier1_attempted is False
+        assert sections.full_text is None
+        assert sections.full_text_flavour is None
+        assert sections.text_tag == "text:abstract-only"
+        assert sections.tier3 is None
+        assert sections.repair_flags == ()
+        assert sections.terminal_flags == ()
+
+
+class TestAcquiredShape:
+    """``Acquired`` exposes the fields the cascade consumes."""
+
+    def test_minimal_construction(self) -> None:
+        acq = Acquired(
+            item_id="2601.00001",
+            source_url="https://arxiv.org/abs/2601.00001",
+            title="t",
+            abstract="a",
+        )
+        assert acq.item_id == "2601.00001"
+        assert acq.archive_path is None
+        assert acq.archive_missing is False
+        assert acq.archive_terminal is False
+        assert acq.extracted_text is None
+        assert acq.text_flavour is None
+        assert acq.identity_tags == ()

--- a/tests/unit/test_telemetry_wiring.py
+++ b/tests/unit/test_telemetry_wiring.py
@@ -838,6 +838,7 @@ class TestInfluxEnrichTier1Span:
         try:
             with (
                 patch("influx.sources.arxiv.get_tracer", return_value=tracer),
+                patch("influx.cascade.get_tracer", return_value=tracer),
                 patch(
                     "influx.sources.arxiv.extract_arxiv_text",
                     return_value=ArxivExtractionResult(
@@ -845,7 +846,7 @@ class TestInfluxEnrichTier1Span:
                     ),
                 ),
                 patch(
-                    "influx.sources.arxiv.tier1_enrich",
+                    "influx.cascade.tier1_enrich",
                     return_value=Tier1Enrichment(
                         contributions=["c1"],
                         method="m",
@@ -854,7 +855,7 @@ class TestInfluxEnrichTier1Span:
                     ),
                 ),
                 patch(
-                    "influx.sources.arxiv.tier3_extract",
+                    "influx.cascade.tier3_extract",
                     return_value=MagicMock(builds_on=["b"]),
                 ),
             ):
@@ -895,6 +896,7 @@ class TestInfluxEnrichTier2Span:
         try:
             with (
                 patch("influx.sources.arxiv.get_tracer", return_value=tracer),
+                patch("influx.cascade.get_tracer", return_value=tracer),
                 patch(
                     "influx.sources.arxiv.extract_arxiv_text",
                     return_value=ArxivExtractionResult(
@@ -902,7 +904,7 @@ class TestInfluxEnrichTier2Span:
                     ),
                 ),
                 patch(
-                    "influx.sources.arxiv.tier1_enrich",
+                    "influx.cascade.tier1_enrich",
                     return_value=MagicMock(contributions=["c"]),
                 ),
             ):
@@ -945,6 +947,7 @@ class TestInfluxEnrichTier3Span:
         try:
             with (
                 patch("influx.sources.arxiv.get_tracer", return_value=tracer),
+                patch("influx.cascade.get_tracer", return_value=tracer),
                 patch(
                     "influx.sources.arxiv.extract_arxiv_text",
                     return_value=ArxivExtractionResult(
@@ -952,11 +955,11 @@ class TestInfluxEnrichTier3Span:
                     ),
                 ),
                 patch(
-                    "influx.sources.arxiv.tier1_enrich",
+                    "influx.cascade.tier1_enrich",
                     return_value=MagicMock(contributions=["c"]),
                 ),
                 patch(
-                    "influx.sources.arxiv.tier3_extract",
+                    "influx.cascade.tier3_extract",
                     return_value=Tier3Extraction(
                         claims=["claim1"],
                         builds_on=["b1"],
@@ -1000,6 +1003,7 @@ class TestEnrichSpansAllThreeTiers:
         try:
             with (
                 patch("influx.sources.arxiv.get_tracer", return_value=tracer),
+                patch("influx.cascade.get_tracer", return_value=tracer),
                 patch(
                     "influx.sources.arxiv.extract_arxiv_text",
                     return_value=ArxivExtractionResult(
@@ -1007,13 +1011,13 @@ class TestEnrichSpansAllThreeTiers:
                     ),
                 ),
                 patch(
-                    "influx.sources.arxiv.tier1_enrich",
+                    "influx.cascade.tier1_enrich",
                     return_value=Tier1Enrichment(
                         contributions=["c"], method="m", result="r", relevance="rel"
                     ),
                 ),
                 patch(
-                    "influx.sources.arxiv.tier3_extract",
+                    "influx.cascade.tier3_extract",
                     return_value=Tier3Extraction(
                         claims=["claim"],
                         builds_on=["b"],
@@ -1064,13 +1068,13 @@ class TestEnrichSpansDisabled:
                 ),
             ),
             patch(
-                "influx.sources.arxiv.tier1_enrich",
+                "influx.cascade.tier1_enrich",
                 return_value=Tier1Enrichment(
                     contributions=["c"], method="m", result="r", relevance="rel"
                 ),
             ) as mock_tier1,
             patch(
-                "influx.sources.arxiv.tier3_extract",
+                "influx.cascade.tier3_extract",
                 return_value=Tier3Extraction(
                     claims=["claim"],
                     builds_on=["b"],


### PR DESCRIPTION
## Summary

- Introduces \`src/influx/cascade.py\` with \`Acquired\`, \`EnrichedSections\`, and \`Cascade.enrich(acquired, score, *, counters=None)\` per CONTEXT.md.
- Tier gating lives **only** in the Cascade now: relevance / full_text / deep_extract thresholds gate Tier 1 / 2 / 3. Tier 2 is source-agnostic via an injected \`Tier2Extractor\` seam — arXiv injects \`extract_arxiv_text\`; RSS will pre-populate \`Acquired.extracted_text\` when it migrates.
- Cascade consults \`RepairCounters\` before each tier and emits \`influx:tier{2,3}-terminal\` when the per-stage cap has been reached on entry; counted-class failures inside the cascade emit \`influx:repair-needed\` via \`repair_flags\`. Telemetry spans + LLM validation metrics move with the cascade.
- \`build_arxiv_note_item\` migrates to: arXiv-specific acquire (PDF download + \`influx:archive-terminal\` handling) → \`Cascade.enrich\` → \`Renderer.render\`. RSS path is untouched.
- Adds \`tests/unit/test_cascade.py\` (20 tests) covering all three tier gates, Tier-2 extractor seam (failure / no-extractor / pre-populated text), Tier-3's full-text precondition, and RepairCounters cap integration. Existing telemetry-patch tests retarget to \`influx.cascade.{tier1_enrich,tier3_extract,get_tracer}\`.

Closes #55. Built on top of #52 (Renderer) and #53 (RepairCounters).

## Test plan

- [x] \`uv run ruff check .\`
- [x] \`uv run ruff format --check .\`
- [x] \`uv run pyright src/\` (0 errors)
- [x] \`uv run pytest tests/ -q\` (1643 passed; 1623 prior + 20 new)
- [x] arXiv fixture content unchanged (substring assertions in \`test_build_arxiv_note_item\`)
- [x] RSS path untouched (\`test_build_rss_note_item\` still green)