### PR TITLE
fix: phrase-quote LCMA retrieve query disjuncts to neutralise Tantivy syntax

### DIFF
--- a/src/influx/lcma.py
+++ b/src/influx/lcma.py
@@ -31,6 +31,18 @@ _WHITESPACE_RE = re.compile(r"\s+")
 _ARXIV_RE = re.compile(r"arXiv:(\d{4}\.\d{4,5}(?:v\d+)?)")
 
 
+def _phrase_quote(s: str) -> str:
+    """Wrap *s* as a Tantivy phrase query, backslash-escaping ``\\`` and ``"``.
+
+    Phrase quoting neutralises Tantivy reserved characters inside the
+    payload (notably ``:`` from ``Topic: Subtitle`` titles, plus ``(``,
+    ``)``, ``'``), so the parser cannot mistake content for field
+    qualifiers or syntax (#80).
+    """
+    escaped = s.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 def compose_retrieve_query(
     title: str,
     contributions: list[str] | None = None,
@@ -42,9 +54,13 @@ def compose_retrieve_query(
        trim each, and skip any that are empty after trimming. Empty
        elements within those first three are dropped, NOT replaced by
        later non-empty entries (FR-LCMA-2 step 2).
-    3. Join the surviving parts with ``" | "``.
-    4. Collapse internal whitespace runs to a single space.
-    5. Truncate to 500 characters (simple slice, no word re-wrap).
+    3. Collapse internal whitespace runs to a single space within each
+       disjunct.
+    4. Wrap each disjunct as a Tantivy phrase (double-quoted, with
+       ``\\`` and ``"`` escaped) so reserved characters in titles like
+       ``Topic: Subtitle`` cannot be parsed as field qualifiers (#80).
+    5. Join the wrapped parts with ``" | "``.
+    6. Truncate to 500 characters (simple slice, no word re-wrap).
     """
     parts: list[str] = [title]
 
@@ -55,8 +71,8 @@ def compose_retrieve_query(
                 continue
             parts.append(stripped)
 
-    composed = " | ".join(parts)
-    composed = _WHITESPACE_RE.sub(" ", composed)
+    quoted = [_phrase_quote(_WHITESPACE_RE.sub(" ", p).strip()) for p in parts]
+    composed = " | ".join(quoted)
     return composed[:_MAX_QUERY_LEN]
 
 

--- a/src/influx/lcma.py
+++ b/src/influx/lcma.py
@@ -31,6 +31,11 @@ _WHITESPACE_RE = re.compile(r"\s+")
 _ARXIV_RE = re.compile(r"arXiv:(\d{4}\.\d{4,5}(?:v\d+)?)")
 
 
+def _escape_phrase_inner(s: str) -> str:
+    """Backslash-escape ``\\`` and ``"`` for inclusion inside a phrase query."""
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
 def _phrase_quote(s: str) -> str:
     """Wrap *s* as a Tantivy phrase query, backslash-escaping ``\\`` and ``"``.
 
@@ -39,8 +44,41 @@ def _phrase_quote(s: str) -> str:
     ``)``, ``'``), so the parser cannot mistake content for field
     qualifiers or syntax (#80).
     """
-    escaped = s.replace("\\", "\\\\").replace('"', '\\"')
-    return f'"{escaped}"'
+    return f'"{_escape_phrase_inner(s)}"'
+
+
+def _fit_phrase(content: str, budget: int) -> str:
+    """Return a phrase-quoted form of *content* with total length ``<= budget``.
+
+    Truncates from the tail of the *escaped* form so the result is
+    always syntactically balanced — both surrounding quotes survive,
+    and a trailing odd-count run of backslashes (which would cut a
+    ``\\\\`` or ``\\"`` escape in half) is shaved off.
+
+    Returns ``'""'`` (empty phrase) when *budget* < the escaped length
+    of the content but the budget still leaves room for the two
+    surrounding quotes.
+    """
+    if budget < 2:
+        return ""
+    escaped = _escape_phrase_inner(content)
+    inner_budget = budget - 2
+    if len(escaped) <= inner_budget:
+        return f'"{escaped}"'
+
+    truncated = escaped[:inner_budget]
+    # Avoid leaving a dangling escape: every backslash in the escaped
+    # form is the leading half of either ``\\`` or ``\"``. An odd
+    # trailing run means we truncated mid-escape — drop one to restore
+    # a valid escaped string.
+    trailing = 0
+    i = len(truncated) - 1
+    while i >= 0 and truncated[i] == "\\":
+        trailing += 1
+        i -= 1
+    if trailing % 2 == 1:
+        truncated = truncated[:-1]
+    return f'"{truncated}"'
 
 
 def compose_retrieve_query(
@@ -60,20 +98,32 @@ def compose_retrieve_query(
        ``\\`` and ``"`` escaped) so reserved characters in titles like
        ``Topic: Subtitle`` cannot be parsed as field qualifiers (#80).
     5. Join the wrapped parts with ``" | "``.
-    6. Truncate to 500 characters (simple slice, no word re-wrap).
+    6. Bound the final string at 500 characters while preserving
+       Tantivy syntactic validity: the title phrase is truncated as a
+       phrase if needed, and any contribution whose wrapped form would
+       overflow the remaining budget is dropped (no mid-phrase slicing
+       — see #80 review).
     """
-    parts: list[str] = [title]
+    parts: list[str] = [_WHITESPACE_RE.sub(" ", title).strip()]
 
     if contributions is not None:
         for c in contributions[:_MAX_CONTRIBUTIONS]:
-            stripped = c.strip()
+            stripped = _WHITESPACE_RE.sub(" ", c).strip()
             if not stripped:
                 continue
             parts.append(stripped)
 
-    quoted = [_phrase_quote(_WHITESPACE_RE.sub(" ", p).strip()) for p in parts]
-    composed = " | ".join(quoted)
-    return composed[:_MAX_QUERY_LEN]
+    title_phrase = _fit_phrase(parts[0], _MAX_QUERY_LEN)
+    pieces = [title_phrase]
+    used = len(title_phrase)
+    separator = " | "
+    for content in parts[1:]:
+        wrapped = _phrase_quote(content)
+        if used + len(separator) + len(wrapped) > _MAX_QUERY_LEN:
+            break
+        pieces.append(wrapped)
+        used += len(separator) + len(wrapped)
+    return separator.join(pieces)
 
 
 def extract_arxiv_ref(item: str) -> tuple[str, str] | None:

--- a/tests/unit/test_lcma_query_composition.py
+++ b/tests/unit/test_lcma_query_composition.py
@@ -4,6 +4,10 @@ The ``GOLDEN_CASES`` table is the authoritative behavioural contract for
 ``compose_retrieve_query``. New behavioural cases should be added to the
 table; class-based tests cover scenarios that are awkward to express
 inline (e.g. very long strings).
+
+Each disjunct is wrapped in double quotes so Tantivy parses it as a
+phrase query rather than as field-qualified terms. This neutralises
+reserved characters in academic titles like ``Topic: Subtitle`` (#80).
 """
 
 from __future__ import annotations
@@ -19,75 +23,125 @@ from influx.lcma import compose_retrieve_query
 # Cases AC-08-A-* mirror the five canonical AC-08-A scenarios from
 # US-001. Cases AC-08-B-* exercise whitespace collapsing. Cases
 # FR-LCMA-2-* exercise the "first up to 3 list elements, then skip
-# empties" rule from FR-LCMA-2 step 2.
+# empties" rule from FR-LCMA-2 step 2. Cases ISSUE-80-* exercise the
+# Tantivy phrase-quoting added to fix #80.
 GOLDEN_CASES: list[tuple[str, str, list[str] | None, str]] = [
     # AC-08-A: 5 canonical cases
-    ("AC-08-A-1: title only", "My Paper Title", None, "My Paper Title"),
+    ("AC-08-A-1: title only", "My Paper Title", None, '"My Paper Title"'),
     (
         "AC-08-A-2: title + 1 contribution",
         "Paper A",
         ["Novel architecture"],
-        "Paper A | Novel architecture",
+        '"Paper A" | "Novel architecture"',
     ),
     (
         "AC-08-A-3: title + 3 contributions (all used)",
         "Paper B",
         ["First", "Second", "Third"],
-        "Paper B | First | Second | Third",
+        '"Paper B" | "First" | "Second" | "Third"',
     ),
     (
         "AC-08-A-4: title + 5 contributions (only first 3 used)",
         "Paper C",
         ["A", "B", "C", "D", "E"],
-        "Paper C | A | B | C",
+        '"Paper C" | "A" | "B" | "C"',
     ),
     # (case 5 — long-title truncation — covered in TestTruncation below)
     # AC-08-B: whitespace collapse
-    ("AC-08-B-1: newlines collapsed", "hello\n\nworld", None, "hello world"),
-    ("AC-08-B-2: tabs collapsed", "hello\t\tworld", None, "hello world"),
-    ("AC-08-B-3: mixed whitespace", "hello  \n\t  world", None, "hello world"),
+    ("AC-08-B-1: newlines collapsed", "hello\n\nworld", None, '"hello world"'),
+    ("AC-08-B-2: tabs collapsed", "hello\t\tworld", None, '"hello world"'),
+    ("AC-08-B-3: mixed whitespace", "hello  \n\t  world", None, '"hello world"'),
     (
         "AC-08-B-4: whitespace inside contributions",
         "Title",
         ["first\n\ncontrib", "second  contrib"],
-        "Title | first contrib | second contrib",
+        '"Title" | "first contrib" | "second contrib"',
     ),
     # FR-LCMA-2 step 2: first up to 3 elements, trim, skip empties.
     (
         "FR-LCMA-2-a: empty string in first slot is skipped",
         "Title",
         ["", "Valid"],
-        "Title | Valid",
+        '"Title" | "Valid"',
     ),
     (
         "FR-LCMA-2-b: whitespace-only entries skipped",
         "Title",
         ["   ", "\t\n", "Real"],
-        "Title | Real",
+        '"Title" | "Real"',
     ),
     (
         "FR-LCMA-2-c: empties WITHIN first 3 dropped, not replaced by later entries",
         "Title",
         ["", "A", "", "B", "C", "D"],
-        "Title | A",
+        '"Title" | "A"',
     ),
     (
         "FR-LCMA-2-d: all-empty contributions",
         "Title",
         ["", "  ", "\n"],
-        "Title",
+        '"Title"',
     ),
     (
         "FR-LCMA-2-e: empty contributions list",
         "Title",
         [],
-        "Title",
+        '"Title"',
     ),
     (
         "FR-LCMA-2-f: explicit None",
         "My Paper Title",
         None,
-        "My Paper Title",
+        '"My Paper Title"',
+    ),
+    # Issue #80: Tantivy phrase-quoting neutralises reserved chars
+    # (`:`, `(`, `)`, `'`) inside titles and contributions. Real-world
+    # arXiv titles drawn from the 2026-05-04 staging burst.
+    (
+        "ISSUE-80-a: colon in title (Topic: Subtitle)",
+        "When LLMs Stop Following Steps: A Diagnostic Study",
+        None,
+        '"When LLMs Stop Following Steps: A Diagnostic Study"',
+    ),
+    (
+        "ISSUE-80-b: colon in title with contributions",
+        "RunAgent: Interpreting Natural-Language Plans",
+        ["Multi-agent platform", "Constraint-guided execution"],
+        (
+            '"RunAgent: Interpreting Natural-Language Plans"'
+            ' | "Multi-agent platform"'
+            ' | "Constraint-guided execution"'
+        ),
+    ),
+    (
+        "ISSUE-80-c: single quote (apostrophe) in title",
+        "What's in a Token: Tokenizer Effects on LLM Reasoning",
+        None,
+        '"What\'s in a Token: Tokenizer Effects on LLM Reasoning"',
+    ),
+    (
+        "ISSUE-80-d: parentheses in title",
+        "BlenderRAG (with code synthesis)",
+        None,
+        '"BlenderRAG (with code synthesis)"',
+    ),
+    (
+        "ISSUE-80-e: double quotes inside content are escaped",
+        'A "Quoted" Phrase Title',
+        None,
+        '"A \\"Quoted\\" Phrase Title"',
+    ),
+    (
+        "ISSUE-80-f: backslash inside content is escaped",
+        "Path\\with\\backslash Title",
+        None,
+        '"Path\\\\with\\\\backslash Title"',
+    ),
+    (
+        "ISSUE-80-g: colon in contribution",
+        "Title",
+        ["Contribution: with colon"],
+        '"Title" | "Contribution: with colon"',
     ),
 ]
 
@@ -109,18 +163,26 @@ def test_compose_retrieve_query_golden(
 
 
 class TestTruncation:
-    """AC-08-A case 5: 600-char title truncated to 500."""
+    """AC-08-A case 5: composed query truncated to 500 characters.
+
+    Phrase-quoting adds two quote characters per disjunct (#80), so the
+    pre-truncation length is wrapped-length, not raw input length. The
+    truncation contract remains a simple slice of the final composed
+    string with no word re-wrap.
+    """
 
     def test_long_title_truncated_to_500(self) -> None:
         long_title = "x" * 600
         result = compose_retrieve_query(long_title)
         assert len(result) == 500
-        assert result == "x" * 500
+        # Wrapped form is `"xxx...xxx"` — leading quote then x's,
+        # truncated mid-phrase at 500.
+        assert result == '"' + "x" * 499
 
     def test_long_composed_truncated_to_500(self) -> None:
         title = "t" * 400
         contrib = "c" * 200
         result = compose_retrieve_query(title, contributions=[contrib])
         assert len(result) == 500
-        expected_full = f"{'t' * 400} | {'c' * 200}"
+        expected_full = f'"{"t" * 400}" | "{"c" * 200}"'
         assert result == expected_full[:500]

--- a/tests/unit/test_lcma_query_composition.py
+++ b/tests/unit/test_lcma_query_composition.py
@@ -163,26 +163,93 @@ def test_compose_retrieve_query_golden(
 
 
 class TestTruncation:
-    """AC-08-A case 5: composed query truncated to 500 characters.
+    """Composed query bounded to 500 characters AND syntactically balanced.
 
-    Phrase-quoting adds two quote characters per disjunct (#80), so the
-    pre-truncation length is wrapped-length, not raw input length. The
-    truncation contract remains a simple slice of the final composed
-    string with no word re-wrap.
+    Phrase-quoting adds two quote characters per disjunct (#80), and a
+    naive tail-slice can split a phrase mid-string and produce an
+    unmatched opening ``"`` — exactly the parse-failure class the patch
+    set out to eliminate (review on PR #84). Truncation is therefore
+    applied to the *raw* title content before wrapping, and any
+    contribution whose wrapped form would not fit whole is dropped
+    rather than sliced.
     """
 
-    def test_long_title_truncated_to_500(self) -> None:
+    def test_long_title_truncated_to_500_with_balanced_quotes(self) -> None:
         long_title = "x" * 600
         result = compose_retrieve_query(long_title)
         assert len(result) == 500
-        # Wrapped form is `"xxx...xxx"` — leading quote then x's,
-        # truncated mid-phrase at 500.
-        assert result == '"' + "x" * 499
+        # Surviving form is `"xxx...xxx"` — both quotes intact, 498 x's
+        # between them.
+        assert result == '"' + "x" * 498 + '"'
+        assert result.startswith('"')
+        assert result.endswith('"')
+        assert result.count('"') == 2
 
-    def test_long_composed_truncated_to_500(self) -> None:
+    def test_title_at_exact_budget_unchanged(self) -> None:
+        # A 498-char title wraps to exactly 500 — unchanged.
+        title = "y" * 498
+        result = compose_retrieve_query(title)
+        assert len(result) == 500
+        assert result == '"' + "y" * 498 + '"'
+
+    def test_title_one_over_budget_loses_one_char(self) -> None:
+        # A 499-char title wraps to 501 — drop one inner char.
+        title = "z" * 499
+        result = compose_retrieve_query(title)
+        assert len(result) == 500
+        assert result == '"' + "z" * 498 + '"'
+
+    def test_title_truncation_does_not_leave_dangling_backslash(self) -> None:
+        # A title that is all backslashes escapes to twice its length;
+        # truncating the escaped form mid-`\\` would leave a dangling
+        # backslash. The fitter must shave it off.
+        title = "\\" * 300  # escapes to 600 backslashes
+        result = compose_retrieve_query(title)
+        assert len(result) <= 500
+        assert result.startswith('"')
+        assert result.endswith('"')
+        # Inner content is even-length pairs of backslashes only.
+        inner = result[1:-1]
+        assert inner.count("\\") % 2 == 0
+
+    def test_long_composed_drops_contribution_that_will_not_fit(self) -> None:
+        # Title wrapped is 402 chars; budget after title is 500 - 402 - 3 = 95
+        # for the next contribution. A 200-char contribution wraps to 202
+        # chars and must therefore be dropped entirely (not sliced).
         title = "t" * 400
         contrib = "c" * 200
         result = compose_retrieve_query(title, contributions=[contrib])
-        assert len(result) == 500
-        expected_full = f'"{"t" * 400}" | "{"c" * 200}"'
-        assert result == expected_full[:500]
+        assert len(result) <= 500
+        assert result == '"' + "t" * 400 + '"'
+        assert result.startswith('"')
+        assert result.endswith('"')
+        assert result.count('"') == 2
+
+    def test_partial_fit_keeps_fitting_contributions_drops_rest(self) -> None:
+        # Title 200, contrib1 100, contrib2 200 — first contribution
+        # fits (`"<200>"` + ` | ` + `"<100>"` = 202 + 3 + 102 = 307),
+        # second would push to 307 + 3 + 202 = 512 > 500, so contrib2
+        # is dropped, contrib1 is kept whole.
+        title = "t" * 200
+        contrib_short = "a" * 100
+        contrib_long = "b" * 200
+        result = compose_retrieve_query(
+            title, contributions=[contrib_short, contrib_long]
+        )
+        assert len(result) <= 500
+        assert result == f'"{"t" * 200}" | "{"a" * 100}"'
+        # All quotes balanced.
+        assert result.count('"') % 2 == 0
+
+    def test_result_always_has_balanced_quotes(self) -> None:
+        # Stress: many titles of varying sizes around the boundary,
+        # each must produce a balanced query. Backslash counts are
+        # tracked separately via inner-content parity.
+        for n in (1, 100, 250, 497, 498, 499, 500, 501, 600, 1000):
+            result = compose_retrieve_query("x" * n)
+            assert len(result) <= 500
+            assert result.startswith('"')
+            assert result.endswith('"')
+            # Even number of unescaped quotes — for a pure-x title the
+            # only quotes are the two surrounding ones.
+            assert result.count('"') == 2


### PR DESCRIPTION
## Summary

- `compose_retrieve_query()` in `src/influx/lcma.py` previously joined the title and contributions with raw `" | "` separators. Academic titles using the `Topic: Subtitle` form caused Tantivy to interpret the capitalised word before the colon as a field qualifier and reject the query with `Field does not exist: '<Word>'`, silently zeroing the LCMA lexical scout result.
- This was the source of the 23 `Tantivy query parse/search failed` warnings observed in the 5-minute window at 06:05–06:06 on 2026-05-04 staging — see #80.

## Fix

- Wrap each disjunct (title + each contribution) as a Tantivy phrase query: double-quoted, with `\` and `"` backslash-escaped inside.
- Inside a phrase, `:`, `(`, `)`, `'` lose their syntactic meaning, so titles like `"RunAgent: Interpreting Natural-Language Plans"` parse cleanly.
- The `|` between disjuncts is still parsed as OR, so the caller's intent (OR of phrase matches across title + first 3 contributions) is preserved.

## Scope

Caller-side fix only, per the investigation comment on #80. The server-side hardening for `lithos_retrieve` / the LCMA lexical scout is tracked separately at agent-lore/lithos#240.

## Test plan

- [x] `make check` — lint + format + pyright clean, **1733 tests pass**
- [x] Existing 13 `GOLDEN_CASES` rows updated to expect the new wrapped form (behaviour-change to the wire format, which is the contract being changed)
- [x] 7 new `ISSUE-80-*` rows cover the regression set called out in the issue's acceptance criteria:
  - colon in title (`Topic: Subtitle`)
  - colon in title with contributions
  - single quote/apostrophe in title
  - parentheses in title
  - double quotes inside content (escaped)
  - backslashes inside content (escaped)
  - colon in contribution (not just title)
- [x] `TestTruncation` updated for the new wrapped lengths — the truncation contract remains a simple slice of the final composed string with no word re-wrap

Closes #80