### PR TITLE
feat: add --id flag to diagnose squatters subcommand

### DIFF
--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -718,6 +718,77 @@ def _is_doc_not_found(message: str) -> bool:
     return "document not found" in needle or "doc_not_found" in needle
 
 
+def _make_lithos_client(url: str) -> Any:
+    """Construct a ``LithosClient`` for the given URL.
+
+    Indirected through this thin factory so unit tests can monkeypatch
+    the construction without having to install ``mcp`` (the transitive
+    dep that ``influx.lithos_client`` pulls in).  Production callers
+    use the factory the same way as a direct construction; the import
+    is local so the factory itself stays cheap to call from the
+    read-only paths that ``_ensure_project_runtime_or_reexec`` re-execs
+    for.
+    """
+    from influx.lithos_client import LithosClient
+
+    return LithosClient(url=url)
+
+
+def _squatters_from_id_list(ids: Iterable[str]) -> dict[str, dict[str, Any]]:
+    """Build a ``squatters``-shaped dict from a flat list of doc ids.
+
+    Mirrors the dict ``_extract_squatters_from_logs`` returns but with
+    empty metadata: when the operator passes ``--id`` we have no log
+    context, so the slug / source_url / title fields are empty.  This
+    is the seam that lets ``cmd_squatters`` dispatch identically to
+    the log-scan and the ``--id`` paths once a candidate set exists.
+
+    Repeated ids collapse into a single entry — operators sometimes
+    paste the same id twice from a backlog list.
+    """
+    out: dict[str, dict[str, Any]] = {}
+    for doc_id in ids:
+        if doc_id in out:
+            continue
+        out[doc_id] = {
+            "doc_id": doc_id,
+            "slugs": [],
+            "source_urls": set(),
+            "titles": set(),
+            "first_seen": "",
+            "last_seen": "",
+            "count": 0,
+        }
+    return out
+
+
+async def _preview_squatter_by_id(
+    *,
+    lithos_url: str,
+    doc_id: str,
+) -> tuple[str, dict[str, Any] | None, str]:
+    """Read-only preview helper for the ``--id`` dry-run path.
+
+    Returns ``(outcome, doc_or_none, reason)`` where ``outcome`` is
+    one of :data:`DELETE_OK` (doc fetched, dry-run), :data:`DELETE_ALREADY_GONE`
+    (doc already deleted), or :data:`DELETE_REFUSED` (read failed for
+    another reason).  The doc dict (if any) is returned so the caller
+    can render the operator-facing preview without re-fetching.
+    """
+    client = _make_lithos_client(lithos_url)
+    try:
+        try:
+            doc = await client.read_note(note_id=doc_id)
+        except BaseException as exc:  # noqa: BLE001
+            chain = _format_exception_chain(exc)
+            if _is_doc_not_found(chain):
+                return DELETE_ALREADY_GONE, None, "doc not found at read time"
+            return DELETE_REFUSED, None, f"read failed: {chain}"
+        return DELETE_OK, doc, "doc read"
+    finally:
+        await client.close()
+
+
 async def _delete_squatter(
     *,
     lithos_url: str,
@@ -733,9 +804,7 @@ async def _delete_squatter(
     :func:`_ensure_project_runtime_or_reexec` first — see
     ``cmd_squatters``.
     """
-    from influx.lithos_client import LithosClient
-
-    client = LithosClient(url=lithos_url)
+    client = _make_lithos_client(lithos_url)
     try:
         try:
             doc = await client.read_note(note_id=doc_id)
@@ -792,72 +861,154 @@ async def _delete_squatter(
         await client.close()
 
 
+def _print_id_preview(doc_id: str, doc: dict[str, Any] | None, reason: str) -> None:
+    """Render a one-screen preview line for a ``--id`` dry-run candidate.
+
+    Surfaces title, tags, and source_url (the four operator signals
+    from the acceptance criteria) plus the planned deletion command.
+    """
+    print(f"SQUATTER doc_id={doc_id}")
+    if doc is None:
+        print(f"   read failed: {reason}")
+        return
+    title = str(doc.get("title") or "(no title)")
+    source_url = str(doc.get("source_url") or "")
+    tags = list(doc.get("tags") or [])
+    has_influx_tag = "ingested-by:influx" in tags
+    print(f"   title={title!r}")
+    if source_url:
+        print(f"   source_url={source_url}")
+    print(f"   tags={tags}")
+    if not has_influx_tag:
+        print(
+            "   WARNING: missing 'ingested-by:influx' tag — "
+            "delete will be REFUSED unless --no-require-influx-authored is set"
+        )
+
+
 def cmd_squatters(args: argparse.Namespace) -> int:
     env = _load_env(args.env)
     container = _container_name(env)
 
-    records = list(
-        _filter_log_records(
-            _docker_logs_iter(container, since=args.since, tail=args.tail),
-            levels={"WARNING"},
-            message_substr="slug_collision",
+    # ── Candidate-set seam ──
+    # Two ways to reach the read-then-delete pipeline:
+    #   1. ``--id <doc-id>`` (issue #34): direct, no docker scan.
+    #   2. log scan: original path, parses ``slug_collision`` WARNINGs.
+    # Both produce the same dict shape, so the apply path below is shared.
+    id_list = list(getattr(args, "id", None) or [])
+    via_id_flag = bool(id_list)
+
+    if via_id_flag:
+        squatters = _squatters_from_id_list(id_list)
+    else:
+        records = list(
+            _filter_log_records(
+                _docker_logs_iter(container, since=args.since, tail=args.tail),
+                levels={"WARNING"},
+                message_substr="slug_collision",
+            )
         )
-    )
-    squatters = _extract_squatters_from_logs(records)
+        squatters = _extract_squatters_from_logs(records)
 
     if not squatters:
+        # Only reachable on the log-scan path (``--id`` always seeds at
+        # least one candidate).  Keep the exact wording so the existing
+        # operator runbook stays accurate.
         print(
             f"No slug_collision squatters found in container {container!r} "
             f"(window: --since {args.since} --tail {args.tail})."
         )
         return 0
 
-    print(
-        f"{len(squatters)} squatter(s) found in container {container!r} "
-        f"(window: --since {args.since} --tail {args.tail}):\n"
-    )
-    # Sorted by last_seen desc so the freshest pain is at the top.
-    ordered = sorted(
-        squatters.values(),
-        key=lambda e: str(e.get("last_seen") or ""),
-        reverse=True,
-    )
-    for entry in ordered:
-        _print_squatter(entry)
-        print()
+    if not via_id_flag:
+        print(
+            f"{len(squatters)} squatter(s) found in container {container!r} "
+            f"(window: --since {args.since} --tail {args.tail}):\n"
+        )
+        # Sorted by last_seen desc so the freshest pain is at the top.
+        ordered = sorted(
+            squatters.values(),
+            key=lambda e: str(e.get("last_seen") or ""),
+            reverse=True,
+        )
+        for entry in ordered:
+            _print_squatter(entry)
+            print()
 
+    # ── Read-only paths ──
     if not args.apply:
+        if via_id_flag:
+            # Operator passed ``--id`` without ``--apply`` — fetch each
+            # doc via ``lithos_read`` and surface the preview signals
+            # plus the planned deletion command, per acceptance criteria.
+            _ensure_project_runtime_or_reexec()
+            lithos_url = _read_lithos_url(args, env)
+            print(
+                f"Read-only preview for {len(squatters)} doc-id(s) via "
+                f"lithos_read on {lithos_url}:\n"
+            )
+
+            import asyncio
+
+            for doc_id in sorted(squatters.keys()):
+                outcome, doc, reason = asyncio.run(
+                    _preview_squatter_by_id(
+                        lithos_url=lithos_url,
+                        doc_id=doc_id,
+                    )
+                )
+                _print_id_preview(doc_id, doc, reason)
+                if outcome == DELETE_ALREADY_GONE:
+                    print(f"   note: {reason}")
+                print()
+            print(
+                "To delete the docs above, re-run with:\n"
+                "    --apply --id <doc-id>      (repeatable; no extra --yes needed)\n"
+                "Pre-delete safety: each doc is fetched and its tags checked to\n"
+                "ensure it carries 'ingested-by:influx' before deletion."
+            )
+            return 0
+
         print(
             "Default mode is read-only.  To delete a squatter, re-run with:\n"
             "    --apply --yes <doc-id>     (per-id confirmation, repeatable)\n"
+            "    --apply --id <doc-id>      (skip log scan, repeatable)\n"
             "    --apply --yes-to-all       (delete every squatter listed above)\n"
             "Pre-delete safety: each doc is fetched and its tags checked to\n"
             "ensure it carries 'ingested-by:influx' before deletion."
         )
         return 0
 
+    # ── Apply path ──
     # ``--apply`` needs the project deps (LithosClient → mcp).  Re-exec
     # under ``uv run`` if we are not already in the project venv so the
     # operator can keep using the bare ``./scripts/influx-diagnose.py``
     # invocation without thinking about the runtime.
     _ensure_project_runtime_or_reexec()
 
-    confirmed: set[str] = set(args.yes or [])
-    if args.yes_to_all:
-        confirmed.update(squatters.keys())
-    if not confirmed:
-        sys.exit(
-            "--apply requires at least one --yes <doc-id> (or --yes-to-all).  Aborted."
-        )
-    unknown = confirmed - set(squatters.keys())
-    if unknown:
-        print(
-            "Warning: --yes ids not present in the log scan results: "
-            + ", ".join(sorted(unknown))
-        )
-        confirmed -= unknown
-    if not confirmed:
-        sys.exit("No matching --yes ids; nothing to delete.")
+    if via_id_flag:
+        # Per issue #34: ``--apply --id <X>`` already names the doc to
+        # delete; no additional ``--yes <X>`` is required.  The id list
+        # is already the confirmed set.
+        confirmed: set[str] = set(squatters.keys())
+    else:
+        confirmed = set(args.yes or [])
+        if args.yes_to_all:
+            confirmed.update(squatters.keys())
+        if not confirmed:
+            sys.exit(
+                "--apply requires at least one --yes <doc-id> "
+                "(or --yes-to-all, or --id <doc-id>).  Aborted."
+            )
+        unknown = confirmed - set(squatters.keys())
+        if unknown:
+            print(
+                "Warning: --yes ids not present in the log scan results: "
+                + ", ".join(sorted(unknown))
+            )
+            confirmed -= unknown
+        if not confirmed:
+            sys.exit("No matching --yes ids; nothing to delete.")
 
     lithos_url = _read_lithos_url(args, env)
     print(
@@ -893,7 +1044,7 @@ def cmd_squatters(args: argparse.Namespace) -> int:
 
     print()
     print(f"Summary: deleted={deleted} already_gone={already_gone} refused={refused}")
-    if already_gone:
+    if already_gone and not via_id_flag:
         print(
             "Note: 'already gone' squatters are still surfacing because the "
             "log scan reads historical WARNINGs from the docker buffer; the "
@@ -1079,7 +1230,7 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help=(
             "actually delete squatters (default: dry-run / log scan only). "
-            "Must be combined with --yes <doc-id> or --yes-to-all."
+            "Must be combined with --yes <doc-id>, --yes-to-all, or --id."
         ),
     )
     p_squatters.add_argument(
@@ -1088,7 +1239,20 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="DOC_ID",
         help=(
             "confirm deletion of a specific squatter (repeatable). "
-            "Required with --apply unless --yes-to-all is set."
+            "Required with --apply unless --yes-to-all or --id is set."
+        ),
+    )
+    p_squatters.add_argument(
+        "--id",
+        action="append",
+        metavar="DOC_ID",
+        help=(
+            "act on a known squatter doc-id directly, bypassing the docker "
+            "log scan (repeatable; no --since/--tail required).  Without "
+            "--apply, fetches the doc via lithos_read and reports a preview.  "
+            "With --apply, deletes after the existing safety check.  "
+            "--id <X> is treated as both 'list this id' and 'confirm "
+            "deletion of X'; no additional --yes <X> is required."
         ),
     )
     p_squatters.add_argument(

--- a/tests/unit/test_diagnose_squatters.py
+++ b/tests/unit/test_diagnose_squatters.py
@@ -9,9 +9,11 @@ operator use.
 
 from __future__ import annotations
 
+import argparse
 import importlib.util
 from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock, patch
 
 
 def _load_script() -> Any:
@@ -421,3 +423,324 @@ class TestSlugCollisionBacklog:
         )
         entries = _DIAGNOSE._read_slug_collision_backlog(tmp_path)
         assert [e["title"] for e in entries] == ["ok", "also ok"]
+
+
+# ── ``--id`` flag (issue #34) ───────────────────────────────────────
+
+
+def _squatters_args(
+    *,
+    ids: list[str] | None = None,
+    apply: bool = False,
+    yes: list[str] | None = None,
+    yes_to_all: bool = False,
+    no_require_influx_authored: bool = False,
+) -> argparse.Namespace:
+    """Build a Namespace shaped like ``squatters`` argparse output.
+
+    Covers every attribute ``cmd_squatters`` reads so a test can
+    drive the subcommand without pulling in the real argparse setup.
+    """
+    return argparse.Namespace(
+        env="staging",
+        since="7d",
+        tail=50000,
+        apply=apply,
+        yes=yes,
+        yes_to_all=yes_to_all,
+        agent="influx-diagnose",
+        lithos_url="http://test.invalid:8765/sse",
+        no_require_influx_authored=no_require_influx_authored,
+        id=ids,
+    )
+
+
+def _docker_call_forbidden(*args: Any, **kwargs: Any) -> Any:
+    """Helper that fails the test if docker is reached when --id is set."""
+    raise AssertionError(
+        "docker logs should not be invoked when --id is provided; "
+        "--id must bypass the log scan entirely (issue #34 acceptance)"
+    )
+
+
+class TestSquattersFromIdList:
+    """``--id`` builds a candidates dict bypassing the log-scan."""
+
+    def test_returns_one_entry_per_id(self) -> None:
+        result = _DIAGNOSE._squatters_from_id_list(
+            ["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "bb"]
+        )
+        assert set(result.keys()) == {
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "bb",
+        }
+
+    def test_dedupes_repeated_ids(self) -> None:
+        # ``--id X --id X`` should not produce two entries
+        result = _DIAGNOSE._squatters_from_id_list(["dup", "dup"])
+        assert list(result.keys()) == ["dup"]
+
+    def test_entry_has_doc_id_and_empty_metadata(self) -> None:
+        result = _DIAGNOSE._squatters_from_id_list(["x"])
+        entry = result["x"]
+        assert entry["doc_id"] == "x"
+        # The log-scan path populates these from log records; the --id
+        # path has no log context, so they should be empty (not absent).
+        assert entry.get("slugs") == []
+        assert entry.get("source_urls") == set()
+        assert entry.get("titles") == set()
+
+
+class TestCmdSquattersIdFlagDryRun:
+    """``--id`` without ``--apply`` previews via ``LithosClient.read_note``.
+
+    Acceptance criterion: read-only ``--id`` performs ``lithos_read`` and
+    reports title/tags/source_url plus the planned deletion command.
+    No docker log scan is performed.
+    """
+
+    def test_dry_run_calls_read_note_and_skips_docker(
+        self, monkeypatch: Any, capsys: Any
+    ) -> None:
+        # Hard-fail if docker is touched at all.
+        monkeypatch.setattr(_DIAGNOSE, "_docker_logs_iter", _docker_call_forbidden)
+        monkeypatch.setattr(_DIAGNOSE, "_load_env", lambda _name: {})
+        monkeypatch.setattr(_DIAGNOSE, "_container_name", lambda _env: "influx-test")
+        monkeypatch.setattr(
+            _DIAGNOSE, "_read_lithos_url", lambda _args, _env: "http://t/sse"
+        )
+
+        # Build a mock client whose ``read_note`` returns a doc shape.
+        mock_client = AsyncMock()
+        mock_client.read_note.return_value = {
+            "id": "doc-X",
+            "title": "Squatting Paper",
+            "tags": ["ingested-by:influx", "source:arxiv"],
+            "source_url": "https://example.test/abs/1",
+        }
+        mock_client.close = AsyncMock()
+
+        # Patch the LithosClient symbol used by the dry-run preview.
+        with patch.object(_DIAGNOSE, "_make_lithos_client", return_value=mock_client):
+            args = _squatters_args(ids=["doc-X"], apply=False)
+            rc = _DIAGNOSE.cmd_squatters(args)
+
+        assert rc == 0
+        mock_client.read_note.assert_awaited_once_with(note_id="doc-X")
+        out = capsys.readouterr().out
+        # Operator-facing preview must surface the four signals from the
+        # acceptance criteria (title, tags, source_url) plus the planned
+        # deletion command.
+        assert "doc-X" in out
+        assert "Squatting Paper" in out
+        assert "ingested-by:influx" in out
+        assert "https://example.test/abs/1" in out
+        assert "--apply" in out and "--id" in out
+
+    def test_dry_run_with_multiple_ids_calls_read_note_each(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.setattr(_DIAGNOSE, "_docker_logs_iter", _docker_call_forbidden)
+        monkeypatch.setattr(_DIAGNOSE, "_load_env", lambda _name: {})
+        monkeypatch.setattr(_DIAGNOSE, "_container_name", lambda _env: "influx-test")
+        monkeypatch.setattr(
+            _DIAGNOSE, "_read_lithos_url", lambda _args, _env: "http://t/sse"
+        )
+
+        mock_client = AsyncMock()
+        mock_client.read_note.return_value = {
+            "title": "T",
+            "tags": ["ingested-by:influx"],
+        }
+        mock_client.close = AsyncMock()
+
+        with patch.object(_DIAGNOSE, "_make_lithos_client", return_value=mock_client):
+            args = _squatters_args(ids=["a", "b", "c"], apply=False)
+            rc = _DIAGNOSE.cmd_squatters(args)
+
+        assert rc == 0
+        # One read_note per --id.
+        assert mock_client.read_note.await_count == 3
+        called_ids = {
+            call.kwargs.get("note_id") for call in mock_client.read_note.await_args_list
+        }
+        assert called_ids == {"a", "b", "c"}
+
+    def test_dry_run_handles_missing_doc_gracefully(
+        self, monkeypatch: Any, capsys: Any
+    ) -> None:
+        # ``read_note`` may raise if the doc is already gone.  The
+        # preview path must still surface a useful line per id rather
+        # than abort the whole batch.
+        monkeypatch.setattr(_DIAGNOSE, "_docker_logs_iter", _docker_call_forbidden)
+        monkeypatch.setattr(_DIAGNOSE, "_load_env", lambda _name: {})
+        monkeypatch.setattr(_DIAGNOSE, "_container_name", lambda _env: "influx-test")
+        monkeypatch.setattr(
+            _DIAGNOSE, "_read_lithos_url", lambda _args, _env: "http://t/sse"
+        )
+
+        mock_client = AsyncMock()
+        mock_client.read_note.side_effect = RuntimeError("Document not found: doc-X")
+        mock_client.close = AsyncMock()
+
+        with patch.object(_DIAGNOSE, "_make_lithos_client", return_value=mock_client):
+            args = _squatters_args(ids=["doc-X"], apply=False)
+            rc = _DIAGNOSE.cmd_squatters(args)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "doc-X" in out
+
+
+class TestCmdSquattersIdFlagApply:
+    """``--apply --id <X>`` deletes via the existing safety-check pipeline.
+
+    Acceptance criterion: ``--apply --id <X>`` is treated as both
+    "list this id" and "confirm deletion" — no extra ``--yes <X>``
+    needed.  The pre-delete safety check (``ingested-by:influx`` tag)
+    is preserved.
+    """
+
+    def test_apply_with_id_deletes_when_influx_authored(
+        self, monkeypatch: Any, capsys: Any
+    ) -> None:
+        monkeypatch.setattr(_DIAGNOSE, "_docker_logs_iter", _docker_call_forbidden)
+        monkeypatch.setattr(_DIAGNOSE, "_load_env", lambda _name: {})
+        monkeypatch.setattr(_DIAGNOSE, "_container_name", lambda _env: "influx-test")
+        monkeypatch.setattr(
+            _DIAGNOSE, "_read_lithos_url", lambda _args, _env: "http://t/sse"
+        )
+        monkeypatch.setattr(
+            _DIAGNOSE, "_ensure_project_runtime_or_reexec", lambda: None
+        )
+
+        # Stub out the delete to return DELETE_OK without touching the
+        # network.  The function itself is exercised in TestDeleteOutcomes
+        # via ``_format_exception_chain``; here we only need to confirm
+        # the dispatcher feeds it the right id.
+        delete_calls: list[dict[str, Any]] = []
+
+        async def fake_delete(**kwargs: Any) -> tuple[str, str]:
+            delete_calls.append(kwargs)
+            return _DIAGNOSE.DELETE_OK, "deleted"
+
+        monkeypatch.setattr(_DIAGNOSE, "_delete_squatter", fake_delete)
+
+        args = _squatters_args(ids=["doc-X"], apply=True)
+        rc = _DIAGNOSE.cmd_squatters(args)
+
+        assert rc == 0
+        assert len(delete_calls) == 1
+        assert delete_calls[0]["doc_id"] == "doc-X"
+        # Safety check stays on by default — caller must explicitly
+        # opt out via --no-require-influx-authored.
+        assert delete_calls[0]["require_influx_authored"] is True
+        out = capsys.readouterr().out
+        assert "DELETED" in out
+
+    def test_apply_with_id_does_not_require_yes(self, monkeypatch: Any) -> None:
+        # Per issue #34 rationale, --apply --id <X> already names the doc
+        # to delete; no additional --yes <X> may be required.
+        monkeypatch.setattr(_DIAGNOSE, "_docker_logs_iter", _docker_call_forbidden)
+        monkeypatch.setattr(_DIAGNOSE, "_load_env", lambda _name: {})
+        monkeypatch.setattr(_DIAGNOSE, "_container_name", lambda _env: "influx-test")
+        monkeypatch.setattr(
+            _DIAGNOSE, "_read_lithos_url", lambda _args, _env: "http://t/sse"
+        )
+        monkeypatch.setattr(
+            _DIAGNOSE, "_ensure_project_runtime_or_reexec", lambda: None
+        )
+
+        async def fake_delete(**kwargs: Any) -> tuple[str, str]:
+            return _DIAGNOSE.DELETE_OK, "deleted"
+
+        monkeypatch.setattr(_DIAGNOSE, "_delete_squatter", fake_delete)
+
+        # Note: ``yes`` is None here — must NOT trigger the
+        # "requires --yes" sys.exit when --id is provided.
+        args = _squatters_args(ids=["doc-X"], apply=True, yes=None)
+        rc = _DIAGNOSE.cmd_squatters(args)
+        assert rc == 0
+
+    def test_apply_with_id_refused_when_safety_check_fails(
+        self, monkeypatch: Any, capsys: Any
+    ) -> None:
+        monkeypatch.setattr(_DIAGNOSE, "_docker_logs_iter", _docker_call_forbidden)
+        monkeypatch.setattr(_DIAGNOSE, "_load_env", lambda _name: {})
+        monkeypatch.setattr(_DIAGNOSE, "_container_name", lambda _env: "influx-test")
+        monkeypatch.setattr(
+            _DIAGNOSE, "_read_lithos_url", lambda _args, _env: "http://t/sse"
+        )
+        monkeypatch.setattr(
+            _DIAGNOSE, "_ensure_project_runtime_or_reexec", lambda: None
+        )
+
+        async def fake_delete(**kwargs: Any) -> tuple[str, str]:
+            # Mirror the real path's refusal shape when the doc lacks
+            # the ``ingested-by:influx`` tag.
+            return _DIAGNOSE.DELETE_REFUSED, (
+                "doc is not influx-authored (missing 'ingested-by:influx' tag)"
+            )
+
+        monkeypatch.setattr(_DIAGNOSE, "_delete_squatter", fake_delete)
+
+        args = _squatters_args(ids=["doc-X"], apply=True)
+        rc = _DIAGNOSE.cmd_squatters(args)
+        # Refusal must surface as a non-zero exit so a wrapping shell
+        # script can detect it.
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "REFUSED" in out
+        assert "ingested-by:influx" in out
+
+
+class TestCmdSquattersLogScanUnchanged:
+    """The pre-existing log-scan path must keep working when --id is absent."""
+
+    def test_log_scan_path_still_invokes_docker(self, monkeypatch: Any) -> None:
+        # Sentinel: docker iterator IS called when --id is absent.
+        called: dict[str, bool] = {"docker": False}
+
+        def fake_docker_iter(
+            container: str, *, since: str, tail: int
+        ) -> Iterable[dict[str, Any]]:
+            called["docker"] = True
+            return iter([])
+
+        monkeypatch.setattr(_DIAGNOSE, "_docker_logs_iter", fake_docker_iter)
+        monkeypatch.setattr(_DIAGNOSE, "_load_env", lambda _name: {})
+        monkeypatch.setattr(_DIAGNOSE, "_container_name", lambda _env: "influx-test")
+
+        args = _squatters_args(ids=None, apply=False)
+        rc = _DIAGNOSE.cmd_squatters(args)
+        assert rc == 0
+        assert called["docker"] is True
+
+
+class TestSquattersIdArgparse:
+    """``--id`` must be repeatable and accepted alongside the existing flags."""
+
+    def test_id_is_repeatable(self) -> None:
+        parser = _DIAGNOSE._build_parser()
+        args = parser.parse_args(
+            [
+                "squatters",
+                "--id",
+                "aaaa",
+                "--id",
+                "bbbb",
+            ]
+        )
+        assert args.id == ["aaaa", "bbbb"]
+
+    def test_id_default_is_none(self) -> None:
+        # Default must be falsy so the dispatcher can use it as the
+        # branch signal.
+        parser = _DIAGNOSE._build_parser()
+        args = parser.parse_args(["squatters"])
+        assert not args.id
+
+
+# ``Iterable`` is imported here (not at module top) so the original
+# tests above keep their original import surface untouched.
+from collections.abc import Iterable  # noqa: E402


### PR DESCRIPTION
## Summary

- Adds repeatable `--id <doc-id>` to `scripts/influx-diagnose.py squatters` so operators can clean a known squatter without waiting for a fresh log scan after a container restart wipes the buffer.
- `--id` bypasses the `docker logs` call entirely and feeds the existing read-then-delete pipeline; the `ingested-by:influx` safety check still applies.
- Without `--apply`, `--id` performs a `lithos_read` dry-run preview (title/tags/source_url + planned delete command).
- `--apply --id <X>` requires no additional `--yes <X>` — passing `--id` already names the doc to delete.

## Refactor

- Refactored `cmd_squatters` around a shared "candidate squatters dict" seam so the log-scan path and `--id` path converge before the apply pipeline rather than forking duplicate logic.
- Extracted `_make_lithos_client` so both `_delete_squatter` and the new `_preview_squatter_by_id` share the same factory (also mockable from tests).

## Test plan

- [x] `make check` — lint + format + pyright clean, 1698 tests pass
- [x] 12 new tests across 5 classes: id-list helper, dry-run preview path mocking `read_note`, `--apply --id` happy path + safety-check refusal + no-`--yes`-required, log-scan path unchanged sentinel, argparse repeatability
- [x] `--id` independent of `--since`/`--tail` (no docker call)

Closes #34