### PR TITLE
Flag archive acquisition failures in run outcomes

### DIFF
--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -81,6 +81,7 @@ class RunLedger:
             "ingested": None,
             "fetched_total": None,
             "filter_errors_total": None,
+            "archive_failures_total": None,
             "error": None,
             "degraded": False,
             "degraded_reasons": [],
@@ -101,6 +102,7 @@ class RunLedger:
         ingested: int | None,
         fetched_total: int | None = None,
         filter_errors_total: int | None = None,
+        archive_failures_total: int | None = None,
         source_acquisition_errors: list[dict[str, str]] | None = None,
     ) -> list[str]:
         """Mark an active run as completed and append it to history.
@@ -118,6 +120,10 @@ class RunLedger:
           exclusive with ``filter_stall``: when both would apply,
           ``filter_error`` wins because the scorer-failure diagnosis
           is more specific.
+        - ``"archive_acquisition"`` — at least one accepted item was
+          ingested with ``influx:archive-missing`` after archive
+          acquisition failed, so note quality degraded even though the
+          run continued.
         - ``"ingestion_stall"`` (issue #36) — this and the immediately
           prior scheduled run both saw ``ingested == 0`` despite
           ``sources_checked > 0``.  Typical cause: every candidate hits
@@ -167,6 +173,8 @@ class RunLedger:
         )
         if has_filter_error:
             reasons.append("filter_error")
+        if isinstance(archive_failures_total, int) and archive_failures_total > 0:
+            reasons.append("archive_acquisition")
 
         # Resolve profile + kind once for the stall checks.  All three
         # stall flags only apply to scheduled runs (backfills
@@ -249,6 +257,7 @@ class RunLedger:
             ingested=ingested,
             fetched_total=fetched_total,
             filter_errors_total=filter_errors_total,
+            archive_failures_total=archive_failures_total,
             error=None,
             degraded=bool(reasons),
             source_acquisition_errors=errors,
@@ -565,6 +574,7 @@ class RunLedger:
         error: str | None,
         fetched_total: int | None = None,
         filter_errors_total: int | None = None,
+        archive_failures_total: int | None = None,
         degraded: bool = False,
         source_acquisition_errors: list[dict[str, str]] | None = None,
         degraded_reasons: list[str] | None = None,
@@ -596,6 +606,7 @@ class RunLedger:
                     "ingested": ingested,
                     "fetched_total": fetched_total,
                     "filter_errors_total": filter_errors_total,
+                    "archive_failures_total": archive_failures_total,
                     "error": error,
                     "degraded": degraded,
                     "degraded_reasons": list(degraded_reasons or []),

--- a/src/influx/run_service.py
+++ b/src/influx/run_service.py
@@ -166,6 +166,13 @@ async def ledger_lifecycle(
         outcome = session.outcome
         sources_checked = outcome.sources_checked if outcome is not None else None
         ingested = outcome.ingested if outcome is not None else None
+        archive_failures_total = 0
+        if outcome is not None and outcome.profile_run_result is not None:
+            archive_failures_total = sum(
+                1
+                for item in outcome.profile_run_result.items
+                if "influx:archive-missing" in item.tags
+            )
         # #85: pull the pre-filter fetched-count from the contextvar
         # bucket the source layer accumulated into.  ``outcome`` may be
         # ``None`` on the early-skip / abort paths; in that case we
@@ -180,6 +187,7 @@ async def ledger_lifecycle(
             ingested=ingested,
             fetched_total=fetched_total,
             filter_errors_total=filter_errors_total,
+            archive_failures_total=archive_failures_total,
             source_acquisition_errors=source_errors,
         )
         run_outcome = "degraded" if source_errors else "success"
@@ -257,6 +265,19 @@ async def ledger_lifecycle(
                 plan.kind.value,
                 run_id,
                 filter_errors_total,
+            )
+        if "archive_acquisition" in degraded_reasons:
+            if run_outcome == "success":
+                run_outcome = "degraded"
+            logger.warning(
+                "run flagged archive_acquisition profile=%s kind=%s run_id=%s "
+                "archive_failures=%d "
+                "(accepted items were ingested with influx:archive-missing "
+                "after archive download failed)",
+                profile,
+                plan.kind.value,
+                run_id,
+                archive_failures_total,
             )
         metrics.run_duration().record(elapsed, metric_attrs)
         metrics.run_completions().add(1, {**metric_attrs, "outcome": run_outcome})

--- a/tests/integration/test_otel_metrics.py
+++ b/tests/integration/test_otel_metrics.py
@@ -268,13 +268,15 @@ class TestRunLifecycleAndFunnelMetrics:
             {"profile": "ai-robotics", "run_type": "scheduled"},
         )
         assert "influx_run_completions_total" in points
-        # Outcome is "success" (no source_acquisition_errors in the fake run).
+        # Archive persistence fails in this isolated test environment, so the
+        # accepted item is tagged ``influx:archive-missing`` and the run
+        # completes as degraded via archive_acquisition.
         assert _has_label_set(
             points["influx_run_completions_total"],
             {
                 "profile": "ai-robotics",
                 "run_type": "scheduled",
-                "outcome": "success",
+                "outcome": "degraded",
             },
         )
         assert "influx_run_duration_seconds" in points

--- a/tests/unit/test_run_ledger.py
+++ b/tests/unit/test_run_ledger.py
@@ -234,6 +234,7 @@ def _start_complete(
     ingested: int | None,
     fetched_total: int | None = None,
     filter_errors_total: int | None = None,
+    archive_failures_total: int | None = None,
     source_acquisition_errors: list[dict[str, str]] | None = None,
 ) -> list[str]:
     """Helper: start + complete a run, return the degraded_reasons list.
