### PR TITLE
Validate LCMA tools on startup and recovery

### DIFF
--- a/src/influx/probes.py
+++ b/src/influx/probes.py
@@ -43,8 +43,9 @@ ProbeStatus = Literal["ok", "degraded"]
 
 
 # The five LCMA tools every Influx-compatible Lithos deployment must
-# expose.  Probed at startup + every probe interval; missing tools flip
-# the ``lcma_unknown_tool_failure`` latch so ``Run.execute()`` (and
+# expose. Validated at startup and after Lithos recovers from an
+# unhealthy period; missing tools flip the
+# ``lcma_unknown_tool_failure`` latch so ``Run.execute()`` (and
 # today's ``run_profile``) can skip the run with
 # ``reason="lcma_tools_unavailable"`` — replacing the legacy per-call
 # ``LCMAError("unknown_tool")`` latch (issue #69).
@@ -60,8 +61,8 @@ REQUIRED_LCMA_TOOLS: frozenset[str] = frozenset(
 
 
 # Async callable returning the tool names the connected Lithos exposes.
-# Wired in production from :meth:`influx.lithos_client.LithosClient.list_tools`.
-# Unit tests inject a stub so the probe behaviour can be exercised
+# Wired in production from an ephemeral ``LithosClient.list_tools`` call.
+# Unit tests inject a stub so the validation behaviour can be exercised
 # without standing up a real MCP transport.
 ToolLister = Callable[[], Awaitable[list[str]]]
 
@@ -315,14 +316,16 @@ class ProbeLoop:
         # is invoked by a successful sweep.
         self._repair_write_failure = False
         self._repair_write_failure_detail = ""
-        # LCMA tools-availability latch (issue #69).  Driven each cycle
-        # by ``_probe_lcma_tools`` — non-sticky.  Replaces the legacy
-        # mid-run ``LCMAError("unknown_tool")`` latch.
+        # LCMA tools-availability latch (issue #69). Revalidated at
+        # startup and whenever Lithos transitions from unhealthy back
+        # to healthy. Replaces the legacy mid-run
+        # ``LCMAError("unknown_tool")`` latch.
         self._lcma_unknown_tool_failure = False
         self._lcma_unknown_tool_failure_detail = ""
         # Async tool-lister wired by the service factory; ``None`` skips
-        # the LCMA-tools probe (e.g. CLI / tests with no MCP transport).
+        # LCMA validation (e.g. CLI / tests with no MCP transport).
         self._tool_lister = tool_lister
+        self._lcma_validation_needed = True
         # Consecutive count of degraded Lithos probes (#40 circuit breaker).
         # Reset to 0 on the first ``ok`` probe; ``lithos_circuit_open``
         # returns True once it crosses the configured threshold so the
@@ -368,11 +371,11 @@ class ProbeLoop:
         )
 
     async def run_once_async(self) -> None:
-        """Execute a full probe cycle including the async LCMA-tools probe.
+        """Execute a full probe cycle plus conditional LCMA validation.
 
