### PR TITLE
feat: stagger profile fan-out within tick to avoid arXiv 429 cluster

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -79,7 +79,7 @@ Status: Aligned with Implementation
 ### 2.2 Runtime Flow
 
 1. `serve` loads config, validates the local admin bind address, creates the FastAPI app, starts the probe loop, and starts the scheduler.
-2. The scheduler registers one `influx-tick` cron dispatcher job. Each tick creates a fresh source provider/cache pair and starts profile runs as background tasks.
+2. The scheduler registers one `influx-tick` cron dispatcher job. Each tick creates a fresh source provider/cache pair and runs profile runs **sequentially in declared config order** within the tick, optionally separated by `schedule.inter_profile_gap_seconds` and preceded by a uniform random delay of `[0, schedule.initial_jitter_seconds]` (issue #87 — avoids arXiv hour-boundary 429 clustering when multiple profiles share the same cron expression). The single shared `begin_fire` / `end_fire` window is preserved, so cross-profile fetch deduplication (R-8 / AC-09-D) still holds.
 3. Manual `POST /runs` and `POST /backfills` requests acquire per-profile locks and spawn background run tasks.
 4. The HTTP / scheduler entry points build a `RunPlan` and hand off to `RunService.execute()`. RunService checks the probe-time skip gates (`lithos_circuit_open`, `lcma_tools_unavailable`), opens the ledger entry + run-level metrics + tracer span, and delegates the body to `Run.execute()`.
 5. `Run.execute()` walks five named stages — repair (skipped on backfill), feedback (negative examples + filter prompt), acquire (`Source.fetch_candidates` → `Filter.score` → `Source.acquire`), ingest (per item: `cache_lookup` → `Cascade.enrich` → `Renderer.render` → `LithosClient.write_note` → `LcmaWiring.wire`), finalise (assemble outcome + fire notifications when `plan.notify`). The Lithos task lifecycle (`task_create` / `task_complete`) brackets the body via an inner CM.
@@ -119,7 +119,7 @@ Environment overrides are applied for selected runtime values. The complete anno
 
 - `[influx]`: `note_schema_version`, stamped as `schema:<version>` on Influx-authored notes.
 - `[lithos]`: Lithos MCP endpoint and transport. Only `transport = "sse"` is supported.
-- `[schedule]`: cron expression, timezone, misfire grace, and shutdown grace.
+- `[schedule]`: cron expression, timezone, misfire grace, shutdown grace, optional initial-tick jitter (`initial_jitter_seconds`), and optional inter-profile gap (`inter_profile_gap_seconds`).
 - `[storage]`: archive directory, local state directory, retention setting, max download size, and download timeout.
 - `[notifications]`: outbound timeout plus typed `[[notifications.webhooks]]` sinks. `notifications.webhook_url` remains as a legacy single-sink generic-digest fallback.
 - `[security]`: outbound/private-IP and remote-admin bind policy.
@@ -767,3 +767,4 @@ Known warnings in the suite:
 6. Archive retention is configured but no retention-pruning worker is implemented in the current code.
 7. RSS filtering requires a configured `models.filter` slot and provider; failed RSS filter batches are skipped.
 8. Source archives and Lithos notes can diverge when archive download fails; repair tags mark those notes for later recovery.
+9. All profiles share a single global cron expression. Within a tick they run sequentially in declared order, separated by `schedule.inter_profile_gap_seconds`, with an initial random jitter of `[0, schedule.initial_jitter_seconds]`. True per-profile cadence (different cron expressions per profile) is not yet supported; tracked separately under issue #90.

--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -361,7 +361,55 @@ the unsuffixed-slug squatter, which can be removed the same way.
 surfacing both squatters in a single WARNING so they can be cleaned
 in one pass.
 
-## 9. Reference
+## 9. Scheduling stagger (issue #87)
+
+Profiles share a single global `[schedule].cron` expression. Within
+each tick, profiles run **sequentially in declared `[[profiles]]`
+order**. Two `[schedule]` knobs shape that fan-out:
+
+| Setting | Effect |
+| ------- | ------ |
+| `initial_jitter_seconds` | Sleep a uniform random `[0, N]` seconds at tick start, before any profile runs. Defaults to `0`. |
+| `inter_profile_gap_seconds` | Sleep `N` seconds between consecutive profiles in the same tick. Not applied before the first profile or after the last. Defaults to `0`. |
+
+Why this exists: when multiple profiles fire on the hour (e.g. `0 *
+* * *`), they hit shared upstreams (arXiv categories, RSS feeds) at
+exactly `:00:NN` of every hour and cluster with every other on-the-hour
+arXiv consumer — easy 429 territory. `initial_jitter_seconds` walks the
+tick off the boundary; `inter_profile_gap_seconds` separates profile-A
+and profile-B requests within the tick.
+
+Recommended starting values for staging:
+
+```toml
+[schedule]
+cron = "0 * * * *"
+initial_jitter_seconds = 30
+inter_profile_gap_seconds = 1800   # 30 minutes
+```
+
+What this does **not** give you:
+
+- Independent cadence per profile (e.g. profile-A every 6h, profile-B
+  every 12h). All profiles share one cron expression. True per-profile
+  cron is tracked separately under issue #90.
+- Any change to the arXiv retry/backoff policy. Backoff after a 429
+  remains `resilience.arxiv_429_backoff_seconds` × `resilience.max_retries`;
+  staggering reduces *whether* we hit 429 in the first place.
+
+Verification after a config change:
+
+```
+./scripts/influx-diagnose.py recent --limit 10
+./scripts/influx-diagnose.py warnings --since 24h --contains "429"
+```
+
+If both staggered profiles still hit 429 clusters, file a follow-up to
+revisit `resilience.arxiv_429_backoff_seconds` (e.g. exponential
+backoff). Don't tune backoff until you can show staggering didn't fix
+the recurrence.
+
+## 10. Reference
 
 - Run ledger schema: `src/influx/run_ledger.py` (`RunEntry` TypedDict).
 - Admin endpoints: `src/influx/http_api.py` (`/live`, `/ready`,

--- a/influx.example.toml
+++ b/influx.example.toml
@@ -13,6 +13,14 @@ note_schema_version = 1         # stamped on every Influx-authored note
 cron = "0 6 * * *"              # daily at 06:00
 timezone = "UTC"
 misfire_grace_seconds = 3600    # tolerate missed fires within an hour
+# Stagger the per-tick request pattern away from exact hour boundaries
+# (issue #87) so we don't cluster with every other arXiv consumer at
+# `:00:NN`.  ``initial_jitter_seconds`` adds a uniform random delay in
+# ``[0, N]`` before fan-out begins; ``inter_profile_gap_seconds``
+# serialises profiles within one tick with the configured gap between
+# them.  Both default to 0 (legacy parallel fan-out).
+# initial_jitter_seconds = 30
+# inter_profile_gap_seconds = 1800   # 30 minutes between profiles
 
 [storage]
 archive_dir = "/archive"

--- a/src/influx/config.py
+++ b/src/influx/config.py
@@ -74,6 +74,28 @@ class ScheduleConfig(BaseModel):
     timezone: str = "UTC"
     misfire_grace_seconds: int = 3600
     shutdown_grace_seconds: int = 30
+    # Issue #87: avoid arXiv hour-boundary 429 clusters.  ``initial_jitter_seconds``
+    # introduces a uniform random delay in ``[0, N]`` at the start of each
+    # cron tick so the request pattern is not perfectly aligned with the
+    # cron expression (e.g. ``:00:00`` of every hour).
+    # ``inter_profile_gap_seconds`` runs profiles sequentially within a
+    # single tick with the configured gap between them, so two profiles
+    # configured on the same cron expression no longer hit shared upstreams
+    # (arXiv categories, RSS feeds) within the same wall-clock second.
+    # Both default to ``0`` to preserve historical behaviour; operators
+    # opt in via ``[schedule]`` in ``influx.toml``.
+    initial_jitter_seconds: int = 0
+    inter_profile_gap_seconds: int = 0
+
+    @field_validator("initial_jitter_seconds", "inter_profile_gap_seconds")
+    @classmethod
+    def _non_negative(cls, v: int) -> int:
+        if v < 0:
+            raise ConfigError(
+                "schedule.initial_jitter_seconds and "
+                "schedule.inter_profile_gap_seconds must be non-negative"
+            )
+        return v
 
 
 class StorageConfig(BaseModel):

--- a/src/influx/scheduler.py
+++ b/src/influx/scheduler.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import random
 from collections.abc import Awaitable, Callable, Iterable
 from typing import Any
 
@@ -308,6 +309,15 @@ class InfluxScheduler:
 
         Per-source fetches within a single tick are deduplicated across
         profiles for that tick's fan-out (R-8, AC-09-D).
+
+        Issue #87: profiles run **sequentially in declared config order**
+        with an optional ``schedule.inter_profile_gap_seconds`` between
+        them, and an optional ``schedule.initial_jitter_seconds`` random
+        delay applied once at the start of the tick.  This avoids
+        arXiv-side rate-limit clustering at exact hour boundaries when
+        multiple profiles share the same cron expression.  The single
+        shared ``begin_fire`` / ``end_fire`` window is preserved so
+        cross-profile fetch deduplication (R-8, AC-09-D) still holds.
         """
         if provider is None and self._item_provider_factory is not None:
             provider, cache = self._item_provider_factory()
@@ -316,16 +326,29 @@ class InfluxScheduler:
         if cache is None:
             cache = self._fetch_cache
 
+        initial_jitter = self._config.schedule.initial_jitter_seconds
+        if initial_jitter > 0:
+            await asyncio.sleep(random.uniform(0, initial_jitter))  # noqa: S311
+
         if cache is not None:
             cache.begin_fire()
         try:
-            await asyncio.gather(
-                *(
-                    self._fire_profile(profile.name, item_provider=provider)
-                    for profile in self._config.profiles
-                ),
-                return_exceptions=True,
-            )
+            gap = self._config.schedule.inter_profile_gap_seconds
+            for index, profile in enumerate(self._config.profiles):
+                if index > 0 and gap > 0:
+                    await asyncio.sleep(gap)
+                try:
+                    await self._fire_profile(profile.name, item_provider=provider)
+                except Exception:  # pragma: no cover — defensive parity
+                    # Mirror the previous ``return_exceptions=True``
+                    # gather behaviour so one profile's failure does not
+                    # abort the rest of the tick.  ``_fire_profile`` already
+                    # swallows ``ProfileBusyError``; this guards against
+                    # ``run_profile`` raising for any other reason.
+                    logger.exception(
+                        "Scheduled fire for %r raised; continuing tick",
+                        profile.name,
+                    )
         finally:
             if cache is not None:
                 cache.end_fire()

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -24,6 +24,8 @@ def _make_config(
     cron: str = "0 6 * * *",
     timezone: str = "UTC",
     misfire_grace_seconds: int = 3600,
+    initial_jitter_seconds: int = 0,
+    inter_profile_gap_seconds: int = 0,
 ) -> AppConfig:
     """Build a minimal AppConfig for scheduler tests."""
     profile_names = profiles if profiles is not None else ["alpha", "beta"]
@@ -33,6 +35,8 @@ def _make_config(
             cron=cron,
             timezone=timezone,
             misfire_grace_seconds=misfire_grace_seconds,
+            initial_jitter_seconds=initial_jitter_seconds,
+            inter_profile_gap_seconds=inter_profile_gap_seconds,
         ),
         profiles=profile_list,
         prompts=PromptsConfig(
@@ -197,52 +201,60 @@ class TestTickOverlapDoesNotBlockUnrelatedProfiles:
     """
 
     async def test_tick2_runs_profile_b_while_tick1_alpha_blocks(self) -> None:
+        """Cross-tick non-blocking under #87 sequential semantics.
+
+        Profiles within a single tick now run sequentially in declared
+        config order, so beta from tick1 cannot overtake a stuck alpha
+        in the same tick.  The cross-tick guarantee still holds though:
+        tick2 fires while tick1's alpha is blocked, sees alpha as busy
+        (skip via the coordinator), and proceeds to run beta — proving
+        APScheduler is not the gate, only the coordinator is.
+        """
         config = _make_config(profiles=["alpha", "beta"])
         coord = Coordinator()
         sched = InfluxScheduler(config, coord)
 
         started: list[str] = []
+        alpha_started = asyncio.Event()
         alpha_block = asyncio.Event()
-        beta_done = asyncio.Event()
 
         async def slow_run(
             profile: str, kind: Any, run_range: Any = None, **_: Any
         ) -> None:
             started.append(profile)
             if profile == "alpha":
+                alpha_started.set()
                 # alpha from tick1 stays in flight until released.
                 await alpha_block.wait()
-            else:
-                # beta finishes promptly so tick2 can re-run it.
-                beta_done.set()
 
         with patch("influx.scheduler.run_profile", side_effect=slow_run):
             tick1 = asyncio.create_task(sched._fire_tick())
-            # Wait for tick1's beta to actually finish (so its lock is free)
-            # while tick1's alpha remains stuck.
-            await asyncio.wait_for(beta_done.wait(), timeout=1.0)
+            # Wait for tick1's alpha to actually start and hold the lock.
+            await asyncio.wait_for(alpha_started.wait(), timeout=1.0)
             assert coord.is_busy("alpha") is True
             assert coord.is_busy("beta") is False
+            # Sequential: tick1's beta has NOT started yet — it queues
+            # behind the still-running alpha.
+            assert started == ["alpha"]
 
-            # Tick2 fires while tick1's alpha is still running.
+            # Tick2 fires while tick1's alpha is still running.  Its alpha
+            # is skipped (busy); its beta runs because beta's lock is free.
             tick2 = asyncio.create_task(sched._fire_tick())
-            # Drain pending callbacks so tick2's fan-out can dispatch.
-            for _ in range(10):
-                await asyncio.sleep(0)
+            await asyncio.wait_for(tick2, timeout=1.0)
 
-            # tick2's beta must have run; tick2's alpha must have been
-            # skipped (lock held by tick1).
-            assert started.count("beta") == 2
+            # tick2 ran beta exactly once, skipped alpha entirely.
+            assert started.count("beta") == 1
             assert started.count("alpha") == 1
             assert coord.is_busy("alpha") is True
 
-            # Tick2 has nothing left to do (alpha skipped, beta done).
-            await asyncio.wait_for(tick2, timeout=1.0)
-
-            # Release alpha so tick1 can finish.
+            # Release alpha so tick1 can finish (which then runs tick1's beta).
             alpha_block.set()
             await asyncio.wait_for(tick1, timeout=1.0)
 
+        # By the time both ticks complete: alpha ran once (tick1, tick2 skipped),
+        # beta ran twice (tick2 first while tick1 was blocked, tick1 after).
+        assert started.count("alpha") == 1
+        assert started.count("beta") == 2
         assert coord.is_busy("alpha") is False
         assert coord.is_busy("beta") is False
 
@@ -361,6 +373,221 @@ class TestTickOverlapDoesNotBlockUnrelatedProfiles:
         for cache in produced_caches:
             assert cache.begin_count == 1
             assert cache.end_count == 1
+
+
+# ── Sequential within-tick fan-out + jitter / gap (issue #87) ──────
+
+
+class TestSequentialFanOutWithJitterAndGap:
+    """Issue #87: avoid arXiv hour-boundary 429 clusters.
+
+    Profiles within a single cron tick now run **sequentially in
+    declared config order** with an optional gap between them, after an
+    optional initial jitter at the start of the tick.  Both knobs live
+    under ``[schedule]`` and default to 0 for backwards-compatible
+    behaviour.  The shared ``begin_fire`` / ``end_fire`` window around
+    the whole fan-out is preserved so cross-profile fetch dedup
+    (R-8 / AC-09-D) still holds.
+    """
+
+    async def test_profiles_run_in_declared_config_order(self) -> None:
+        """Sequential, in the order profiles appear in ``[[profiles]]``."""
+        config = _make_config(profiles=["alpha", "beta", "gamma"])
+        coord = Coordinator()
+        sched = InfluxScheduler(config, coord)
+
+        order: list[str] = []
+
+        async def spy(profile: str, kind: Any, run_range: Any = None, **_: Any) -> None:
+            order.append(profile)
+
+        with patch("influx.scheduler.run_profile", side_effect=spy):
+            await sched._fire_tick()
+
+        assert order == ["alpha", "beta", "gamma"]
+
+    async def test_initial_jitter_sleeps_before_first_profile(self) -> None:
+        """``initial_jitter_seconds`` produces one sleep at tick start."""
+        config = _make_config(
+            profiles=["alpha", "beta"],
+            initial_jitter_seconds=30,
+        )
+        coord = Coordinator()
+        sched = InfluxScheduler(config, coord)
+
+        sleep_calls: list[float] = []
+        order: list[str] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+            order.append(f"sleep:{seconds}")
+
+        async def spy(profile: str, kind: Any, run_range: Any = None, **_: Any) -> None:
+            order.append(profile)
+
+        with (
+            patch(
+                "influx.scheduler.random.uniform",
+                return_value=17.0,
+            ),
+            patch("influx.scheduler.asyncio.sleep", side_effect=fake_sleep),
+            patch("influx.scheduler.run_profile", side_effect=spy),
+        ):
+            await sched._fire_tick()
+
+        # The jitter sleep is the first thing that happens, before any
+        # profile runs.
+        assert order[0] == "sleep:17.0"
+        assert order[1:] == ["alpha", "beta"]
+        # No inter-profile gap configured → only the jitter sleep fires.
+        assert sleep_calls == [17.0]
+
+    async def test_zero_jitter_skips_sleep(self) -> None:
+        """``initial_jitter_seconds = 0`` does not call sleep."""
+        config = _make_config(
+            profiles=["alpha"],
+            initial_jitter_seconds=0,
+        )
+        coord = Coordinator()
+        sched = InfluxScheduler(config, coord)
+
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        async def spy(profile: str, kind: Any, run_range: Any = None, **_: Any) -> None:
+            pass
+
+        with (
+            patch("influx.scheduler.asyncio.sleep", side_effect=fake_sleep),
+            patch("influx.scheduler.run_profile", side_effect=spy),
+        ):
+            await sched._fire_tick()
+
+        assert sleep_calls == []
+
+    async def test_inter_profile_gap_sleeps_between_profiles(self) -> None:
+        """``inter_profile_gap_seconds`` sleeps between each pair, not before
+        the first profile and not after the last."""
+        config = _make_config(
+            profiles=["alpha", "beta", "gamma"],
+            inter_profile_gap_seconds=42,
+        )
+        coord = Coordinator()
+        sched = InfluxScheduler(config, coord)
+
+        events: list[str] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            events.append(f"sleep:{seconds}")
+
+        async def spy(profile: str, kind: Any, run_range: Any = None, **_: Any) -> None:
+            events.append(profile)
+
+        with (
+            patch("influx.scheduler.asyncio.sleep", side_effect=fake_sleep),
+            patch("influx.scheduler.run_profile", side_effect=spy),
+        ):
+            await sched._fire_tick()
+
+        # Gap fires between profile pairs only — not before alpha,
+        # not after gamma.
+        assert events == [
+            "alpha",
+            "sleep:42",
+            "beta",
+            "sleep:42",
+            "gamma",
+        ]
+
+    async def test_zero_gap_runs_back_to_back(self) -> None:
+        """``inter_profile_gap_seconds = 0`` does not insert sleeps."""
+        config = _make_config(
+            profiles=["alpha", "beta"],
+            inter_profile_gap_seconds=0,
+        )
+        coord = Coordinator()
+        sched = InfluxScheduler(config, coord)
+
+        events: list[str] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            events.append(f"sleep:{seconds}")
+
+        async def spy(profile: str, kind: Any, run_range: Any = None, **_: Any) -> None:
+            events.append(profile)
+
+        with (
+            patch("influx.scheduler.asyncio.sleep", side_effect=fake_sleep),
+            patch("influx.scheduler.run_profile", side_effect=spy),
+        ):
+            await sched._fire_tick()
+
+        assert events == ["alpha", "beta"]
+
+    async def test_profile_failure_does_not_abort_remaining_profiles(
+        self,
+    ) -> None:
+        """One profile raising must not skip subsequent profiles in the tick."""
+        config = _make_config(profiles=["alpha", "beta", "gamma"])
+        coord = Coordinator()
+        sched = InfluxScheduler(config, coord)
+
+        ran: list[str] = []
+
+        async def maybe_fail(
+            profile: str, kind: Any, run_range: Any = None, **_: Any
+        ) -> None:
+            ran.append(profile)
+            if profile == "beta":
+                raise RuntimeError("beta exploded")
+
+        with patch("influx.scheduler.run_profile", side_effect=maybe_fail):
+            await sched._fire_tick()
+
+        assert ran == ["alpha", "beta", "gamma"]
+        # Locks released for every profile despite the middle one raising.
+        for name in ("alpha", "beta", "gamma"):
+            assert coord.is_busy(name) is False
+
+    async def test_fetch_cache_window_brackets_full_sequential_fanout(
+        self,
+    ) -> None:
+        """The single shared ``begin_fire`` / ``end_fire`` window is preserved.
+
+        Sequential within-tick fan-out must still bracket all profiles
+        in one cache scope so cross-profile fetch dedup (R-8, AC-09-D)
+        keeps working.
+        """
+        config = _make_config(
+            profiles=["alpha", "beta"],
+            inter_profile_gap_seconds=0,
+        )
+        coord = Coordinator()
+
+        events: list[str] = []
+
+        class _RecordingCache:
+            def begin_fire(self) -> None:
+                events.append("begin_fire")
+
+            def end_fire(self) -> None:
+                events.append("end_fire")
+
+        sched = InfluxScheduler(
+            config,
+            coord,
+            fetch_cache=_RecordingCache(),
+        )
+
+        async def spy(profile: str, kind: Any, run_range: Any = None, **_: Any) -> None:
+            events.append(profile)
+
+        with patch("influx.scheduler.run_profile", side_effect=spy):
+            await sched._fire_tick()
+
+        assert events == ["begin_fire", "alpha", "beta", "end_fire"]
 
 
 # ── Cross-profile parallelism (AC-M3-1) ────────────────────────────


### PR DESCRIPTION
## Summary

- Profiles within a cron tick now run **sequentially in declared `[[profiles]]` order** instead of fanning out via `asyncio.gather`.
- New `[schedule].initial_jitter_seconds` adds a uniform random `[0, N]` delay at the start of each tick; new `[schedule].inter_profile_gap_seconds` separates consecutive profiles within the tick. Both default to `0`.
- Single global cron trigger and the shared `begin_fire` / `end_fire` window are preserved, so cross-profile fetch deduplication (R-8 / AC-09-D) still holds.
- True per-profile cadence (different cron expressions per profile) remains a separate follow-up tracked under #90.

## Why

`staging-ai` hit arXiv 429 clusters at exact `:00:NN` on both visible cron ticks of 2026-05-04 — every profile fired at the same wall-clock second and competed with every other on-the-hour arXiv consumer. Walking the tick off the boundary and serialising profile requests addresses the observed clustering with minimal scheduler churn (per the recommendation in #87).

The arXiv retry/backoff policy is intentionally **not** changed here. If 429 clusters recur after staggering is configured, that becomes evidence to file a follow-up bumping `resilience.arxiv_429_backoff_seconds` to exponential.

## Notes

- `_fire_tick` swallows non-`ProfileBusyError` exceptions per profile (parity with the old `gather(return_exceptions=True)` so one profile's failure doesn't abort the rest of the tick).
- `tests/unit/test_scheduler.py::TestTickOverlapDoesNotBlockUnrelatedProfiles::test_tick2_runs_profile_b_while_tick1_alpha_blocks` was rewritten — it still proves the cross-tick non-blocking guarantee, but under sequential within-tick semantics.

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .` clean
- [x] `uv run pyright src/` clean
- [x] `uv run pytest tests/ -q` — full suite passes (1767 tests)
- [x] New unit tests cover: declared-order execution, initial-jitter sleep + ordering, zero-jitter no-sleep, gap between pairs only, zero-gap back-to-back, profile-failure isolation, fetch-cache window bracketing
- [ ] Verify on staging: set `initial_jitter_seconds = 30`, `inter_profile_gap_seconds = 1800`, then 24h check via `./scripts/influx-diagnose.py warnings --since 24h --contains "429"` shows no clusters

Closes #87