### PR TITLE
refactor: promote LCMA tool-availability check to startup probe (#69)

### DIFF
--- a/src/influx/lcma_wiring.py
+++ b/src/influx/lcma_wiring.py
@@ -9,8 +9,13 @@ the scheduler used to inline:
 - Resolving Tier 3 ``builds_on`` entries via ``lithos_cache_lookup`` and
   upserting ``builds_on`` edges only on exact ``source_url`` match
   (FR-LCMA-4, AC-M2-7/8).
-- Latching the ``lcma_unknown_tool_failure`` probe flag (FR-LCMA-6) when
-  Lithos returns ``unknown_tool`` for any of those calls.
+
+LCMA tool-availability checking has moved out of the per-call latch
+path (issue #69).  The probe loop now asserts the LCMA tool surface
+once per probe interval and gates the run with
+``reason="lcma_tools_unavailable"``; mid-run ``LCMAError("unknown_tool")``
+propagates as a normal failure here, and the next probe cycle
+re-evaluates the latch.
 
 The actual retrieve / cache-lookup / edge-upsert primitives still live
 in :mod:`influx.lcma`.  This module is the seam the scheduler (and,
@@ -20,11 +25,9 @@ later, the ``Run`` module) calls into after each successful write.
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from influx.errors import LCMAError
 from influx.lcma import after_write, resolve_builds_on
 
 if TYPE_CHECKING:
@@ -32,18 +35,11 @@ if TYPE_CHECKING:
 
 __all__ = [
     "CascadeOutput",
-    "LcmaUnknownToolLatch",
     "LcmaWiringDeps",
     "wire",
 ]
 
 logger = logging.getLogger(__name__)
-
-
-# Latch callback shape — typically ``ProbeLoop.mark_lcma_unknown_tool_failure``
-# (kwargs: ``profile``, ``detail``).  Any callable accepting those kwargs
-# is acceptable so unit tests can pass a plain capturing fake.
-LcmaUnknownToolLatch = Callable[..., None]
 
 
 @dataclass(frozen=True, slots=True)
@@ -74,7 +70,6 @@ class LcmaWiringDeps:
     profile: str
     run_task_id: str
     lcma_edge_score: float
-    on_unknown_tool: LcmaUnknownToolLatch | None = field(default=None)
 
 
 # ── Entry point ─────────────────────────────────────────────────────
@@ -98,7 +93,7 @@ async def wire(
         from the cascade output for this item.
     deps:
         Per-run wiring dependencies (Lithos client, profile, run task,
-        edge-score threshold, optional unknown-tool latch).
+        edge-score threshold).
 
     Returns
     -------
@@ -110,75 +105,23 @@ async def wire(
     Raises
     ------
     LCMAError
-        Propagated verbatim after latching ``lcma_unknown_tool_failure``
-        on ``unknown_tool``; other errors propagate unchanged.
+        Propagated verbatim.  ``unknown_tool`` failures are no longer
+        latched here — the probe loop's tool-availability check
+        (issue #69) drives the latch and the next probe cycle
+        re-evaluates.
     """
-    related: list[dict[str, Any]] = []
-    try:
-        related = await after_write(
-            client=deps.client,
-            title=cascade.title,
-            contributions=cascade.contributions,
-            run_task_id=deps.run_task_id,
-            profile=deps.profile,
-            lcma_edge_score=deps.lcma_edge_score,
-            source_note_id=written_note_id,
-        )
-    except LCMAError as exc:
-        _maybe_latch_unknown_tool(
-            exc=exc,
-            profile=deps.profile,
-            fallback_tool="lithos_retrieve",
-            on_unknown_tool=deps.on_unknown_tool,
-        )
-        raise
-
-    try:
-        await resolve_builds_on(
-            client=deps.client,
-            builds_on=cascade.builds_on,
-            source_note_id=written_note_id,
-        )
-    except LCMAError as exc:
-        _maybe_latch_unknown_tool(
-            exc=exc,
-            profile=deps.profile,
-            fallback_tool="lithos_cache_lookup",
-            on_unknown_tool=deps.on_unknown_tool,
-        )
-        raise
-
-    return related
-
-
-# ── Unknown-tool latch helper ──────────────────────────────────────
-
-
-def _maybe_latch_unknown_tool(
-    *,
-    exc: LCMAError,
-    profile: str,
-    fallback_tool: str,
-    on_unknown_tool: LcmaUnknownToolLatch | None,
-) -> None:
-    """Log + latch readiness when *exc* is an LCMA ``unknown_tool`` failure.
-
-    Mirrors the original ``_handle_lcma_unknown_tool`` behaviour from the
-    scheduler: an ERROR log line names the offending tool, and the
-    optional latch callback flips the probe flag so ``/ready`` reports
-    degraded.  Other LCMAError values are no-ops here so the caller can
-    re-raise unchanged.
-    """
-    if str(exc) != "unknown_tool":
-        return
-
-    tool = getattr(exc, "stage", "") or fallback_tool
-    logger.error(
-        "LCMA deployment error: unknown_tool for %s during profile %r run "
-        "— aborting run. Check that the connected Lithos deployment "
-        "supports the required LCMA tools.",
-        tool,
-        profile,
+    related = await after_write(
+        client=deps.client,
+        title=cascade.title,
+        contributions=cascade.contributions,
+        run_task_id=deps.run_task_id,
+        profile=deps.profile,
+        lcma_edge_score=deps.lcma_edge_score,
+        source_note_id=written_note_id,
     )
-    if on_unknown_tool is not None:
-        on_unknown_tool(profile=profile, detail=f"tool={tool!r}")
+    await resolve_builds_on(
+        client=deps.client,
+        builds_on=cascade.builds_on,
+        source_note_id=written_note_id,
+    )
+    return related

--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -1214,6 +1214,19 @@ class LithosClient:
         session = await self._ensure_connected()
         return await session.call_tool(name, arguments)
 
+    async def list_tools(self) -> list[str]:
+        """List the names of every tool the connected Lithos exposes.
+
+        Used by the probe loop to assert the LCMA tool surface is
+        present at deployment time (issue #69) — replacing the legacy
+        per-call ``LCMAError("unknown_tool")`` latch with a probe-time
+        gate.  Returns the tool names as an ordered list (MCP's
+        ``tools/list`` ordering preserved).
+        """
+        session = await self._ensure_connected()
+        result = await session.list_tools()
+        return [tool.name for tool in result.tools]
+
     async def close(self) -> None:
         """Close the SSE connection if open."""
         if self._exit_stack is not None:

--- a/src/influx/probes.py
+++ b/src/influx/probes.py
@@ -18,8 +18,10 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
 import os
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -31,9 +33,37 @@ __all__ = [
     "ProbeResult",
     "ProbeState",
     "ProbeLoop",
+    "ToolLister",
+    "REQUIRED_LCMA_TOOLS",
 ]
 
+logger = logging.getLogger(__name__)
+
 ProbeStatus = Literal["ok", "degraded"]
+
+
+# The five LCMA tools every Influx-compatible Lithos deployment must
+# expose.  Probed at startup + every probe interval; missing tools flip
+# the ``lcma_unknown_tool_failure`` latch so ``Run.execute()`` (and
+# today's ``run_profile``) can skip the run with
+# ``reason="lcma_tools_unavailable"`` — replacing the legacy per-call
+# ``LCMAError("unknown_tool")`` latch (issue #69).
+REQUIRED_LCMA_TOOLS: frozenset[str] = frozenset(
+    {
+        "lithos_retrieve",
+        "lithos_edge_upsert",
+        "lithos_cache_lookup",
+        "lithos_task_create",
+        "lithos_task_complete",
+    }
+)
+
+
+# Async callable returning the tool names the connected Lithos exposes.
+# Wired in production from :meth:`influx.lithos_client.LithosClient.list_tools`.
+# Unit tests inject a stub so the probe behaviour can be exercised
+# without standing up a real MCP transport.
+ToolLister = Callable[[], Awaitable[list[str]]]
 
 
 @dataclass(frozen=True)
@@ -178,6 +208,56 @@ def _probe_lithos(lithos_url: str) -> ProbeResult:
         )
 
 
+async def _probe_lcma_tools(tool_lister: ToolLister | None) -> ProbeResult:
+    """Probe the LCMA tool surface (issue #69).
+
+    Calls the injected *tool_lister* (typically
+    :meth:`LithosClient.list_tools`) and asserts every name in
+    :data:`REQUIRED_LCMA_TOOLS` is present.
+
+    Behaviour:
+    - ``tool_lister is None`` → probe is skipped.  Returns
+      ``status="ok"``, ``detail="skipped"`` so downstream readiness
+      checks treat a probe-less deployment (CLI, tests) the same as a
+      healthy one rather than blocking it.
+    - ``tool_lister`` raises → ``status="degraded"`` with the exception
+      kind in ``detail``.  This subsumes connectivity failures (the
+      existing ``_probe_lithos`` SSE check still runs in parallel and
+      drives the circuit breaker independently).
+    - Tool list missing one or more required names → ``status="degraded"``
+      with the missing names enumerated in ``detail``.
+    - All required names present → ``status="ok"``, ``detail="all
+      required LCMA tools present"``.
+
+    Unlike the previous mid-run latch, the result of this probe is
+    **non-sticky** — every cycle re-evaluates and the latch flips on
+    or off accordingly.
+    """
+    now = time.monotonic()
+    if tool_lister is None:
+        return ProbeResult(status="ok", detail="skipped", timestamp=now)
+    try:
+        tool_names = await tool_lister()
+    except Exception as exc:
+        return ProbeResult(
+            status="degraded",
+            detail=f"tools/list failed: {type(exc).__name__}: {exc}",
+            timestamp=now,
+        )
+    missing = sorted(REQUIRED_LCMA_TOOLS - set(tool_names))
+    if missing:
+        return ProbeResult(
+            status="degraded",
+            detail=f"missing LCMA tools: {', '.join(missing)}",
+            timestamp=now,
+        )
+    return ProbeResult(
+        status="ok",
+        detail="all required LCMA tools present",
+        timestamp=now,
+    )
+
+
 def _probe_llm_credentials(
     providers: dict[str, ProviderConfig],
 ) -> ProbeResult:
@@ -220,6 +300,7 @@ class ProbeLoop:
         *,
         interval: float = 30.0,
         max_age: float | None = None,
+        tool_lister: ToolLister | None = None,
     ) -> None:
         if interval < 30.0:
             raise ValueError("Probe interval must be >= 30 seconds")
@@ -234,9 +315,14 @@ class ProbeLoop:
         # is invoked by a successful sweep.
         self._repair_write_failure = False
         self._repair_write_failure_detail = ""
-        # LCMA unknown_tool failure latch (PRD 08 FR-LCMA-6).
+        # LCMA tools-availability latch (issue #69).  Driven each cycle
+        # by ``_probe_lcma_tools`` — non-sticky.  Replaces the legacy
+        # mid-run ``LCMAError("unknown_tool")`` latch.
         self._lcma_unknown_tool_failure = False
         self._lcma_unknown_tool_failure_detail = ""
+        # Async tool-lister wired by the service factory; ``None`` skips
+        # the LCMA-tools probe (e.g. CLI / tests with no MCP transport).
+        self._tool_lister = tool_lister
         # Consecutive count of degraded Lithos probes (#40 circuit breaker).
         # Reset to 0 on the first ``ok`` probe; ``lithos_circuit_open``
         # returns True once it crosses the configured threshold so the
@@ -252,10 +338,16 @@ class ProbeLoop:
         return self._state
 
     def run_once(self) -> None:
-        """Execute a single probe cycle (synchronous, no scheduling).
+        """Execute the synchronous portion of a probe cycle.
 
-        Useful for tests and for running an initial probe before the
-        background loop starts.
+        Refreshes the Lithos SSE probe + LLM-credentials probe.  The
+        async LCMA-tools probe is **not** run here — its cached latch
+        state is preserved.  Use :meth:`run_once_async` to refresh
+        every probe in one cycle.
+
+        Kept as a sync API for backward compatibility with tests that
+        drive the loop synchronously and for the legacy bootstrap path.
+        Production wiring uses :meth:`run_once_async` via :meth:`start`.
         """
         lithos_result = _probe_lithos(self._config.lithos.url)
         # Update the consecutive-degraded counter (#40 circuit breaker).
@@ -274,6 +366,52 @@ class ProbeLoop:
             lcma_unknown_tool_failure=self._lcma_unknown_tool_failure,
             lcma_unknown_tool_failure_detail=self._lcma_unknown_tool_failure_detail,
         )
+
+    async def run_once_async(self) -> None:
+        """Execute a full probe cycle including the async LCMA-tools probe.
+
+        Drives the LCMA tool-availability latch directly from the
+        probe result — non-sticky.  When ``tool_lister`` is ``None``
+        the LCMA latch state is left at its previous value (typically
+        cleared) so a probe-less deployment never spuriously reports
+        ``lcma_tools_unavailable``.
+        """
+        # Synchronous probes first so the Lithos SSE probe state and
+        # circuit-breaker counter are refreshed before the LCMA-tools
+        # probe runs.  ``_probe_lithos`` also catches transport
+        # failures, so a totally-down Lithos shows up as a degraded
+        # probe before the LCMA-tools probe reports its own failure.
+        self.run_once()
+        if self._tool_lister is not None:
+            lcma_result = await _probe_lcma_tools(self._tool_lister)
+            if lcma_result.status == "degraded":
+                self._lcma_unknown_tool_failure = True
+                self._lcma_unknown_tool_failure_detail = lcma_result.detail
+            else:
+                self._lcma_unknown_tool_failure = False
+                self._lcma_unknown_tool_failure_detail = ""
+            self._state = ProbeState(
+                lithos=self._state.lithos,
+                llm_credentials=self._state.llm_credentials,
+                max_age=self._max_age,
+                repair_write_failure=self._repair_write_failure,
+                repair_write_failure_detail=self._repair_write_failure_detail,
+                lcma_unknown_tool_failure=self._lcma_unknown_tool_failure,
+                lcma_unknown_tool_failure_detail=(
+                    self._lcma_unknown_tool_failure_detail
+                ),
+            )
+
+    def lcma_tools_unavailable(self) -> bool:
+        """Return ``True`` when the latest probe found the LCMA surface missing.
+
+        The scheduler / Run module consults this before kicking off
+        the body; when set, the run is recorded as ``skipped`` with
+        ``reason="lcma_tools_unavailable"`` and no source-fetch /
+        write work is done.  The latch is non-sticky — the next
+        probe cycle re-evaluates from a fresh ``tools/list`` call.
+        """
+        return self._lcma_unknown_tool_failure
 
     @property
     def lithos_unhealthy_consecutive(self) -> int:
@@ -323,39 +461,14 @@ class ProbeLoop:
         self._state.repair_write_failure = False
         self._state.repair_write_failure_detail = ""
 
-    def mark_lcma_unknown_tool_failure(
-        self,
-        *,
-        profile: str = "",
-        detail: str = "",
-    ) -> None:
-        """Latch an LCMA unknown_tool failure (PRD 08, FR-LCMA-6).
-
-        Called by ``run_profile`` when ``LCMAError("unknown_tool")``
-        propagates from an LCMA-dependent call.  Flips
-        ``ProbeState.lcma_unknown_tool_failure`` so ``/ready`` reports
-        degraded.
-        """
-        self._lcma_unknown_tool_failure = True
-        self._lcma_unknown_tool_failure_detail = detail or f"profile={profile!r}"
-        self._state.lcma_unknown_tool_failure = True
-        self._state.lcma_unknown_tool_failure_detail = (
-            self._lcma_unknown_tool_failure_detail
-        )
-
-    def clear_lcma_unknown_tool_failure(self) -> None:
-        """Clear the LCMA unknown_tool failure latch."""
-        self._lcma_unknown_tool_failure = False
-        self._lcma_unknown_tool_failure_detail = ""
-        self._state.lcma_unknown_tool_failure = False
-        self._state.lcma_unknown_tool_failure_detail = ""
-
     async def start(self) -> None:
         """Start the background probe loop as an ``asyncio.Task``."""
         if self._task is not None:
             return
-        # Run one probe cycle immediately so state is populated.
-        self.run_once()
+        # Run one full probe cycle (including the async LCMA-tools
+        # probe) so the latch state is populated before any HTTP
+        # handler reads ``/ready``.
+        await self.run_once_async()
         self._task = asyncio.create_task(self._loop())
 
     async def stop(self) -> None:
@@ -368,7 +481,7 @@ class ProbeLoop:
         self._task = None
 
     async def _loop(self) -> None:
-        """Internal loop — runs ``run_once()`` at fixed intervals."""
+        """Internal loop — runs a full probe cycle at fixed intervals."""
         while True:
             await asyncio.sleep(self._interval)
-            self.run_once()
+            await self.run_once_async()

--- a/src/influx/scheduler.py
+++ b/src/influx/scheduler.py
@@ -37,7 +37,6 @@ from apscheduler.triggers.cron import CronTrigger
 from influx import metrics
 from influx.config import AppConfig
 from influx.coordinator import Coordinator, ProfileBusyError, RunKind
-from influx.errors import LCMAError
 from influx.feedback import build_negative_examples_block
 from influx.lcma_wiring import CascadeOutput, LcmaWiringDeps
 from influx.lcma_wiring import wire as lcma_wire
@@ -209,6 +208,36 @@ async def run_profile(
         )
         return None
 
+    # #69: skip the run when the LCMA tool surface is unavailable.
+    # Probe-time check replaces the legacy mid-run
+    # ``LCMAError("unknown_tool")`` latch — by the time we get here we
+    # already know the deployment lacks one or more of the five
+    # required LCMA tools, so there is no point starting a body that
+    # will fail on the very first ``lithos_task_create``.
+    if (
+        probe_loop is not None
+        and hasattr(probe_loop, "lcma_tools_unavailable")
+        and probe_loop.lcma_tools_unavailable()
+    ):
+        ledger.start(
+            run_id=run_id,
+            profile=profile,
+            kind=kind.value,
+            run_range=run_range,
+        )
+        ledger.skip(run_id=run_id, reason="lcma_tools_unavailable")
+        metrics.runs_skipped().add(
+            1,
+            {"profile": profile, "reason": "lcma_tools_unavailable"},
+        )
+        logger.warning(
+            "run skipped profile=%s kind=%s run_id=%s reason=lcma_tools_unavailable",
+            profile,
+            kind.value,
+            run_id,
+        )
+        return None
+
     ledger.start(
         run_id=run_id,
         profile=profile,
@@ -352,24 +381,6 @@ async def _run_profile_body(
     provider = item_provider
     profile_cfg = next((p for p in config.profiles if p.name == profile), None)
 
-    def _handle_lcma_unknown_tool(exc: LCMAError, *, fallback_tool: str) -> None:
-        """Log + latch readiness for an LCMA ``unknown_tool`` failure."""
-        tool = getattr(exc, "stage", "") or fallback_tool
-        logger.error(
-            "LCMA deployment error: unknown_tool for %s during profile %r run "
-            "— aborting run. Check that the connected Lithos deployment "
-            "supports the required LCMA tools.",
-            tool,
-            profile,
-        )
-        if probe_loop is not None and hasattr(
-            probe_loop, "mark_lcma_unknown_tool_failure"
-        ):
-            probe_loop.mark_lcma_unknown_tool_failure(
-                profile=profile,
-                detail=f"tool={tool!r}",
-            )
-
     client = LithosClient(url=config.lithos.url, transport=config.lithos.transport)
     try:
         # ── LCMA task bracketing (FR-LCMA-5, FR-BF-5, AC-M2-10) ──
@@ -377,32 +388,24 @@ async def _run_profile_body(
         # run.  The task tag depends on ``kind``:
         #   - scheduled / manual → ``influx:run``
         #   - backfill           → ``influx:backfill``
-        run_task_id: str | None = None
+        # ``LCMAError("unknown_tool")`` is no longer caught locally —
+        # the probe loop's tool-availability check (issue #69) gates
+        # the run before we get here.  A mid-run race is handled by
+        # the next probe cycle re-evaluating the latch.
         task_tag = "influx:backfill" if kind == RunKind.BACKFILL else "influx:run"
         run_date = datetime.now(UTC).date().isoformat()
         task_title = f"Influx run {profile} {run_date}"
-        try:
-            task_result = await client.task_create(
-                title=task_title,
-                agent="influx",
-                tags=[task_tag, f"profile:{profile}"],
-            )
-        except LCMAError as exc:
-            if str(exc) == "unknown_tool":
-                _handle_lcma_unknown_tool(exc, fallback_tool="lithos_task_create")
-            raise
+        task_result = await client.task_create(
+            title=task_title,
+            agent="influx",
+            tags=[task_tag, f"profile:{profile}"],
+        )
         task_body = json.loads(
             task_result.content[0].text  # type: ignore[union-attr]
         )
         run_task_id = str(task_body["task_id"])
 
         # ── Build LCMA wiring deps once per run (issue #54) ─────────
-        lcma_unknown_tool_latch = (
-            probe_loop.mark_lcma_unknown_tool_failure
-            if probe_loop is not None
-            and hasattr(probe_loop, "mark_lcma_unknown_tool_failure")
-            else None
-        )
         lcma_deps = LcmaWiringDeps(
             client=client,
             profile=profile,
@@ -410,7 +413,6 @@ async def _run_profile_body(
             lcma_edge_score=(
                 profile_cfg.thresholds.lcma_edge_score if profile_cfg else 0.75
             ),
-            on_unknown_tool=lcma_unknown_tool_latch,
         )
 
         outcome = "success"
@@ -733,12 +735,6 @@ async def _run_profile_body(
                 run_id=current_run_id.get() or None,
             )
             return result
-        except LCMAError as exc:
-            outcome = "error"
-            body_failed = True
-            if str(exc) == "unknown_tool":
-                _handle_lcma_unknown_tool(exc, fallback_tool="lcma_call")
-            raise
         except Exception:
             outcome = "error"
             body_failed = True
@@ -751,29 +747,20 @@ async def _run_profile_body(
                         agent="influx",
                         outcome=outcome,
                     )
-                except LCMAError as exc:
-                    if str(exc) == "unknown_tool":
-                        _handle_lcma_unknown_tool(
-                            exc, fallback_tool="lithos_task_complete"
-                        )
-                        # Only re-raise from finally when the body did
-                        # not already fail — otherwise the body's
-                        # exception propagates after this block.
-                        if not body_failed:
-                            raise
-                    else:
-                        logger.warning(
-                            "lithos_task_complete failed for profile %r: %s",
-                            profile,
-                            exc,
-                            exc_info=True,
-                        )
                 except Exception:
+                    # ``LCMAError("unknown_tool")`` is no longer caught
+                    # specially — the probe-time gate (#69) keeps it
+                    # off the runtime path in the steady state.  Any
+                    # mid-run race is logged and swallowed here so the
+                    # outer ledger.complete still records the body's
+                    # outcome.
                     logger.warning(
                         "lithos_task_complete failed for profile %r",
                         profile,
                         exc_info=True,
                     )
+                    if not body_failed:
+                        raise
     finally:
         await client.close()
 

--- a/src/influx/service.py
+++ b/src/influx/service.py
@@ -28,6 +28,7 @@ from influx.coordinator import Coordinator, RunKind
 from influx.errors import ConfigError
 from influx.filter import make_default_arxiv_filter_scorer
 from influx.http_api import install_exception_handlers, router
+from influx.lithos_client import LithosClient
 from influx.notifications import ProfileRunResult, dispatch_notifications
 from influx.probes import ProbeLoop
 from influx.run_ledger import RunLedger
@@ -140,7 +141,24 @@ def create_app(
     # scheduler-fired — so that shutdown can await them within
     # ``schedule.shutdown_grace_seconds`` (US-008).
     active_tasks: set[asyncio.Task[Any]] = set()
-    probe_loop = ProbeLoop(config, interval=30.0)
+
+    # Tool-lister opens a transient MCP session per probe cycle and
+    # asks Lithos which tools it exposes (issue #69).  Probing each
+    # cycle keeps the latch non-sticky — the next cycle re-evaluates
+    # so a deployment that adds the missing tools recovers
+    # automatically without an Influx restart.
+    async def _list_lithos_tools() -> list[str]:
+        client = LithosClient(url=config.lithos.url, transport=config.lithos.transport)
+        try:
+            return await client.list_tools()
+        finally:
+            await client.close()
+
+    probe_loop = ProbeLoop(
+        config,
+        interval=30.0,
+        tool_lister=_list_lithos_tools,
+    )
 
     # Production default item provider — drives arXiv + RSS fetch with
     # shared FetchCache for per-fire dedup (R-8 mitigation, AC-09-D).

--- a/tests/integration/test_lcma_edges_end_to_end.py
+++ b/tests/integration/test_lcma_edges_end_to_end.py
@@ -599,24 +599,50 @@ class TestUnknownToolAbort:
         assert len(complete_calls) == 1
         assert complete_calls[0]["outcome"] == "error"
 
-    def test_retrieve_unknown_tool_degrades_readiness(
+    def test_lcma_tools_probe_drives_readiness_latch(
         self,
         fake_lithos: FakeLithosServer,
         fake_lithos_url: str,
     ) -> None:
-        """lithos_retrieve unknown_tool → readiness reports degraded (AC-M2-9)."""
+        """Probe-time tool-availability check drives the readiness latch (#69).
+
+        Replaces the legacy mid-run ``LCMAError("unknown_tool")``
+        latch.  When the probe's injected ``tool_lister`` reports a
+        truncated tool surface, the latch flips and ``Run.execute()``
+        (today: ``run_profile``) skips with
+        ``reason="lcma_tools_unavailable"`` rather than starting a
+        body that will fail on the very first ``lithos_task_create``.
+        """
         config = _make_config(fake_lithos_url)
-        probe_loop = ProbeLoop(config, interval=30.0)
-        probe_loop.run_once()
 
-        # Readiness is ok before the failure.
-        assert probe_loop.state.is_ready is True
+        async def _missing_retrieve_lister() -> list[str]:
+            # Simulates a Lithos that exposes the task tools but is
+            # missing the LCMA edge tools — the realistic deployment
+            # misconfiguration this latch was designed to catch.
+            return [
+                "lithos_write",
+                "lithos_task_create",
+                "lithos_task_complete",
+                "lithos_cache_lookup",
+                "lithos_edge_upsert",
+                # ``lithos_retrieve`` deliberately omitted
+            ]
 
-        fake_lithos.raise_on_retrieve = True
+        probe_loop = ProbeLoop(
+            config,
+            interval=30.0,
+            tool_lister=_missing_retrieve_lister,
+        )
+        asyncio.run(probe_loop.run_once_async())
+
+        assert probe_loop.lcma_tools_unavailable() is True
+        assert probe_loop.state.is_ready is False
+        assert probe_loop.state.overall_status == "degraded"
+        assert "lithos_retrieve" in probe_loop.state.lcma_unknown_tool_failure_detail
 
         items = [
             {
-                "title": "Paper Before Degraded",
+                "title": "Paper Skipped By Latch",
                 "source_url": "https://arxiv.org/abs/2601.00100",
                 "content": "# Summary\nPaper.",
                 "tags": ["profile:ai-robotics", "source:arxiv"],
@@ -625,18 +651,19 @@ class TestUnknownToolAbort:
             }
         ]
 
-        with pytest.raises(LCMAError, match="unknown_tool"):
-            asyncio.run(
-                run_profile(
-                    "ai-robotics",
-                    RunKind.MANUAL,
-                    config=config,
-                    item_provider=_single_item_provider(items),
-                    probe_loop=probe_loop,
-                )
+        # The run is skipped before any tool call — no LCMAError leaks.
+        result = asyncio.run(
+            run_profile(
+                "ai-robotics",
+                RunKind.MANUAL,
+                config=config,
+                item_provider=_single_item_provider(items),
+                probe_loop=probe_loop,
             )
+        )
+        assert result is None
 
-        # Readiness is now degraded.
-        assert probe_loop.state.is_ready is False
-        assert probe_loop.state.overall_status == "degraded"
-        assert probe_loop.state.lcma_unknown_tool_failure is True
+        # No retrieve / edge_upsert / task_complete calls were made.
+        assert _calls_by_tool(fake_lithos.calls, "lithos_retrieve") == []
+        assert _calls_by_tool(fake_lithos.calls, "lithos_edge_upsert") == []
+        assert _calls_by_tool(fake_lithos.calls, "lithos_task_create") == []

--- a/tests/unit/test_lcma_wiring.py
+++ b/tests/unit/test_lcma_wiring.py
@@ -1,13 +1,15 @@
 """Unit tests for the post-write LCMA wiring entry point (issue #54).
 
-Covers the three issue acceptance areas:
+Covers the two acceptance areas that remain after #69 lifted the
+unknown-tool latch out of the per-call path:
 
 - ``related_to`` edge_score threshold honoured by ``lithos_retrieve``
   scoring (FR-LCMA-3, AC-M2-5/6).
 - Tier 3 ``builds_on`` resolution path via ``lithos_cache_lookup``
   (FR-LCMA-4, AC-M2-7/8).
-- Unknown LCMA tool latches the ``lcma_unknown_tool_failure`` flag
-  (FR-LCMA-6) and re-raises so the run aborts.
+
+Mid-run ``LCMAError("unknown_tool")`` propagates as a plain exception
+now; latch flipping happens at probe time (see ``test_probes.py``).
 
 Lower-level retrieve / cache-lookup primitives are exercised in
 ``influx.lcma`` tests; these tests focus on the wiring seam.
@@ -55,14 +57,12 @@ def _make_deps(
     client: AsyncMock,
     *,
     lcma_edge_score: float = 0.75,
-    on_unknown_tool: Any = None,
 ) -> LcmaWiringDeps:
     return LcmaWiringDeps(
         client=client,
         profile="research",
         run_task_id="task-1",
         lcma_edge_score=lcma_edge_score,
-        on_unknown_tool=on_unknown_tool,
     )
 
 
@@ -261,93 +261,39 @@ class TestBuildsOnResolution:
         client.cache_lookup.assert_not_awaited()
 
 
-# ── Unknown LCMA tool latch ────────────────────────────────────────
+# ── LCMA error propagation (post-#69) ──────────────────────────────
 
 
-class TestUnknownToolLatch:
-    """Unknown LCMA tools latch the readiness flag and re-raise."""
+class TestLcmaErrorPropagation:
+    """``LCMAError`` propagates verbatim — no per-call latching here.
+
+    The probe loop drives the ``lcma_unknown_tool_failure`` latch via
+    ``tools/list`` (issue #69); ``wire`` is purely a tools-call seam
+    now.
+    """
 
     @pytest.mark.asyncio
-    async def test_unknown_tool_on_retrieve_latches(self) -> None:
+    async def test_unknown_tool_on_retrieve_propagates(self) -> None:
         client = _make_client()
         client.retrieve = AsyncMock(
             side_effect=LCMAError("unknown_tool", stage="lithos_retrieve")
         )
-        latched: list[dict[str, str]] = []
+        deps = _make_deps(client)
 
-        def fake_latch(*, profile: str, detail: str) -> None:
-            latched.append({"profile": profile, "detail": detail})
-
-        deps = _make_deps(client, on_unknown_tool=fake_latch)
-
-        with pytest.raises(LCMAError):
+        with pytest.raises(LCMAError, match="unknown_tool"):
             await wire(
                 written_note_id="note-new",
                 cascade=CascadeOutput(title="A Paper"),
                 deps=deps,
             )
 
-        assert latched == [
-            {"profile": "research", "detail": "tool='lithos_retrieve'"},
-        ]
-
     @pytest.mark.asyncio
-    async def test_unknown_tool_on_cache_lookup_latches(self) -> None:
-        client = _make_client()
-        client.cache_lookup = AsyncMock(
-            side_effect=LCMAError("unknown_tool", stage="lithos_cache_lookup")
-        )
-        latched: list[dict[str, str]] = []
-
-        def fake_latch(*, profile: str, detail: str) -> None:
-            latched.append({"profile": profile, "detail": detail})
-
-        deps = _make_deps(client, on_unknown_tool=fake_latch)
-
-        with pytest.raises(LCMAError):
-            await wire(
-                written_note_id="note-new",
-                cascade=CascadeOutput(
-                    title="A Paper",
-                    builds_on=["FooNet (arXiv:2412.12345)"],
-                ),
-                deps=deps,
-            )
-
-        assert latched == [
-            {"profile": "research", "detail": "tool='lithos_cache_lookup'"},
-        ]
-
-    @pytest.mark.asyncio
-    async def test_other_lcma_error_is_not_latched(self) -> None:
-        """Non-unknown_tool LCMA errors propagate without latching."""
+    async def test_other_lcma_error_propagates(self) -> None:
         client = _make_client()
         client.retrieve = AsyncMock(
             side_effect=LCMAError("transport refused", stage="http")
         )
-        latched: list[dict[str, str]] = []
-
-        def fake_latch(*, profile: str, detail: str) -> None:
-            latched.append({"profile": profile, "detail": detail})
-
-        deps = _make_deps(client, on_unknown_tool=fake_latch)
-
-        with pytest.raises(LCMAError):
-            await wire(
-                written_note_id="note-new",
-                cascade=CascadeOutput(title="A Paper"),
-                deps=deps,
-            )
-
-        assert latched == []  # no latch for non-unknown_tool error
-
-    @pytest.mark.asyncio
-    async def test_unknown_tool_without_latch_callback_still_reraises(self) -> None:
-        """The latch callback is optional; absence does not swallow the error."""
-        client = _make_client()
-        client.retrieve = AsyncMock(side_effect=LCMAError("unknown_tool"))
-
-        deps = _make_deps(client, on_unknown_tool=None)
+        deps = _make_deps(client)
 
         with pytest.raises(LCMAError):
             await wire(

--- a/tests/unit/test_probes.py
+++ b/tests/unit/test_probes.py
@@ -602,3 +602,99 @@ class TestLithosCircuitBreaker:
         loop.run_once()
         assert loop.lithos_unhealthy_consecutive == 0
         assert loop.lithos_circuit_open() is False
+
+
+# ── LCMA tool-availability probe (issue #69) ────────────────────────
+
+
+class TestLcmaToolsProbe:
+    """Probe-time LCMA tool-availability check (issue #69).
+
+    Replaces the legacy mid-run ``LCMAError("unknown_tool")`` latch
+    with a probe-driven, non-sticky latch flipped from ``tools/list``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_all_required_tools_present_clears_latch(self) -> None:
+        """Tool list containing every required name → latch cleared."""
+        from influx.probes import REQUIRED_LCMA_TOOLS
+
+        async def lister() -> list[str]:
+            return list(REQUIRED_LCMA_TOOLS) + ["lithos_write", "lithos_ping"]
+
+        cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")
+        loop = ProbeLoop(cfg, interval=30.0, tool_lister=lister)
+        await loop.run_once_async()
+
+        assert loop.lcma_tools_unavailable() is False
+        assert loop.state.lcma_unknown_tool_failure is False
+
+    @pytest.mark.asyncio
+    async def test_missing_required_tool_flips_latch(self) -> None:
+        """Tool list missing one required name → latch flips, detail names it."""
+
+        async def lister() -> list[str]:
+            return [
+                "lithos_write",
+                "lithos_task_create",
+                "lithos_task_complete",
+                "lithos_cache_lookup",
+                "lithos_edge_upsert",
+                # ``lithos_retrieve`` deliberately missing
+            ]
+
+        cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")
+        loop = ProbeLoop(cfg, interval=30.0, tool_lister=lister)
+        await loop.run_once_async()
+
+        assert loop.lcma_tools_unavailable() is True
+        assert loop.state.lcma_unknown_tool_failure is True
+        assert "lithos_retrieve" in loop.state.lcma_unknown_tool_failure_detail
+
+    @pytest.mark.asyncio
+    async def test_tools_list_transport_error_flips_latch(self) -> None:
+        """tools/list raising → latch set with degraded detail (transport error)."""
+
+        async def failing_lister() -> list[str]:
+            raise RuntimeError("MCP connection refused")
+
+        cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")
+        loop = ProbeLoop(cfg, interval=30.0, tool_lister=failing_lister)
+        await loop.run_once_async()
+
+        assert loop.lcma_tools_unavailable() is True
+        assert "tools/list failed" in loop.state.lcma_unknown_tool_failure_detail
+
+    @pytest.mark.asyncio
+    async def test_no_tool_lister_skips_probe_and_clears_latch(self) -> None:
+        """``tool_lister=None`` → probe is a no-op, latch stays cleared."""
+        cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")
+        loop = ProbeLoop(cfg, interval=30.0, tool_lister=None)
+        await loop.run_once_async()
+
+        assert loop.lcma_tools_unavailable() is False
+        assert loop.state.lcma_unknown_tool_failure is False
+
+    @pytest.mark.asyncio
+    async def test_latch_recovers_when_tools_become_available(self) -> None:
+        """Non-sticky behaviour: missing → present across cycles re-clears."""
+        from influx.probes import REQUIRED_LCMA_TOOLS
+
+        cycle_state = {"missing_retrieve": True}
+
+        async def lister() -> list[str]:
+            base = list(REQUIRED_LCMA_TOOLS)
+            if cycle_state["missing_retrieve"]:
+                return [t for t in base if t != "lithos_retrieve"]
+            return base
+
+        cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")
+        loop = ProbeLoop(cfg, interval=30.0, tool_lister=lister)
+        await loop.run_once_async()
+        assert loop.lcma_tools_unavailable() is True
+
+        # Deployment fixed mid-flight; next probe cycle clears the latch.
+        cycle_state["missing_retrieve"] = False
+        await loop.run_once_async()
+        assert loop.lcma_tools_unavailable() is False
+        assert loop.state.lcma_unknown_tool_failure is False

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -948,3 +948,66 @@ class TestLithosCircuitBreakerShortCircuit:
         # Either a failed entry or no terminal entry yet — neither
         # should be ``skipped``.
         assert all(e.get("status") != "skipped" for e in entries)
+
+
+class TestLcmaToolsUnavailableShortCircuit:
+    """``run_profile`` skips when the LCMA-tools probe latch is set (#69).
+
+    Probe-time tool-availability check (`lcma_tools_unavailable()`)
+    replaces the legacy mid-run `LCMAError("unknown_tool")` latch.
+    """
+
+    async def test_skips_when_lcma_tools_latch_set(self, tmp_path: Any) -> None:
+        """Latch set → no provider invocation, ledger reflects the skip."""
+        from influx.run_ledger import RunLedger
+
+        config = _make_config(profiles=["staging-robotics"])
+        config = config.model_copy(
+            update={
+                "storage": config.storage.model_copy(
+                    update={"state_dir": str(tmp_path)}
+                )
+            }
+        )
+
+        provider_called = False
+
+        async def spy_provider(
+            profile: str,
+            kind: RunKind,
+            run_range: dict[str, str | int] | None,
+            filter_prompt: str,
+        ) -> list[dict[str, Any]]:
+            nonlocal provider_called
+            provider_called = True
+            return []
+
+        class StubProbeLoop:
+            lithos_unhealthy_consecutive = 0
+
+            def lithos_circuit_open(self, *, threshold: int = 3) -> bool:
+                return False
+
+            def lcma_tools_unavailable(self) -> bool:
+                return True
+
+        ledger = RunLedger(tmp_path)
+        result = await run_profile(
+            "staging-robotics",
+            RunKind.SCHEDULED,
+            config=config,
+            item_provider=spy_provider,
+            probe_loop=StubProbeLoop(),
+            run_ledger=ledger,
+        )
+
+        assert result is None
+        assert provider_called is False, (
+            "LCMA-tools-unavailable latch must short-circuit BEFORE the "
+            "item provider runs — the deployment is misconfigured and any "
+            "lithos_task_create call would fail anyway."
+        )
+        entries = ledger.recent()
+        assert len(entries) == 1
+        assert entries[0]["status"] == "skipped"
+        assert entries[0]["error"] == "lcma_tools_unavailable"


### PR DESCRIPTION
## Summary

- `LithosClient.list_tools()` calls MCP `tools/list` and returns the connected Lithos's tool names
- `ProbeLoop` accepts an injected `tool_lister` callable; new `_probe_lcma_tools` asserts the five required LCMA tools each cycle and flips the (now non-sticky) `lcma_unknown_tool_failure` latch
- `run_profile` gains a probe-time gate alongside `lithos_circuit_open` — `ledger.skip(reason="lcma_tools_unavailable")` when the latch is set
- Deleted four mid-run catch sites in `scheduler.py` + `lcma_wiring.LcmaWiringDeps.on_unknown_tool` + `_maybe_latch_unknown_tool` helper. `LCMAError("unknown_tool")` now propagates verbatim; next probe re-evaluates
- `LCMAError("call_failed")` handling untouched — operational failures still surface as ordinary per-call errors
- Simplifies #58's `Health`-action surface to a single latch (`repair_write_failure`)

## Test plan

- [x] New `tests/unit/test_probes.py::TestLcmaToolsProbe` (5 tests): all required tools present clears latch; missing tool flips latch with detail naming the missing tool; transport error flips latch; no `tool_lister` skips probe; recovery clears latch on next cycle
- [x] New `tests/unit/test_scheduler.py::TestLcmaToolsUnavailableShortCircuit`: latch set short-circuits `run_profile` before provider call; ledger reflects `skipped` / `lcma_tools_unavailable`
- [x] Rewritten `tests/integration/test_lcma_edges_end_to_end.py::test_lcma_tools_probe_drives_readiness_latch`: probe-time tool list omits `lithos_retrieve` → latch flips → `run_profile` skips with no LCMA calls made
- [x] Existing `lcma_wiring` tests updated for the dropped `on_unknown_tool` field
- [x] `uv run ruff check . && uv run ruff format --check . && uv run pyright src/ && uv run pytest tests/ -q` — 1665 tests green

Closes #69