-        Drives the LCMA tool-availability latch directly from the
-        probe result — non-sticky.  When ``tool_lister`` is ``None``
-        the LCMA latch state is left at its previous value (typically
+        LCMA tool validation runs at startup and after Lithos recovers
+        from an unhealthy period. When ``tool_lister`` is ``None`` the
+        LCMA latch state is left at its previous value (typically
         cleared) so a probe-less deployment never spuriously reports
         ``lcma_tools_unavailable``.
         """
@@ -382,7 +385,11 @@ class ProbeLoop:
         # failures, so a totally-down Lithos shows up as a degraded
         # probe before the LCMA-tools probe reports its own failure.
         self.run_once()
-        if self._tool_lister is not None:
+        if (
+            self._tool_lister is not None
+            and self._state.lithos.status == "ok"
+            and self._lcma_validation_needed
+        ):
             lcma_result = await _probe_lcma_tools(self._tool_lister)
             if lcma_result.status == "degraded":
                 self._lcma_unknown_tool_failure = True
@@ -390,6 +397,7 @@ class ProbeLoop:
             else:
                 self._lcma_unknown_tool_failure = False
                 self._lcma_unknown_tool_failure_detail = ""
+            self._lcma_validation_needed = False
             self._state = ProbeState(
                 lithos=self._state.lithos,
                 llm_credentials=self._state.llm_credentials,
@@ -401,6 +409,8 @@ class ProbeLoop:
                     self._lcma_unknown_tool_failure_detail
                 ),
             )
+        elif self._state.lithos.status != "ok":
+            self._lcma_validation_needed = True
 
     def lcma_tools_unavailable(self) -> bool:
         """Return ``True`` when the latest probe found the LCMA surface missing.

--- a/tests/unit/test_probes.py
+++ b/tests/unit/test_probes.py
@@ -608,11 +608,21 @@ class TestLithosCircuitBreaker:
 
 
 class TestLcmaToolsProbe:
-    """Probe-time LCMA tool-availability check (issue #69).
+    """Startup/reconnect LCMA tool-availability validation (issue #69).
 
     Replaces the legacy mid-run ``LCMAError("unknown_tool")`` latch
-    with a probe-driven, non-sticky latch flipped from ``tools/list``.
+    with a validation-driven latch flipped from ``tools/list``.
     """
+
+    @staticmethod
+    def _patch_healthy_lithos_probe(mp: pytest.MonkeyPatch) -> None:
+        from influx import probes as probes_mod
+
+        def fake_probe_lithos(url: str) -> ProbeResult:
+            del url
+            return ProbeResult(status="ok", detail="ok", timestamp=1.0)
+
+        mp.setattr(probes_mod, "_probe_lithos", fake_probe_lithos)
 
     @pytest.mark.asyncio
     async def test_all_required_tools_present_clears_latch(self) -> None:
@@ -622,9 +632,11 @@ class TestLcmaToolsProbe:
         async def lister() -> list[str]:
             return list(REQUIRED_LCMA_TOOLS) + ["lithos_write", "lithos_ping"]
 
-        cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")
-        loop = ProbeLoop(cfg, interval=30.0, tool_lister=lister)
-        await loop.run_once_async()
+        with pytest.MonkeyPatch.context() as mp:
+            self._patch_healthy_lithos_probe(mp)
+            cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")
+            loop = ProbeLoop(cfg, interval=30.0, tool_lister=lister)
+            await loop.run_once_async()
 
         assert loop.lcma_tools_unavailable() is False
         assert loop.state.lcma_unknown_tool_failure is False
@@ -643,9 +655,11 @@ class TestLcmaToolsProbe:
                 # ``lithos_retrieve`` deliberately missing
             ]
 
-        cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")
-        loop = ProbeLoop(cfg, interval=30.0, tool_lister=lister)
-        await loop.run_once_async()
+        with pytest.MonkeyPatch.context() as mp:
+            self._patch_healthy_lithos_probe(mp)
+            cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")
+            loop = ProbeLoop(cfg, interval=30.0, tool_lister=lister)
+            await loop.run_once_async()
 
         assert loop.lcma_tools_unavailable() is True
         assert loop.state.lcma_unknown_tool_failure is True
@@ -658,9 +672,11 @@ class TestLcmaToolsProbe:
         async def failing_lister() -> list[str]:
             raise RuntimeError("MCP connection refused")
 
-        cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")
-        loop = ProbeLoop(cfg, interval=30.0, tool_lister=failing_lister)
-        await loop.run_once_async()
+        with pytest.MonkeyPatch.context() as mp:
+            self._patch_healthy_lithos_probe(mp)
+            cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")
+            loop = ProbeLoop(cfg, interval=30.0, tool_lister=failing_lister)
+            await loop.run_once_async()
 
         assert loop.lcma_tools_unavailable() is True
         assert "tools/list failed" in loop.state.lcma_unknown_tool_failure_detail
@@ -676,11 +692,35 @@ class TestLcmaToolsProbe:
         assert loop.state.lcma_unknown_tool_failure is False
 
     @pytest.mark.asyncio
-    async def test_latch_recovers_when_tools_become_available(self) -> None:
-        """Non-sticky behaviour: missing → present across cycles re-clears."""
+    async def test_validation_does_not_repeat_while_lithos_stays_healthy(self) -> None:
+        """Healthy steady state does not keep polling ``tools/list`` every cycle."""
         from influx.probes import REQUIRED_LCMA_TOOLS
 
-        cycle_state = {"missing_retrieve": True}
+        call_count = 0
+
+        async def lister() -> list[str]:
+            nonlocal call_count
+            call_count += 1
+            return list(REQUIRED_LCMA_TOOLS)
+
+        with pytest.MonkeyPatch.context() as mp:
+            self._patch_healthy_lithos_probe(mp)
+            cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")
+            loop = ProbeLoop(cfg, interval=30.0, tool_lister=lister)
+            await loop.run_once_async()
+            await loop.run_once_async()
+
+        assert call_count == 1
+        assert loop.lcma_tools_unavailable() is False
+
+    @pytest.mark.asyncio
+    async def test_latch_recovers_when_lithos_recovers_and_tools_become_available(
+        self,
+    ) -> None:
+        """Lithos unhealthy -> healthy triggers a fresh LCMA validation."""
+        from influx.probes import REQUIRED_LCMA_TOOLS
+
+        cycle_state = {"healthy": True, "missing_retrieve": True}
 
         async def lister() -> list[str]:
             base = list(REQUIRED_LCMA_TOOLS)
@@ -688,13 +728,58 @@ class TestLcmaToolsProbe:
                 return [t for t in base if t != "lithos_retrieve"]
             return base
 
-        cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")
-        loop = ProbeLoop(cfg, interval=30.0, tool_lister=lister)
-        await loop.run_once_async()
-        assert loop.lcma_tools_unavailable() is True
+        with pytest.MonkeyPatch.context() as mp:
+            from influx import probes as probes_mod
 
-        # Deployment fixed mid-flight; next probe cycle clears the latch.
-        cycle_state["missing_retrieve"] = False
-        await loop.run_once_async()
+            def fake_probe_lithos(url: str) -> ProbeResult:
+                del url
+                status = "ok" if cycle_state["healthy"] else "degraded"
+                detail = "ok" if cycle_state["healthy"] else "down"
+                return ProbeResult(status=status, detail=detail, timestamp=1.0)
+
+            mp.setattr(probes_mod, "_probe_lithos", fake_probe_lithos)
+            cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")
+            loop = ProbeLoop(cfg, interval=30.0, tool_lister=lister)
+
+            await loop.run_once_async()
+            assert loop.lcma_tools_unavailable() is True
+
+            # Steady healthy state does not revalidate.
+            cycle_state["missing_retrieve"] = False
+            await loop.run_once_async()
+            assert loop.lcma_tools_unavailable() is True
+
+            # Lithos outage marks the validation stale.
+            cycle_state["healthy"] = False
+            await loop.run_once_async()
+            assert loop.lcma_tools_unavailable() is True
+
+            # On recovery, validation runs again and clears the latch.
+            cycle_state["healthy"] = True
+            await loop.run_once_async()
+
         assert loop.lcma_tools_unavailable() is False
         assert loop.state.lcma_unknown_tool_failure is False
+
+    @pytest.mark.asyncio
+    async def test_startup_transport_error_is_not_retried_each_healthy_cycle(
+        self,
+    ) -> None:
+        """A startup validation failure stays latched until Lithos reconnects."""
+        attempts = 0
+
+        async def lister() -> list[str]:
+            nonlocal attempts
+            attempts += 1
+            raise RuntimeError("MCP connection refused")
+
+        with pytest.MonkeyPatch.context() as mp:
+            self._patch_healthy_lithos_probe(mp)
+            cfg = _make_config(lithos_url="http://127.0.0.1:1/sse")
+            loop = ProbeLoop(cfg, interval=30.0, tool_lister=lister)
+            await loop.run_once_async()
+            await loop.run_once_async()
+
+        assert attempts == 1
+        assert loop.lcma_tools_unavailable() is True
+        assert "tools/list failed" in loop.state.lcma_unknown_tool_failure_detail


### PR DESCRIPTION
## Summary
- stop polling Lithos tools/list every 30 seconds from the probe loop
- validate the LCMA tool surface only at startup and after Lithos recovers from an unhealthy period
- preserve the existing lcma_tools_unavailable skip gate while removing steady-state capability polling
- add probe-loop tests for startup validation, no-repeat healthy cycles, and revalidation after recovery

## Tests
- uv run pytest tests/unit/test_probes.py tests/unit/test_run_service.py tests/unit/test_scheduler.py -q
- uv run ruff check src/influx/probes.py tests/unit/test_probes.py
- uv run pyright src/influx/probes.py tests/unit/test_probes.py