@@ -256,6 +257,7 @@ def _start_complete(
         ingested=ingested,
         fetched_total=fetched_total,
         filter_errors_total=filter_errors_total,
+        archive_failures_total=archive_failures_total,
         source_acquisition_errors=source_acquisition_errors,
     )
 
@@ -293,6 +295,24 @@ def test_complete_returns_source_acquisition_reason(tmp_path: Path) -> None:
     entry = ledger.recent()[0]
     assert entry["degraded"] is True
     assert entry["degraded_reasons"] == ["source_acquisition"]
+
+
+def test_complete_returns_archive_acquisition_reason(tmp_path: Path) -> None:
+    """Accepted archive failures mark the run degraded for note-quality loss."""
+    ledger = RunLedger(tmp_path / "state")
+    reasons = _start_complete(
+        ledger,
+        run_id="r-1",
+        profile="p",
+        sources_checked=5,
+        ingested=2,
+        archive_failures_total=2,
+    )
+    assert reasons == ["archive_acquisition"]
+    entry = ledger.recent()[0]
+    assert entry["degraded"] is True
+    assert entry["degraded_reasons"] == ["archive_acquisition"]
+    assert entry["archive_failures_total"] == 2
 
 
 def test_single_zero_ingestion_run_is_not_yet_a_stall(tmp_path: Path) -> None:

--- a/tests/unit/test_run_service.py
+++ b/tests/unit/test_run_service.py
@@ -563,6 +563,56 @@ async def test_run_completed_log_degraded_false_for_clean_run(
     assert "degraded=False" in record.message
 
 
+async def test_archive_acquisition_degrades_run_and_logs_warning(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Accepted archive failures surface as a degraded run-level signal."""
+    from influx.notifications import HighlightItem, ProfileRunResult, RunStats
+
+    config = _make_config()
+    ledger = RunLedger(tmp_path)
+    service = RunService(config=config, ledger=ledger)
+
+    body_outcome = RunOutcome(
+        sources_checked=2,
+        ingested=1,
+        profile_run_result=ProfileRunResult(
+            run_date="2026-05-08",
+            profile="alpha",
+            stats=RunStats(sources_checked=2, ingested=1),
+            items=[
+                HighlightItem(
+                    id="note-1",
+                    title="Archived Poorly",
+                    score=8,
+                    tags=["profile:alpha", "influx:archive-missing"],
+                    reason="archive fetch accepted without attachment",
+                    url="https://example.com/archive-429",
+                    related_in_lithos=[],
+                )
+            ],
+        ),
+    )
+    with (
+        caplog.at_level(logging.WARNING, logger="influx.run_service"),
+        patch(
+            "influx.run.Run.execute",
+            new_callable=AsyncMock,
+            return_value=body_outcome,
+        ),
+    ):
+        await service.execute(_scheduled_plan())
+
+    entry = next(e for e in ledger.recent() if e["status"] == "completed")
+    assert entry["degraded_reasons"] == ["archive_acquisition"]
+    assert entry["archive_failures_total"] == 1
+
+    warning = next(r for r in caplog.records if "archive_acquisition" in r.message)
+    assert "archive_failures=1" in warning.message
+    assert "influx:archive-missing" in warning.message
+
+
 async def test_filter_error_emits_warning_with_scorer_failure_guidance(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
## Summary
- count archive-missing note outcomes at the run level
- mark runs degraded when archive acquisition failures occur and log an operator-facing warning
- persist archive failure totals in the run ledger and cover the new degraded reason with unit tests

## Testing
- uv run pytest tests/unit/test_run_ledger.py tests/unit/test_run_service.py -q
- uv run ruff check src/influx/run_ledger.py src/influx/run_service.py tests/unit/test_run_ledger.py tests/unit/test_run_service.py
- uv run ruff format --check src/influx/run_ledger.py src/influx/run_service.py tests/unit/test_run_ledger.py tests/unit/test_run_service.py

Fixes #112