### PR TITLE
Harden Lithos probe resilience

### DIFF
--- a/src/influx/probes.py
+++ b/src/influx/probes.py
@@ -494,4 +494,7 @@ class ProbeLoop:
         """Internal loop — runs a full probe cycle at fixed intervals."""
         while True:
             await asyncio.sleep(self._interval)
-            await self.run_once_async()
+            try:
+                await self.run_once_async()
+            except Exception:
+                logger.exception("Probe cycle failed; continuing background probe loop")

--- a/src/influx/service.py
+++ b/src/influx/service.py
@@ -142,31 +142,25 @@ def create_app(
     # ``schedule.shutdown_grace_seconds`` (US-008).
     active_tasks: set[asyncio.Task[Any]] = set()
 
-    # Tool-lister reuses one lazy LithosClient for the service lifetime.
-    # Each probe still re-evaluates the LCMA tool surface, so missing-tool
-    # deployments recover without restart, but steady-state probes no
-    # longer re-register the agent or flap the SSE connection every cycle.
-    lithos_probe_client: LithosClient | None = None
-
     async def _list_lithos_tools() -> list[str]:
-        nonlocal lithos_probe_client
-        if lithos_probe_client is None:
-            lithos_probe_client = LithosClient(
-                url=config.lithos.url,
-                transport=config.lithos.transport,
-            )
+        # Keep the LCMA validation path side-effect-free with respect to
+        # service lifetime: open a short-lived SSE session only for the
+        # validation call, then close it immediately so Lithos restarts
+        # cannot strand a background probe client.
+        client = LithosClient(
+            url=config.lithos.url,
+            transport=config.lithos.transport,
+        )
         try:
-            return await lithos_probe_client.list_tools()
+            return await client.list_tools()
         except Exception:
-            await lithos_probe_client.close()
-            lithos_probe_client = None
             raise
+        finally:
+            await client.close()
 
     async def _close_lithos_probe_client() -> None:
-        nonlocal lithos_probe_client
-        if lithos_probe_client is not None:
-            await lithos_probe_client.close()
-            lithos_probe_client = None
+        # The probe lister now uses an ephemeral client per validation.
+        return
 
     probe_loop = ProbeLoop(
         config,

--- a/tests/unit/test_probes.py
+++ b/tests/unit/test_probes.py
@@ -356,6 +356,37 @@ class TestProbeLoopLifecycle:
         loop = ProbeLoop(cfg, interval=30.0)
         await loop.stop()  # no-op, should not raise
 
+    async def test_background_loop_continues_after_unexpected_exception(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A single escaped probe-cycle exception does not kill the loop."""
+        import asyncio as asyncio_mod
+
+        calls = 0
+        cfg = _make_config()
+        loop = ProbeLoop(cfg, interval=30.0)
+
+        async def fake_sleep(_seconds: float) -> None:
+            return None
+
+        async def fake_run_once_async() -> None:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise RuntimeError("boom")
+            raise asyncio_mod.CancelledError()
+
+        monkeypatch.setattr("influx.probes.asyncio.sleep", fake_sleep)
+        monkeypatch.setattr(loop, "run_once_async", fake_run_once_async)
+
+        with pytest.raises(asyncio_mod.CancelledError):
+            await loop._loop()
+
+        assert calls == 2
+        assert "Probe cycle failed" in caplog.text
+
 
 # ── Degraded state driven by both probes ─────────────────────────────
 

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -137,11 +137,11 @@ class TestCreateApp:
         assert "/runs" in paths
         assert "/backfills" in paths
 
-    async def test_lcma_tool_probe_reuses_lithos_client(
+    async def test_lcma_tool_probe_uses_ephemeral_lithos_client(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Issue #93: repeated tool probes reuse one client and close at shutdown."""
+        """Each tool probe gets its own short-lived client."""
         instances: list[Any] = []
 
         class FakeLithosClient:
@@ -169,18 +169,21 @@ class TestCreateApp:
         await tool_lister()
         await tool_lister()
 
-        assert len(instances) == 1
-        assert instances[0].list_calls == 2
-        assert instances[0].close_calls == 0
+        assert len(instances) == 2
+        assert instances[0].list_calls == 1
+        assert instances[1].list_calls == 1
+        assert instances[0].close_calls == 1
+        assert instances[1].close_calls == 1
 
         await app.state.close_lithos_probe_client()
         assert instances[0].close_calls == 1
+        assert instances[1].close_calls == 1
 
-    async def test_lcma_tool_probe_resets_client_after_failure(
+    async def test_lcma_tool_probe_closes_client_after_failure(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A failing tool probe closes the client so the next cycle reconnects."""
+        """A failing tool probe still closes its ephemeral client."""
         instances: list[Any] = []
 
         class FakeLithosClient:
@@ -213,7 +216,7 @@ class TestCreateApp:
 
         assert len(instances) == 2
         assert instances[0].close_calls == 1
-        assert instances[1].close_calls == 0
+        assert instances[1].close_calls == 1
 
 
 # ── InfluxService lifecycle ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- make LCMA probe validation use an ephemeral Lithos client instead of a service-lifetime SSE session
- keep the background probe loop alive when an unexpected probe-cycle exception escapes
- add regression tests for ephemeral tool probing and probe-loop exception handling

## Testing
- uv run pytest tests/unit/test_service.py tests/unit/test_probes.py tests/unit/test_lithos_client.py tests/contract/test_lithos_client.py -q
- uv run pytest tests/unit/test_scheduler.py tests/unit/test_run_module.py -q
- uv run ruff check src/influx/service.py src/influx/probes.py tests/unit/test_service.py tests/unit/test_probes.py
- uv run pyright src/influx/service.py src/influx/probes.py tests/unit/test_service.py tests/unit/test_probes.py