### PR TITLE
Fix RSS filter chunking

### DIFF
--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -375,28 +375,6 @@ async def _score_rss_items(
     if provider is None:
         raise FilterScorerError(f"filter provider {slot.provider!r} not configured")
 
-    candidates = [
-        {"id": _rss_filter_id(item), "title": item.title, "abstract": item.summary}
-        for item in items
-    ]
-    body: dict[str, Any] = {
-        "model": slot.model,
-        "temperature": slot.temperature,
-        "messages": [
-            {
-                "role": "user",
-                "content": (
-                    f"{filter_prompt}\n\n## CANDIDATES\n"
-                    f"{json.dumps(candidates, ensure_ascii=False)}"
-                ),
-            }
-        ],
-    }
-    if slot.max_tokens is not None:
-        body["max_tokens"] = slot.max_tokens
-    if slot.json_mode:
-        body["response_format"] = {"type": "json_object"}
-
     headers: dict[str, str] = {**provider.extra_headers}
     if provider.api_key_env:
         api_key = os.environ.get(provider.api_key_env, "")
@@ -405,30 +383,69 @@ async def _score_rss_items(
 
     url = f"{provider.base_url.rstrip('/')}/chat/completions"
     attempts = slot.max_retries + 1
-    last_error: Exception | None = None
-    for _attempt in range(attempts):
-        try:
-            response = guarded_post_json_fetch(
-                url,
-                body,
-                headers=headers,
-                allow_private_ips=config.security.allow_private_ips,
-                max_response_bytes=config.storage.max_download_bytes,
-                timeout_seconds=slot.request_timeout,
-            )
-            if response.status_code >= 400:
-                last_error = FilterScorerError(f"HTTP {response.status_code}")
+
+    all_scores: dict[str, Any] = {}
+    batch_size = max(int(config.filter.batch_size), 1)
+    for chunk_start in range(0, len(items), batch_size):
+        chunk = items[chunk_start : chunk_start + batch_size]
+        candidates = [
+            {"id": _rss_filter_id(item), "title": item.title, "abstract": item.summary}
+            for item in chunk
+        ]
+        body: dict[str, Any] = {
+            "model": slot.model,
+            "temperature": slot.temperature,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": (
+                        f"{filter_prompt}\n\n## CANDIDATES\n"
+                        f"{json.dumps(candidates, ensure_ascii=False)}"
+                    ),
+                }
+            ],
+        }
+        if slot.max_tokens is not None:
+            body["max_tokens"] = slot.max_tokens
+        if slot.json_mode:
+            body["response_format"] = {"type": "json_object"}
+
+        last_error: Exception | None = None
+        for _attempt in range(attempts):
+            try:
+                response = guarded_post_json_fetch(
+                    url,
+                    body,
+                    headers=headers,
+                    allow_private_ips=config.security.allow_private_ips,
+                    max_response_bytes=config.storage.max_download_bytes,
+                    timeout_seconds=slot.request_timeout,
+                )
+                if response.status_code >= 400:
+                    last_error = FilterScorerError(f"HTTP {response.status_code}")
+                    continue
+                envelope = json.loads(response.body.decode("utf-8"))
+                content = envelope["choices"][0]["message"]["content"]
+                parsed = FilterResponse.model_validate(json.loads(content))
+                all_scores.update({result.id: result for result in parsed.results})
+                break
+            except Exception as exc:
+                last_error = exc
                 continue
-            envelope = json.loads(response.body.decode("utf-8"))
-            content = envelope["choices"][0]["message"]["content"]
-            parsed = FilterResponse.model_validate(json.loads(content))
-            return {result.id: result for result in parsed.results}
-        except Exception as exc:
-            last_error = exc
-            continue
-    raise FilterScorerError(f"RSS filter failed after {attempts} attempts") from (
-        last_error
-    )
+        else:
+            exc_info = None
+            if last_error is not None:
+                exc_info = (type(last_error), last_error, last_error.__traceback__)
+            _log.warning(
+                "RSS filter failed for profile %r items %d-%d; skipping chunk",
+                profile,
+                chunk_start,
+                chunk_start + len(chunk) - 1,
+                exc_info=exc_info,
+            )
+            record_filter_error()
+
+    return all_scores
 
 
 def _rss_filter_id(item: RssFeedItem) -> str:

--- a/tests/integration/test_rss_to_lithos.py
+++ b/tests/integration/test_rss_to_lithos.py
@@ -14,26 +14,32 @@ Drives end-to-end ingest of fixture RSS feeds through
 from __future__ import annotations
 
 import http.server
+import json
 import threading
 from collections.abc import Generator
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Literal
 
 import pytest
 
 from influx.config import (
     AppConfig,
+    FilterTuningConfig,
     LithosConfig,
+    ModelSlotConfig,
     ProfileConfig,
     ProfileSources,
     PromptEntryConfig,
     PromptsConfig,
+    ProviderConfig,
     RssSourceEntry,
     ScheduleConfig,
     SecurityConfig,
     StorageConfig,
 )
 from influx.slugs import slugify_feed_name
+from influx.sources import rss as rss_module
 from influx.sources.rss import RssFeedItem, build_rss_note_item, parse_feed
 from influx.urls import url_hash
 
@@ -143,6 +149,27 @@ def _make_config(
     )
 
 
