### PR TITLE
feat: surface both squatter ids in exhausted slug_collision detail

### DIFF
--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -129,11 +129,61 @@ def _arxiv_id_from_url(source_url: str) -> str | None:
 
 
 def _existing_id_from_detail(detail: str) -> str | None:
-    """Parse ``existing_id=<uuid>`` out of a slug_collision detail string (#30)."""
+    """Parse ``existing_id=<uuid>`` out of a slug_collision detail string (#30).
+
+    Tolerates both the original single-attempt shape
+    ``existing_id=<id>; ...`` and the issue-#32 enriched form
+    ``first_existing_id=<A>; ...; retry_existing_id=<B>; ...`` —
+    in the latter case the retry id wins because it is the squatter
+    that ultimately blocked the write.
+    """
     if not detail:
         return None
+    # Prefer the retry id when the issue-#32 enriched form is present.
+    retry = re.search(r"retry_existing_id=([^\s;,]+)", detail)
+    if retry:
+        return retry.group(1)
     m = _EXISTING_ID_RE.search(detail)
     return m.group(1) if m else None
+
+
+def _format_unresolved_detail(
+    *,
+    first_existing_id: str | None,
+    first_slug: str,
+    retry_existing_id: str | None,
+    retry_slug: str,
+    retry_detail: str,
+) -> str:
+    """Build the issue-#32 detail string enumerating BOTH squatters.
+
+    Format::
+
+        first_existing_id=<A>; first_slug='<unsuffixed>';
+        retry_existing_id=<B>; retry_slug='<suffixed>'; <retry message>
+
+    The retry envelope's human-readable ``message`` (everything after
+    ``existing_id=...; `` in *retry_detail*) is appended verbatim so the
+    operator-facing WARNING still carries Lithos's own diagnostic.
+    Either id may be missing on older Lithos response shapes — emit
+    ``<missing>`` rather than dropping the field so downstream parsers
+    see a stable schema.
+    """
+    parts: list[str] = [
+        f"first_existing_id={first_existing_id or '<missing>'}",
+        f"first_slug='{first_slug}'",
+        f"retry_existing_id={retry_existing_id or '<missing>'}",
+        f"retry_slug='{retry_slug}'",
+    ]
+    # Strip the leading ``existing_id=<id>; `` from retry_detail so the
+    # tail is just Lithos's message, avoiding a duplicated existing_id.
+    tail = retry_detail
+    if tail.startswith("existing_id="):
+        sep = tail.find("; ")
+        tail = tail[sep + 2 :] if sep != -1 else ""
+    if tail:
+        parts.append(tail)
+    return "; ".join(parts)
 
 
 def _doc_tags(doc: dict[str, Any]) -> list[str]:
