### PR TITLE
refactor: unify Source seam; extract Filter module (#57)

### DIFF
--- a/src/influx/filter.py
+++ b/src/influx/filter.py
@@ -36,18 +36,34 @@ from __future__ import annotations
 import json
 import logging
 import os
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from pydantic import ValidationError
 
-from influx.config import AppConfig
+from influx import metrics
+from influx.config import AppConfig, ProfileConfig
 from influx.errors import NetworkError
 from influx.http_client import guarded_post_json_fetch
 from influx.schemas import FilterResponse
+from influx.source import Candidate, ScoredCandidate
 
 __all__ = [
+    "BatchScorer",
+    "Filter",
     "FilterScorerError",
     "make_default_arxiv_filter_scorer",
+    "make_default_batch_scorer",
+]
+
+
+# Source-agnostic batched scorer signature.  Receives the candidate list
+# (post fetch_candidates) plus profile name + rendered filter prompt and
+# returns a mapping of ``Candidate.item_id`` → ``ScoredCandidate``.
+# Items omitted from the mapping are dropped by :class:`Filter.score`.
+BatchScorer = Callable[
+    [list[Candidate], str, str],
+    Awaitable[dict[str, ScoredCandidate]],
 ]
 
 
@@ -215,3 +231,227 @@ def make_default_arxiv_filter_scorer(
         )
 
     return _scorer
+
+
+# ── Source-agnostic Filter (issue #57) ───────────────────────────────
+
+
+def make_default_batch_scorer(config: AppConfig) -> BatchScorer | None:
+    """Build the production-default source-agnostic batched scorer.
+
+    Returns an async :data:`BatchScorer` that posts the rendered filter
+    prompt + candidates to the ``models.filter`` slot and parses the
+    response against :class:`FilterResponse`.  Returns ``None`` when
+    ``[models.filter]`` is not configured so misconfigured deployments
+    still ingest abstract-only notes (PRD 07 §5.6 graceful degradation).
+    """
+    if "filter" not in config.models:
+        return None
+
+    async def _scorer(
+        candidates: list[Candidate],
+        profile: str,
+        filter_prompt: str,
+    ) -> dict[str, ScoredCandidate]:
+        if not candidates:
+            return {}
+
+        slot = config.models["filter"]
+        provider = config.providers.get(slot.provider)
+        if provider is None:
+            raise FilterScorerError(
+                f"filter provider {slot.provider!r} not configured",
+            )
+
+        candidate_payload = [
+            {"id": c.item_id, "title": c.title, "abstract": c.abstract}
+            for c in candidates
+        ]
+        user_message = (
+            f"{filter_prompt}\n\n"
+            "## CANDIDATES\n"
+            f"{json.dumps(candidate_payload, ensure_ascii=False)}"
+        )
+
+        api_key = ""
+        if provider.api_key_env:
+            api_key = os.environ.get(provider.api_key_env, "")
+
+        url = f"{provider.base_url.rstrip('/')}/chat/completions"
+        headers: dict[str, str] = {**provider.extra_headers}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        body: dict[str, Any] = {
+            "model": slot.model,
+            "temperature": slot.temperature,
+            "messages": [{"role": "user", "content": user_message}],
+        }
+        if slot.max_tokens is not None:
+            body["max_tokens"] = slot.max_tokens
+        if slot.json_mode:
+            body["response_format"] = {"type": "json_object"}
+
+        by_id: dict[str, Candidate] = {c.item_id: c for c in candidates}
+        attempts = slot.max_retries + 1
+        last_error: Exception | None = None
+        for attempt in range(attempts):
+            try:
+                result = guarded_post_json_fetch(
+                    url,
+                    body,
+                    headers=headers,
+                    allow_private_ips=config.security.allow_private_ips,
+                    max_response_bytes=config.storage.max_download_bytes,
+                    timeout_seconds=slot.request_timeout,
+                )
+            except NetworkError as exc:
+                last_error = exc
+                _log.warning(
+                    "filter HTTP error for profile %r on attempt %d/%d: %s",
+                    profile,
+                    attempt + 1,
+                    attempts,
+                    exc,
+                )
+                continue
+
+            if result.status_code >= 400:
+                last_error = FilterScorerError(f"filter slot HTTP {result.status_code}")
+                continue
+
+            try:
+                resp_json = json.loads(result.body.decode("utf-8"))
+                content_str: str = resp_json["choices"][0]["message"]["content"]
+                parsed = json.loads(content_str)
+                response = FilterResponse.model_validate(parsed)
+                return {
+                    r.id: ScoredCandidate(
+                        candidate=by_id[r.id],
+                        score=r.score,
+                        confidence=1.0,
+                        reason=r.reason,
+                        filter_tags=tuple(r.tags),
+                    )
+                    for r in response.results
+                    if r.id in by_id
+                }
+            except (
+                UnicodeDecodeError,
+                json.JSONDecodeError,
+                KeyError,
+                IndexError,
+                TypeError,
+                ValidationError,
+                ValueError,
+            ) as exc:
+                last_error = exc
+                continue
+
+        raise FilterScorerError(f"filter failed after {attempts} attempts") from (
+            last_error
+        )
+
+    return _scorer
+
+
+class Filter:
+    """Score-gated entry to ingestion (CONTEXT.md ``Filter``).
+
+    Wraps the LLM filter scorer + threshold gate + drop-missing logic
+    in one source-agnostic seam.  The scheduler / source orchestrator
+    calls :meth:`score` between ``Source.fetch_candidates`` and
+    ``Source.acquire``.
+
+    Behaviour
+    ---------
+    - Items absent from the scorer's response are dropped (the LLM
+      explicitly chose not to score them).
+    - Items below ``profile_cfg.thresholds.relevance`` are dropped
+      (FR-FLT-7).
+    - When the scorer raises :class:`FilterScorerError`, the entire
+      batch is skipped (FR-FLT-6 / spec §7.1) — the run yields zero
+      items rather than ingesting abstract-only notes for them.
+    - When *scorer* is ``None`` (no ``[models.filter]`` configured),
+      :meth:`score` returns an empty list so misconfigured deployments
+      still complete the run cleanly.
+
+    The ``profile_cfg``-bound shape mirrors :class:`influx.cascade.Cascade`
+    and :class:`influx.lcma_wiring.LcmaWiringDeps` — built once per
+    profile run, reused for every fetch_candidates batch.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: AppConfig,
+        profile_cfg: ProfileConfig,
+        scorer: BatchScorer | None,
+    ) -> None:
+        self._config = config
+        self._profile_cfg = profile_cfg
+        self._scorer = scorer
+
+    @property
+    def has_scorer(self) -> bool:
+        """``True`` when a batched scorer is wired (production default)."""
+        return self._scorer is not None
+
+    async def score(
+        self,
+        candidates: list[Candidate],
+        *,
+        filter_prompt: str,
+        source: str,
+    ) -> list[ScoredCandidate]:
+        """Score *candidates* and return those above the relevance threshold.
+
+        Parameters
+        ----------
+        candidates:
+            The unscored candidates returned by ``Source.fetch_candidates``.
+        filter_prompt:
+            The rendered prompt (profile description + negative-feedback
+            examples + ``min_score_in_results``) composed by the
+            scheduler.
+        source:
+            Source family for metric labels (``"arxiv"``, ``"rss"``…).
+        """
+        if not candidates:
+            return []
+        if self._scorer is None:
+            return []
+
+        profile = self._profile_cfg.name
+        threshold = self._profile_cfg.thresholds.relevance
+        batch_size = max(int(self._config.filter.batch_size), 1)
+
+        all_scores: dict[str, ScoredCandidate] = {}
+        for chunk_start in range(0, len(candidates), batch_size):
+            chunk = candidates[chunk_start : chunk_start + batch_size]
+            try:
+                chunk_scores = await self._scorer(chunk, profile, filter_prompt)
+            except FilterScorerError:
+                _log.warning(
+                    "filter scorer failed for profile %r source=%s; skipping batch",
+                    profile,
+                    source,
+                    exc_info=True,
+                )
+                return []
+            all_scores.update(chunk_scores)
+
+        drop_attrs = {"profile": profile, "decision": "drop"}
+        pass_attrs = {"profile": profile, "decision": "pass"}
+        kept: list[ScoredCandidate] = []
+        for cand in candidates:
+            scored = all_scores.get(cand.item_id)
+            if scored is None:
+                metrics.articles_filtered().add(1, drop_attrs)
+                continue
+            if scored.score < threshold:
+                metrics.articles_filtered().add(1, drop_attrs)
+                continue
+            metrics.articles_filtered().add(1, pass_attrs)
+            kept.append(scored)
+        return kept

--- a/src/influx/source.py
+++ b/src/influx/source.py
@@ -1,0 +1,103 @@
+"""Unified Source seam (CONTEXT.md ``Source``).
+
+Defines the protocol every source adapter (arXiv, RSS, blog) implements
+and the candidate / scored-candidate value types that flow through the
+Run's Acquire stage.
+
+Per CONTEXT.md the Run's Acquire stage walks::
+
+    Source.fetch_candidates → Filter.score → Source.acquire → Acquired
+
+This module owns the seam.  Source adapters live under
+``influx.sources.*``; the Filter that scores candidates lives in
+``influx.filter``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from influx.config import AppConfig, ProfileConfig
+from influx.coordinator import RunKind
+
+__all__ = [
+    "Candidate",
+    "ScoredCandidate",
+    "Source",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class Candidate:
+    """An unscored item returned from :meth:`Source.fetch_candidates`.
+
+    Carries the minimal identity surface every Filter needs (id, title,
+    abstract, source URL) plus a ``payload`` slot for the source-native
+    metadata the adapter's :meth:`Source.acquire` will consume.
+
+    The ``payload`` is opaque to the Filter — typically the original
+    :class:`influx.sources.arxiv.ArxivItem` or
+    :class:`influx.sources.rss.RssFeedItem`.
+    """
+
+    item_id: str
+    title: str
+    abstract: str
+    source_url: str
+    payload: Any = None
+
+
+@dataclass(frozen=True, slots=True)
+class ScoredCandidate:
+    """A :class:`Candidate` plus the Filter's 1–10 relevance score.
+
+    ``filter_tags`` carries the LLM-filter tags (FR-FLT-3) used by
+    rejection-rate logging, distinct from the persisted note tags the
+    source builder later attaches.  Items below
+    ``thresholds.relevance`` or absent from the filter response are
+    dropped by the Filter and never reach this stage.
+    """
+
+    candidate: Candidate
+    score: int
+    confidence: float
+    reason: str
+    filter_tags: tuple[str, ...] = ()
+
+
+@runtime_checkable
+class Source(Protocol):
+    """Unified Source seam (CONTEXT.md).
+
+    A Source adapter exposes two stages:
+
+    - :meth:`fetch_candidates` — bulk per-Profile, called once per Run.
+      Returns the unscored candidates the Filter will score.
+    - :meth:`acquire` — per-item, called by the orchestrator after
+      Filter scoring.  Performs download/archive/extract and returns
+      the ready-to-yield ``ProfileItem`` dict consumed by the
+      scheduler's ``run_profile``.
+
+    The score-gated cascade (Tier 1/2/3 + Renderer) is reached only
+    via :meth:`acquire`; sources do not score candidates themselves.
+    """
+
+    name: str
+
+    def fetch_candidates(
+        self,
+        *,
+        profile_cfg: ProfileConfig,
+        kind: RunKind,
+        run_range: dict[str, str | int] | None,
+    ) -> Awaitable[list[Candidate]]: ...
+
+    def acquire(
+        self,
+        scored: ScoredCandidate,
+        *,
+        profile_cfg: ProfileConfig,
+        config: AppConfig,
+    ) -> dict[str, Any] | None: ...

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -32,6 +32,7 @@ from influx.cascade import Acquired, Cascade, Tier2Result
 from influx.config import (
     AppConfig,
     ArxivSourceConfig,
+    ProfileConfig,
     ProfileThresholds,
     ResilienceConfig,
     StorageConfig,
@@ -42,6 +43,7 @@ from influx.extraction.pipeline import extract_arxiv_text
 from influx.filter import FilterScorerError
 from influx.http_client import guarded_fetch
 from influx.renderer import render
+from influx.source import Candidate, ScoredCandidate
 from influx.storage import download_archive
 from influx.telemetry import (
     current_archive_terminal_arxiv_ids,
@@ -58,6 +60,7 @@ __all__ = [
     "ArxivItem",
     "ArxivScorer",
     "ArxivScoreResult",
+    "ArxivSource",
     "BackfillRange",
     "build_arxiv_note_item",
     "build_query_url",
@@ -745,6 +748,243 @@ def _make_arxiv_tier2_extractor(
     return _extractor
 
 
+# ── Source adapter (issue #57) ──────────────────────────────────────
+
+
+class ArxivSource:
+    """arXiv adapter conforming to :class:`influx.source.Source`.
+
+    Splits the legacy provider closure into the two stages CONTEXT.md
+    names: :meth:`fetch_candidates` and :meth:`acquire`.  Filter scoring
+    happens between them in :class:`influx.filter.Filter`; the cascade /
+    renderer run inside :meth:`acquire`.
+    """
+
+    name = "arxiv"
+
+    def __init__(
+        self,
+        config: AppConfig,
+        *,
+        fetch_cache: FetchCache | None = None,
+    ) -> None:
+        self._config = config
+        self._cache = fetch_cache
+
+    async def fetch_candidates(
+        self,
+        *,
+        profile_cfg: ProfileConfig,
+        kind: RunKind,
+        run_range: dict[str, str | int] | None,
+    ) -> list[Candidate]:
+        """Fetch raw arXiv items and wrap them as :class:`Candidate` records.
+
+        Surfaces fetch failures via the run-ledger ``source_acquisition``
+        path (issue #20) and returns an empty list when the source is
+        disabled or fetch failed; the orchestrator then yields zero
+        items for arXiv.
+        """
+        config = self._config
+        profile = profile_cfg.name
+        if not profile_cfg.sources.arxiv.enabled:
+            _log.info("arxiv source skipped profile=%s reason=disabled", profile)
+            return []
+
+        arxiv_cfg = profile_cfg.sources.arxiv
+        backfill_range = (
+            resolve_backfill_range(run_range) if kind == RunKind.BACKFILL else None
+        )
+        cache_key = "arxiv:" + build_query_url(
+            categories=arxiv_cfg.categories,
+            max_results=arxiv_cfg.max_results_per_category,
+            backfill_range=backfill_range,
+        )
+
+        async def _do_fetch() -> list[ArxivItem]:
+            return await _fetch_arxiv_items(
+                profile=profile,
+                kind=kind,
+                arxiv_cfg=arxiv_cfg,
+                config=config,
+                backfill_range=backfill_range,
+            )
+
+        tracer = get_tracer()
+        with tracer.span(
+            "influx.fetch.arxiv",
+            attributes={
+                "influx.profile": profile,
+                "influx.run_id": current_run_id.get() or "",
+                "influx.source": "arxiv",
+            },
+        ) as fetch_span:
+            try:
+                if self._cache is not None:
+                    items = await self._cache.get_or_fetch(cache_key, _do_fetch)
+                else:
+                    items = await _do_fetch()
+            except NetworkError as exc:
+                _log.warning(
+                    "arxiv fetch failed for profile %r; yielding zero items",
+                    profile,
+                    exc_info=True,
+                )
+                record_source_acquisition_error(
+                    source="arxiv",
+                    kind=exc.kind or "unknown",
+                    detail=str(exc),
+                )
+                metrics.source_acquisition_errors().add(
+                    1,
+                    {
+                        "profile": profile,
+                        "source": "arxiv",
+                        "kind": exc.kind or "unknown",
+                    },
+                )
+                return []
+            fetch_span.set_attribute("influx.item_count", len(items))
+            metrics.candidates_fetched().add(
+                len(items), {"profile": profile, "source": "arxiv"}
+            )
+            _log.info(
+                "arxiv fetch completed profile=%s kind=%s items=%d",
+                profile,
+                kind.value,
+                len(items),
+            )
+
+        return [
+            Candidate(
+                item_id=item.arxiv_id,
+                title=item.title,
+                abstract=item.abstract,
+                source_url=f"https://arxiv.org/abs/{item.arxiv_id}",
+                payload=item,
+            )
+            for item in items
+        ]
+
+    def acquire(
+        self,
+        scored: ScoredCandidate,
+        *,
+        profile_cfg: ProfileConfig,
+        config: AppConfig,
+    ) -> dict[str, Any]:
+        """Acquire stage: download archive + run cascade + render note.
+
+        Delegates to :func:`build_arxiv_note_item`.  The legacy module
+        binding is preserved so existing tests that patch
+        ``influx.sources.arxiv.build_arxiv_note_item`` continue to work.
+        """
+        item = scored.candidate.payload
+        if not isinstance(item, ArxivItem):
+            raise TypeError(
+                "ArxivSource.acquire requires Candidate.payload to be ArxivItem; "
+                f"got {type(item).__name__}",
+            )
+        return build_arxiv_note_item(
+            item=item,
+            score=scored.score,
+            confidence=scored.confidence,
+            reason=scored.reason,
+            profile_name=profile_cfg.name,
+            config=config,
+            filter_tags=scored.filter_tags,
+        )
+
+
+async def _fetch_arxiv_items(
+    *,
+    profile: str,
+    kind: RunKind,
+    arxiv_cfg: ArxivSourceConfig,
+    config: AppConfig,
+    backfill_range: BackfillRange | None,
+) -> list[ArxivItem]:
+    """Run the (possibly per-day) arXiv fetch loop and return raw items.
+
+    Extracted from the legacy provider closure so :class:`ArxivSource`
+    and the legacy ``make_arxiv_item_provider`` share one fetch
+    implementation.
+    """
+    if kind != RunKind.BACKFILL or backfill_range is None:
+        _log.info(
+            "arxiv fetch started profile=%s kind=%s categories=%s "
+            "max_results=%d lookback_days=%d",
+            profile,
+            kind.value,
+            arxiv_cfg.categories,
+            arxiv_cfg.max_results_per_category,
+            arxiv_cfg.lookback_days,
+        )
+        return fetch_arxiv(
+            arxiv_config=arxiv_cfg,
+            resilience=config.resilience,
+            backfill_range=backfill_range,
+            max_download_bytes=config.storage.max_download_bytes,
+            timeout_seconds=config.storage.download_timeout_seconds,
+        )
+
+    n_categories = max(len(arxiv_cfg.categories), 1)
+    per_day_max = arxiv_cfg.max_results_per_category * n_categories
+    per_day_arxiv_cfg = ArxivSourceConfig(
+        enabled=arxiv_cfg.enabled,
+        categories=list(arxiv_cfg.categories),
+        max_results_per_category=per_day_max,
+        lookback_days=arxiv_cfg.lookback_days,
+    )
+    pacing = float(config.resilience.arxiv_request_min_interval_seconds)
+    collected: list[ArxivItem] = []
+    seen_ids: set[str] = set()
+    current = backfill_range.date_from
+    while current < backfill_range.date_to:
+        day_range = BackfillRange(
+            date_from=current,
+            date_to=current + timedelta(days=1),
+        )
+        _log.info(
+            "arxiv backfill day fetch started profile=%s day=%s "
+            "categories=%s max_results=%d",
+            profile,
+            current.isoformat(),
+            arxiv_cfg.categories,
+            per_day_max,
+        )
+        _sleep(pacing)
+        try:
+            day_items = fetch_arxiv(
+                arxiv_config=per_day_arxiv_cfg,
+                resilience=config.resilience,
+                backfill_range=day_range,
+                max_download_bytes=config.storage.max_download_bytes,
+                timeout_seconds=config.storage.download_timeout_seconds,
+            )
+        except NetworkError:
+            _log.warning(
+                "arxiv fetch failed for day %s; continuing backfill",
+                current.isoformat(),
+                exc_info=True,
+            )
+            day_items = []
+        for it in day_items:
+            if it.arxiv_id not in seen_ids:
+                seen_ids.add(it.arxiv_id)
+                collected.append(it)
+        _log.info(
+            "arxiv backfill day fetch completed profile=%s day=%s items=%d "
+            "collected=%d",
+            profile,
+            current.isoformat(),
+            len(day_items),
+            len(collected),
+        )
+        current = current + timedelta(days=1)
+    return collected
+
+
 # ── Production-default item provider (PRD 07 finding #1) ──────────────
 
 
@@ -803,330 +1043,148 @@ def make_arxiv_item_provider(
         if profile_cfg is None:
             _log.info("arxiv source skipped profile=%s reason=unknown_profile", profile)
             return ()
-        if not profile_cfg.sources.arxiv.enabled:
-            _log.info("arxiv source skipped profile=%s reason=disabled", profile)
+
+        # ── 1. Source.fetch_candidates ────────────────────────────
+        source = ArxivSource(config, fetch_cache=cache)
+        candidates = await source.fetch_candidates(
+            profile_cfg=profile_cfg,
+            kind=kind,
+            run_range=run_range,
+        )
+        if not candidates:
             return ()
 
-        # ── Cached fetch (R-8 dedup) ─────────────────────────────
-        # Backfill runs build a date-bounded query so the requested
-        # historical window is honoured (FR-BF-1).  The cache key
-        # includes the bounded URL so that two profiles requesting the
-        # same window dedup, but distinct windows do not collide.
-        arxiv_cfg = profile_cfg.sources.arxiv
-        thresholds = profile_cfg.thresholds
-        backfill_range = (
-            resolve_backfill_range(run_range) if kind == RunKind.BACKFILL else None
-        )
-        cache_key = "arxiv:" + build_query_url(
-            categories=arxiv_cfg.categories,
-            max_results=arxiv_cfg.max_results_per_category,
-            backfill_range=backfill_range,
+        # ── 2. Filter.score (per-item or batched seams) ───────────
+        scored_list = await _score_arxiv_candidates(
+            candidates,
+            profile_cfg=profile_cfg,
+            filter_prompt=filter_prompt,
+            batch_size=int(config.filter.batch_size),
+            scorer=scorer,
+            filter_scorer=filter_scorer,
         )
 
-        async def _do_fetch() -> list[ArxivItem]:
-            # FR-BF-3 / review finding 2: multi-day backfills MUST split
-            # into per-day windows so the run actually realizes the
-            # ``days × len(categories) × max_results_per_category``
-            # contract.  A single OR-joined query with ``max_results=N``
-            # returns at most N items total across all days/categories,
-            # so a 7-day backfill against ``cs.AI`` with
-            # ``max_results_per_category=10`` would only fetch 10 items
-            # — not 70.  Splitting per day also means
-            # ``arxiv_request_min_interval_seconds`` is applied between
-            # each request (not just one sleep up front), giving the
-            # required ~30s-per-day-of-backfill pacing budget.
-            #
-            # Scheduled / manual runs make a single fetch per category
-            # set, so pacing is irrelevant there.
-            if kind != RunKind.BACKFILL or backfill_range is None:
-                _log.info(
-                    "arxiv fetch started profile=%s kind=%s categories=%s "
-                    "max_results=%d lookback_days=%d",
-                    profile,
-                    kind.value,
-                    arxiv_cfg.categories,
-                    arxiv_cfg.max_results_per_category,
-                    arxiv_cfg.lookback_days,
-                )
-                return fetch_arxiv(
-                    arxiv_config=profile_cfg.sources.arxiv,
-                    resilience=config.resilience,
-                    backfill_range=backfill_range,
-                    max_download_bytes=config.storage.max_download_bytes,
-                    timeout_seconds=config.storage.download_timeout_seconds,
-                )
-
-            # Per-day fetch with pacing.  ``per_day_max`` widens
-            # ``max_results`` so the OR-joined query can return up to
-            # ``len(categories) * max_results_per_category`` items for
-            # one day, matching the estimator contract (Q-3 / FR-BF-6).
-            n_categories = max(len(arxiv_cfg.categories), 1)
-            per_day_max = arxiv_cfg.max_results_per_category * n_categories
-            per_day_arxiv_cfg = ArxivSourceConfig(
-                enabled=arxiv_cfg.enabled,
-                categories=list(arxiv_cfg.categories),
-                max_results_per_category=per_day_max,
-                lookback_days=arxiv_cfg.lookback_days,
-            )
-            pacing = float(config.resilience.arxiv_request_min_interval_seconds)
-            collected: list[ArxivItem] = []
-            seen_ids: set[str] = set()
-            current = backfill_range.date_from
-            while current < backfill_range.date_to:
-                day_range = BackfillRange(
-                    date_from=current,
-                    date_to=current + timedelta(days=1),
-                )
-                _log.info(
-                    "arxiv backfill day fetch started profile=%s day=%s "
-                    "categories=%s max_results=%d",
-                    profile,
-                    current.isoformat(),
-                    arxiv_cfg.categories,
-                    per_day_max,
-                )
-                # Pace BEFORE each request so the very first fetch also
-                # respects the spacing budget on a fresh fire.
-                _sleep(pacing)
-                try:
-                    day_items = fetch_arxiv(
-                        arxiv_config=per_day_arxiv_cfg,
-                        resilience=config.resilience,
-                        backfill_range=day_range,
-                        max_download_bytes=config.storage.max_download_bytes,
-                        timeout_seconds=config.storage.download_timeout_seconds,
-                    )
-                except NetworkError:
-                    _log.warning(
-                        "arxiv fetch failed for day %s; continuing backfill",
-                        current.isoformat(),
-                        exc_info=True,
-                    )
-                    day_items = []
-                for it in day_items:
-                    if it.arxiv_id not in seen_ids:
-                        seen_ids.add(it.arxiv_id)
-                        collected.append(it)
-                _log.info(
-                    "arxiv backfill day fetch completed profile=%s day=%s items=%d "
-                    "collected=%d",
-                    profile,
-                    current.isoformat(),
-                    len(day_items),
-                    len(collected),
-                )
-                current = current + timedelta(days=1)
-            return collected
-
-        # ── Telemetry: influx.fetch.arxiv span (FR-OBS-4) ──
-        _tracer = get_tracer()
-        with _tracer.span(
-            "influx.fetch.arxiv",
-            attributes={
-                "influx.profile": profile,
-                "influx.run_id": current_run_id.get() or "",
-                "influx.source": "arxiv",
-            },
-        ) as fetch_span:
-            try:
-                if cache is not None:
-                    items = await cache.get_or_fetch(cache_key, _do_fetch)
-                else:
-                    items = await _do_fetch()
-            except NetworkError as exc:
-                _log.warning(
-                    "arxiv fetch failed for profile %r; yielding zero items",
-                    profile,
-                    exc_info=True,
-                )
-                # Surface to the run ledger so a degraded run is no longer
-                # indistinguishable from a quiet window (issue #20).
-                record_source_acquisition_error(
-                    source="arxiv",
-                    kind=exc.kind or "unknown",
-                    detail=str(exc),
-                )
-                metrics.source_acquisition_errors().add(
-                    1,
-                    {
-                        "profile": profile,
-                        "source": "arxiv",
-                        "kind": exc.kind or "unknown",
-                    },
-                )
-                return ()
-            fetch_span.set_attribute("influx.item_count", len(items))
-            metrics.candidates_fetched().add(
-                len(items), {"profile": profile, "source": "arxiv"}
-            )
-            _log.info(
-                "arxiv fetch completed profile=%s kind=%s items=%d",
-                profile,
-                kind.value,
-                len(items),
-            )
-
-        # Batched LLM filter takes precedence as the production default.
-        # The per-item ``scorer`` seam stays available for tests that
-        # want deterministic, synchronous scoring without an LLM.
-        #
-        # A failed filter batch is skipped per FR-FLT-6. Items returned
-        # by the filter but below the profile relevance threshold are
-        # also discarded per FR-FLT-7.
-        batch_scores: dict[str, ArxivScoreResult] = {}
-        filter_failed = False
-        if scorer is None and filter_scorer is not None:
-            # ── Telemetry: influx.filter span (FR-OBS-4) ──
-            _tracer = get_tracer()
-            with _tracer.span(
-                "influx.filter",
-                attributes={
-                    "influx.profile": profile,
-                    "influx.run_id": current_run_id.get() or "",
-                    "influx.item_count": len(items),
-                },
-            ):
-                # ``filter.batch_size`` caps how many candidates are sent
-                # to the LLM filter in a single request so the configured
-                # tunable actually shapes runtime behaviour (AC-X-1).
-                batch_size = max(int(config.filter.batch_size), 1)
-                for chunk_start in range(0, len(items), batch_size):
-                    chunk = items[chunk_start : chunk_start + batch_size]
-                    _log.info(
-                        "arxiv filter batch started profile=%s batch_start=%d "
-                        "batch_size=%d",
-                        profile,
-                        chunk_start,
-                        len(chunk),
-                    )
-                    try:
-                        chunk_scores = await filter_scorer(
-                            chunk, profile, filter_prompt
-                        )
-                    except FilterScorerError:
-                        _log.warning(
-                            "filter_scorer failed for profile %r; skipping batch",
-                            profile,
-                            exc_info=True,
-                        )
-                        filter_failed = True
-                        break
-                    batch_scores.update(chunk_scores)
-                    _log.info(
-                        "arxiv filter batch completed profile=%s batch_start=%d "
-                        "batch_size=%d scores_returned=%d",
-                        profile,
-                        chunk_start,
-                        len(chunk),
-                        len(chunk_scores),
-                    )
-
-        results: list[dict[str, Any]] = []
-        drop_attrs = {"profile": profile, "decision": "drop"}
-        pass_attrs = {"profile": profile, "decision": "pass"}
-        for arxiv_item in items:
-            if scorer is not None:
-                score_result: ArxivScoreResult | None = scorer(arxiv_item, profile)
-                if score_result is None:
-                    metrics.articles_filtered().add(1, drop_attrs)
-                    _log.info(
-                        "article inspected source=arxiv profile=%s arxiv_id=%s "
-                        "published=%s score=none decision=drop reason=scorer_none "
-                        "title=%r",
-                        profile,
-                        arxiv_item.arxiv_id,
-                        arxiv_item.published.isoformat(),
-                        arxiv_item.title,
-                    )
-                    continue
-            elif filter_scorer is not None:
-                if filter_failed:
-                    metrics.articles_filtered().add(1, drop_attrs)
-                    _log.info(
-                        "article inspected source=arxiv profile=%s arxiv_id=%s "
-                        "published=%s score=none decision=drop reason=filter_failed "
-                        "title=%r",
-                        profile,
-                        arxiv_item.arxiv_id,
-                        arxiv_item.published.isoformat(),
-                        arxiv_item.title,
-                    )
-                    continue
-                elif arxiv_item.arxiv_id not in batch_scores:
-                    # Items absent from the LLM filter response are
-                    # dropped entirely — the filter explicitly chose not
-                    # to score them (typically because they fell below
-                    # ``filter.min_score_in_results``).
-                    metrics.articles_filtered().add(1, drop_attrs)
-                    _log.info(
-                        "article inspected source=arxiv profile=%s arxiv_id=%s "
-                        "published=%s score=none decision=drop "
-                        "reason=not_returned_by_filter title=%r",
-                        profile,
-                        arxiv_item.arxiv_id,
-                        arxiv_item.published.isoformat(),
-                        arxiv_item.title,
-                    )
-                    continue
-                else:
-                    score_result = batch_scores[arxiv_item.arxiv_id]
-            else:
-                metrics.articles_filtered().add(1, drop_attrs)
-                _log.info(
-                    "article inspected source=arxiv profile=%s arxiv_id=%s "
-                    "published=%s score=none decision=drop reason=no_scorer "
-                    "title=%r",
-                    profile,
-                    arxiv_item.arxiv_id,
-                    arxiv_item.published.isoformat(),
-                    arxiv_item.title,
-                )
-                continue
-
-            if score_result.score < thresholds.relevance:
-                metrics.articles_filtered().add(1, drop_attrs)
-                _log.info(
-                    "article inspected source=arxiv profile=%s arxiv_id=%s "
-                    "published=%s score=%d threshold=%d decision=drop "
-                    "reason=below_relevance title=%r",
-                    profile,
-                    arxiv_item.arxiv_id,
-                    arxiv_item.published.isoformat(),
-                    score_result.score,
-                    thresholds.relevance,
-                    arxiv_item.title,
-                )
-                continue
-
-            metrics.articles_filtered().add(1, pass_attrs)
-            _log.info(
-                "article inspected source=arxiv profile=%s arxiv_id=%s "
-                "published=%s score=%d threshold=%d decision=accept title=%r",
-                profile,
-                arxiv_item.arxiv_id,
-                arxiv_item.published.isoformat(),
-                score_result.score,
-                thresholds.relevance,
-                arxiv_item.title,
-            )
-            results.append(
-                build_arxiv_note_item(
-                    item=arxiv_item,
-                    score=score_result.score,
-                    confidence=score_result.confidence,
-                    reason=score_result.reason,
-                    profile_name=profile,
-                    config=config,
-                    filter_tags=score_result.filter_tags,
-                )
-            )
+        # ── 3. Source.acquire per scored candidate ────────────────
+        results: list[dict[str, Any]] = [
+            source.acquire(sc, profile_cfg=profile_cfg, config=config)
+            for sc in scored_list
+        ]
 
         _log.info(
             "arxiv source completed profile=%s fetched=%d accepted=%d",
             profile,
-            len(items),
+            len(candidates),
             len(results),
         )
         return results
 
     return provider
+
+
+# ── Score helper for the legacy provider seams ─────────────────────
+
+
+async def _score_arxiv_candidates(
+    candidates: list[Candidate],
+    *,
+    profile_cfg: ProfileConfig,
+    filter_prompt: str,
+    batch_size: int,
+    scorer: ArxivScorer | None,
+    filter_scorer: ArxivFilterScorer | None,
+) -> list[ScoredCandidate]:
+    """Score arXiv candidates via the per-item or batched legacy seams.
+
+    Mirrors the contract from PRD 07 §5.6:
+
+    - Per-item *scorer* takes precedence when supplied (test seam).
+    - Batched *filter_scorer* is the production default.  When the
+      scorer raises :class:`FilterScorerError`, the whole batch is
+      skipped (FR-FLT-6 / spec §7.1) — items are not ingested with a
+      default score.
+    - Items absent from the filter response are dropped (FR-FLT-7).
+    - Items below ``profile_cfg.thresholds.relevance`` are dropped.
+    - When NEITHER scorer is wired the function returns an empty list
+      so misconfigured deployments still complete the run cleanly.
+    """
+    profile = profile_cfg.name
+    threshold = profile_cfg.thresholds.relevance
+    drop_attrs = {"profile": profile, "decision": "drop"}
+    pass_attrs = {"profile": profile, "decision": "pass"}
+
+    # Per-item synchronous scorer (test seam)
+    if scorer is not None:
+        kept: list[ScoredCandidate] = []
+        for cand in candidates:
+            arxiv_item = cand.payload
+            score_result = scorer(arxiv_item, profile)
+            if score_result is None or score_result.score < threshold:
+                metrics.articles_filtered().add(1, drop_attrs)
+                continue
+            metrics.articles_filtered().add(1, pass_attrs)
+            kept.append(
+                ScoredCandidate(
+                    candidate=cand,
+                    score=score_result.score,
+                    confidence=score_result.confidence,
+                    reason=score_result.reason,
+                    filter_tags=score_result.filter_tags,
+                )
+            )
+        return kept
+
+    if filter_scorer is None:
+        # No scorer wired: drop every item rather than fabricating a score.
+        for _ in candidates:
+            metrics.articles_filtered().add(1, drop_attrs)
+        return []
+
+    # Batched scorer is the production default — chunk into
+    # ``filter.batch_size`` requests so the configured tunable shapes
+    # runtime behaviour (AC-X-1).
+    batch_size = max(batch_size, 1)
+    chunked_scores: dict[str, ArxivScoreResult] = {}
+    tracer = get_tracer()
+    with tracer.span(
+        "influx.filter",
+        attributes={
+            "influx.profile": profile,
+            "influx.run_id": current_run_id.get() or "",
+            "influx.item_count": len(candidates),
+        },
+    ):
+        for chunk_start in range(0, len(candidates), batch_size):
+            chunk = candidates[chunk_start : chunk_start + batch_size]
+            chunk_items = [c.payload for c in chunk]
+            try:
+                chunk_scores = await filter_scorer(chunk_items, profile, filter_prompt)
+            except FilterScorerError:
+                _log.warning(
+                    "filter_scorer failed for profile %r; skipping batch",
+                    profile,
+                    exc_info=True,
+                )
+                # FR-FLT-6 / spec §7.1: failed batch is skipped, not
+                # ingested with a default score.
+                for _ in candidates:
+                    metrics.articles_filtered().add(1, drop_attrs)
+                return []
+            chunked_scores.update(chunk_scores)
+
+    kept = []
+    for cand in candidates:
+        score_result = chunked_scores.get(cand.item_id)
+        if score_result is None or score_result.score < threshold:
+            metrics.articles_filtered().add(1, drop_attrs)
+            continue
+        metrics.articles_filtered().add(1, pass_attrs)
+        kept.append(
+            ScoredCandidate(
+                candidate=cand,
+                score=score_result.score,
+                confidence=score_result.confidence,
+                reason=score_result.reason,
+                filter_tags=score_result.filter_tags,
+            )
+        )
+    return kept

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -41,6 +41,7 @@ from influx.http_client import guarded_post_json_fetch
 from influx.renderer import render
 from influx.schemas import FilterResponse
 from influx.slugs import slugify_feed_name
+from influx.source import Candidate, ScoredCandidate
 from influx.storage import download_archive
 from influx.telemetry import (
     current_run_id,
@@ -50,11 +51,12 @@ from influx.telemetry import (
 from influx.urls import normalise_url, url_hash
 
 if TYPE_CHECKING:
-    from influx.config import AppConfig, RssSourceEntry
+    from influx.config import AppConfig, ProfileConfig, RssSourceEntry
     from influx.sources import FetchCache
 
 __all__ = [
     "RssFeedItem",
+    "RssSource",
     "build_rss_note_item",
     "make_rss_item_provider",
     "parse_feed",
@@ -429,6 +431,94 @@ async def _score_rss_items(
 
 def _rss_filter_id(item: RssFeedItem) -> str:
     return url_hash(item.url)
+
+
+# ── Source adapter (issue #57) ──────────────────────────────────────
+
+
+class RssSource:
+    """RSS adapter conforming to :class:`influx.source.Source`.
+
+    Fans out across the profile's configured feeds in
+    :meth:`fetch_candidates`; per-feed filter scoring stays in the
+    legacy provider closure so :func:`_score_rss_items` retains its
+    test seam.
+    """
+
+    name = "rss"
+
+    def __init__(
+        self,
+        config: AppConfig,
+        *,
+        fetch_cache: FetchCache | None = None,
+    ) -> None:
+        self._config = config
+        self._cache = fetch_cache
+
+    async def fetch_candidates(
+        self,
+        *,
+        profile_cfg: ProfileConfig,
+        kind: RunKind,
+        run_range: dict[str, str | int] | None,
+    ) -> list[Candidate]:
+        """Fetch every configured feed and flatten into a list of Candidates.
+
+        Each :class:`Candidate.payload` is the original
+        :class:`RssFeedItem`, so :meth:`acquire` can reconstruct the
+        feed-specific metadata (source_tag, feed_name) without a
+        secondary lookup.
+        """
+        del kind, run_range
+        config = self._config
+        candidates: list[Candidate] = []
+        for feed_entry in profile_cfg.sources.rss:
+            items = await _fetch_rss_feed(
+                feed_entry,
+                self._cache,
+                max_download_bytes=config.storage.max_download_bytes,
+                timeout_seconds=config.storage.download_timeout_seconds,
+                profile=profile_cfg.name,
+            )
+            metrics.candidates_fetched().add(
+                len(items), {"profile": profile_cfg.name, "source": "rss"}
+            )
+            for item in items:
+                candidates.append(
+                    Candidate(
+                        item_id=_rss_filter_id(item),
+                        title=item.title,
+                        abstract=item.summary,
+                        source_url=item.url,
+                        payload=item,
+                    )
+                )
+        return candidates
+
+    def acquire(
+        self,
+        scored: ScoredCandidate,
+        *,
+        profile_cfg: ProfileConfig,
+        config: AppConfig,
+    ) -> dict[str, Any]:
+        """Acquire stage: download archive + run cascade + render note."""
+        item = scored.candidate.payload
+        if not isinstance(item, RssFeedItem):
+            raise TypeError(
+                "RssSource.acquire requires Candidate.payload to be RssFeedItem; "
+                f"got {type(item).__name__}",
+            )
+        return build_rss_note_item(
+            item=item,
+            profile_name=profile_cfg.name,
+            config=config,
+            score=scored.score,
+            confidence=scored.confidence,
+            reason=scored.reason,
+            filter_tags=scored.filter_tags,
+        )
 
 
 # ── Production-default RSS item provider ────────────────────────────

--- a/tests/unit/test_filter.py
+++ b/tests/unit/test_filter.py
@@ -1,0 +1,268 @@
+"""Tests for the source-agnostic ``Filter`` (issue #57).
+
+Covers the three behaviours called out in the AC:
+
+- threshold gating (drop items below ``thresholds.relevance``)
+- missing-from-response handling (drop items the scorer omits)
+- negative-feedback wiring (the rendered ``filter_prompt`` actually
+  reaches the scorer untouched, so feedback examples flow through)
+
+Also exercises :data:`FilterScorerError` skip-the-batch behaviour
+(FR-FLT-6 / spec §7.1) and the no-scorer fallback.
+"""
+
+from __future__ import annotations
+
+from influx.config import (
+    AppConfig,
+    FilterTuningConfig,
+    ProfileConfig,
+    ProfileThresholds,
+    PromptEntryConfig,
+    PromptsConfig,
+    ScheduleConfig,
+)
+from influx.filter import BatchScorer, Filter, FilterScorerError
+from influx.source import Candidate, ScoredCandidate
+
+
+def _make_config(batch_size: int = 25) -> AppConfig:
+    return AppConfig(
+        schedule=ScheduleConfig(
+            cron="0 6 * * *",
+            timezone="UTC",
+            misfire_grace_seconds=3600,
+        ),
+        profiles=[
+            ProfileConfig(
+                name="alpha",
+                thresholds=ProfileThresholds(relevance=7),
+            )
+        ],
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="t"),
+            tier1_enrich=PromptEntryConfig(text="t"),
+            tier3_extract=PromptEntryConfig(text="t"),
+        ),
+        filter=FilterTuningConfig(batch_size=batch_size),
+    )
+
+
+def _candidate(item_id: str) -> Candidate:
+    return Candidate(
+        item_id=item_id,
+        title=f"Title {item_id}",
+        abstract=f"Abstract {item_id}",
+        source_url=f"https://example.com/{item_id}",
+    )
+
+
+def _make_scorer(scores: dict[str, int]) -> BatchScorer:
+    """Return a deterministic batch scorer keyed by ``Candidate.item_id``."""
+
+    async def _scorer(
+        chunk: list[Candidate],
+        profile: str,
+        filter_prompt: str,
+    ) -> dict[str, ScoredCandidate]:
+        return {
+            c.item_id: ScoredCandidate(
+                candidate=c,
+                score=scores[c.item_id],
+                confidence=1.0,
+                reason="ok",
+                filter_tags=("ai-safety",),
+            )
+            for c in chunk
+            if c.item_id in scores
+        }
+
+    return _scorer
+
+
+# ── Threshold gating ────────────────────────────────────────────────
+
+
+async def test_score_drops_items_below_threshold() -> None:
+    """Filter drops items whose score < ``thresholds.relevance``."""
+    config = _make_config()
+    profile_cfg = config.profiles[0]
+    candidates = [_candidate("a"), _candidate("b"), _candidate("c")]
+    scorer = _make_scorer({"a": 9, "b": 6, "c": 7})  # b drops, threshold=7
+
+    f = Filter(config=config, profile_cfg=profile_cfg, scorer=scorer)
+    result = await f.score(candidates, filter_prompt="prompt", source="arxiv")
+
+    assert [s.candidate.item_id for s in result] == ["a", "c"]
+    assert all(s.score >= 7 for s in result)
+
+
+async def test_score_keeps_item_at_exact_threshold() -> None:
+    """A score exactly equal to the threshold passes (>= comparison)."""
+    config = _make_config()
+    profile_cfg = config.profiles[0]
+    candidates = [_candidate("a")]
+    scorer = _make_scorer({"a": 7})
+
+    f = Filter(config=config, profile_cfg=profile_cfg, scorer=scorer)
+    result = await f.score(candidates, filter_prompt="prompt", source="arxiv")
+
+    assert [s.candidate.item_id for s in result] == ["a"]
+
+
+# ── Missing-from-response handling ─────────────────────────────────
+
+
+async def test_score_drops_items_missing_from_response() -> None:
+    """Items the scorer omits are dropped — not re-scored or fabricated."""
+    config = _make_config()
+    profile_cfg = config.profiles[0]
+    candidates = [_candidate("a"), _candidate("b"), _candidate("c")]
+    # Scorer only returns "a"; b and c are absent → both dropped.
+    scorer = _make_scorer({"a": 9})
+
+    f = Filter(config=config, profile_cfg=profile_cfg, scorer=scorer)
+    result = await f.score(candidates, filter_prompt="prompt", source="arxiv")
+
+    assert [s.candidate.item_id for s in result] == ["a"]
+
+
+# ── Failed-batch handling (FR-FLT-6 / spec §7.1) ───────────────────
+
+
+async def test_score_skips_entire_batch_on_filter_scorer_error() -> None:
+    """A scorer that raises FilterScorerError causes the run to ingest zero."""
+    config = _make_config()
+    profile_cfg = config.profiles[0]
+    candidates = [_candidate("a"), _candidate("b")]
+
+    async def failing_scorer(
+        chunk: list[Candidate],
+        profile: str,
+        filter_prompt: str,
+    ) -> dict[str, ScoredCandidate]:
+        raise FilterScorerError("upstream LLM down")
+
+    f = Filter(config=config, profile_cfg=profile_cfg, scorer=failing_scorer)
+    result = await f.score(candidates, filter_prompt="prompt", source="arxiv")
+
+    # Failed batches must NOT be ingested with a default score.
+    assert result == []
+
+
+# ── No-scorer fallback ─────────────────────────────────────────────
+
+
+async def test_score_returns_empty_when_no_scorer_configured() -> None:
+    """A misconfigured deployment (scorer=None) yields zero items, not crashes."""
+    config = _make_config()
+    profile_cfg = config.profiles[0]
+    candidates = [_candidate("a")]
+
+    f = Filter(config=config, profile_cfg=profile_cfg, scorer=None)
+    result = await f.score(candidates, filter_prompt="prompt", source="arxiv")
+
+    assert result == []
+    assert f.has_scorer is False
+
+
+async def test_score_returns_empty_for_empty_candidates() -> None:
+    """No candidates → no scorer call, empty result."""
+    config = _make_config()
+    profile_cfg = config.profiles[0]
+    called = False
+
+    async def scorer(
+        chunk: list[Candidate], profile: str, filter_prompt: str
+    ) -> dict[str, ScoredCandidate]:
+        nonlocal called
+        called = True
+        return {}
+
+    f = Filter(config=config, profile_cfg=profile_cfg, scorer=scorer)
+    result = await f.score([], filter_prompt="prompt", source="arxiv")
+
+    assert result == []
+    assert called is False
+
+
+# ── Negative-feedback wiring ───────────────────────────────────────
+
+
+async def test_score_passes_filter_prompt_through_to_scorer() -> None:
+    """The rendered filter_prompt (with negative-feedback block) reaches
+    the scorer unmodified — proving feedback examples flow through."""
+    config = _make_config()
+    profile_cfg = config.profiles[0]
+    candidates = [_candidate("a"), _candidate("b")]
+
+    rendered_prompt = (
+        "Score these candidates...\n\n"
+        "## NEGATIVE EXAMPLES\n"
+        "- Boring paper about widgets\n"
+        "- Another irrelevant title\n"
+    )
+    captured: list[str] = []
+
+    async def scorer(
+        chunk: list[Candidate],
+        profile: str,
+        filter_prompt: str,
+    ) -> dict[str, ScoredCandidate]:
+        captured.append(filter_prompt)
+        return {
+            c.item_id: ScoredCandidate(
+                candidate=c, score=8, confidence=1.0, reason="ok"
+            )
+            for c in chunk
+        }
+
+    f = Filter(config=config, profile_cfg=profile_cfg, scorer=scorer)
+    await f.score(candidates, filter_prompt=rendered_prompt, source="arxiv")
+
+    assert captured == [rendered_prompt]
+    assert "## NEGATIVE EXAMPLES" in captured[0]
+
+
+# ── Batching ───────────────────────────────────────────────────────
+
+
+async def test_score_chunks_by_filter_batch_size() -> None:
+    """Filter splits candidates into ``filter.batch_size`` chunks (AC-X-1)."""
+    config = _make_config(batch_size=3)
+    profile_cfg = config.profiles[0]
+    candidates = [_candidate(f"id-{i}") for i in range(10)]
+    chunk_lens: list[int] = []
+
+    async def scorer(
+        chunk: list[Candidate], profile: str, filter_prompt: str
+    ) -> dict[str, ScoredCandidate]:
+        chunk_lens.append(len(chunk))
+        return {
+            c.item_id: ScoredCandidate(
+                candidate=c, score=8, confidence=1.0, reason="ok"
+            )
+            for c in chunk
+        }
+
+    f = Filter(config=config, profile_cfg=profile_cfg, scorer=scorer)
+    result = await f.score(candidates, filter_prompt="p", source="arxiv")
+
+    assert chunk_lens == [3, 3, 3, 1]
+    assert len(result) == 10
+
+
+async def test_score_propagates_filter_tags_and_reason() -> None:
+    """The scored candidate carries through filter_tags + reason."""
+    config = _make_config()
+    profile_cfg = config.profiles[0]
+    cand = _candidate("a")
+    scorer = _make_scorer({"a": 9})
+
+    f = Filter(config=config, profile_cfg=profile_cfg, scorer=scorer)
+    result = await f.score([cand], filter_prompt="p", source="arxiv")
+
+    assert len(result) == 1
+    assert result[0].filter_tags == ("ai-safety",)
+    assert result[0].reason == "ok"
+    assert result[0].confidence == 1.0

--- a/tests/unit/test_source_protocol.py
+++ b/tests/unit/test_source_protocol.py
@@ -1,0 +1,279 @@
+"""Tests for the unified ``Source`` protocol (issue #57).
+
+Verifies that the arXiv and RSS adapter classes conform to the
+:class:`influx.source.Source` protocol and that their
+:meth:`fetch_candidates` / :meth:`acquire` stages compose into the
+``Source.fetch_candidates → Filter.score → Source.acquire`` sequence
+called out in CONTEXT.md.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from influx.config import (
+    AppConfig,
+    ProfileConfig,
+    PromptEntryConfig,
+    PromptsConfig,
+    RssSourceEntry,
+    ScheduleConfig,
+)
+from influx.coordinator import RunKind
+from influx.source import Candidate, ScoredCandidate, Source
+from influx.sources.arxiv import ArxivItem, ArxivSource
+from influx.sources.rss import RssFeedItem, RssSource
+
+
+def _make_config(profile: ProfileConfig | None = None) -> AppConfig:
+    return AppConfig(
+        schedule=ScheduleConfig(cron="0 6 * * *", misfire_grace_seconds=3600),
+        profiles=[profile or ProfileConfig(name="alpha")],
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="t"),
+            tier1_enrich=PromptEntryConfig(text="t"),
+            tier3_extract=PromptEntryConfig(text="t"),
+        ),
+    )
+
+
+# ── Protocol conformance ───────────────────────────────────────────
+
+
+def test_arxiv_source_conforms_to_source_protocol() -> None:
+    """ArxivSource conforms to the runtime-checkable Source protocol."""
+    config = _make_config()
+    source = ArxivSource(config)
+    assert isinstance(source, Source)
+    assert source.name == "arxiv"
+
+
+def test_rss_source_conforms_to_source_protocol() -> None:
+    """RssSource conforms to the runtime-checkable Source protocol."""
+    config = _make_config()
+    source = RssSource(config)
+    assert isinstance(source, Source)
+    assert source.name == "rss"
+
+
+# ── ArxivSource: fetch_candidates → acquire ───────────────────────
+
+
+async def test_arxiv_source_fetch_candidates_returns_typed_candidates() -> None:
+    """fetch_candidates wraps each ArxivItem in a Candidate."""
+    config = _make_config()
+    profile_cfg = config.profiles[0]
+    items = [
+        ArxivItem(
+            arxiv_id="2401.00001",
+            title="Sample paper",
+            abstract="Body",
+            published=datetime(2024, 1, 1, tzinfo=UTC),
+            categories=["cs.AI"],
+        )
+    ]
+
+    with patch(
+        "influx.sources.arxiv.fetch_arxiv",
+        new_callable=MagicMock,
+        return_value=items,
+    ):
+        source = ArxivSource(config)
+        candidates = await source.fetch_candidates(
+            profile_cfg=profile_cfg,
+            kind=RunKind.SCHEDULED,
+            run_range=None,
+        )
+
+    assert len(candidates) == 1
+    cand = candidates[0]
+    assert cand.item_id == "2401.00001"
+    assert cand.title == "Sample paper"
+    assert cand.abstract == "Body"
+    assert cand.source_url == "https://arxiv.org/abs/2401.00001"
+    assert cand.payload is items[0]
+
+
+async def test_arxiv_source_fetch_candidates_returns_empty_when_disabled() -> None:
+    """A profile with arxiv.enabled=False yields zero candidates."""
+    profile_cfg = ProfileConfig(name="alpha")
+    profile_cfg.sources.arxiv.enabled = False
+    config = _make_config(profile_cfg)
+
+    source = ArxivSource(config)
+    candidates = await source.fetch_candidates(
+        profile_cfg=profile_cfg,
+        kind=RunKind.SCHEDULED,
+        run_range=None,
+    )
+
+    assert candidates == []
+
+
+def test_arxiv_source_acquire_delegates_to_build_arxiv_note_item() -> None:
+    """acquire wires the cascade + renderer via build_arxiv_note_item."""
+    config = _make_config()
+    profile_cfg = config.profiles[0]
+    item = ArxivItem(
+        arxiv_id="2401.00001",
+        title="Sample",
+        abstract="Body",
+        published=datetime(2024, 1, 1, tzinfo=UTC),
+        categories=["cs.AI"],
+    )
+    candidate = Candidate(
+        item_id=item.arxiv_id,
+        title=item.title,
+        abstract=item.abstract,
+        source_url=f"https://arxiv.org/abs/{item.arxiv_id}",
+        payload=item,
+    )
+    scored = ScoredCandidate(
+        candidate=candidate,
+        score=8,
+        confidence=1.0,
+        reason="relevant",
+        filter_tags=("ai-safety",),
+    )
+
+    sentinel = {"title": "Sample", "tags": ["x"]}
+    with patch(
+        "influx.sources.arxiv.build_arxiv_note_item",
+        new_callable=MagicMock,
+        return_value=sentinel,
+    ) as build_mock:
+        source = ArxivSource(config)
+        result = source.acquire(scored, profile_cfg=profile_cfg, config=config)
+
+    assert result is sentinel
+    build_mock.assert_called_once()
+    kwargs = build_mock.call_args.kwargs
+    assert kwargs["item"] is item
+    assert kwargs["score"] == 8
+    assert kwargs["confidence"] == 1.0
+    assert kwargs["reason"] == "relevant"
+    assert kwargs["profile_name"] == "alpha"
+    assert kwargs["filter_tags"] == ("ai-safety",)
+
+
+def test_arxiv_source_acquire_rejects_wrong_payload_type() -> None:
+    """acquire raises TypeError when the payload isn't an ArxivItem."""
+    config = _make_config()
+    profile_cfg = config.profiles[0]
+    candidate = Candidate(
+        item_id="x",
+        title="t",
+        abstract="a",
+        source_url="https://example.com",
+        payload="not-an-arxiv-item",
+    )
+    scored = ScoredCandidate(candidate=candidate, score=8, confidence=1.0, reason="")
+
+    source = ArxivSource(config)
+    with pytest.raises(TypeError, match="ArxivItem"):
+        source.acquire(scored, profile_cfg=profile_cfg, config=config)
+
+
+# ── RssSource: fetch_candidates → acquire ─────────────────────────
+
+
+async def test_rss_source_fetch_candidates_flattens_feeds() -> None:
+    """fetch_candidates concatenates items across configured feeds."""
+    profile_cfg = ProfileConfig(name="alpha")
+    profile_cfg.sources.rss = [
+        RssSourceEntry(
+            name="Feed One",
+            url="https://a.example/feed",
+            source_tag="blog",
+        ),
+    ]
+    config = _make_config(profile_cfg)
+
+    items = [
+        RssFeedItem(
+            title="Post 1",
+            url="https://a.example/post-1",
+            published=datetime(2024, 1, 1, tzinfo=UTC),
+            summary="Summary 1",
+            source_tag="blog",
+            feed_name="Feed One",
+        )
+    ]
+
+    async def fake_fetch(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return items
+
+    with patch("influx.sources.rss._fetch_rss_feed", side_effect=fake_fetch):
+        source = RssSource(config)
+        candidates = await source.fetch_candidates(
+            profile_cfg=profile_cfg,
+            kind=RunKind.SCHEDULED,
+            run_range=None,
+        )
+
+    assert len(candidates) == 1
+    cand = candidates[0]
+    assert cand.title == "Post 1"
+    assert cand.abstract == "Summary 1"
+    assert cand.source_url == "https://a.example/post-1"
+    assert cand.payload is items[0]
+
+
+def test_rss_source_acquire_delegates_to_build_rss_note_item() -> None:
+    """acquire wires the RSS cascade + renderer via build_rss_note_item."""
+    config = _make_config()
+    profile_cfg = config.profiles[0]
+    item = RssFeedItem(
+        title="Post",
+        url="https://a.example/post",
+        published=datetime(2024, 1, 1, tzinfo=UTC),
+        summary="Summary",
+        source_tag="blog",
+        feed_name="Feed One",
+    )
+    candidate = Candidate(
+        item_id="hash-1",
+        title=item.title,
+        abstract=item.summary,
+        source_url=item.url,
+        payload=item,
+    )
+    scored = ScoredCandidate(
+        candidate=candidate,
+        score=8,
+        confidence=1.0,
+        reason="relevant",
+        filter_tags=("blog-ai",),
+    )
+
+    sentinel = {"title": "Post", "tags": ["x"]}
+    with patch(
+        "influx.sources.rss.build_rss_note_item",
+        new_callable=MagicMock,
+        return_value=sentinel,
+    ) as build_mock:
+        source = RssSource(config)
+        result = source.acquire(scored, profile_cfg=profile_cfg, config=config)
+
+    assert result is sentinel
+    kwargs = build_mock.call_args.kwargs
+    assert kwargs["item"] is item
+    assert kwargs["profile_name"] == "alpha"
+    assert kwargs["filter_tags"] == ("blog-ai",)
+
+
+def test_rss_source_acquire_rejects_wrong_payload_type() -> None:
+    """acquire raises TypeError when the payload isn't an RssFeedItem."""
+    config = _make_config()
+    profile_cfg = config.profiles[0]
+    candidate = Candidate(
+        item_id="x", title="t", abstract="a", source_url="u", payload=42
+    )
+    scored = ScoredCandidate(candidate=candidate, score=8, confidence=1.0, reason="")
+
+    source = RssSource(config)
+    with pytest.raises(TypeError, match="RssFeedItem"):
+        source.acquire(scored, profile_cfg=profile_cfg, config=config)


### PR DESCRIPTION
## Summary

- Introduces unified `Source` protocol (`fetch_candidates` + `acquire`) and `Candidate`/`ScoredCandidate` value types in `src/influx/source.py`
- Adds source-agnostic `Filter` class in `src/influx/filter.py` that owns score-gating (threshold, drop-missing, batched chunking, fail-skip)
- arXiv and RSS modules expose `ArxivSource` / `RssSource` adapters; provider closures now walk `Source.fetch_candidates → Filter score → Source.acquire → Cascade.enrich → Renderer.render`
- Failed filter batches yield zero items per FR-FLT-6 / spec §7.1 — no default-score fabrication

## Test plan

- [x] All existing scheduler / arXiv / RSS / integration tests still pass (1643 → 1661, +18 new)
- [x] New Filter tests: threshold gating, missing-from-response, negative-feedback prompt pass-through, FilterScorerError skip-batch, no-scorer fallback, batched chunking by `filter.batch_size`
- [x] New Source-protocol conformance tests for `ArxivSource` and `RssSource`
- [x] `uv run ruff check . && uv run ruff format --check . && uv run pyright src/ && uv run pytest tests/ -q` all green

Closes #57