+def _make_filter_config(*, archive_dir: Path, batch_size: int) -> AppConfig:
+    """Build a minimal AppConfig with an LLM filter slot for RSS scoring."""
+    config = _make_config(archive_dir=archive_dir)
+    return config.model_copy(
+        update={
+            "providers": {
+                "test": ProviderConfig(base_url="https://llm.example/v1"),
+            },
+            "models": {
+                "filter": ModelSlotConfig(
+                    provider="test",
+                    model="test-filter",
+                    max_retries=0,
+                    json_mode=True,
+                ),
+            },
+            "filter": FilterTuningConfig(batch_size=batch_size),
+        }
+    )
+
+
 def _make_item(
     *,
     title: str = "Test Article",
@@ -163,6 +190,125 @@ def _make_item(
         source_tag=source_tag,
         feed_name=feed_name,
     )
+
+
+def _filter_response_for(candidate_ids: list[str]) -> SimpleNamespace:
+    content = json.dumps(
+        {
+            "results": [
+                {"id": candidate_id, "score": 8, "tags": [], "reason": "ok"}
+                for candidate_id in candidate_ids
+            ]
+        }
+    )
+    envelope = {"choices": [{"message": {"content": content}}]}
+    return SimpleNamespace(status_code=200, body=json.dumps(envelope).encode())
+
+
+def _candidate_ids_from_filter_body(body: dict[str, object]) -> list[str]:
+    messages = body["messages"]
+    assert isinstance(messages, list)
+    content = messages[0]["content"]
+    assert isinstance(content, str)
+    candidates_json = content.split("## CANDIDATES\n", 1)[1]
+    candidates = json.loads(candidates_json)
+    return [candidate["id"] for candidate in candidates]
+
+
+# ── Issue #94: RSS filter chunking ──────────────────────────────────────
+
+
+async def test_score_rss_items_chunks_by_filter_batch_size(
+    archive_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _make_filter_config(archive_dir=archive_dir, batch_size=3)
+    items = [
+        _make_item(url=f"https://example.com/post-{i}", title=f"Post {i}")
+        for i in range(7)
+    ]
+    chunk_lengths: list[int] = []
+
+    def fake_post_json_fetch(
+        url: str,
+        body: dict[str, object],
+        **kwargs: object,
+    ) -> SimpleNamespace:
+        candidate_ids = _candidate_ids_from_filter_body(body)
+        chunk_lengths.append(len(candidate_ids))
+        return _filter_response_for(candidate_ids)
+
+    monkeypatch.setattr(
+        rss_module,
+        "guarded_post_json_fetch",
+        fake_post_json_fetch,
+    )
+
+    scores = await rss_module._score_rss_items(
+        items=items,
+        profile="test-profile",
+        filter_prompt="score these",
+        config=config,
+    )
+
+    assert chunk_lengths == [3, 3, 1]
+    assert set(scores) == {_rss_filter_id_for(item) for item in items}
+
+
+async def test_score_rss_items_skips_failed_chunk_but_keeps_other_scores(
+    archive_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _make_filter_config(archive_dir=archive_dir, batch_size=2)
+    items = [
+        _make_item(url=f"https://example.com/post-{i}", title=f"Post {i}")
+        for i in range(5)
+    ]
+    failed_chunk_ids = {
+        url_hash("https://example.com/post-2"),
+        url_hash("https://example.com/post-3"),
+    }
+    recorded_errors: list[None] = []
+
+    def fake_post_json_fetch(
+        url: str,
+        body: dict[str, object],
+        **kwargs: object,
+    ) -> SimpleNamespace:
+        candidate_ids = _candidate_ids_from_filter_body(body)
+        if set(candidate_ids) == failed_chunk_ids:
+            envelope = {"choices": [{"message": {"content": '{"results": ['}}]}
+            return SimpleNamespace(status_code=200, body=json.dumps(envelope).encode())
+        return _filter_response_for(candidate_ids)
+
+    monkeypatch.setattr(
+        rss_module,
+        "guarded_post_json_fetch",
+        fake_post_json_fetch,
+    )
+    monkeypatch.setattr(
+        rss_module,
+        "record_filter_error",
+        lambda: recorded_errors.append(None),
+    )
+
+    scores = await rss_module._score_rss_items(
+        items=items,
+        profile="test-profile",
+        filter_prompt="score these",
+        config=config,
+    )
+
+    assert set(scores) == {
+        url_hash("https://example.com/post-0"),
+        url_hash("https://example.com/post-1"),
+        url_hash("https://example.com/post-4"),
+    }
+    assert len(recorded_errors) == 1
+
+
+def _rss_filter_id_for(item: RssFeedItem) -> str:
+    return url_hash(item.url)
 
 
 # ── AC-09-A: source tag, archive path, and note path all agree ───────


### PR DESCRIPTION
## Summary
- chunk RSS filter scoring requests by config.filter.batch_size instead of sending entire feeds in one prompt
- merge successful chunk scores and record filter_error only for chunks that exhaust retries
- add RSS regression tests for chunk sizing and partial failure handling

Fixes #94.

## Tests
- uv run pytest tests/integration/test_rss_to_lithos.py -q
- uv run pytest tests/unit/test_filter.py tests/unit/test_filter_batch_size.py tests/integration/test_rss_to_lithos.py -q
- uv run ruff check src/influx/sources/rss.py tests/integration/test_rss_to_lithos.py
- uv run pyright src/influx/sources/rss.py tests/integration/test_rss_to_lithos.py