### PR TITLE
Honor arXiv Retry-After backoff

### DIFF
--- a/influx.example.toml
+++ b/influx.example.toml
@@ -293,6 +293,9 @@ strip_tags = ["script", "iframe", "object", "embed"]
 # ---------------------------------------------------------------------------
 
 [resilience]
+# Recommended for staging/prod arXiv traffic: max_retries = 5 and
+# arxiv_429_backoff_seconds = 30. Retry-After headers override the flat
+# 429 backoff when arXiv provides them.
 max_retries = 3
 backoff_base_seconds = 1
 arxiv_request_min_interval_seconds = 3

--- a/src/influx/http_client.py
+++ b/src/influx/http_client.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import ipaddress
 import socket
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 from urllib.parse import urljoin, urlparse
 
@@ -57,6 +57,7 @@ class FetchResult:
     status_code: int
     content_type: str
     final_url: str
+    headers: dict[str, str] = field(default_factory=dict)
 
 
 # ── Scheme validation ────────────────────────────────────────────────
@@ -232,6 +233,7 @@ def guarded_fetch(
                     body = b"".join(chunks)
                     status_code = response.status_code
                     content_type = response.headers.get("content-type", "")
+                    response_headers = dict(response.headers)
                     final_url = str(response.url)
                     break
             else:
@@ -266,6 +268,7 @@ def guarded_fetch(
         status_code=status_code,
         content_type=content_type,
         final_url=final_url,
+        headers=response_headers,
     )
 
 
@@ -384,6 +387,7 @@ def guarded_post_json_fetch(
                 status_code=response.status_code,
                 content_type=response.headers.get("content-type", ""),
                 final_url=str(response.url),
+                headers=dict(response.headers),
             )
     except NetworkError:
         raise

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -6,8 +6,8 @@ client-side date filtering against ``profile.sources.arxiv.lookback_days``
 (FR-SRC-1, FR-SRC-2).
 
 Retry behaviour:
-- HTTP 429 → sleep ``resilience.arxiv_429_backoff_seconds`` then retry
-  (FR-RES-2)
+- HTTP 429 → honour ``Retry-After`` when present, otherwise sleep
+  ``resilience.arxiv_429_backoff_seconds`` then retry (FR-RES-2)
 - Other transient failures → exponential backoff from
   ``resilience.backoff_base_seconds`` (FR-RES-1)
 
@@ -24,6 +24,7 @@ import xml.etree.ElementTree as ET
 from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -90,6 +91,7 @@ _XML_CONTENT_TYPES: frozenset[str] = frozenset(
         "application/rss+xml",
     }
 )
+_RETRY_AFTER_MAX_SECONDS = 300.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -338,6 +340,47 @@ def _sleep(seconds: float) -> None:
     time.sleep(seconds)
 
 
