### PR TITLE
feat: add fetch_stall degraded reason for zero-fetch stalls

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -652,8 +652,9 @@ Run-ledger entries carry a structured `degraded_reasons` field listing why a com
 
 - `"source_acquisition"` — at least one source-fetch failure was swallowed during the run (issue #20).
 - `"ingestion_stall"` — this and the immediately prior scheduled run for the same profile both saw `ingested == 0` despite `sources_checked > 0` (issue #36).  Typical causes: every candidate hit `slug_collision`/`duplicate`, the LLM filter rejected everything, or upstream sources started returning content the profile no longer accepts.  Backfills are excluded from this check (their ingest pattern is fundamentally different — they legitimately ingest 0 when every candidate is a cache hit).
+- `"fetch_stall"` — this and the immediately prior scheduled run for the same profile both saw `sources_checked == 0`, AND the profile has historically seen `sources_checked > 0` within the recent ledger window (issue #50).  Catches the case `ingestion_stall` filters out: nothing reached the inspection loop at all (e.g. too-narrow `lookback_days`, upstream feed shape change).  The historical ratchet silences brand-new profiles and profiles that genuinely never receive items.  Mutually exclusive with `ingestion_stall` (different `sources_checked` conditions).  Backfills are excluded.
 
-Both reasons can apply to a single run.  `influx_ingestion_stall_runs_total{profile}` ticks once per stall-flagged run so dashboards have an alertable counter independent of source-fetch errors.
+Multiple reasons can apply to a single run.  `influx_ingestion_stall_runs_total{profile, reason}` ticks once per stall-flagged run, split by reason so dashboards can alert on each signal independently.
 
 ### 13.2 Telemetry
 
@@ -682,7 +683,7 @@ Metric instruments cover run lifecycle, the source funnel, write outcomes, and f
 | `influx_slug_collision_reclaimed_total` | Counter | _(no labels)_ |
 | `influx_slug_collision_unresolved_total` | Counter | `profile`, `source` |
 | `influx_runs_skipped_total` | Counter | `profile`, `reason` |
-| `influx_ingestion_stall_runs_total` | Counter | `profile` |
+| `influx_ingestion_stall_runs_total` | Counter | `profile`, `reason` (`ingestion_stall` \| `fetch_stall`) |
 
 When `OTEL_EXPORTER_OTLP_ENDPOINT` is set the OTLP HTTP exporter is used. With `INFLUX_OTEL_CONSOLE_FALLBACK=true` and no endpoint configured, both spans and metrics are written to stdout for local development.
 

--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -49,6 +49,13 @@ Three quick signals, all read-only:
     / `duplicate`, the LLM filter rejecting everything, or an
     upstream content shift.  The diagnose row prints the reason
     list so you can triage without parsing the JSON.
+  - `fetch_stall` (issue #50) — this and the prior scheduled run
+    for the same profile both saw `sources_checked == 0` despite
+    historical non-zero fetches in the recent ledger window;
+    typical cause is too-narrow `lookback_days` (nothing reached
+    the inspection loop) or an upstream feed shape change.
+    Mutually exclusive with `ingestion_stall`.  Brand-new profiles
+    are not flagged.
   A `skipped` run (#40) means the Lithos circuit breaker fired:
   ProbeLoop saw 3+ consecutive `degraded` Lithos probes, so the
   scheduler short-circuited to avoid burning LLM tokens against a

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -134,9 +134,10 @@ def _filter_runs(
 def _print_run_row(run: dict[str, Any]) -> None:
     status = run.get("status", "?")
     if run.get("degraded"):
-        # #36: surface the structured degraded_reasons so an operator
-        # immediately sees WHY a run was flagged (source_acquisition vs
-        # ingestion_stall vs both) rather than just ``(degraded)``.
+        # #36 / #50: surface the structured degraded_reasons so an
+        # operator immediately sees WHY a run was flagged
+        # (source_acquisition / ingestion_stall / fetch_stall / a
+        # combination) rather than just ``(degraded)``.
         reasons = run.get("degraded_reasons") or []
         if reasons:
             status = f"{status} (degraded: {','.join(str(r) for r in reasons)})"

--- a/src/influx/metrics.py
+++ b/src/influx/metrics.py
@@ -193,27 +193,38 @@ def archive_missing() -> Any:
 
 
 def ingestion_stalls() -> Any:
-    """Counter of runs flagged ``degraded_reasons=['ingestion_stall']`` (#36).
+    """Counter of runs flagged with a stall ``degraded_reasons`` value.
 
-    Increments once per scheduled run that completes with
-    ``ingested == 0 AND sources_checked > 0`` AND the immediately
-    prior scheduled run for the same profile also matched that
-    shape — i.e. a profile has now seen TWO consecutive
-    inspect-something-but-write-nothing sweeps.
+    Combines the #36 ``ingestion_stall`` and #50 ``fetch_stall``
+    signals on a single instrument, split by the ``reason`` label so
+    dashboards can alert on each independently.
 
-    Typical causes: every candidate hits ``slug_collision`` /
-    ``duplicate``, or the LLM filter is rejecting everything.
-    Sustained non-zero rate is the early-warning signal that
-    ``degraded`` (which today only fires for source-acquisition
-    errors) was missing.
+    ``reason="ingestion_stall"`` (#36): increments once per scheduled
+    run that completes with ``ingested == 0 AND sources_checked > 0``
+    AND the immediately prior scheduled run for the same profile
+    also matched that shape — TWO consecutive
+    inspect-something-but-write-nothing sweeps.  Typical causes: every
+    candidate hits ``slug_collision`` / ``duplicate``, or the LLM
+    filter is rejecting everything.
 
-    Labels: ``profile``.
+    ``reason="fetch_stall"`` (#50): increments once per scheduled run
+    that completes with ``sources_checked == 0`` AND the immediately
+    prior scheduled run for the same profile also saw zero
+    sources_checked AND the profile has historically seen
+    ``sources_checked > 0`` within the recent ledger window.  Typical
+    cause: too-narrow ``lookback_days`` or an upstream feed shape
+    change leaving the inspection loop empty.
+
+    Labels: ``profile``, ``reason``
+    (``"ingestion_stall"`` | ``"fetch_stall"``).
     """
     return get_meter().counter(
         "influx_ingestion_stall_runs_total",
         description=(
-            "scheduled runs flagged ingestion_stall (this and the prior "
-            "scheduled run both inspected items but ingested zero)"
+            "scheduled runs flagged with a stall reason — "
+            "ingestion_stall (two consecutive runs inspected items but "
+            "ingested zero) or fetch_stall (two consecutive runs saw zero "
+            "sources_checked despite prior non-zero history)"
         ),
     )
 

--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -20,6 +20,16 @@ logger = logging.getLogger(__name__)
 
 RunEntry = dict[str, Any]
 
+# How many prior runs to consider when computing the stall flags.
+#
+# Twenty is chosen to roughly match a *day* of scheduled runs at the
+# typical hourly cadence, so the historical-ratchet for #50
+# (``fetch_stall``) tolerates a half-day window of zero fetches before
+# stale history disqualifies the profile from ratcheting.  It also
+# matches the historical default of :meth:`recent` which the
+# ``ingestion_stall`` (#36) check used implicitly.
+_STALL_HISTORY_LIMIT = 20
+
 
 @dataclass(frozen=True)
 class RunLedger:
@@ -92,12 +102,22 @@ class RunLedger:
 
         Returns the structured ``degraded_reasons`` list that was
         recorded — one of: ``[]`` (clean run), ``["source_acquisition"]``
-        (issue #20: swallowed source-fetch failures), or
+        (issue #20: swallowed source-fetch failures),
         ``["ingestion_stall"]`` (issue #36: this and the immediately
         prior scheduled run for the same profile both saw
         ``ingested == 0`` despite ``sources_checked > 0`` — typically a
-        slug-collision squatter, all-duplicate writes, etc.).  When
-        both apply the list contains both reasons.
+        slug-collision squatter, all-duplicate writes, etc.), or
+        ``["fetch_stall"]`` (issue #50: this and the immediately prior
+        scheduled run for the same profile both saw
+        ``sources_checked == 0``, AND the profile has historically seen
+        ``sources_checked > 0`` within the recent window — typically a
+        too-narrow ``lookback_days`` or an upstream feed shape change).
+        When several apply the list contains every reason.
+
+        ``ingestion_stall`` and ``fetch_stall`` are mutually exclusive
+        for any single run: ``ingestion_stall`` requires
+        ``sources_checked > 0`` while ``fetch_stall`` requires
+        ``sources_checked == 0``.
 
         Returning the reasons lets the caller (the scheduler) emit
         per-reason metrics without re-deriving the logic.
@@ -107,29 +127,51 @@ class RunLedger:
         if errors:
             reasons.append("source_acquisition")
 
+        # Resolve profile + kind once for both stall checks.  Both flags
+        # only apply to scheduled runs (backfills legitimately ingest 0
+        # when every candidate is a cache hit, and operator-triggered
+        # manual runs may use a deliberately narrow lookback).
+        active = self._read_active()
+        entry = active.get(run_id, {})
+        profile = entry.get("profile")
+        kind = entry.get("kind")
+        is_scheduled = isinstance(profile, str) and kind == "scheduled"
+
         # #36 ingestion-stall detection: only meaningful when the run
-        # actually inspected something.  Backfills are excluded — they
-        # legitimately ingest 0 when every candidate is a cache hit.
+        # actually inspected something.
         if (
-            isinstance(ingested, int)
+            is_scheduled
+            and isinstance(ingested, int)
             and ingested == 0
             and isinstance(sources_checked, int)
             and sources_checked > 0
         ):
-            # Look up the *currently-active* entry to learn this run's
-            # profile + kind, then count consecutive prior scheduled runs
-            # for the same profile that match the stall shape.  We add
-            # 1 for *this* run since it hasn't been written yet.
-            active = self._read_active()
-            entry = active.get(run_id, {})
-            profile = entry.get("profile")
-            kind = entry.get("kind")
-            if isinstance(profile, str) and kind == "scheduled":
-                consecutive = 1 + self._consecutive_zero_ingestion_runs(
-                    profile=profile, exclude_run_id=run_id
-                )
-                if consecutive >= 2:
-                    reasons.append("ingestion_stall")
+            # Count consecutive prior scheduled runs for the same
+            # profile that match the stall shape.  We add 1 for *this*
+            # run since it hasn't been written yet.
+            assert isinstance(profile, str)  # narrowed by is_scheduled
+            consecutive = 1 + self._consecutive_zero_ingestion_runs(
+                profile=profile, exclude_run_id=run_id
+            )
+            if consecutive >= 2:
+                reasons.append("ingestion_stall")
+
+        # #50 fetch-stall detection: complementary to ingestion_stall.
+        # Catches the zero-fetch case (sources_checked == 0) that #36
+        # explicitly filtered out as a "quiet window".  The
+        # historical-ratchet — profile has previously seen
+        # ``sources_checked > 0`` within the recent ledger window —
+        # silences brand-new profiles and profiles that genuinely never
+        # receive items.
+        if is_scheduled and isinstance(sources_checked, int) and sources_checked == 0:
+            assert isinstance(profile, str)  # narrowed by is_scheduled
+            consecutive_zero_fetch = 1 + self._consecutive_zero_fetch_runs(
+                profile=profile, exclude_run_id=run_id
+            )
+            if consecutive_zero_fetch >= 2 and self._has_prior_non_zero_fetch(
+                profile=profile, exclude_run_id=run_id
+            ):
+                reasons.append("fetch_stall")
 
         self._finish(
             run_id=run_id,
@@ -155,7 +197,7 @@ class RunLedger:
         reason (#36).
         """
         count = 0
-        for prior in self.recent(limit=20, profile=profile):
+        for prior in self.recent(limit=_STALL_HISTORY_LIMIT, profile=profile):
             if prior.get("run_id") == exclude_run_id:
                 continue
             if prior.get("kind") != "scheduled":
@@ -175,6 +217,45 @@ class RunLedger:
                 continue
             break
         return count
+
+    def _consecutive_zero_fetch_runs(self, *, profile: str, exclude_run_id: str) -> int:
+        """Count consecutive prior scheduled runs with ``sources_checked == 0``.
+
+        Walks ``recent()`` newest-first.  Stops at the first scheduled
+        run that doesn't match.  Used by :meth:`complete` to compute the
+        ``fetch_stall`` degraded reason (#50).  Symmetric with
+        :meth:`_consecutive_zero_ingestion_runs`.
+        """
+        count = 0
+        for prior in self.recent(limit=_STALL_HISTORY_LIMIT, profile=profile):
+            if prior.get("run_id") == exclude_run_id:
+                continue
+            if prior.get("kind") != "scheduled":
+                continue
+            sources_checked = prior.get("sources_checked")
+            if isinstance(sources_checked, int) and sources_checked == 0:
+                count += 1
+                continue
+            break
+        return count
+
+    def _has_prior_non_zero_fetch(self, *, profile: str, exclude_run_id: str) -> bool:
+        """Return whether *profile* has ever fetched items in recent history.
+
+        Implements the #50 historical-ratchet: ``fetch_stall`` only
+        fires for profiles that have previously seen
+        ``sources_checked > 0`` within the last ``_STALL_HISTORY_LIMIT``
+        runs.  This silences brand-new profiles (no history at all) and
+        profiles that genuinely never receive items — for them, a
+        run of zero fetches is the steady-state, not a regression.
+        """
+        for prior in self.recent(limit=_STALL_HISTORY_LIMIT, profile=profile):
+            if prior.get("run_id") == exclude_run_id:
+                continue
+            sources_checked = prior.get("sources_checked")
+            if isinstance(sources_checked, int) and sources_checked > 0:
+                return True
+        return False
 
     def fail(self, *, run_id: str, error: str) -> None:
         """Mark an active run as failed and append it to history."""

--- a/src/influx/run_service.py
+++ b/src/influx/run_service.py
@@ -161,13 +161,30 @@ async def ledger_lifecycle(
         )
         run_outcome = "degraded" if source_errors else "success"
         if "ingestion_stall" in degraded_reasons:
-            metrics.ingestion_stalls().add(1, {"profile": profile})
+            metrics.ingestion_stalls().add(
+                1, {"profile": profile, "reason": "ingestion_stall"}
+            )
             if run_outcome == "success":
                 run_outcome = "degraded"
             logger.warning(
                 "run flagged ingestion_stall profile=%s kind=%s run_id=%s "
                 "(this + prior scheduled run both ingested 0 with "
                 "sources_checked > 0)",
+                profile,
+                plan.kind.value,
+                run_id,
+            )
+        if "fetch_stall" in degraded_reasons:
+            metrics.ingestion_stalls().add(
+                1, {"profile": profile, "reason": "fetch_stall"}
+            )
+            if run_outcome == "success":
+                run_outcome = "degraded"
+            logger.warning(
+                "run flagged fetch_stall profile=%s kind=%s run_id=%s "
+                "(this + prior scheduled run both saw sources_checked == 0 "
+                "despite prior non-zero history — likely too-narrow "
+                "lookback_days or upstream feed change)",
                 profile,
                 plan.kind.value,
                 run_id,

--- a/tests/unit/test_run_ledger.py
+++ b/tests/unit/test_run_ledger.py
@@ -386,3 +386,125 @@ def test_combined_source_acquisition_and_stall(tmp_path: Path) -> None:
         source_acquisition_errors=[{"source": "arxiv", "kind": "x", "detail": "y"}],
     )
     assert reasons == ["source_acquisition", "ingestion_stall"]
+
+
+# ── #50: fetch-stall detection (zero sources_checked) ───────────────
+
+
+def test_two_consecutive_zero_fetch_runs_after_history_flag_fetch_stall(
+    tmp_path: Path,
+) -> None:
+    """Two consecutive zero-fetch runs after non-zero history → fetch_stall.
+
+    The historical-ratchet means the profile has previously seen
+    ``sources_checked > 0``, so the silence is degenerate, not just a
+    brand-new profile that hasn't started fetching yet.
+    """
+    ledger = RunLedger(tmp_path / "state")
+    # Seed history: a normal run that did inspect items.
+    _start_complete(ledger, run_id="r-0", profile="p", sources_checked=5, ingested=2)
+    # Two consecutive zero-fetch sweeps.
+    _start_complete(ledger, run_id="r-1", profile="p", sources_checked=0, ingested=0)
+    reasons = _start_complete(
+        ledger, run_id="r-2", profile="p", sources_checked=0, ingested=0
+    )
+    assert reasons == ["fetch_stall"]
+    entry = ledger.recent()[0]
+    assert entry["degraded"] is True
+    assert entry["degraded_reasons"] == ["fetch_stall"]
+
+
+def test_two_consecutive_zero_fetch_with_no_history_does_not_flag(
+    tmp_path: Path,
+) -> None:
+    """Brand-new profile with no prior non-zero sources_checked → no flag.
+
+    The ratchet exists precisely to silence this case: if the profile
+    has never had a non-zero fetch in the recent ledger window, we
+    can't distinguish "broken lookback" from "new profile coming online".
+    """
+    ledger = RunLedger(tmp_path / "state")
+    _start_complete(ledger, run_id="r-1", profile="p", sources_checked=0, ingested=0)
+    reasons = _start_complete(
+        ledger, run_id="r-2", profile="p", sources_checked=0, ingested=0
+    )
+    assert reasons == []
+    entry = ledger.recent()[0]
+    assert entry["degraded"] is False
+    assert entry["degraded_reasons"] == []
+
+
+def test_fetch_stall_and_ingestion_stall_are_mutually_exclusive(
+    tmp_path: Path,
+) -> None:
+    """A single run can't be both — different sources_checked conditions.
+
+    ``ingestion_stall`` requires ``sources_checked > 0`` while
+    ``fetch_stall`` requires ``sources_checked == 0``; mutually
+    exclusive by construction.
+    """
+    ledger = RunLedger(tmp_path / "state")
+    # Seed history so fetch_stall ratchet would be satisfied.
+    _start_complete(ledger, run_id="r-0", profile="p", sources_checked=5, ingested=2)
+    # Two consecutive zero-fetch runs → fetch_stall, not ingestion_stall.
+    _start_complete(ledger, run_id="r-1", profile="p", sources_checked=0, ingested=0)
+    reasons_fetch = _start_complete(
+        ledger, run_id="r-2", profile="p", sources_checked=0, ingested=0
+    )
+    assert "fetch_stall" in reasons_fetch
+    assert "ingestion_stall" not in reasons_fetch
+
+    # And vice versa: two consecutive zero-ingest (with sources_checked > 0)
+    # runs → ingestion_stall, not fetch_stall.
+    _start_complete(ledger, run_id="r-3", profile="q", sources_checked=5, ingested=0)
+    reasons_ingest = _start_complete(
+        ledger, run_id="r-4", profile="q", sources_checked=4, ingested=0
+    )
+    assert reasons_ingest == ["ingestion_stall"]
+    assert "fetch_stall" not in reasons_ingest
+
+
+def test_single_zero_fetch_run_is_not_yet_a_fetch_stall(tmp_path: Path) -> None:
+    """One zero-fetch run alone (even with history) doesn't flag — needs two."""
+    ledger = RunLedger(tmp_path / "state")
+    _start_complete(ledger, run_id="r-0", profile="p", sources_checked=5, ingested=2)
+    reasons = _start_complete(
+        ledger, run_id="r-1", profile="p", sources_checked=0, ingested=0
+    )
+    assert reasons == []
+
+
+def test_fetch_stall_streak_resets_on_non_zero_fetch(tmp_path: Path) -> None:
+    """A run that fetched anything resets the fetch-stall streak."""
+    ledger = RunLedger(tmp_path / "state")
+    _start_complete(ledger, run_id="r-0", profile="p", sources_checked=5, ingested=2)
+    _start_complete(ledger, run_id="r-1", profile="p", sources_checked=0, ingested=0)
+    _start_complete(ledger, run_id="r-2", profile="p", sources_checked=3, ingested=1)
+    reasons = _start_complete(
+        ledger, run_id="r-3", profile="p", sources_checked=0, ingested=0
+    )
+    # r-3 is the first zero-fetch after a non-zero one; not yet a stall.
+    assert reasons == []
+
+
+def test_fetch_stall_does_not_apply_to_backfills(tmp_path: Path) -> None:
+    """Backfills are excluded from fetch_stall (mirrors ingestion_stall)."""
+    ledger = RunLedger(tmp_path / "state")
+    _start_complete(ledger, run_id="r-0", profile="p", sources_checked=5, ingested=2)
+    _start_complete(
+        ledger,
+        run_id="r-1",
+        profile="p",
+        kind="backfill",
+        sources_checked=0,
+        ingested=0,
+    )
+    reasons = _start_complete(
+        ledger,
+        run_id="r-2",
+        profile="p",
+        kind="backfill",
+        sources_checked=0,
+        ingested=0,
+    )
+    assert reasons == []


### PR DESCRIPTION
## Summary

- Broadens ingestion-stall detection to also catch the zero-fetch case (`sources_checked == 0`) that bit `staging-ai` on 2026-05-02 — 4 consecutive sweeps with zero fetches went undetected.
- `RunLedger.complete` now emits `fetch_stall` when this and the prior scheduled run both saw `sources_checked == 0` AND the profile has historically had non-zero fetches in the last 20 runs (avoids flagging brand-new profiles that are still ramping up).
- `influx_ingestion_stall_runs_total` gains a `reason` label (`ingestion_stall` | `fetch_stall`).
- Diagnose `failures` view surfaces both reasons via the existing `degraded_reasons` join.

## Breaking-change note

Adding the `reason` label is a Prometheus selector-breaking change for any external dashboards querying the bare `influx_ingestion_stall_runs_total` metric — they'll need to rewrite to `influx_ingestion_stall_runs_total{reason="ingestion_stall"}` to preserve original semantics. No in-repo dashboards reference this metric.

## Test plan

- [x] `make check` — lint + format + pyright clean, 1692 tests pass
- [x] Two-consecutive zero-fetch with prior non-zero history → `fetch_stall`
- [x] Two-consecutive zero-fetch with no prior non-zero history → no flag (new profile)
- [x] `fetch_stall` and `ingestion_stall` mutually exclusive on the same run
- [x] Plus reinforcing tests: single-zero, streak-reset, backfill-excluded
- [x] `docs/SPECIFICATION.md` and `docs/operations/staging-runbook.md` updated

Closes #50