### PR TITLE
Make LCMA wiring best-effort

### DIFF
--- a/src/influx/lcma.py
+++ b/src/influx/lcma.py
@@ -165,6 +165,7 @@ async def after_write(
     profile: str,
     lcma_edge_score: float,
     source_note_id: str = "",
+    source_url: str = "",
 ) -> list[dict[str, Any]]:
     """Retrieve related Lithos memory and upsert ``related_to`` edges.
 
@@ -199,6 +200,16 @@ async def after_write(
 
     body = json.loads(result.content[0].text)  # type: ignore[union-attr]
     results: list[dict[str, Any]] = body.get("results", [])
+    logger.info(
+        "LCMA retrieve completed profile=%s run_id=%s source_url=%s "
+        "note_id=%s tool=%s results=%d",
+        profile,
+        current_run_id.get() or "",
+        source_url,
+        source_note_id,
+        "lithos_retrieve",
+        len(results),
+    )
 
     related: list[dict[str, Any]] = []
     for r in results:
@@ -218,7 +229,29 @@ async def after_write(
             source_note_id=source_note_id,
             target_note_id=target_note_id,
         )
+        logger.info(
+            "LCMA related_to edge upserted profile=%s run_id=%s "
+            "source_url=%s note_id=%s tool=%s target_note_id=%s score=%.3f",
+            profile,
+            current_run_id.get() or "",
+            source_url,
+            source_note_id,
+            "lithos_edge_upsert",
+            target_note_id,
+            score,
+        )
         related.append({"title": r.get("title", ""), "score": score})
+
+    if not related:
+        logger.info(
+            "LCMA retrieve produced no related matches above threshold "
+            "profile=%s run_id=%s source_url=%s note_id=%s threshold=%.3f",
+            profile,
+            current_run_id.get() or "",
+            source_url,
+            source_note_id,
+            lcma_edge_score,
+        )
 
     return related
 
@@ -231,6 +264,8 @@ async def resolve_builds_on(
     client: LithosClient,
     builds_on: list[str] | None = None,
     source_note_id: str = "",
+    profile: str = "",
+    written_source_url: str = "",
 ) -> None:
     """Resolve Tier 3 ``builds_on`` items via ``lithos_cache_lookup``.
 
