### PR TITLE
feat: raise Tier 3 list cap to 30 and reinforce via prompt suffix

### DIFF
--- a/src/influx/enrich.py
+++ b/src/influx/enrich.py
@@ -24,9 +24,21 @@ from influx.errors import LCMAError, NetworkError
 from influx.http_client import guarded_post_json_fetch
 from influx.prompts import load_prompt
 from influx.schemas import (
+    TIER3_LIST_MAX,
     Tier1Enrichment,
     Tier3Extraction,
     openai_strict_response_format,
+)
+
+# Constant-derived suffix appended to the rendered Tier-3 prompt so the
+# "at most N" instruction stays in lockstep with the schema cap (issue
+# #81).  Kept in code rather than the user's TOML so existing operator
+# configs continue to validate against ``REQUIRED_VARIABLES`` without
+# requiring a new ``{max_list_items}`` template variable.
+_TIER3_CAP_REMINDER = (
+    f"\n\nReturn at most {TIER3_LIST_MAX} items in datasets and at most "
+    f"{TIER3_LIST_MAX} items in builds_on, prioritised by relevance and "
+    "centrality to the paper's contribution.  Drop the rest."
 )
 
 __all__ = [
@@ -270,9 +282,12 @@ def tier3_extract(
     """
     prompt_cfg = config.prompts.tier3_extract
     prompt_text = load_prompt(text=prompt_cfg.text, path=prompt_cfg.path)
-    rendered = prompt_text.format(
-        title=title,
-        full_text=full_text,
+    rendered = (
+        prompt_text.format(
+            title=title,
+            full_text=full_text,
+        )
+        + _TIER3_CAP_REMINDER
     )
 
     raw = _call_json_model(config, "extract", rendered, schema_class=Tier3Extraction)

--- a/src/influx/schemas.py
+++ b/src/influx/schemas.py
@@ -13,6 +13,14 @@ from pydantic import BaseModel, Field, field_validator
 _TIER3_MAX_CHARS = 500
 _FILTER_MAX_TAGS = 5
 
+# Single source of truth for the upper bound on Tier-3 ``datasets`` and
+# ``builds_on`` list lengths (FR-ENR-5, issue #81).  Bumped from 10 → 30
+# after structured-output models routinely returned 14-39 items, breaking
+# validation.  Both the schema's ``max_length`` and the constant-derived
+# cap reminder appended to the rendered Tier-3 prompt read from this
+# value, so a future bump propagates automatically.
+TIER3_LIST_MAX = 30
+
 
 def _trim_and_truncate(values: list[str]) -> list[str]:
     """Trim whitespace and truncate each element to 500 chars (FR-ENR-5).
@@ -46,15 +54,19 @@ class Tier3Extraction(BaseModel):
 
     Constraints:
     - ``claims`` length must be in ``[1, 10]`` inclusive.
-    - ``datasets``, ``builds_on``, ``open_questions``, ``potential_connections``
-      lengths must be in ``[0, 10]`` inclusive.
+    - ``datasets`` and ``builds_on`` lengths must be in
+      ``[0, TIER3_LIST_MAX]`` inclusive (issue #81 — raised from 10 to
+      accommodate structured-output models routinely returning 14-39
+      items).
+    - ``open_questions`` and ``potential_connections`` lengths must be
+      in ``[0, 10]`` inclusive.
     - All string elements are trimmed and truncated to 500 characters on ingest.
     - Empty/whitespace-only elements fail validation.
     """
 
     claims: list[str] = Field(min_length=1, max_length=10)
-    datasets: list[str] = Field(default_factory=list, max_length=10)
-    builds_on: list[str] = Field(default_factory=list, max_length=10)
+    datasets: list[str] = Field(default_factory=list, max_length=TIER3_LIST_MAX)
+    builds_on: list[str] = Field(default_factory=list, max_length=TIER3_LIST_MAX)
     open_questions: list[str] = Field(default_factory=list, max_length=10)
     potential_connections: list[str] = Field(default_factory=list, max_length=10)
 

--- a/tests/unit/test_enrich.py
+++ b/tests/unit/test_enrich.py
@@ -26,7 +26,7 @@ from influx.config import AppConfig, load_config
 from influx.enrich import _call_json_model, tier1_enrich, tier3_extract
 from influx.errors import LCMAError
 from influx.http_client import FetchResult
-from influx.schemas import Tier1Enrichment, Tier3Extraction
+from influx.schemas import TIER3_LIST_MAX, Tier1Enrichment, Tier3Extraction
 
 
 def _valid_tier1_response(**overrides: Any) -> dict[str, Any]:
@@ -548,7 +548,32 @@ class TestTier3ExtractPromptRendering:
             )
 
         # Template from conftest: "Extract: {title} {full_text}"
-        assert captured[0] == "Extract: T F"
+        # Issue #81: a constant-derived cap reminder is appended after.
+        assert captured[0].startswith("Extract: T F")
+
+    def test_prompt_includes_list_cap_reminder(
+        self, influx_config_env: Any, tmp_path: Any
+    ) -> None:
+        """Issue #81: rendered prompt must include the cap value sourced from
+        ``TIER3_LIST_MAX`` so future bumps propagate without code drift.
+        """
+        config = load_config()
+        payload = _valid_tier3_response()
+        captured: list[str] = []
+
+        def fake_call(
+            cfg: Any, slot: str, prompt: str, **kwargs: Any
+        ) -> dict[str, Any]:
+            captured.append(prompt)
+            return payload
+
+        with patch("influx.enrich._call_json_model", side_effect=fake_call):
+            tier3_extract(title="T", full_text="F", config=config)
+
+        rendered = captured[0]
+        assert str(TIER3_LIST_MAX) in rendered
+        assert "datasets" in rendered
+        assert "builds_on" in rendered
 
 
 class TestTier3ExtractModelSlot:

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from influx.schemas import (
+    TIER3_LIST_MAX,
     FilterResponse,
     FilterResult,
     Tier1Enrichment,
@@ -188,7 +189,10 @@ class TestTier3Extraction:
 
     def test_too_many_datasets(self) -> None:
         with pytest.raises(ValidationError):
-            Tier3Extraction(claims=["c"], datasets=[f"d{i}" for i in range(11)])
+            Tier3Extraction(
+                claims=["c"],
+                datasets=[f"d{i}" for i in range(TIER3_LIST_MAX + 1)],
+            )
 
 
 # ── OpenAI structured-outputs response_format builder ────────────────

--- a/tests/unit/test_tier3_schema.py
+++ b/tests/unit/test_tier3_schema.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from influx.schemas import Tier3Extraction
+from influx.schemas import TIER3_LIST_MAX, Tier3Extraction
 
 
 def _valid(**overrides: list[str]) -> dict[str, list[str]]:
@@ -40,6 +40,11 @@ class TestTier3ExtractionPositive:
         t = Tier3Extraction(**_valid(datasets=[f"d{i}" for i in range(10)]))
         assert len(t.datasets) == 10
 
+    def test_datasets_length_at_cap(self) -> None:
+        """Issue #81: datasets accepts up to TIER3_LIST_MAX items."""
+        t = Tier3Extraction(**_valid(datasets=[f"d{i}" for i in range(TIER3_LIST_MAX)]))
+        assert len(t.datasets) == TIER3_LIST_MAX
+
     def test_builds_on_length_0(self) -> None:
         t = Tier3Extraction(**_valid(builds_on=[]))
         assert len(t.builds_on) == 0
@@ -47,6 +52,25 @@ class TestTier3ExtractionPositive:
     def test_builds_on_length_10(self) -> None:
         t = Tier3Extraction(**_valid(builds_on=[f"b{i}" for i in range(10)]))
         assert len(t.builds_on) == 10
+
+    def test_builds_on_length_at_cap(self) -> None:
+        """Issue #81: builds_on accepts up to TIER3_LIST_MAX items."""
+        t = Tier3Extraction(
+            **_valid(builds_on=[f"b{i}" for i in range(TIER3_LIST_MAX)])
+        )
+        assert len(t.builds_on) == TIER3_LIST_MAX
+
+    @pytest.mark.parametrize("size", [13, 14, 23, 30])
+    def test_observed_failure_sizes_now_parse(self, size: int) -> None:
+        """Issue #81: 13-, 14-, 23-, 30-item datasets/builds_on now parse."""
+        t = Tier3Extraction(
+            **_valid(
+                datasets=[f"d{i}" for i in range(size)],
+                builds_on=[f"b{i}" for i in range(size)],
+            )
+        )
+        assert len(t.datasets) == size
+        assert len(t.builds_on) == size
 
     def test_open_questions_length_0(self) -> None:
         t = Tier3Extraction(**_valid(open_questions=[]))
@@ -100,13 +124,24 @@ class TestTier3ExtractionNegative:
         with pytest.raises(ValidationError):
             Tier3Extraction(**_valid(claims=[f"c{i}" for i in range(11)]))
 
-    def test_datasets_length_11(self) -> None:
+    def test_datasets_length_over_cap(self) -> None:
+        """Issue #81: datasets length TIER3_LIST_MAX + 1 is still rejected."""
         with pytest.raises(ValidationError):
-            Tier3Extraction(**_valid(datasets=[f"d{i}" for i in range(11)]))
+            Tier3Extraction(
+                **_valid(datasets=[f"d{i}" for i in range(TIER3_LIST_MAX + 1)])
+            )
 
-    def test_builds_on_length_11(self) -> None:
+    def test_builds_on_length_over_cap(self) -> None:
+        """Issue #81: builds_on length TIER3_LIST_MAX + 1 is still rejected."""
         with pytest.raises(ValidationError):
-            Tier3Extraction(**_valid(builds_on=[f"b{i}" for i in range(11)]))
+            Tier3Extraction(
+                **_valid(builds_on=[f"b{i}" for i in range(TIER3_LIST_MAX + 1)])
+            )
+
+    def test_observed_39_item_case_still_rejected(self) -> None:
+        """Issue #81: 39-item datasets case from the bug report still fails."""
+        with pytest.raises(ValidationError):
+            Tier3Extraction(**_valid(datasets=[f"d{i}" for i in range(39)]))
 
     def test_open_questions_length_11(self) -> None:
         with pytest.raises(ValidationError):
@@ -173,3 +208,19 @@ class TestTier3ExtractionNegative:
                 open_questions=["q"],
                 potential_connections=["p"],
             )  # type: ignore[call-arg]
+
+
+class TestTier3ListMaxConstant:
+    """Issue #81: TIER3_LIST_MAX is the single source of truth for the cap."""
+
+    def test_constant_value(self) -> None:
+        """The cap is 30 today (raised from 10 per issue #81)."""
+        assert TIER3_LIST_MAX == 30
+
+    def test_schema_max_length_reads_from_constant(self) -> None:
+        """The schema's ``max_length`` for the bumped fields must equal
+        ``TIER3_LIST_MAX`` so a future bump propagates without code drift.
+        """
+        schema = Tier3Extraction.model_json_schema()
+        assert schema["properties"]["datasets"]["maxItems"] == TIER3_LIST_MAX
+        assert schema["properties"]["builds_on"]["maxItems"] == TIER3_LIST_MAX


### PR DESCRIPTION
## Summary

- Raises `Tier3Extraction.datasets` and `Tier3Extraction.builds_on` cap from 10 to 30 to absorb survey-paper outputs that were silently failing on staging-ai (5+ `LCMAError: List should have at most …` rejections in the 24h window of 2026-05-04, with observed list lengths of 13, 14, 23, and 39).
- Reinforces the Tier 3 prompt with an "at most N items, prioritise by relevance/centrality" reminder appended at render time. The reminder is generated from the same `TIER3_LIST_MAX` constant the schema reads, so future cap changes propagate to both sides without divergence.

## Design choice

Implementation uses the **additive-suffix path (Path B)**:

- `TIER3_LIST_MAX = 30` defined as a module constant in `src/influx/schemas.py`.
- Both `Field(max_length=...)` declarations on `Tier3Extraction` read from the constant.
- `enrich.tier3_extract` appends a constant-derived suffix to the rendered user prompt body.

This avoids the breaking alternative of adding a new required template variable to user TOMLs. `REQUIRED_VARIABLES["tier3_extract"]` stays `{title, full_text}` and `influx.example.toml` is unchanged. Operators do not need to edit their config to pick up the cap change — the suffix is enforced in code.

## Test plan

- [x] `make check` — lint + format + pyright clean, 1726 tests pass
- [x] `Tier3Extraction` accepts payloads with `datasets`/`builds_on` of length 30
- [x] `Tier3Extraction` rejects payloads of length 31 (`TIER3_LIST_MAX + 1`) — cap is still enforced
- [x] Parametrised tests cover the 13-, 14-, 23-, 30-item now-parses cases and the 39-item still-rejected case
- [x] New `TestTier3ListMaxConstant` asserts the constant value and the JSON-schema `maxItems` derived from it
- [x] New `test_prompt_includes_list_cap_reminder` asserts the rendered Tier 3 prompt contains `str(TIER3_LIST_MAX)` plus "datasets" and "builds_on" — guards against future literal-`30` regressions

Closes #81