### PR TITLE
Fix LCMA edge_upsert MCP argument shape

### DIFF
--- a/src/influx/lcma.py
+++ b/src/influx/lcma.py
@@ -173,9 +173,9 @@ async def after_write(
     FR-LCMA-3, AC-M2-5, AC-M2-6).
 
     *source_note_id* is the id of the note that was just written; it is
-    passed verbatim as ``source_note_id`` to each ``edge_upsert`` so a
-    real graph edge can be created (per finding 1).  Each retrieve
-    result contributes its own ``note_id`` as ``target_note_id``.
+    passed verbatim as ``from_id`` to each ``edge_upsert`` so a real
+    graph edge can be created. Each retrieve result contributes its own
+    ``note_id`` as ``to_id``.
 
     Returns a list of ``{"title": str, "score": float}`` dicts for
     high-scoring results so the webhook digest can populate
@@ -220,14 +220,18 @@ async def after_write(
         receipt_id = r.get("receipt_id", "")
         target_note_id = r.get("note_id", "")
         await client.edge_upsert(
+            from_id=source_note_id,
+            to_id=target_note_id,
             type="related_to",
+            weight=score,
+            namespace="influx",
+            provenance_actor="influx-lcma-retrieve",
+            provenance_type="lcma_retrieve",
             evidence={
                 "kind": "lithos_retrieve",
                 "score": score,
                 "receipt_id": receipt_id,
             },
-            source_note_id=source_note_id,
-            target_note_id=target_note_id,
         )
         logger.info(
             "LCMA related_to edge upserted profile=%s run_id=%s "
@@ -276,8 +280,8 @@ async def resolve_builds_on(
     matching cache entry are silently skipped (AC-M2-8).
 
     *source_note_id* is the id of the note that was just written; the
-    cache-lookup hit supplies the prior note's id as
-    ``target_note_id``.  Both are forwarded to ``edge_upsert`` so a real
+    cache-lookup hit supplies the prior note's id as ``to_id``. Both are
+    forwarded to ``edge_upsert`` so a real
     graph edge can be created (per finding 1).
     """
     if not builds_on:
@@ -327,10 +331,14 @@ async def resolve_builds_on(
             continue
 
         await client.edge_upsert(
+            from_id=source_note_id,
+            to_id=body.get("note_id", ""),
             type="builds_on",
+            weight=1.0,
+            namespace="influx",
+            provenance_actor="influx-tier3-builds-on",
+            provenance_type="tier3_extraction",
             evidence={"kind": "tier3_builds_on_extraction"},
-            source_note_id=source_note_id,
-            target_note_id=body.get("note_id", ""),
         )
         logger.info(
             "LCMA builds_on edge upserted profile=%s run_id=%s "

--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -1237,20 +1237,32 @@ class LithosClient:
     async def edge_upsert(
         self,
         *,
+        from_id: str,
+        to_id: str,
         type: str,
-        evidence: dict[str, Any],
-        source_note_id: str = "",
-        target_note_id: str = "",
+        weight: float,
+        namespace: str = "influx",
+        provenance_actor: str | None = None,
+        provenance_type: str | None = None,
+        evidence: dict[str, Any] | list[Any] | None = None,
+        conflict_state: str | None = None,
     ) -> mcp_types.CallToolResult:
         """Call ``lithos_edge_upsert`` (FR-LCMA-3)."""
         args: dict[str, Any] = {
+            "from_id": from_id,
+            "to_id": to_id,
             "type": type,
-            "evidence": evidence,
+            "weight": weight,
+            "namespace": namespace,
         }
-        if source_note_id:
-            args["source_note_id"] = source_note_id
-        if target_note_id:
-            args["target_note_id"] = target_note_id
+        if provenance_actor is not None:
+            args["provenance_actor"] = provenance_actor
+        if provenance_type is not None:
+            args["provenance_type"] = provenance_type
+        if evidence is not None:
+            args["evidence"] = evidence
+        if conflict_state is not None:
+            args["conflict_state"] = conflict_state
         return await self._call_lcma_tool("lithos_edge_upsert", args)
 
     async def task_create(

--- a/tests/contract/test_lcma_calls.py
+++ b/tests/contract/test_lcma_calls.py
@@ -95,19 +95,29 @@ class FakeLCMAServer:
 
         @self._mcp.tool(name="lithos_edge_upsert")
         async def lithos_edge_upsert(
+            from_id: str = "",
+            to_id: str = "",
             type: str = "",
-            source_note_id: str = "",
-            target_note_id: str = "",
+            weight: float = 0.0,
+            namespace: str = "",
+            provenance_actor: str | None = None,
+            provenance_type: str | None = None,
             evidence: dict[str, Any] | None = None,
+            conflict_state: str | None = None,
         ) -> str:
             calls.append(
                 (
                     "lithos_edge_upsert",
                     {
+                        "from_id": from_id,
+                        "to_id": to_id,
                         "type": type,
-                        "source_note_id": source_note_id,
-                        "target_note_id": target_note_id,
+                        "weight": weight,
+                        "namespace": namespace,
+                        "provenance_actor": provenance_actor,
+                        "provenance_type": provenance_type,
                         "evidence": evidence,
+                        "conflict_state": conflict_state,
                     },
                 )
             )
@@ -335,9 +345,13 @@ class TestEdgeUpsertHappyPath:
         client = LithosClient(url=lcma_url)
         try:
             result = await client.edge_upsert(
+                from_id="note-a",
+                to_id="note-b",
                 type="related_to",
-                source_note_id="note-a",
-                target_note_id="note-b",
+                weight=0.85,
+                namespace="influx",
+                provenance_actor="influx-lcma-retrieve",
+                provenance_type="lcma_retrieve",
                 evidence={
                     "kind": "lithos_retrieve",
                     "score": 0.85,
@@ -348,7 +362,21 @@ class TestEdgeUpsertHappyPath:
             assert not result.isError
             edge_calls = [c for c in lcma_server.calls if c[0] == "lithos_edge_upsert"]
             assert len(edge_calls) == 1
-            assert edge_calls[0][1]["type"] == "related_to"
+            assert edge_calls[0][1] == {
+                "from_id": "note-a",
+                "to_id": "note-b",
+                "type": "related_to",
+                "weight": 0.85,
+                "namespace": "influx",
+                "provenance_actor": "influx-lcma-retrieve",
+                "provenance_type": "lcma_retrieve",
+                "evidence": {
+                    "kind": "lithos_retrieve",
+                    "score": 0.85,
+                    "receipt_id": "r-001",
+                },
+                "conflict_state": None,
+            }
         finally:
             await client.close()
 
@@ -473,7 +501,11 @@ class TestEdgeUpsertUnknownTool:
         try:
             with pytest.raises(LCMAError, match="unknown_tool"):
                 await client.edge_upsert(
+                    from_id="note-a",
+                    to_id="note-b",
                     type="related_to",
+                    weight=0.85,
+                    namespace="influx",
                     evidence={"kind": "test"},
                 )
         finally:

--- a/tests/contract/test_lithos_client.py
+++ b/tests/contract/test_lithos_client.py
@@ -217,19 +217,29 @@ class FakeLithosServer:
 
         @self._mcp.tool(name="lithos_edge_upsert")
         async def lithos_edge_upsert(
+            from_id: str = "",
+            to_id: str = "",
             type: str = "",
-            source_note_id: str = "",
-            target_note_id: str = "",
+            weight: float = 0.0,
+            namespace: str = "",
+            provenance_actor: str | None = None,
+            provenance_type: str | None = None,
             evidence: dict[str, Any] | None = None,
+            conflict_state: str | None = None,
         ) -> str:
             calls.append(
                 (
                     "lithos_edge_upsert",
                     {
+                        "from_id": from_id,
+                        "to_id": to_id,
                         "type": type,
-                        "source_note_id": source_note_id,
-                        "target_note_id": target_note_id,
+                        "weight": weight,
+                        "namespace": namespace,
+                        "provenance_actor": provenance_actor,
+                        "provenance_type": provenance_type,
                         "evidence": evidence,
+                        "conflict_state": conflict_state,
                     },
                 )
             )

--- a/tests/integration/test_lcma_edges_end_to_end.py
+++ b/tests/integration/test_lcma_edges_end_to_end.py
@@ -338,11 +338,13 @@ class TestAfterWriteEdgeWiring:
         assert evidence["score"] == 0.85
         assert evidence["receipt_id"] == "rcpt-001"
 
-        # Verify graph endpoints are wired (finding 1):
-        # source_note_id from the just-written note,
-        # target_note_id from the retrieve result.
-        assert edge_calls[0]["source_note_id"] == "note-source-001"
-        assert edge_calls[0]["target_note_id"] == "note-related-001"
+        # Verify graph endpoints and provenance are wired end-to-end.
+        assert edge_calls[0]["from_id"] == "note-source-001"
+        assert edge_calls[0]["to_id"] == "note-related-001"
+        assert edge_calls[0]["weight"] == 0.85
+        assert edge_calls[0]["namespace"] == "influx"
+        assert edge_calls[0]["provenance_actor"] == "influx-lcma-retrieve"
+        assert edge_calls[0]["provenance_type"] == "lcma_retrieve"
 
         # Verify the result carries related_in_lithos for webhook digest.
         assert result is not None
@@ -488,9 +490,13 @@ class TestBuildsOnResolver:
         builds_on_edges = [c for c in edge_calls if c["type"] == "builds_on"]
         assert len(builds_on_edges) == 1
         assert builds_on_edges[0]["evidence"] == {"kind": "tier3_builds_on_extraction"}
-        # Graph endpoints are wired end-to-end (finding 1).
-        assert builds_on_edges[0]["source_note_id"] == "note-builds-source"
-        assert builds_on_edges[0]["target_note_id"] == "note-foonet"
+        # Graph endpoints and provenance are wired end-to-end.
+        assert builds_on_edges[0]["from_id"] == "note-builds-source"
+        assert builds_on_edges[0]["to_id"] == "note-foonet"
+        assert builds_on_edges[0]["weight"] == 1.0
+        assert builds_on_edges[0]["namespace"] == "influx"
+        assert builds_on_edges[0]["provenance_actor"] == "influx-tier3-builds-on"
+        assert builds_on_edges[0]["provenance_type"] == "tier3_extraction"
 
     def test_cache_miss_produces_no_builds_on_edge(
         self,

--- a/tests/unit/test_lcma_wiring.py
+++ b/tests/unit/test_lcma_wiring.py
@@ -99,8 +99,10 @@ class TestRelatedToEdgeScoreThreshold:
         client.edge_upsert.assert_awaited_once()
         call = client.edge_upsert.await_args
         assert call.kwargs["type"] == "related_to"
-        assert call.kwargs["source_note_id"] == "note-new"
-        assert call.kwargs["target_note_id"] == "note-prior"
+        assert call.kwargs["from_id"] == "note-new"
+        assert call.kwargs["to_id"] == "note-prior"
+        assert call.kwargs["weight"] == 0.9
+        assert call.kwargs["namespace"] == "influx"
         assert call.kwargs["evidence"]["score"] == 0.9
 
     @pytest.mark.asyncio
@@ -182,8 +184,10 @@ class TestBuildsOnResolution:
             if call.kwargs.get("type") == "builds_on"
         ]
         assert len(upserts) == 1
-        assert upserts[0]["source_note_id"] == "note-new"
-        assert upserts[0]["target_note_id"] == "note-prior"
+        assert upserts[0]["from_id"] == "note-new"
+        assert upserts[0]["to_id"] == "note-prior"
+        assert upserts[0]["weight"] == 1.0
+        assert upserts[0]["namespace"] == "influx"
 
     @pytest.mark.asyncio
     async def test_no_arxiv_id_skips_lookup(self) -> None:


### PR DESCRIPTION
Fixes #99

## Summary
- update `LithosClient.edge_upsert` to match the current Lithos MCP contract
- pass `from_id` / `to_id`, `weight`, `namespace`, and provenance from both LCMA edge call sites
- update contract and integration coverage to assert the exact edge payload shape

## Testing
- uv run pytest tests/contract/test_lcma_calls.py tests/integration/test_lcma_edges_end_to_end.py -q