@@ -646,6 +696,8 @@ class LithosClient:
         """
         from influx import metrics
 
+        first_title = args["title"]
+
         # Round 1: inspect the squatter named in the initial collision.
         recovered = await self._try_recover_collision(
             args,
@@ -660,7 +712,8 @@ class LithosClient:
         # Round 2: the suffix retry collided too.  One more inspection in
         # case the suffixed-slug squatter is itself a reclaimable residue.
         suffix = _extract_slug_suffix(source_url)
-        suffixed_args = {**args, "title": args["title"] + suffix}
+        retry_title = first_title + suffix
+        suffixed_args = {**args, "title": retry_title}
         recovered = await self._try_recover_collision(
             suffixed_args,
             source_url=source_url,
@@ -670,9 +723,28 @@ class LithosClient:
         )
 
         if recovered.status == "slug_collision":
+            # Issue #32: surface BOTH colliding squatters in the final
+            # detail so the operator-facing WARNING / unresolved-collision
+            # backlog enumerates the first AND the retry squatter — not
+            # just the retry's id.  An operator can then clean both with
+            # one command.  The per-attempt envelope details are otherwise
+            # lost because each retry overwrites the previous WriteResult.
+            recovered = dataclasses.replace(
+                recovered,
+                detail=_format_unresolved_detail(
+                    first_existing_id=_existing_id_from_detail(
+                        initial_collision.detail
+                    ),
+                    first_slug=first_title,
+                    retry_existing_id=_existing_id_from_detail(recovered.detail),
+                    retry_slug=retry_title,
+                    retry_detail=recovered.detail,
+                ),
+            )
             logger.warning(
-                "lithos_write slug_collision unresolved after recovery for %s",
+                "lithos_write slug_collision unresolved after recovery for %s: %s",
                 source_url,
+                recovered.detail,
             )
         return recovered
 

--- a/tests/contract/test_lithos_client.py
+++ b/tests/contract/test_lithos_client.py
@@ -1284,13 +1284,15 @@ class TestWriteEnvelopeSlugCollision:
             await client.close()
 
         assert result.status == "slug_collision"
-        # The diagnostic from the *retry* response wins (it is the value
-        # actually returned to the scheduler), and it must include both
-        # the colliding doc id and lithos's human-readable message.
+        # Issue #32: the exhausted-path detail must enumerate BOTH the
+        # first squatter (whose id is otherwise lost on retry) AND the
+        # retry squatter, with their respective titles, so an operator
+        # can clean both with one command.
         assert result.detail
-        assert "doc-squatter-456" in result.detail
-        assert "existing_id=" in result.detail
-        assert "already in use" in result.detail
+        assert "first_existing_id=doc-squatter-123" in result.detail
+        assert "retry_existing_id=doc-squatter-456" in result.detail
+        assert "first_slug='Diagnostic Slug'" in result.detail
+        assert "retry_slug='Diagnostic Slug [arXiv 2601.77777]'" in result.detail
 
 
 class TestWriteSlugCollisionRecovery:
@@ -1531,6 +1533,13 @@ class TestWriteSlugCollisionRecovery:
         assert result.status == "slug_collision"
         # No deletes attempted (both squatters were 'distinct').
         assert all(c[0] != "lithos_delete" for c in fake_lithos_server.calls)
+        # Issue #32: when the recovery chain is exhausted, BOTH squatter
+        # ids must surface in the final detail so an operator can clean
+        # both with one command.
+        assert "first_existing_id=doc-a" in result.detail
+        assert "retry_existing_id=doc-b" in result.detail
+        assert "first_slug='OmniRobotHome'" in result.detail
+        assert "retry_slug='OmniRobotHome [arXiv 2604.28197]'" in result.detail
 
 
 # ── Write envelopes — version_conflict (FR-MCP-7, AC-05-E) ────────

--- a/tests/unit/test_lithos_client.py
+++ b/tests/unit/test_lithos_client.py
@@ -231,3 +231,49 @@ class TestExistingIdParsing:
 
         assert _existing_id_from_detail("") is None
         assert _existing_id_from_detail("no id here") is None
+
+    def test_prefers_retry_id_in_issue32_form(self) -> None:
+        """Issue #32: when both ids are present, return the retry id."""
+        from influx.lithos_client import _existing_id_from_detail
+
+        detail = (
+            "first_existing_id=doc-a; first_slug='Title'; "
+            "retry_existing_id=doc-b; retry_slug='Title [arXiv 1.2]'"
+        )
+        assert _existing_id_from_detail(detail) == "doc-b"
+
+
+class TestUnresolvedDetailFormat:
+    """Issue #32: ``_format_unresolved_detail`` enumerates both squatters."""
+
+    def test_includes_both_ids_and_slugs(self) -> None:
+        from influx.lithos_client import _format_unresolved_detail
+
+        out = _format_unresolved_detail(
+            first_existing_id="doc-a",
+            first_slug="Paper",
+            retry_existing_id="doc-b",
+            retry_slug="Paper [arXiv 1.2]",
+            retry_detail="existing_id=doc-b; Slug 'paper-arxiv-1-2' in use",
+        )
+        assert "first_existing_id=doc-a" in out
+        assert "first_slug='Paper'" in out
+        assert "retry_existing_id=doc-b" in out
+        assert "retry_slug='Paper [arXiv 1.2]'" in out
+        # The retry envelope's human-readable message tail is preserved.
+        assert "Slug 'paper-arxiv-1-2' in use" in out
+        # And not duplicated as a second existing_id.
+        assert out.count("existing_id=doc-b") == 1
+
+    def test_emits_placeholder_when_id_missing(self) -> None:
+        from influx.lithos_client import _format_unresolved_detail
+
+        out = _format_unresolved_detail(
+            first_existing_id=None,
+            first_slug="Paper",
+            retry_existing_id="doc-b",
+            retry_slug="Paper [host]",
+            retry_detail="",
+        )
+        assert "first_existing_id=<missing>" in out
+        assert "retry_existing_id=doc-b" in out


### PR DESCRIPTION
## Summary

- When both the initial write and the suffixed retry hit `slug_collision`, `WriteResult.detail` now enumerates both squatters as `first_existing_id=<A>; first_slug='<unsuffixed>'; retry_existing_id=<B>; retry_slug='<suffixed>'; <retry message>`.
- A single operator-visible WARNING now names every doc that needs cleanup, removing the "second sweep to expose squatter A" cycle from the 2026-05-02 staging incident.
- Threaded through PR #46's recovery chain — only the terminal exhaust-path return is enriched; success/version-conflict branches are unchanged. `_existing_id_from_detail` prefers `retry_existing_id` so single-id consumers (diagnose script, run_ledger backlog) keep seeing the squatter that ultimately blocked the write.

## Test plan

- [x] `make check` — lint + format + pyright clean, 1689 tests pass
- [x] `TestWriteEnvelopeSlugCollision` extended to assert both ids and both slugs in the final detail
- [x] New `TestUnresolvedDetailFormat` covers the formatter helper
- [x] `_existing_id_from_detail` test confirms `retry_existing_id` wins when both keys are present

Closes #32