@@ -263,10 +298,32 @@ async def resolve_builds_on(
 
         body = json.loads(result.content[0].text)  # type: ignore[union-attr]
         if not body.get("hit"):
+            logger.info(
+                "LCMA builds_on lookup miss profile=%s run_id=%s "
+                "source_url=%s note_id=%s tool=%s target_source_url=%s",
+                profile,
+                current_run_id.get() or "",
+                written_source_url,
+                source_note_id,
+                "lithos_cache_lookup",
+                source_url,
+            )
             continue
 
         # Exact source_url match required — no fuzzy matching (AC-M2-8).
         if body.get("source_url") != source_url:
+            logger.info(
+                "LCMA builds_on lookup source_url mismatch profile=%s run_id=%s "
+                "source_url=%s note_id=%s tool=%s expected_source_url=%s "
+                "actual_source_url=%s",
+                profile,
+                current_run_id.get() or "",
+                written_source_url,
+                source_note_id,
+                "lithos_cache_lookup",
+                source_url,
+                body.get("source_url", ""),
+            )
             continue
 
         await client.edge_upsert(
@@ -274,4 +331,14 @@ async def resolve_builds_on(
             evidence={"kind": "tier3_builds_on_extraction"},
             source_note_id=source_note_id,
             target_note_id=body.get("note_id", ""),
+        )
+        logger.info(
+            "LCMA builds_on edge upserted profile=%s run_id=%s "
+            "source_url=%s note_id=%s tool=%s target_note_id=%s",
+            profile,
+            current_run_id.get() or "",
+            written_source_url,
+            source_note_id,
+            "lithos_edge_upsert",
+            body.get("note_id", ""),
         )

--- a/src/influx/lcma_wiring.py
+++ b/src/influx/lcma_wiring.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from influx.lcma import after_write, resolve_builds_on
+from influx.telemetry import current_run_id
 
 if TYPE_CHECKING:
     from influx.lithos_client import LithosClient
@@ -78,6 +79,7 @@ class LcmaWiringDeps:
 async def wire(
     *,
     written_note_id: str,
+    source_url: str,
     cascade: CascadeOutput,
     deps: LcmaWiringDeps,
 ) -> list[dict[str, Any]]:
@@ -110,18 +112,44 @@ async def wire(
         (issue #69) drives the latch and the next probe cycle
         re-evaluates.
     """
-    related = await after_write(
-        client=deps.client,
-        title=cascade.title,
-        contributions=cascade.contributions,
-        run_task_id=deps.run_task_id,
-        profile=deps.profile,
-        lcma_edge_score=deps.lcma_edge_score,
-        source_note_id=written_note_id,
-    )
-    await resolve_builds_on(
-        client=deps.client,
-        builds_on=cascade.builds_on,
-        source_note_id=written_note_id,
-    )
+    related: list[dict[str, Any]] = []
+    try:
+        related = await after_write(
+            client=deps.client,
+            title=cascade.title,
+            contributions=cascade.contributions,
+            run_task_id=deps.run_task_id,
+            profile=deps.profile,
+            lcma_edge_score=deps.lcma_edge_score,
+            source_note_id=written_note_id,
+            source_url=source_url,
+        )
+    except Exception:
+        logger.warning(
+            "LCMA related_to wiring failed profile=%s run_id=%s "
+            "source_url=%s note_id=%s",
+            deps.profile,
+            current_run_id.get() or "",
+            source_url,
+            written_note_id,
+            exc_info=True,
+        )
+    try:
+        await resolve_builds_on(
+            client=deps.client,
+            builds_on=cascade.builds_on,
+            source_note_id=written_note_id,
+            profile=deps.profile,
+            written_source_url=source_url,
+        )
+    except Exception:
+        logger.warning(
+            "LCMA builds_on wiring failed profile=%s run_id=%s "
+            "source_url=%s note_id=%s",
+            deps.profile,
+            current_run_id.get() or "",
+            source_url,
+            written_note_id,
+            exc_info=True,
+        )
     return related

--- a/src/influx/run.py
+++ b/src/influx/run.py
@@ -517,15 +517,28 @@ async def _run_ingest_stage(
                 write_result.note_id,
                 str(cache_hit).lower(),
             )
-            related_in_lithos = await lcma_wire(
-                written_note_id=write_result.note_id,
-                cascade=CascadeOutput(
-                    title=title,
-                    contributions=item.get("contributions"),
-                    builds_on=item.get("builds_on"),
-                ),
-                deps=lcma_deps,
-            )
+            try:
+                related_in_lithos = await lcma_wire(
+                    written_note_id=write_result.note_id,
+                    source_url=source_url,
+                    cascade=CascadeOutput(
+                        title=title,
+                        contributions=item.get("contributions"),
+                        builds_on=item.get("builds_on"),
+                    ),
+                    deps=lcma_deps,
+                )
+            except Exception:
+                logger.warning(
+                    "LCMA wiring failed unexpectedly outside best-effort guard "
+                    "profile=%s source_url=%s title=%r note_id=%s",
+                    profile,
+                    source_url,
+                    title,
+                    write_result.note_id,
+                    exc_info=True,
+                )
+                related_in_lithos = []
             ingested.append(
                 HighlightItem(
                     id=item.get("id", f"note-{len(ingested) + 1}"),

--- a/tests/integration/test_lcma_edges_end_to_end.py
+++ b/tests/integration/test_lcma_edges_end_to_end.py
@@ -30,7 +30,6 @@ from influx.config import (
     SecurityConfig,
 )
 from influx.coordinator import RunKind
-from influx.errors import LCMAError
 from influx.probes import ProbeLoop
 from influx.scheduler import run_profile
 from tests.contract.test_lithos_client import FakeLithosServer
@@ -543,18 +542,18 @@ class TestBuildsOnResolver:
         assert len(builds_on_edges) == 0
 
 
-# ── US-007: Abort on LCMAError("unknown_tool") ──────────────────
+# ── US-007: Best-effort containment for post-write LCMA failures ───
 
 
 class TestUnknownToolAbort:
-    """LCMAError("unknown_tool") aborts run, degrades readiness."""
+    """Post-write LCMA failures do not abort a run after the note is written."""
 
-    def test_retrieve_unknown_tool_aborts_run(
+    def test_retrieve_unknown_tool_is_contained(
         self,
         fake_lithos: FakeLithosServer,
         fake_lithos_url: str,
     ) -> None:
-        """Retrieve unknown_tool mid-run: aborts, no edges, notes remain."""
+        """Retrieve unknown_tool mid-run: note stays written and run completes."""
         config = _make_config(fake_lithos_url)
 
         # Make lithos_retrieve raise (simulates unknown_tool on Lithos).
@@ -571,15 +570,15 @@ class TestUnknownToolAbort:
             }
         ]
 
-        with pytest.raises(LCMAError, match="unknown_tool"):
-            asyncio.run(
-                run_profile(
-                    "ai-robotics",
-                    RunKind.MANUAL,
-                    config=config,
-                    item_provider=_single_item_provider(items),
-                )
+        result = asyncio.run(
+            run_profile(
+                "ai-robotics",
+                RunKind.MANUAL,
+                config=config,
+                item_provider=_single_item_provider(items),
             )
+        )
+        assert result is not None
 
         # (1) The prior lithos_write call remains visible (note was written).
         write_calls = _calls_by_tool(fake_lithos.calls, "lithos_write")
@@ -594,10 +593,10 @@ class TestUnknownToolAbort:
         edge_calls = _calls_by_tool(fake_lithos.calls, "lithos_edge_upsert")
         assert len(edge_calls) == 0
 
-        # (4) task_complete was still called with outcome="error".
+        # (4) task_complete still records a successful run outcome.
         complete_calls = _calls_by_tool(fake_lithos.calls, "lithos_task_complete")
         assert len(complete_calls) == 1
-        assert complete_calls[0]["outcome"] == "error"
+        assert complete_calls[0]["outcome"] == "success"
 
     def test_lcma_tools_probe_drives_readiness_latch(
         self,

--- a/tests/unit/test_lcma_wiring.py
+++ b/tests/unit/test_lcma_wiring.py
@@ -90,6 +90,7 @@ class TestRelatedToEdgeScoreThreshold:
 
         related = await wire(
             written_note_id="note-new",
+            source_url="https://arxiv.org/abs/2601.00001",
             cascade=CascadeOutput(title="A Paper", contributions=["c1"]),
             deps=deps,
         )
@@ -115,6 +116,7 @@ class TestRelatedToEdgeScoreThreshold:
 
         related = await wire(
             written_note_id="note-new",
+            source_url="https://arxiv.org/abs/2601.00001",
             cascade=CascadeOutput(title="A Paper"),
             deps=deps,
         )
@@ -136,6 +138,7 @@ class TestRelatedToEdgeScoreThreshold:
 
         related = await wire(
             written_note_id="note-new",
+            source_url="https://arxiv.org/abs/2601.00001",
             cascade=CascadeOutput(title="A Paper"),
             deps=deps,
         )
@@ -163,6 +166,7 @@ class TestBuildsOnResolution:
 
         await wire(
             written_note_id="note-new",
+            source_url="https://arxiv.org/abs/2601.00001",
             cascade=CascadeOutput(
                 title="A Paper",
                 builds_on=["FooNet (arXiv:2412.12345)"],
@@ -188,6 +192,7 @@ class TestBuildsOnResolution:
 
         await wire(
             written_note_id="note-new",
+            source_url="https://arxiv.org/abs/2601.00001",
             cascade=CascadeOutput(
                 title="A Paper",
                 builds_on=["A handwave reference with no id"],
@@ -204,6 +209,7 @@ class TestBuildsOnResolution:
 
         await wire(
             written_note_id="note-new",
+            source_url="https://arxiv.org/abs/2601.00001",
             cascade=CascadeOutput(
                 title="A Paper",
                 builds_on=["FooNet (arXiv:2412.12345)"],
@@ -220,8 +226,12 @@ class TestBuildsOnResolution:
         assert builds_on_upserts == []
 
     @pytest.mark.asyncio
-    async def test_source_url_mismatch_skips_edge(self) -> None:
+    async def test_source_url_mismatch_skips_edge(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         """AC-M2-8: cache hit with a different source_url is treated as miss."""
+        caplog.set_level("INFO")
         client = _make_client(
             cache_lookup_payload={
                 "hit": True,
@@ -233,6 +243,7 @@ class TestBuildsOnResolution:
 
         await wire(
             written_note_id="note-new",
+            source_url="https://arxiv.org/abs/2601.00001",
             cascade=CascadeOutput(
                 title="A Paper",
                 builds_on=["FooNet (arXiv:2412.12345)"],
@@ -246,6 +257,7 @@ class TestBuildsOnResolution:
             if call.kwargs.get("type") == "builds_on"
         ]
         assert builds_on_upserts == []
+        assert "LCMA builds_on lookup source_url mismatch" in caplog.text
 
     @pytest.mark.asyncio
     async def test_empty_builds_on_is_noop(self) -> None:
@@ -254,6 +266,7 @@ class TestBuildsOnResolution:
 
         await wire(
             written_note_id="note-new",
+            source_url="https://arxiv.org/abs/2601.00001",
             cascade=CascadeOutput(title="A Paper", builds_on=None),
             deps=deps,
         )
@@ -265,39 +278,48 @@ class TestBuildsOnResolution:
 
 
 class TestLcmaErrorPropagation:
-    """``LCMAError`` propagates verbatim — no per-call latching here.
+    """LCMA wiring is best-effort at the item boundary.
 
-    The probe loop drives the ``lcma_unknown_tool_failure`` latch via
-    ``tools/list`` (issue #69); ``wire`` is purely a tools-call seam
-    now.
+    The probe loop still drives the ``lcma_unknown_tool_failure`` latch
+    via ``tools/list`` (issue #69), but post-write LCMA execution no
+    longer aborts the rest of the run after the note has already been
+    written.
     """
 
     @pytest.mark.asyncio
-    async def test_unknown_tool_on_retrieve_propagates(self) -> None:
+    async def test_unknown_tool_on_retrieve_is_contained(self) -> None:
         client = _make_client()
         client.retrieve = AsyncMock(
             side_effect=LCMAError("unknown_tool", stage="lithos_retrieve")
         )
         deps = _make_deps(client)
 
-        with pytest.raises(LCMAError, match="unknown_tool"):
-            await wire(
-                written_note_id="note-new",
-                cascade=CascadeOutput(title="A Paper"),
-                deps=deps,
-            )
+        related = await wire(
+            written_note_id="note-new",
+            source_url="https://arxiv.org/abs/2601.00001",
+            cascade=CascadeOutput(title="A Paper"),
+            deps=deps,
+        )
+
+        assert related == []
 
     @pytest.mark.asyncio
-    async def test_other_lcma_error_propagates(self) -> None:
+    async def test_other_lcma_error_is_contained_and_builds_on_still_runs(self) -> None:
         client = _make_client()
         client.retrieve = AsyncMock(
             side_effect=LCMAError("transport refused", stage="http")
         )
         deps = _make_deps(client)
 
-        with pytest.raises(LCMAError):
-            await wire(
-                written_note_id="note-new",
-                cascade=CascadeOutput(title="A Paper"),
-                deps=deps,
-            )
+        related = await wire(
+            written_note_id="note-new",
+            source_url="https://arxiv.org/abs/2601.00001",
+            cascade=CascadeOutput(
+                title="A Paper",
+                builds_on=["FooNet (arXiv:2412.12345)"],
+            ),
+            deps=deps,
+        )
+
+        assert related == []
+        client.cache_lookup.assert_awaited_once()

--- a/tests/unit/test_run_module.py
+++ b/tests/unit/test_run_module.py
@@ -386,6 +386,95 @@ async def test_run_execute_walks_provider_and_writes_per_item() -> None:
     wire.assert_awaited_once()
 
 
+async def test_run_execute_continues_after_lcma_wiring_failure() -> None:
+    """A post-write LCMA failure does not prevent later items from ingesting."""
+    config = _make_config()
+    plan = _scheduled_plan()
+
+    items = [
+        {
+            "title": "First Paper",
+            "source_url": "https://arxiv.org/abs/2401.00001",
+            "content": "# Summary\n\nbody",
+            "tags": ["profile:alpha", "source:arxiv"],
+            "confidence": 0.9,
+            "score": 9,
+            "path": "papers/arxiv/2024/01",
+            "abstract_or_summary": "abs",
+        },
+        {
+            "title": "Second Paper",
+            "source_url": "https://arxiv.org/abs/2401.00002",
+            "content": "# Summary\n\nbody",
+            "tags": ["profile:alpha", "source:arxiv"],
+            "confidence": 0.9,
+            "score": 9,
+            "path": "papers/arxiv/2024/01",
+            "abstract_or_summary": "abs",
+        },
+    ]
+
+    async def provider(
+        profile: str, kind: RunKind, run_range: Any, filter_prompt: str
+    ) -> list[dict[str, Any]]:
+        return items
+
+    from mcp import types as mcp_types
+
+    deps = RunDeps(config=config, item_provider=provider, probe_loop=None)
+
+    mock_client = MagicMock()
+    mock_client.close = AsyncMock()
+    mock_client.list_archive_terminal_arxiv_ids = AsyncMock(return_value=frozenset())
+    mock_client.task_create = AsyncMock(
+        return_value=mcp_types.CallToolResult(
+            content=[
+                mcp_types.TextContent(
+                    type="text", text=json.dumps({"task_id": "task-1"})
+                )
+            ]
+        )
+    )
+    mock_client.task_complete = AsyncMock(
+        return_value=mcp_types.CallToolResult(
+            content=[
+                mcp_types.TextContent(
+                    type="text", text=json.dumps({"status": "completed"})
+                )
+            ]
+        )
+    )
+    mock_client.cache_lookup_for_item = AsyncMock(
+        return_value=mcp_types.CallToolResult(
+            content=[mcp_types.TextContent(type="text", text='{"hit": false}')]
+        )
+    )
+    write_result_1 = MagicMock()
+    write_result_1.status = "created"
+    write_result_1.note_id = "note-1"
+    write_result_2 = MagicMock()
+    write_result_2.status = "created"
+    write_result_2.note_id = "note-2"
+    mock_client.write_note = AsyncMock(side_effect=[write_result_1, write_result_2])
+
+    with (
+        patch("influx.run.LithosClient", return_value=mock_client),
+        patch("influx.run.repair_sweep", new_callable=AsyncMock, return_value=[]),
+        patch("influx.run.build_negative_examples_block", side_effect=_empty_neg_block),
+        patch(
+            "influx.run.lcma_wire",
+            new_callable=AsyncMock,
+            side_effect=[RuntimeError("retrieve failed"), []],
+        ) as wire,
+        patch("influx.service.post_run_webhook_hook"),
+    ):
+        outcome = await Run(plan, deps).execute()
+
+    assert outcome.sources_checked == 2
+    assert outcome.ingested == 2
+    assert wire.await_count == 2
+
+
 def test_run_aborted_carries_diagnostics_for_apply() -> None:
     """``RunAborted.diagnostics`` is the channel for abort-path health actions."""
     diagnostics = StageDiagnostics(


### PR DESCRIPTION
Fixes #104

## Summary
- make post-write LCMA wiring best-effort so one retrieve or edge failure does not abort the rest of a run after the note is already written
- log LCMA retrieve, edge upsert, cache miss, and source-url mismatch outcomes with run and note context
- add regressions for contained retrieve failures, continued ingestion, and builds_on mismatch diagnostics

## Testing
- uv run pytest tests/unit/test_lcma_wiring.py tests/unit/test_run_module.py tests/integration/test_lcma_edges_end_to_end.py -q
- uv run ruff check src/influx/lcma.py src/influx/lcma_wiring.py src/influx/run.py tests/unit/test_lcma_wiring.py tests/unit/test_run_module.py tests/integration/test_lcma_edges_end_to_end.py
- uv run pyright src/influx/lcma.py src/influx/lcma_wiring.py src/influx/run.py tests/unit/test_lcma_wiring.py tests/unit/test_run_module.py