+def _header_value(headers: dict[str, str], name: str) -> str | None:
+    """Return an HTTP header value using case-insensitive lookup."""
+    name_lower = name.lower()
+    for key, value in headers.items():
+        if key.lower() == name_lower:
+            return value
+    return None
+
+
+def _parse_retry_after_seconds(value: str) -> float | None:
+    """Parse RFC 7231 ``Retry-After`` as seconds or HTTP-date."""
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        seconds = float(value)
+    except ValueError:
+        try:
+            retry_at = parsedate_to_datetime(value)
+        except (TypeError, ValueError, IndexError):
+            return None
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=UTC)
+        seconds = retry_at.timestamp() - time.time()
+    if seconds < 0:
+        return 0.0
+    return min(seconds, _RETRY_AFTER_MAX_SECONDS)
+
+
+def _arxiv_429_delay(
+    result_headers: dict[str, str],
+    resilience: ResilienceConfig,
+) -> float:
+    retry_after = _header_value(result_headers, "Retry-After")
+    if retry_after is not None:
+        parsed = _parse_retry_after_seconds(retry_after)
+        if parsed is not None:
+            return max(float(resilience.arxiv_request_min_interval_seconds), parsed)
+    return float(resilience.arxiv_429_backoff_seconds)
+
+
 def fetch_arxiv(
     *,
     arxiv_config: ArxivSourceConfig,
@@ -440,7 +483,6 @@ def _fetch_with_retry(
 
     max_retries = resilience.max_retries
     backoff_base = resilience.backoff_base_seconds
-    backoff_429 = resilience.arxiv_429_backoff_seconds
 
     last_error: Exception | None = None
 
@@ -477,13 +519,14 @@ def _fetch_with_retry(
                 kind="rate_limit",
             )
             if attempt < max_retries:
+                delay = _arxiv_429_delay(result.headers, resilience)
                 _log.warning(
-                    "arXiv 429 on attempt %d/%d, backing off %ds (FR-RES-2)",
+                    "arXiv 429 on attempt %d/%d, backing off %.1fs (FR-RES-2)",
                     attempt + 1,
                     max_retries + 1,
-                    backoff_429,
+                    delay,
                 )
-                _sleep(backoff_429)
+                _sleep(delay)
                 continue
             raise last_error
 

--- a/tests/unit/test_arxiv_fetcher.py
+++ b/tests/unit/test_arxiv_fetcher.py
@@ -34,12 +34,14 @@ def _make_fetch_result(
     status_code: int = 200,
     content_type: str = "application/atom+xml",
     final_url: str = "https://export.arxiv.org/api/query",
+    headers: dict[str, str] | None = None,
 ) -> FetchResult:
     return FetchResult(
         body=body,
         status_code=status_code,
         content_type=content_type,
         final_url=final_url,
+        headers=headers or {},
     )
 
 
@@ -577,6 +579,123 @@ class TestFetchRetry:
         assert len(items) == 2
         # Must be the fixed 429 backoff, NOT base * 2**0 = 1s.
         mock_sleep.assert_called_once_with(12)
+
+    @patch("influx.sources.arxiv._sleep")
+    @patch("influx.sources.arxiv.guarded_fetch")
+    def test_429_numeric_retry_after_honoured(
+        self,
+        mock_fetch: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        body = _load_fixture("recent_two.atom")
+        mock_fetch.side_effect = [
+            _make_fetch_result(
+                b"Too many requests",
+                status_code=429,
+                headers={"Retry-After": "42"},
+            ),
+            _make_fetch_result(body),
+        ]
+
+        resilience = ResilienceConfig(
+            arxiv_429_backoff_seconds=10,
+            arxiv_request_min_interval_seconds=3,
+            max_retries=3,
+        )
+        cfg = ArxivSourceConfig(categories=["cs.AI"], lookback_days=30)
+        now = datetime(2026, 4, 24, 0, 0, 0, tzinfo=UTC)
+        items = fetch_arxiv(arxiv_config=cfg, resilience=resilience, now=now)
+
+        assert len(items) == 2
+        mock_sleep.assert_called_once_with(42)
+
+    @patch("influx.sources.arxiv.time.time", return_value=1_778_068_800.0)
+    @patch("influx.sources.arxiv._sleep")
+    @patch("influx.sources.arxiv.guarded_fetch")
+    def test_429_http_date_retry_after_honoured(
+        self,
+        mock_fetch: MagicMock,
+        mock_sleep: MagicMock,
+        mock_time: MagicMock,
+    ) -> None:
+        del mock_time
+        body = _load_fixture("recent_two.atom")
+        mock_fetch.side_effect = [
+            _make_fetch_result(
+                b"Too many requests",
+                status_code=429,
+                headers={"Retry-After": "Wed, 06 May 2026 12:01:30 GMT"},
+            ),
+            _make_fetch_result(body),
+        ]
+
+        resilience = ResilienceConfig(
+            arxiv_429_backoff_seconds=10,
+            arxiv_request_min_interval_seconds=3,
+            max_retries=3,
+        )
+        cfg = ArxivSourceConfig(categories=["cs.AI"], lookback_days=30)
+        now = datetime(2026, 4, 24, 0, 0, 0, tzinfo=UTC)
+        items = fetch_arxiv(arxiv_config=cfg, resilience=resilience, now=now)
+
+        assert len(items) == 2
+        mock_sleep.assert_called_once_with(90)
+
+    @patch("influx.sources.arxiv._sleep")
+    @patch("influx.sources.arxiv.guarded_fetch")
+    def test_429_malformed_retry_after_uses_default_backoff(
+        self,
+        mock_fetch: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        body = _load_fixture("recent_two.atom")
+        mock_fetch.side_effect = [
+            _make_fetch_result(
+                b"Too many requests",
+                status_code=429,
+                headers={"Retry-After": "not a date"},
+            ),
+            _make_fetch_result(body),
+        ]
+
+        resilience = ResilienceConfig(
+            arxiv_429_backoff_seconds=12,
+            max_retries=3,
+        )
+        cfg = ArxivSourceConfig(categories=["cs.AI"], lookback_days=30)
+        now = datetime(2026, 4, 24, 0, 0, 0, tzinfo=UTC)
+        items = fetch_arxiv(arxiv_config=cfg, resilience=resilience, now=now)
+
+        assert len(items) == 2
+        mock_sleep.assert_called_once_with(12)
+
+    @patch("influx.sources.arxiv._sleep")
+    @patch("influx.sources.arxiv.guarded_fetch")
+    def test_429_retry_after_is_clamped(
+        self,
+        mock_fetch: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        body = _load_fixture("recent_two.atom")
+        mock_fetch.side_effect = [
+            _make_fetch_result(
+                b"Too many requests",
+                status_code=429,
+                headers={"Retry-After": "999"},
+            ),
+            _make_fetch_result(body),
+        ]
+
+        resilience = ResilienceConfig(
+            arxiv_429_backoff_seconds=10,
+            max_retries=3,
+        )
+        cfg = ArxivSourceConfig(categories=["cs.AI"], lookback_days=30)
+        now = datetime(2026, 4, 24, 0, 0, 0, tzinfo=UTC)
+        items = fetch_arxiv(arxiv_config=cfg, resilience=resilience, now=now)
+
+        assert len(items) == 2
+        mock_sleep.assert_called_once_with(300)
 
     @patch("influx.sources.arxiv.guarded_fetch")
     def test_successful_non_xml_content_type_raises(


### PR DESCRIPTION
## Summary
- carry HTTP response headers through FetchResult so source retry code can inspect Retry-After
- honor arXiv 429 Retry-After headers as seconds or HTTP-date, capped at 300s and floored by arxiv_request_min_interval_seconds
- keep missing or malformed Retry-After on the existing arxiv_429_backoff_seconds fallback
- document recommended staging/prod arXiv retry values in influx.example.toml

Fixes #95.

## Tests
- uv run ruff check src/influx/http_client.py src/influx/sources/arxiv.py tests/unit/test_arxiv_fetcher.py
- uv run pyright src/influx/http_client.py src/influx/sources/arxiv.py tests/unit/test_arxiv_fetcher.py
- uv run pytest tests/unit/test_arxiv_fetcher.py tests/unit/test_archive_download.py tests/unit/test_rss_fetcher.py tests/integration/test_arxiv_pipeline_end_to_end.py -q