### PR TITLE
Reuse Lithos client for LCMA probes

### DIFF
--- a/src/influx/service.py
+++ b/src/influx/service.py
@@ -142,17 +142,31 @@ def create_app(
     # ``schedule.shutdown_grace_seconds`` (US-008).
     active_tasks: set[asyncio.Task[Any]] = set()
 
-    # Tool-lister opens a transient MCP session per probe cycle and
-    # asks Lithos which tools it exposes (issue #69).  Probing each
-    # cycle keeps the latch non-sticky — the next cycle re-evaluates
-    # so a deployment that adds the missing tools recovers
-    # automatically without an Influx restart.
+    # Tool-lister reuses one lazy LithosClient for the service lifetime.
+    # Each probe still re-evaluates the LCMA tool surface, so missing-tool
+    # deployments recover without restart, but steady-state probes no
+    # longer re-register the agent or flap the SSE connection every cycle.
+    lithos_probe_client: LithosClient | None = None
+
     async def _list_lithos_tools() -> list[str]:
-        client = LithosClient(url=config.lithos.url, transport=config.lithos.transport)
+        nonlocal lithos_probe_client
+        if lithos_probe_client is None:
+            lithos_probe_client = LithosClient(
+                url=config.lithos.url,
+                transport=config.lithos.transport,
+            )
         try:
-            return await client.list_tools()
-        finally:
-            await client.close()
+            return await lithos_probe_client.list_tools()
+        except Exception:
+            await lithos_probe_client.close()
+            lithos_probe_client = None
+            raise
+
+    async def _close_lithos_probe_client() -> None:
+        nonlocal lithos_probe_client
+        if lithos_probe_client is not None:
+            await lithos_probe_client.close()
+            lithos_probe_client = None
 
     probe_loop = ProbeLoop(
         config,
@@ -216,6 +230,7 @@ def create_app(
     app.state.item_provider = item_provider
     app.state.fetch_cache = fetch_cache
     app.state.run_ledger = run_ledger
+    app.state.close_lithos_probe_client = _close_lithos_probe_client
 
     return app
 
@@ -321,6 +336,7 @@ class InfluxService:
         self.scheduler.stop(wait=False)
 
         await self.probe_loop.stop()
+        await self._app.state.close_lithos_probe_client()
         self._started = False
         logger.info("Influx service stopped")
 

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -11,6 +11,7 @@ import pytest
 
 from influx.config import (
     AppConfig,
+    LithosConfig,
     ProfileConfig,
     PromptEntryConfig,
     PromptsConfig,
@@ -135,6 +136,84 @@ class TestCreateApp:
         assert "/status" in paths
         assert "/runs" in paths
         assert "/backfills" in paths
+
+    async def test_lcma_tool_probe_reuses_lithos_client(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Issue #93: repeated tool probes reuse one client and close at shutdown."""
+        instances: list[Any] = []
+
+        class FakeLithosClient:
+            def __init__(self, *, url: str, transport: str) -> None:
+                self.url = url
+                self.transport = transport
+                self.list_calls = 0
+                self.close_calls = 0
+                instances.append(self)
+
+            async def list_tools(self) -> list[str]:
+                self.list_calls += 1
+                return ["lithos_retrieve"]
+
+            async def close(self) -> None:
+                self.close_calls += 1
+
+        monkeypatch.setattr("influx.service.LithosClient", FakeLithosClient)
+
+        config = _make_config()
+        app = create_app(config)
+        tool_lister = app.state.probe_loop._tool_lister
+        assert tool_lister is not None
+
+        await tool_lister()
+        await tool_lister()
+
+        assert len(instances) == 1
+        assert instances[0].list_calls == 2
+        assert instances[0].close_calls == 0
+
+        await app.state.close_lithos_probe_client()
+        assert instances[0].close_calls == 1
+
+    async def test_lcma_tool_probe_resets_client_after_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failing tool probe closes the client so the next cycle reconnects."""
+        instances: list[Any] = []
+
+        class FakeLithosClient:
+            def __init__(self, *, url: str, transport: str) -> None:
+                self.url = url
+                self.transport = transport
+                self.close_calls = 0
+                instances.append(self)
+
+            async def list_tools(self) -> list[str]:
+                if len(instances) == 1:
+                    raise RuntimeError("stale SSE session")
+                return ["lithos_retrieve"]
+
+            async def close(self) -> None:
+                self.close_calls += 1
+
+        monkeypatch.setattr("influx.service.LithosClient", FakeLithosClient)
+
+        config = _make_config().model_copy(
+            update={"lithos": LithosConfig(url="http://localhost:8766/sse")}
+        )
+        app = create_app(config)
+        tool_lister = app.state.probe_loop._tool_lister
+        assert tool_lister is not None
+
+        with pytest.raises(RuntimeError, match="stale SSE session"):
+            await tool_lister()
+        await tool_lister()
+
+        assert len(instances) == 2
+        assert instances[0].close_calls == 1
+        assert instances[1].close_calls == 0
 
 
 # ── InfluxService lifecycle ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- reuse one lazy LithosClient for LCMA tool probes across the service lifetime
- stop closing the probe client after every tools/list call, preventing steady-state register/connect/close churn
- close and reset the probe client when list_tools fails so the next probe can reconnect
- close the probe client during service shutdown

Fixes #93.

## Tests
- uv run pytest tests/unit/test_service.py tests/unit/test_probes.py tests/integration/test_serve.py -q
- uv run ruff check src/influx/service.py tests/unit/test_service.py
- uv run pyright src/influx/service.py tests/unit/test_service.py