### PR TITLE
feat: add OTEL log export alongside traces and metrics

### DIFF
--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -244,8 +244,35 @@ Resource attributes on every metric: `service.name=influx` plus
 `deployment.environment=<INFLUX_ENVIRONMENT>` (e.g. `staging`). Filter
 by these on the collector if multiple environments share a backend.
 
-OTEL log export is **not** wired in this revision; the runbook still
-relies on `docker logs` (and `influx-diagnose.py`) for log inspection.
+### Reading logs in the OTEL backend
+
+The same `INFLUX_OTEL_ENABLED=true` toggle that wires traces and metrics
+also forwards Influx's structured log records to the OTEL backend
+(issue #28). Each `logger.info / warning / exception` call is exported
+as an OTEL log record alongside the existing stderr JSON stream — so
+`docker logs` and `scripts/influx-diagnose.py` keep working unchanged,
+and the OTEL backend becomes a second, queryable view of the same
+records.
+
+| Question | Query shape (LogQL-like) |
+| -------- | ------------------------ |
+| Why did this run degrade? | Filter by `run_id=<the one from the run_completions metric>` to see every log line emitted under that run. |
+| What article writes were skipped? | Filter for body matching `article write skipped`; group by `status` (e.g. `duplicate`, `slug_collision`). |
+| Which sources are throwing acquisition errors? | Filter for body matching `source acquisition error`; group by `source` and `kind`. |
+| What is the repair sweep doing right now? | Filter for `sweep_stage` attribute presence; group by `sweep_stage`. |
+| Did this exception fire during a specific run? | Severity `ERROR` filtered by `run_id` and `profile`. |
+
+Every OTEL log record carries the same structured fields the JSON
+formatter writes to stderr (`run_id`, `profile`, `source_url`, `status`,
+`detail`, `note_id`, `sweep_stage`, `tags`, `cache_hit`, `exc_type`, …)
+as OTEL log attributes — anything passed to `logger.<level>(...,
+extra={...})` survives the trip to the collector. Resource attributes
+on every record match the metric set: `service.name=influx` plus
+`deployment.environment=<INFLUX_ENVIRONMENT>`.
+
+When OTEL is disabled, no log handler is constructed and no records are
+exported — the disabled path follows the same AC-10-A discipline as
+spans and metrics.
 
 ## 8. Cleaning up slug-collision squatters
 

--- a/src/influx/logging_config.py
+++ b/src/influx/logging_config.py
@@ -4,6 +4,17 @@ Influx follows the same operational logging shape as Lithos: JSON logs
 by default with ``timestamp``, ``level``, ``logger``, and ``message``
 fields, plus any caller-provided ``extra`` fields.  Set
 ``INFLUX_LOG_FORMAT=text`` for local plain-text logs.
+
+When ``INFLUX_OTEL_ENABLED=true`` the same records are *also* forwarded
+to an OTEL ``LoggingHandler`` attached to the root logger, so the
+existing ``extra={...}`` fields (``run_id``, ``profile``, ``source_url``,
+``status``, ``detail``, …) become OTEL log attributes and ride alongside
+spans + metrics in the configured backend (issue #28).  The stderr JSON
+handler keeps running unchanged so ``docker logs`` and
+``scripts/influx-diagnose.py`` are unaffected.
+
+The OTEL path is strictly opt-in: when the toggle is unset / false, no
+OTEL imports run and no ``LoggingHandler`` is constructed (AC-10-A).
 """
 
 from __future__ import annotations
@@ -15,9 +26,12 @@ import sys
 from datetime import UTC, datetime
 from typing import Any
 
+from influx.telemetry import _build_logger_provider
+
 __all__ = ["InfluxJsonFormatter", "setup_logging"]
 
 _HANDLER_MARKER = "_influx_json_handler"
+_OTEL_HANDLER_MARKER = "_influx_otel_log_handler"
 _STANDARD_LOG_RECORD_ATTRS = frozenset(
     {
         "args",
@@ -78,6 +92,12 @@ def setup_logging(level: int = logging.INFO, stream: Any = None) -> None:
     Repeated calls are idempotent unless the previously installed stream
     was closed, matching the Lithos closed-stream recovery behavior used
     by CLI tests.
+
+    When ``INFLUX_OTEL_ENABLED=true`` an OTEL ``LoggingHandler`` is
+    *additionally* attached to the root logger so the same records are
+    exported to the OTEL backend.  When OTEL is disabled, no OTEL
+    objects are constructed and no OTEL handler is installed
+    (AC-10-A discipline).
     """
     root = logging.getLogger()
 
@@ -92,11 +112,16 @@ def setup_logging(level: int = logging.INFO, stream: Any = None) -> None:
         survivors.append(handler)
     root.handlers = survivors
 
-    if not replace:
-        for handler in root.handlers:
-            if getattr(handler, _HANDLER_MARKER, False):
-                root.setLevel(level)
-                return
+    json_handler_present = any(
+        getattr(handler, _HANDLER_MARKER, False) for handler in root.handlers
+    )
+    if not replace and json_handler_present:
+        # Stderr handler is already installed.  Attach the OTEL handler
+        # if missing (so a subsequent ``setup_logging`` call after env
+        # changes can still wire OTEL), then bail.
+        _maybe_attach_otel_log_handler(root, level)
+        root.setLevel(level)
+        return
 
     if stream is None:
         stream = sys.stderr
@@ -116,3 +141,33 @@ def setup_logging(level: int = logging.INFO, stream: Any = None) -> None:
 
     root.setLevel(level)
     root.addHandler(handler)
+
+    _maybe_attach_otel_log_handler(root, level)
+
+
+def _maybe_attach_otel_log_handler(root: logging.Logger, level: int) -> None:
+    """Attach an OTEL ``LoggingHandler`` when (and only when) OTEL is enabled.
+
+    Strict AC-10-A discipline: the disabled path performs only a single
+    boolean check (``INFLUX_OTEL_ENABLED`` via :func:`_build_logger_provider`)
+    and never imports the OTEL SDK or constructs a handler object.
+    """
+    # Skip if an OTEL handler is already present (idempotent re-entry).
+    for handler in root.handlers:
+        if getattr(handler, _OTEL_HANDLER_MARKER, False):
+            return
+
+    provider = _build_logger_provider()
+    if provider is None:
+        # OTEL disabled or SDK unavailable — no handler attached
+        # (AC-10-A: no OTEL objects on the disabled path).
+        return
+
+    # Lazy import: this line only runs when OTEL is enabled and the
+    # SDK is installed (``_build_logger_provider`` would have returned
+    # ``None`` otherwise), so the disabled path never imports this.
+    from opentelemetry.sdk._logs import LoggingHandler
+
+    otel_handler = LoggingHandler(level=level, logger_provider=provider)
+    setattr(otel_handler, _OTEL_HANDLER_MARKER, True)
+    root.addHandler(otel_handler)

--- a/src/influx/telemetry.py
+++ b/src/influx/telemetry.py
@@ -419,6 +419,69 @@ class InfluxMeter:
         return instrument
 
 
+def _build_logger_provider() -> Any | None:
+    """Construct an OTEL ``LoggerProvider`` based on env + package state.
+
+    Mirrors :func:`_build_tracer` and :func:`_build_meter`: shares the
+    ``INFLUX_OTEL_ENABLED`` toggle, the ``OTEL_EXPORTER_OTLP_ENDPOINT``
+    configuration, and the same resource-attribute set, so traces,
+    metrics, and logs always describe the same service from the
+    collector's point of view.
+
+    Returns ``None`` when OTEL is disabled or the OTEL packages are not
+    importable — callers must treat ``None`` as "do not attach any OTEL
+    log handler" (AC-10-A discipline: the disabled path must not
+    construct any OTEL objects).
+    """
+    if not _otel_enabled():
+        return None
+    if not _otel_packages_available():
+        return None
+
+    try:
+        from opentelemetry.sdk._logs import LoggerProvider
+        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+        from opentelemetry.sdk.resources import Resource
+    except ImportError:
+        logger.warning("OTEL logs SDK not installed; logs will not be exported")
+        return None
+
+    resource_attrs = _build_resource_attributes()
+    provider = LoggerProvider(resource=Resource.create(resource_attrs))
+
+    if _otlp_endpoint_configured():
+        try:
+            from opentelemetry.exporter.otlp.proto.http._log_exporter import (
+                OTLPLogExporter,
+            )
+        except ImportError:
+            if not _console_fallback_enabled():
+                logger.warning(
+                    "OTEL enabled but OTLP HTTP log exporter is not installed; "
+                    "logs will not be exported"
+                )
+                return provider
+        else:
+            provider.add_log_record_processor(
+                BatchLogRecordProcessor(OTLPLogExporter())
+            )
+            logger.info(
+                "OTEL OTLP log exporter configured endpoint=%s logs_endpoint=%s",
+                os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", ""),
+                os.environ.get("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", ""),
+            )
+
+    if _console_fallback_enabled() and not _otlp_endpoint_configured():
+        from opentelemetry.sdk._logs.export import ConsoleLogExporter
+
+        provider.add_log_record_processor(BatchLogRecordProcessor(ConsoleLogExporter()))
+        logger.info("OTEL console log exporter configured")
+    elif not _otlp_endpoint_configured():
+        logger.warning("OTEL enabled but no log exporter endpoint is configured")
+
+    return provider
+
+
 def _build_meter() -> InfluxMeter:
     """Construct an ``InfluxMeter`` based on current env + package state.
 

--- a/tests/integration/test_otel_logs.py
+++ b/tests/integration/test_otel_logs.py
@@ -1,0 +1,240 @@
+"""End-to-end OTEL log emission test (issue #28).
+
+Mirrors :mod:`tests.integration.test_otel_metrics` but for logs:
+configures the logger provider with an in-memory log exporter and emits
+representative ``logger.info / warning`` calls, then asserts the
+documented attribute keys (``run_id``, ``profile``, ``source_url``,
+``status``, ``detail`` …) and resource attributes (``service.name``,
+``deployment.environment``) are preserved on the OTEL log records.
+
+A complementary test confirms zero ``LoggingHandler`` instances are
+attached to the root logger when OTEL is disabled (AC-10-A discipline
+extended to logs).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+pytest.importorskip(
+    "opentelemetry.sdk._logs",
+    reason="OTEL logs SDK required for log integration tests",
+)
+
+
+def _clear_influx_handlers() -> None:
+    """Strip any prior Influx-installed handlers between cases."""
+    root = logging.getLogger()
+    root.handlers = [
+        handler
+        for handler in root.handlers
+        if not getattr(handler, "_influx_json_handler", False)
+        and not getattr(handler, "_influx_otel_log_handler", False)
+    ]
+
+
+class TestOtelLogsEnabled:
+    """OTEL enabled: log records carry both extras and resource attrs."""
+
+    def setup_method(self) -> None:
+        _clear_influx_handlers()
+
+    def teardown_method(self) -> None:
+        _clear_influx_handlers()
+
+    def test_log_record_carries_extras_and_resource_attrs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ``logger.info("...", extra={...})`` call produces an OTEL
+        log record carrying the supplied extras plus ``service.name`` /
+        ``deployment.environment`` from the resource."""
+        from opentelemetry.sdk._logs import LoggerProvider
+        from opentelemetry.sdk._logs.export import (
+            InMemoryLogRecordExporter,
+            SimpleLogRecordProcessor,
+        )
+        from opentelemetry.sdk.resources import Resource
+
+        from influx.logging_config import setup_logging
+
+        monkeypatch.setenv("INFLUX_OTEL_ENABLED", "true")
+        monkeypatch.setenv("INFLUX_ENVIRONMENT", "staging")
+
+        # Build an explicit in-memory provider and inject it so we don't
+        # depend on the production OTLP exporter being reachable.
+        exporter = InMemoryLogRecordExporter()
+        provider = LoggerProvider(
+            resource=Resource.create(
+                {"service.name": "influx", "deployment.environment": "staging"}
+            )
+        )
+        provider.add_log_record_processor(SimpleLogRecordProcessor(exporter))
+
+        # Patch _build_logger_provider so setup_logging picks up our test
+        # provider rather than constructing one from env (which would try
+        # to wire OTLP HTTP).
+        from influx import logging_config
+
+        monkeypatch.setattr(
+            logging_config,
+            "_build_logger_provider",
+            lambda: provider,
+        )
+
+        setup_logging()
+
+        logger = logging.getLogger("influx.test")
+        logger.info(
+            "article write skipped",
+            extra={
+                "run_id": "run-xyz",
+                "profile": "ai-robotics",
+                "source_url": "https://example.com/post",
+                "status": "duplicate",
+                "detail": "already ingested",
+            },
+        )
+
+        provider.force_flush()
+
+        records = exporter.get_finished_logs()
+        assert len(records) >= 1, "Expected at least one OTEL log record"
+
+        # Find the record matching our message
+        matching = [
+            r for r in records if "article write skipped" in str(r.log_record.body)
+        ]
+        assert matching, (
+            f"Expected a record with body 'article write skipped', got: "
+            f"{[str(r.log_record.body) for r in records]}"
+        )
+        record = matching[-1]
+
+        attrs = dict(record.log_record.attributes or {})
+        assert attrs.get("run_id") == "run-xyz"
+        assert attrs.get("profile") == "ai-robotics"
+        assert attrs.get("source_url") == "https://example.com/post"
+        assert attrs.get("status") == "duplicate"
+        assert attrs.get("detail") == "already ingested"
+
+        # Resource attributes (service.name, deployment.environment) live
+        # on the record's resource, not its per-record attributes.
+        resource_attrs = dict(record.resource.attributes or {})
+        assert resource_attrs.get("service.name") == "influx"
+        assert resource_attrs.get("deployment.environment") == "staging"
+
+    def test_logging_handler_attached_when_enabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With OTEL enabled, a ``LoggingHandler`` is attached to the root."""
+        from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+        from opentelemetry.sdk._logs.export import (
+            InMemoryLogRecordExporter,
+            SimpleLogRecordProcessor,
+        )
+
+        from influx import logging_config
+        from influx.logging_config import setup_logging
+
+        monkeypatch.setenv("INFLUX_OTEL_ENABLED", "true")
+
+        exporter = InMemoryLogRecordExporter()
+        provider = LoggerProvider()
+        provider.add_log_record_processor(SimpleLogRecordProcessor(exporter))
+
+        monkeypatch.setattr(
+            logging_config,
+            "_build_logger_provider",
+            lambda: provider,
+        )
+
+        setup_logging()
+
+        root = logging.getLogger()
+        otel_handlers = [h for h in root.handlers if isinstance(h, LoggingHandler)]
+        assert len(otel_handlers) >= 1, (
+            f"Expected at least one OTEL LoggingHandler on root, got: "
+            f"{[type(h).__name__ for h in root.handlers]}"
+        )
+
+    def test_stderr_json_handler_still_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Enabling OTEL must NOT remove the stderr JSON handler — both run."""
+        from opentelemetry.sdk._logs import LoggerProvider
+        from opentelemetry.sdk._logs.export import (
+            InMemoryLogRecordExporter,
+            SimpleLogRecordProcessor,
+        )
+
+        from influx import logging_config
+        from influx.logging_config import setup_logging
+
+        monkeypatch.setenv("INFLUX_OTEL_ENABLED", "true")
+
+        exporter = InMemoryLogRecordExporter()
+        provider = LoggerProvider()
+        provider.add_log_record_processor(SimpleLogRecordProcessor(exporter))
+
+        monkeypatch.setattr(
+            logging_config,
+            "_build_logger_provider",
+            lambda: provider,
+        )
+
+        setup_logging()
+
+        root = logging.getLogger()
+        stderr_handlers = [
+            h for h in root.handlers if getattr(h, "_influx_json_handler", False)
+        ]
+        assert len(stderr_handlers) == 1, (
+            "Stderr JSON handler must remain installed when OTEL is enabled."
+        )
+
+
+class TestOtelLogsDisabled:
+    """OTEL disabled → no ``LoggingHandler`` installed (AC-10-A)."""
+
+    def setup_method(self) -> None:
+        _clear_influx_handlers()
+
+    def teardown_method(self) -> None:
+        _clear_influx_handlers()
+
+    def test_no_otel_handler_when_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With OTEL disabled, the root logger has no ``LoggingHandler``."""
+        from opentelemetry.sdk._logs import LoggingHandler
+
+        from influx.logging_config import setup_logging
+
+        monkeypatch.delenv("INFLUX_OTEL_ENABLED", raising=False)
+
+        setup_logging()
+
+        root = logging.getLogger()
+        otel_handlers = [h for h in root.handlers if isinstance(h, LoggingHandler)]
+        assert otel_handlers == [], (
+            f"Expected zero OTEL LoggingHandler instances when disabled, got: "
+            f"{[type(h).__name__ for h in otel_handlers]}"
+        )
+
+    def test_no_otel_handler_when_explicitly_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``INFLUX_OTEL_ENABLED=false`` must not install any OTEL handler."""
+        from opentelemetry.sdk._logs import LoggingHandler
+
+        from influx.logging_config import setup_logging
+
+        monkeypatch.setenv("INFLUX_OTEL_ENABLED", "false")
+
+        setup_logging()
+
+        root = logging.getLogger()
+        otel_handlers = [h for h in root.handlers if isinstance(h, LoggingHandler)]
+        assert otel_handlers == []


### PR DESCRIPTION
## Summary

- Wires an OTEL `LoggerProvider` + `BatchLogRecordProcessor` next to the existing tracer and meter providers in `src/influx/telemetry.py`.
- When `INFLUX_OTEL_ENABLED=true` and `OTEL_EXPORTER_OTLP_ENDPOINT` is set, structured logs flow to the OTLP backend with `service.name=influx` and `deployment.environment=<INFLUX_ENVIRONMENT>`. Existing extras (`run_id`, `profile`, `source_url`, `status`, `detail`, etc.) are preserved as OTEL log attributes.
- The stderr `InfluxJsonFormatter` handler stays installed in parallel, so `docker logs` and `scripts/influx-diagnose.py` are unaffected.
- Reuses the single `INFLUX_OTEL_ENABLED` toggle — no new env vars. No `pyproject.toml` extras change needed; the existing `otel` extra already covers `opentelemetry.sdk._logs` and `OTLPLogExporter`.

## Disabled-path discipline (AC-10-A)

- Disabled path imports zero OTEL objects: `_build_logger_provider` short-circuits on the env-bool check before any OTEL import.
- `LoggingHandler` import is fenced inside `_maybe_attach_otel_log_handler` after the `provider is None` early-return.
- Idempotent re-entry via `_OTEL_HANDLER_MARKER`, mirroring the existing `_HANDLER_MARKER` pattern.
- `tests/integration/test_otel_absent_service.py` continues to pass.

## Test plan

- [x] `make check` — lint + format + pyright clean, 1712 tests pass
- [x] New `tests/integration/test_otel_logs.py` (5 cases): extras + resource attrs flow through the in-memory exporter; OTEL handler attached when enabled; stderr JSON handler still present alongside; no OTEL handler when disabled (unset and explicit false)
- [x] `docs/operations/staging-runbook.md` gains a "Reading logs in the OTEL backend" subsection mirroring the metrics section

Closes #28