### PR TITLE
refactor: migrate manual runs (POST /runs) to Run module (#59)

### DIFF
--- a/src/influx/scheduler.py
+++ b/src/influx/scheduler.py
@@ -378,13 +378,15 @@ async def _run_profile_body(
     real ledger; when ``None`` the unresolved-collision write is
     skipped (the metric still fires).
 
-    For ``RunKind.SCHEDULED`` (#58) the body delegates to the
-    :class:`influx.run.Run` module — five named stages, typed
-    StageDiagnostics, ``RunAborted``-driven abort path.  Manual and
-    backfill kinds stay on the legacy inline body until #59 / #60
-    migrate them.
+    For ``RunKind.SCHEDULED`` (#58) and ``RunKind.MANUAL`` (#59) the
+    body delegates to the :class:`influx.run.Run` module — five named
+    stages, typed StageDiagnostics, ``RunAborted``-driven abort path.
+    The ``RunPlan`` flag values are identical (``skip_repair=False``,
+    ``skip_cache_hits=False``, ``notify=True``); only ``kind`` differs,
+    which is why one branch handles both.  Backfills stay on the
+    legacy inline body until #60 migrates them.
     """
-    if kind == RunKind.SCHEDULED:
+    if kind in (RunKind.SCHEDULED, RunKind.MANUAL):
         from influx.run import Run, RunDeps, RunPlan
 
         plan = RunPlan(

--- a/tests/integration/test_backfill_exclusion.py
+++ b/tests/integration/test_backfill_exclusion.py
@@ -149,8 +149,10 @@ class TestBackfillExclusion:
         config = _make_config(lithos_url=fake_lithos_url)
         app = _make_app(config)
 
+        # MANUAL runs dispatch through ``influx.run.Run.execute()`` since
+        # #59, so the sweep call lives at the ``influx.run`` binding.
         with patch(
-            "influx.scheduler.repair_sweep",
+            "influx.run.repair_sweep",
             new_callable=AsyncMock,
         ) as mock_sweep:
             with TestClient(app) as tc:
@@ -212,7 +214,7 @@ class TestBackfillExclusion:
         assert app.state.item_provider is not None
 
         with patch(
-            "influx.scheduler.repair_sweep",
+            "influx.run.repair_sweep",
             new_callable=AsyncMock,
         ) as mock_sweep:
             with TestClient(app) as tc:

--- a/tests/integration/test_coordinator_slot.py
+++ b/tests/integration/test_coordinator_slot.py
@@ -185,6 +185,7 @@ class TestCoordinatorSlotIntegration:
 
         with (
             patch("influx.scheduler.repair_sweep", side_effect=_spy_sweep),
+            patch("influx.run.repair_sweep", side_effect=_spy_sweep),
             TestClient(app) as tc,
         ):
             resp = tc.post("/runs", json={"profile": "profile-a"})
@@ -226,7 +227,11 @@ class TestCoordinatorSlotIntegration:
 
         from unittest.mock import patch
 
-        with patch("influx.scheduler.repair_sweep", sweep_mock), TestClient(app) as tc:
+        with (
+            patch("influx.scheduler.repair_sweep", sweep_mock),
+            patch("influx.run.repair_sweep", sweep_mock),
+            TestClient(app) as tc,
+        ):
             resp = tc.post("/runs", json={"profile": "profile-a"})
             assert resp.status_code == 202
             _wait_for_idle(coordinator, "profile-a")
@@ -260,7 +265,11 @@ class TestCoordinatorSlotIntegration:
 
         from unittest.mock import patch
 
-        with patch("influx.scheduler.repair_sweep", sweep_mock), TestClient(app) as tc:
+        with (
+            patch("influx.scheduler.repair_sweep", sweep_mock),
+            patch("influx.run.repair_sweep", sweep_mock),
+            TestClient(app) as tc,
+        ):
             # Launch both profiles.
             resp_a = tc.post("/runs", json={"profile": "profile-a"})
             resp_b = tc.post("/runs", json={"profile": "profile-b"})

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -1031,3 +1031,108 @@ class TestLcmaToolsUnavailableShortCircuit:
         assert len(entries) == 1
         assert entries[0]["status"] == "skipped"
         assert entries[0]["error"] == "lcma_tools_unavailable"
+
+
+class TestManualRunDispatchesToRunModule:
+    """Manual runs (#59) dispatch through ``influx.run.Run.execute()``.
+
+    Replaces the legacy ``_run_profile_body`` inline path for
+    ``RunKind.MANUAL``; the Run module's five-stage executor now owns
+    the body for both scheduled and manual runs.  Backfills stay on
+    the legacy path until #60.
+    """
+
+    async def test_manual_run_routes_through_run_module(self, tmp_path: Any) -> None:
+        """A manual run hits ``influx.run`` bindings, not the legacy body."""
+        from influx.run_ledger import RunLedger
+
+        config = _make_config(profiles=["alpha"])
+        config = config.model_copy(
+            update={
+                "storage": config.storage.model_copy(
+                    update={"state_dir": str(tmp_path)}
+                )
+            }
+        )
+
+        legacy_sweep_called = False
+        run_sweep_called = False
+
+        async def _legacy_sweep(*args: Any, **kwargs: Any) -> list[Any]:
+            nonlocal legacy_sweep_called
+            legacy_sweep_called = True
+            return []
+
+        async def _run_sweep(*args: Any, **kwargs: Any) -> list[Any]:
+            nonlocal run_sweep_called
+            run_sweep_called = True
+            return []
+
+        class _NoopClient:
+            async def close(self) -> None: ...
+
+            async def list_archive_terminal_arxiv_ids(
+                self, *, profile: str
+            ) -> frozenset[str]:
+                return frozenset()
+
+            async def task_create(self, **kwargs: Any) -> Any:
+                import json as _json
+
+                from mcp import types as _mcp_types
+
+                return _mcp_types.CallToolResult(
+                    content=[
+                        _mcp_types.TextContent(
+                            type="text",
+                            text=_json.dumps({"task_id": "manual-task"}),
+                        ),
+                    ],
+                )
+
+            async def task_complete(self, **kwargs: Any) -> Any:
+                import json as _json
+
+                from mcp import types as _mcp_types
+
+                return _mcp_types.CallToolResult(
+                    content=[
+                        _mcp_types.TextContent(
+                            type="text",
+                            text=_json.dumps({"status": "completed"}),
+                        ),
+                    ],
+                )
+
+        async def _empty_neg_block(*args: Any, **kwargs: Any) -> str:
+            return ""
+
+        ledger = RunLedger(tmp_path)
+        with (
+            patch("influx.scheduler.repair_sweep", side_effect=_legacy_sweep),
+            patch("influx.run.repair_sweep", side_effect=_run_sweep),
+            patch("influx.run.LithosClient", return_value=_NoopClient()),
+            patch("influx.scheduler.LithosClient", return_value=_NoopClient()),
+            patch(
+                "influx.run.build_negative_examples_block",
+                side_effect=_empty_neg_block,
+            ),
+            patch("influx.service.post_run_webhook_hook"),
+        ):
+            await run_profile(
+                "alpha",
+                RunKind.MANUAL,
+                config=config,
+                item_provider=None,
+                run_ledger=ledger,
+            )
+
+        # The Run module's repair sweep ran; the legacy scheduler.repair_sweep
+        # was NOT called -- proving the dispatch routed manual runs through
+        # influx.run rather than the legacy inline body.
+        assert run_sweep_called is True, (
+            "Manual runs must dispatch through influx.run.Run.execute()"
+        )
+        assert legacy_sweep_called is False, (
+            "The legacy _run_profile_body path must not run for manual kind"
+        )


### PR DESCRIPTION
## Summary

- `_run_profile_body`'s SCHEDULED dispatch (#58) extended to also route `RunKind.MANUAL` through `influx.run.Run.execute()`
- `RunPlan` flag values identical to scheduled runs (`skip_repair=False`, `skip_cache_hits=False`, `notify=True`); only `kind` differs
- `http_api.py` untouched — POST /runs response shapes (202/409/422), `all_profiles=true` lock acquire/release semantics, and `ProfileBusyError` paths all flow unchanged
- Backfills stay on the legacy inline body until #60 migrates them

## Test plan

- [x] New `tests/unit/test_scheduler.py::TestManualRunDispatchesToRunModule` — patches both `influx.scheduler.repair_sweep` and `influx.run.repair_sweep`, asserts only the latter fires (proving the dispatch routes manual through Run.execute())
- [x] Updated `tests/integration/test_coordinator_slot.py` (3 sites) and `tests/integration/test_backfill_exclusion.py` (2 sites) to patch the new `influx.run.repair_sweep` binding for tests that exercise POST /runs
- [x] All 1676 existing tests still pass; +1 new (1677 total)
- [x] `uv run ruff check . && uv run ruff format --check . && uv run pyright src/ && uv run pytest tests/ -q` — green

Closes #59