### PR TITLE
Make service startup transactional

### DIFF
--- a/src/influx/service.py
+++ b/src/influx/service.py
@@ -281,8 +281,15 @@ class InfluxService:
         )
         tracer = get_tracer(force_rebuild=True)
         logger.info("OTEL telemetry %s", "enabled" if tracer.enabled else "disabled")
-        await self.probe_loop.start()
-        self.scheduler.start()
+        probe_started = False
+        try:
+            await self.probe_loop.start()
+            probe_started = True
+            self.scheduler.start()
+        except Exception:
+            if probe_started:
+                await self.probe_loop.stop()
+            raise
         self._started = True
         logger.info("Influx service started")
 

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -255,6 +255,26 @@ class TestInfluxService:
         await svc.start()  # should be a no-op
         await svc.stop()
 
+    async def test_start_rolls_back_probe_loop_when_scheduler_start_fails(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A scheduler startup failure must not leave the probe loop running."""
+        config = _make_config()
+        svc = InfluxService(config)
+
+        def failing_scheduler_start() -> None:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(svc.scheduler, "start", failing_scheduler_start)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await svc.start()
+
+        assert svc.probe_loop._task is None
+        assert svc.probe_loop.state.overall_status != "starting"
+        assert svc._started is False
+
     async def test_stop_without_start_is_safe(self) -> None:
         """Calling stop() before start() does not crash."""
         config = _make_config()


### PR DESCRIPTION
## Summary
- roll back the probe loop if scheduler startup fails
- keep InfluxService startup all-or-nothing instead of leaving background probe work running
- add a regression test for probe-started plus scheduler-start failure

## Testing
- uv run pytest tests/unit/test_service.py -q
- uv run pytest tests/unit/test_scheduler.py tests/unit/test_probes.py -q
- uv run ruff check src/influx/service.py tests/unit/test_service.py
- uv run pyright src/influx/service.py tests/unit/test_service.py