### PR TITLE
Centralize Lithos MCP response decoding

### DIFF
--- a/src/influx/feedback.py
+++ b/src/influx/feedback.py
@@ -7,7 +7,6 @@ consumed by the filter prompt (§6.3).
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -33,12 +32,10 @@ async def fetch_rejection_titles(
 
     Returns a list of title strings (possibly empty).
     """
-    result = await client.list_notes(
+    body: dict[str, Any] = await client.list_notes_body(
         tags=[f"influx:rejected:{profile}"],
         limit=limit,
     )
-    text = result.content[0].text  # type: ignore[union-attr]
-    body: dict[str, Any] = json.loads(text)
     items: list[dict[str, Any]] = body.get("items", [])
 
     titles: list[str] = []

--- a/src/influx/lcma.py
+++ b/src/influx/lcma.py
@@ -6,7 +6,6 @@ and the post-write retrieve + edge wiring used by the LCMA flow.
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 from typing import TYPE_CHECKING, Any
@@ -190,15 +189,13 @@ async def after_write(
             "influx.run_id": current_run_id.get() or "",
         },
     ):
-        result = await client.retrieve(
+        body = await client.retrieve_body(
             query=query,
             limit=5,
             agent_id="influx",
             task_id=run_task_id,
             tags=[f"profile:{profile}"],
         )
-
-    body = json.loads(result.content[0].text)  # type: ignore[union-attr]
     results: list[dict[str, Any]] = body.get("results", [])
     logger.info(
         "LCMA retrieve completed profile=%s run_id=%s source_url=%s "
@@ -295,12 +292,10 @@ async def resolve_builds_on(
         prior_title, arxiv_id = ref
         source_url = f"https://arxiv.org/abs/{arxiv_id}"
 
-        result = await client.cache_lookup(
+        body = await client.cache_lookup_body(
             query=prior_title,
             source_url=source_url,
         )
-
-        body = json.loads(result.content[0].text)  # type: ignore[union-attr]
         if not body.get("hit"):
             logger.info(
                 "LCMA builds_on lookup miss profile=%s run_id=%s "

--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -571,6 +571,68 @@ class LithosClient:
             {"query": query, "source_url": source_url},
         )
 
+    def _result_text(
+        self,
+        result: mcp_types.CallToolResult,
+        *,
+        operation: str,
+    ) -> str:
+        """Extract the first text payload from a tool result."""
+        try:
+            text = result.content[0].text  # type: ignore[union-attr]
+        except (AttributeError, IndexError) as exc:
+            raise LithosError(
+                "malformed_tool_response",
+                operation=operation,
+                detail="missing text content",
+            ) from exc
+        if not isinstance(text, str):
+            raise LithosError(
+                "malformed_tool_response",
+                operation=operation,
+                detail="non-string text content",
+            )
+        return text
+
+    def _result_json_dict(
+        self,
+        result: mcp_types.CallToolResult,
+        *,
+        operation: str,
+    ) -> dict[str, Any]:
+        """Decode a tool result into a JSON object with consistent errors."""
+        text = self._result_text(result, operation=operation)
+        if getattr(result, "isError", False) is True:
+            raise LithosError(
+                f"{operation} failed",
+                operation=operation,
+                detail=text,
+            )
+        try:
+            body = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise LithosError(
+                "malformed_tool_response",
+                operation=operation,
+                detail="invalid JSON payload",
+            ) from exc
+        if not isinstance(body, dict):
+            raise LithosError(
+                "malformed_tool_response",
+                operation=operation,
+                detail="JSON payload was not an object",
+            )
+        return body
+
+    async def cache_lookup_body(
+        self, *, query: str | None, source_url: str | None
+    ) -> dict[str, Any]:
+        """Run ``cache_lookup`` and decode the JSON body."""
+        return self._result_json_dict(
+            await self.cache_lookup(query=query, source_url=source_url),
+            operation="cache_lookup",
+        )
+
     async def cache_lookup_for_item(
         self,
         *,
@@ -595,11 +657,27 @@ class LithosClient:
         query = compose_dedup_query(title, abstract_or_summary)
         return await self.cache_lookup(query=query, source_url=source_url)
 
+    async def cache_lookup_for_item_body(
+        self,
+        *,
+        title: str,
+        source_url: str | None,
+        abstract_or_summary: str | None = None,
+    ) -> dict[str, Any]:
+        """Run ``cache_lookup_for_item`` and decode the JSON body."""
+        return self._result_json_dict(
+            await self.cache_lookup_for_item(
+                title=title,
+                source_url=source_url,
+                abstract_or_summary=abstract_or_summary,
+            ),
+            operation="cache_lookup",
+        )
+
     async def read_note(self, *, note_id: str) -> dict[str, Any]:
         """Read a note by ID (used for version_conflict re-reads)."""
         result = await self.call_tool("lithos_read", {"id": note_id})
-        text = result.content[0].text  # type: ignore[union-attr]
-        return json.loads(text)
+        return self._result_json_dict(result, operation="read_note")
 
     async def write_note(
         self,
@@ -1108,6 +1186,25 @@ class LithosClient:
             args["limit"] = limit
         return await self.call_tool("lithos_list", args)
 
+    async def list_notes_body(
+        self,
+        *,
+        tags: list[str],
+        limit: int | None = None,
+        order_by: str | None = None,
+        order: str | None = None,
+    ) -> dict[str, Any]:
+        """Run ``list_notes`` and decode the JSON body."""
+        return self._result_json_dict(
+            await self.list_notes(
+                tags=tags,
+                limit=limit,
+                order_by=order_by,
+                order=order,
+            ),
+            operation="list_notes",
+        )
+
     async def list_archive_terminal_arxiv_ids(
         self,
         *,
@@ -1124,33 +1221,13 @@ class LithosClient:
         run continues at worst as today.
         """
         try:
-            result = await self.list_notes(
+            body = await self.list_notes_body(
                 tags=["influx:archive-terminal", f"profile:{profile}"],
             )
         except (LithosError, McpError):
             logger.warning(
                 "list_archive_terminal_arxiv_ids: lithos_list failed for "
                 "profile %r; assuming empty terminal set",
-                profile,
-                exc_info=True,
-            )
-            return frozenset()
-
-        if getattr(result, "isError", False) is True:
-            logger.warning(
-                "list_archive_terminal_arxiv_ids: lithos_list returned "
-                "isError=True for profile %r; assuming empty terminal set",
-                profile,
-            )
-            return frozenset()
-
-        try:
-            text = result.content[0].text  # type: ignore[union-attr]
-            body = json.loads(text)
-        except (AttributeError, IndexError, json.JSONDecodeError, KeyError):
-            logger.warning(
-                "list_archive_terminal_arxiv_ids: malformed lithos_list "
-                "response for profile %r; assuming empty terminal set",
                 profile,
                 exc_info=True,
             )
@@ -1234,6 +1311,27 @@ class LithosClient:
             },
         )
 
+    async def retrieve_body(
+        self,
+        *,
+        query: str,
+        limit: int,
+        agent_id: str,
+        task_id: str,
+        tags: list[str],
+    ) -> dict[str, Any]:
+        """Run ``retrieve`` and decode the JSON body."""
+        return self._result_json_dict(
+            await self.retrieve(
+                query=query,
+                limit=limit,
+                agent_id=agent_id,
+                task_id=task_id,
+                tags=tags,
+            ),
+            operation="retrieve",
+        )
+
     async def edge_upsert(
         self,
         *,
@@ -1278,6 +1376,19 @@ class LithosClient:
             {"title": title, "agent": agent, "tags": tags},
         )
 
+    async def task_create_body(
+        self,
+        *,
+        title: str,
+        agent: str,
+        tags: list[str],
+    ) -> dict[str, Any]:
+        """Run ``task_create`` and decode the JSON body."""
+        return self._result_json_dict(
+            await self.task_create(title=title, agent=agent, tags=tags),
+            operation="task_create",
+        )
+
     async def task_complete(
         self,
         *,
@@ -1290,6 +1401,19 @@ class LithosClient:
         if outcome is not None:
             args["outcome"] = outcome
         return await self._call_lcma_tool("lithos_task_complete", args)
+
+    async def task_complete_body(
+        self,
+        *,
+        task_id: str,
+        agent: str,
+        outcome: str | None = None,
+    ) -> dict[str, Any]:
+        """Run ``task_complete`` and decode the JSON body."""
+        return self._result_json_dict(
+            await self.task_complete(task_id=task_id, agent=agent, outcome=outcome),
+            operation="task_complete",
+        )
 
     async def call_tool(
         self, name: str, arguments: dict[str, Any] | None = None

--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -1261,21 +1261,12 @@ async def sweep(
         effective_hooks = make_default_sweep_hooks(config).to_sweep_hooks()
 
     limit = config.repair.max_items_per_run
-    list_result = await client.list_notes(
+    body = await client.list_notes_body(
         tags=["influx:repair-needed", f"profile:{profile}"],
         limit=limit,
         order_by="updated_at",
         order="asc",
     )
-
-    text = list_result.content[0].text  # type: ignore[union-attr]
-    if getattr(list_result, "isError", False) is True:
-        raise LithosError(
-            "lithos_list failed during repair sweep",
-            operation="repair_sweep",
-            detail=text,
-        )
-    body = json.loads(text)
     items: list[dict[str, Any]] = body.get("items", [])
     items.sort(
         key=lambda item: str(item.get("updated_at") or item.get("updated") or "")

--- a/src/influx/run.py
+++ b/src/influx/run.py
@@ -30,7 +30,6 @@ from both success and abort paths uniformly.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
 from contextlib import asynccontextmanager
@@ -275,13 +274,10 @@ async def lithos_task_lifecycle(
     task_tag = "influx:backfill" if plan.kind == RunKind.BACKFILL else "influx:run"
     run_date = datetime.now(UTC).date().isoformat()
     task_title = f"Influx run {profile} {run_date}"
-    task_result = await client.task_create(
+    task_body = await client.task_create_body(
         title=task_title,
         agent="influx",
         tags=[task_tag, f"profile:{profile}"],
-    )
-    task_body = json.loads(
-        task_result.content[0].text  # type: ignore[union-attr]
     )
     run_task_id = str(task_body["task_id"])
 
@@ -472,13 +468,10 @@ async def _run_ingest_stage(
             item.get("path", ""),
             item.get("tags", []),
         )
-        cache_result = await client.cache_lookup_for_item(
+        cache_body = await client.cache_lookup_for_item_body(
             title=title,
             source_url=source_url,
             abstract_or_summary=item.get("abstract_or_summary"),
-        )
-        cache_body = json.loads(
-            cache_result.content[0].text  # type: ignore[union-attr]
         )
         cache_hit = bool(cache_body.get("hit"))
         if cache_hit:

--- a/tests/integration/test_otel_metrics.py
+++ b/tests/integration/test_otel_metrics.py
@@ -100,19 +100,13 @@ def _full_config() -> Any:
 
 def _mock_lithos_client() -> AsyncMock:
     client = AsyncMock()
-    client.task_create.return_value = MagicMock(
-        content=[MagicMock(text='{"task_id": "task-1"}')],
-    )
-    client.cache_lookup_for_item.return_value = MagicMock(
-        content=[MagicMock(text='{"hit": false}')],
-    )
+    client.task_create_body.return_value = {"task_id": "task-1"}
+    client.cache_lookup_for_item_body.return_value = {"hit": False}
     write_result = MagicMock()
     write_result.status = "created"
     write_result.note_id = "note-123"
     client.write_note.return_value = write_result
-    client.retrieve.return_value = MagicMock(
-        content=[MagicMock(text='{"results": []}')],
-    )
+    client.retrieve_body.return_value = {"results": []}
     client.close = AsyncMock()
     client.task_complete = AsyncMock()
     return client

--- a/tests/integration/test_otel_spans.py
+++ b/tests/integration/test_otel_spans.py
@@ -157,19 +157,13 @@ EXPECTED_ATTRS: dict[str, set[str]] = {
 def _mock_lithos_client() -> AsyncMock:
     """Build a mock LithosClient sufficient for ``run_profile``."""
     client = AsyncMock()
-    client.task_create.return_value = MagicMock(
-        content=[MagicMock(text='{"task_id": "task-1"}')],
-    )
-    client.cache_lookup_for_item.return_value = MagicMock(
-        content=[MagicMock(text='{"hit": false}')],
-    )
+    client.task_create_body.return_value = {"task_id": "task-1"}
+    client.cache_lookup_for_item_body.return_value = {"hit": False}
     write_result = MagicMock()
     write_result.status = "created"
     write_result.note_id = "note-123"
     client.write_note.return_value = write_result
-    client.retrieve.return_value = MagicMock(
-        content=[MagicMock(text='{"results": []}')],
-    )
+    client.retrieve_body.return_value = {"results": []}
     client.close = AsyncMock()
     client.task_complete = AsyncMock()
     return client

--- a/tests/unit/test_lcma_wiring.py
+++ b/tests/unit/test_lcma_wiring.py
@@ -17,23 +17,13 @@ Lower-level retrieve / cache-lookup primitives are exercised in
 
 from __future__ import annotations
 
-import json
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
 from influx.errors import LCMAError
 from influx.lcma_wiring import CascadeOutput, LcmaWiringDeps, wire
-
-
-def _mcp_text_result(payload: dict[str, Any]) -> MagicMock:
-    """Build a fake MCP-style result whose ``content[0].text`` is JSON."""
-    text_content = MagicMock()
-    text_content.text = json.dumps(payload)
-    result = MagicMock()
-    result.content = [text_content]
-    return result
 
 
 def _make_client(
@@ -43,11 +33,9 @@ def _make_client(
 ) -> AsyncMock:
     """Build an AsyncMock LithosClient with the listed call returns."""
     client = AsyncMock()
-    client.retrieve = AsyncMock(
-        return_value=_mcp_text_result(retrieve_payload or {"results": []})
-    )
-    client.cache_lookup = AsyncMock(
-        return_value=_mcp_text_result(cache_lookup_payload or {"hit": False})
+    client.retrieve_body = AsyncMock(return_value=retrieve_payload or {"results": []})
+    client.cache_lookup_body = AsyncMock(
+        return_value=cache_lookup_payload or {"hit": False}
     )
     client.edge_upsert = AsyncMock()
     return client
@@ -176,7 +164,7 @@ class TestBuildsOnResolution:
             deps=deps,
         )
 
-        client.cache_lookup.assert_awaited_once()
+        client.cache_lookup_body.assert_awaited_once()
         # Find the builds_on edge among the upsert calls.
         upserts = [
             call.kwargs
@@ -204,7 +192,7 @@ class TestBuildsOnResolution:
             deps=deps,
         )
 
-        client.cache_lookup.assert_not_awaited()
+        client.cache_lookup_body.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_cache_miss_skips_edge(self) -> None:
@@ -221,7 +209,7 @@ class TestBuildsOnResolution:
             deps=deps,
         )
 
-        client.cache_lookup.assert_awaited_once()
+        client.cache_lookup_body.assert_awaited_once()
         builds_on_upserts = [
             call.kwargs
             for call in client.edge_upsert.await_args_list
@@ -293,7 +281,7 @@ class TestLcmaErrorPropagation:
     @pytest.mark.asyncio
     async def test_unknown_tool_on_retrieve_is_contained(self) -> None:
         client = _make_client()
-        client.retrieve = AsyncMock(
+        client.retrieve_body = AsyncMock(
             side_effect=LCMAError("unknown_tool", stage="lithos_retrieve")
         )
         deps = _make_deps(client)
@@ -310,7 +298,7 @@ class TestLcmaErrorPropagation:
     @pytest.mark.asyncio
     async def test_other_lcma_error_is_contained_and_builds_on_still_runs(self) -> None:
         client = _make_client()
-        client.retrieve = AsyncMock(
+        client.retrieve_body = AsyncMock(
             side_effect=LCMAError("transport refused", stage="http")
         )
         deps = _make_deps(client)
@@ -326,4 +314,4 @@ class TestLcmaErrorPropagation:
         )
 
         assert related == []
-        client.cache_lookup.assert_awaited_once()
+        client.cache_lookup_body.assert_awaited_once()

--- a/tests/unit/test_lithos_client.py
+++ b/tests/unit/test_lithos_client.py
@@ -8,11 +8,12 @@ live in ``tests/contract/test_lcma_calls.py`` (PRD 08).
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+import json
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from influx.errors import ConfigError
+from influx.errors import ConfigError, LithosError
 from influx.lithos_client import LithosClient
 
 
@@ -76,6 +77,38 @@ class TestListNotes:
             "lithos_list",
             {"tags": ["influx:repair-needed", "profile:staging-ai"], "limit": 25},
         )
+
+
+def _tool_result(payload: object, *, is_error: bool = False) -> MagicMock:
+    text_content = MagicMock()
+    text_content.text = payload if isinstance(payload, str) else json.dumps(payload)
+    result = MagicMock()
+    result.content = [text_content]
+    result.isError = is_error
+    return result
+
+
+class TestDecodedBodies:
+    """Centralized decode helpers raise consistent LithosError shapes."""
+
+    async def test_list_notes_body_decodes_json_object(self) -> None:
+        client = LithosClient(url="http://localhost:1234/sse")
+        client.list_notes = AsyncMock(  # type: ignore[method-assign]
+            return_value=_tool_result({"items": [{"id": "note-1"}]})
+        )
+
+        body = await client.list_notes_body(tags=["foo"], limit=10)
+
+        assert body == {"items": [{"id": "note-1"}]}
+
+    async def test_list_notes_body_rejects_invalid_json(self) -> None:
+        client = LithosClient(url="http://localhost:1234/sse")
+        client.list_notes = AsyncMock(  # type: ignore[method-assign]
+            return_value=_tool_result("{not-json")
+        )
+
+        with pytest.raises(LithosError, match="malformed_tool_response"):
+            await client.list_notes_body(tags=["foo"], limit=10)
 
 
 class TestClassifySquatter:

--- a/tests/unit/test_rejection_rate_logging.py
+++ b/tests/unit/test_rejection_rate_logging.py
@@ -48,7 +48,7 @@ def _make_client(rejected_titles: list[str] | None = None) -> Any:
     mock_content.text = result_text
     list_result = MagicMock()
     list_result.content = [mock_content]
-    client.list_notes = AsyncMock(return_value=list_result)
+    client.list_notes_body = AsyncMock(return_value=json.loads(result_text))
     return client
 
 

--- a/tests/unit/test_repair_hook_rollback.py
+++ b/tests/unit/test_repair_hook_rollback.py
@@ -61,7 +61,7 @@ def _make_client(
     write_status: str = "updated",
 ) -> AsyncMock:
     client = AsyncMock()
-    client.list_notes = AsyncMock(return_value=_make_list_result(list_items))
+    client.list_notes_body = AsyncMock(return_value={"items": list_items})
     client.read_note = AsyncMock(side_effect=read_responses)
     client.call_tool = AsyncMock(return_value=_make_write_result(write_status))
     return client

--- a/tests/unit/test_repair_sweep.py
+++ b/tests/unit/test_repair_sweep.py
@@ -23,16 +23,6 @@ from influx.repair import ContentTooLargeSkipped, SweepHooks, SweepWriteError, s
 # ── Helpers ──────────────────────────────────────────────────────────
 
 
-def _make_list_result(items: list[dict[str, Any]]) -> MagicMock:
-    """Build a fake ``CallToolResult`` for ``list_notes``."""
-    text_content = MagicMock()
-    text_content.text = json.dumps({"items": items})
-    result = MagicMock()
-    result.content = [text_content]
-    result.isError = False
-    return result
-
-
 def _make_write_result(status: str = "updated") -> MagicMock:
     """Build a fake ``CallToolResult`` for ``lithos_write``."""
     text_content = MagicMock()
@@ -58,7 +48,7 @@ def _make_client(
 ) -> AsyncMock:
     """Build a mock LithosClient with ``list_notes`` / ``read_note`` / ``call_tool``."""
     client = AsyncMock()
-    client.list_notes = AsyncMock(return_value=_make_list_result(list_items or []))
+    client.list_notes_body = AsyncMock(return_value={"items": list_items or []})
     if read_responses:
         client.read_note = AsyncMock(side_effect=read_responses)
     else:
@@ -81,7 +71,7 @@ class TestSweepListCall:
 
         await sweep("ai-robotics", client=client, config=config, hooks=SweepHooks())
 
-        client.list_notes.assert_awaited_once_with(
+        client.list_notes_body.assert_awaited_once_with(
             tags=["influx:repair-needed", "profile:ai-robotics"],
             limit=50,
             order_by="updated_at",
@@ -94,7 +84,7 @@ class TestSweepListCall:
 
         await sweep("web-tech", client=client, config=config, hooks=SweepHooks())
 
-        call_kwargs = client.list_notes.call_args.kwargs
+        call_kwargs = client.list_notes_body.call_args.kwargs
         assert call_kwargs["limit"] == 100
 
     async def test_profile_name_interpolated_into_tag(self) -> None:
@@ -103,7 +93,7 @@ class TestSweepListCall:
 
         await sweep("ml-research", client=client, config=config, hooks=SweepHooks())
 
-        call_kwargs = client.list_notes.call_args.kwargs
+        call_kwargs = client.list_notes_body.call_args.kwargs
         assert call_kwargs["tags"] == [
             "influx:repair-needed",
             "profile:ml-research",
@@ -403,7 +393,7 @@ class TestSweepVersionConflict:
         }
         config = _make_config()
         client = AsyncMock()
-        client.list_notes = AsyncMock(return_value=_make_list_result(items))
+        client.list_notes_body = AsyncMock(return_value={"items": items})
         # read_note: first call is the initial re-read, second is the
         # FR-MCP-7 re-read after version_conflict.
         client.read_note = AsyncMock(side_effect=[note, refreshed])
@@ -449,7 +439,7 @@ class TestSweepVersionConflict:
         }
         config = _make_config()
         client = AsyncMock()
-        client.list_notes = AsyncMock(return_value=_make_list_result(items))
+        client.list_notes_body = AsyncMock(return_value={"items": items})
         client.read_note = AsyncMock(side_effect=[note, refreshed])
         # Both writes return version_conflict.
         client.call_tool = AsyncMock(
@@ -485,7 +475,7 @@ class TestSweepVersionConflict:
         }
         config = _make_config()
         client = AsyncMock()
-        client.list_notes = AsyncMock(return_value=_make_list_result(items))
+        client.list_notes_body = AsyncMock(return_value={"items": items})
         client.read_note = AsyncMock(side_effect=[note1, refreshed1])
         client.call_tool = AsyncMock(
             side_effect=[
@@ -517,7 +507,7 @@ class TestSweepTransportFailure:
         }
         config = _make_config()
         client = AsyncMock()
-        client.list_notes = AsyncMock(return_value=_make_list_result(items))
+        client.list_notes_body = AsyncMock(return_value={"items": items})
         client.read_note = AsyncMock(return_value=note)
         client.call_tool = AsyncMock(side_effect=LithosError("connection lost"))
 
@@ -536,7 +526,7 @@ class TestSweepTransportFailure:
         }
         config = _make_config()
         client = AsyncMock()
-        client.list_notes = AsyncMock(return_value=_make_list_result(items))
+        client.list_notes_body = AsyncMock(return_value={"items": items})
         client.read_note = AsyncMock(return_value=note1)
         client.call_tool = AsyncMock(side_effect=LithosError("connection lost"))
 
@@ -576,7 +566,7 @@ class TestSweepContentTooLargeSkipped:
         }
         config = _make_config()
         client = AsyncMock()
-        client.list_notes = AsyncMock(return_value=_make_list_result(items))
+        client.list_notes_body = AsyncMock(return_value={"items": items})
         client.read_note = AsyncMock(side_effect=[note1, note2])
         # n1 chronic-oversize: 3 content_too_large (orig + Tier-2-dropped
         # + Tier-1-only) → ContentTooLargeSkipped.  Then n2 → updated.
@@ -621,7 +611,7 @@ class TestSweepContentTooLargeSkipped:
         }
         config = _make_config()
         client = AsyncMock()
-        client.list_notes = AsyncMock(return_value=_make_list_result(items))
+        client.list_notes_body = AsyncMock(return_value={"items": items})
         client.read_note = AsyncMock(return_value=note)
         client.call_tool = AsyncMock(
             return_value=_make_write_result("content_too_large"),
@@ -667,7 +657,7 @@ class TestSweepContentTooLargeSkipped:
         ]
         config = _make_config()
         client = AsyncMock()
-        client.list_notes = AsyncMock(return_value=_make_list_result(items))
+        client.list_notes_body = AsyncMock(return_value={"items": items})
         client.read_note = AsyncMock(side_effect=notes)
         # n1 → oversize×3 (chronic), n2 + n3 → success.
         client.call_tool = AsyncMock(
@@ -713,7 +703,7 @@ class TestSweepContentTooLargeSkipped:
         ]
         config = _make_config()
         client = AsyncMock()
-        client.list_notes = AsyncMock(return_value=_make_list_result(items))
+        client.list_notes_body = AsyncMock(return_value={"items": items})
         client.read_note = AsyncMock(side_effect=notes)
         # Each note gets 3 content_too_large attempts → chronic skip.
         client.call_tool = AsyncMock(

--- a/tests/unit/test_run_module.py
+++ b/tests/unit/test_run_module.py
@@ -91,6 +91,10 @@ class _NoopClient:
             ]
         )
 
+    async def task_create_body(self, **kwargs: Any) -> dict[str, Any]:
+        await self.task_create(**kwargs)
+        return {"task_id": "task-1"}
+
     async def task_complete(self, **kwargs: Any) -> Any:
         from mcp import types as mcp_types
 
@@ -424,15 +428,7 @@ async def test_run_execute_walks_provider_and_writes_per_item() -> None:
     mock_client = MagicMock()
     mock_client.close = AsyncMock()
     mock_client.list_archive_terminal_arxiv_ids = AsyncMock(return_value=frozenset())
-    mock_client.task_create = AsyncMock(
-        return_value=mcp_types.CallToolResult(
-            content=[
-                mcp_types.TextContent(
-                    type="text", text=json.dumps({"task_id": "task-1"})
-                )
-            ]
-        )
-    )
+    mock_client.task_create_body = AsyncMock(return_value={"task_id": "task-1"})
     mock_client.task_complete = AsyncMock(
         return_value=mcp_types.CallToolResult(
             content=[
@@ -442,11 +438,7 @@ async def test_run_execute_walks_provider_and_writes_per_item() -> None:
             ]
         )
     )
-    mock_client.cache_lookup_for_item = AsyncMock(
-        return_value=mcp_types.CallToolResult(
-            content=[mcp_types.TextContent(type="text", text='{"hit": false}')]
-        )
-    )
+    mock_client.cache_lookup_for_item_body = AsyncMock(return_value={"hit": False})
     write_result = MagicMock()
     write_result.status = "created"
     write_result.note_id = "note-new"
@@ -507,15 +499,7 @@ async def test_run_execute_continues_after_lcma_wiring_failure() -> None:
     mock_client = MagicMock()
     mock_client.close = AsyncMock()
     mock_client.list_archive_terminal_arxiv_ids = AsyncMock(return_value=frozenset())
-    mock_client.task_create = AsyncMock(
-        return_value=mcp_types.CallToolResult(
-            content=[
-                mcp_types.TextContent(
-                    type="text", text=json.dumps({"task_id": "task-1"})
-                )
-            ]
-        )
-    )
+    mock_client.task_create_body = AsyncMock(return_value={"task_id": "task-1"})
     mock_client.task_complete = AsyncMock(
         return_value=mcp_types.CallToolResult(
             content=[
@@ -525,11 +509,7 @@ async def test_run_execute_continues_after_lcma_wiring_failure() -> None:
             ]
         )
     )
-    mock_client.cache_lookup_for_item = AsyncMock(
-        return_value=mcp_types.CallToolResult(
-            content=[mcp_types.TextContent(type="text", text='{"hit": false}')]
-        )
-    )
+    mock_client.cache_lookup_for_item_body = AsyncMock(return_value={"hit": False})
     write_result_1 = MagicMock()
     write_result_1.status = "created"
     write_result_1.note_id = "note-1"
@@ -594,15 +574,7 @@ async def test_run_execute_persists_unresolved_slug_collision_without_injected_l
     mock_client = MagicMock()
     mock_client.close = AsyncMock()
     mock_client.list_archive_terminal_arxiv_ids = AsyncMock(return_value=frozenset())
-    mock_client.task_create = AsyncMock(
-        return_value=mcp_types.CallToolResult(
-            content=[
-                mcp_types.TextContent(
-                    type="text", text=json.dumps({"task_id": "task-1"})
-                )
-            ]
-        )
-    )
+    mock_client.task_create_body = AsyncMock(return_value={"task_id": "task-1"})
     mock_client.task_complete = AsyncMock(
         return_value=mcp_types.CallToolResult(
             content=[
@@ -612,11 +584,7 @@ async def test_run_execute_persists_unresolved_slug_collision_without_injected_l
             ]
         )
     )
-    mock_client.cache_lookup_for_item = AsyncMock(
-        return_value=mcp_types.CallToolResult(
-            content=[mcp_types.TextContent(type="text", text='{"hit": false}')]
-        )
-    )
+    mock_client.cache_lookup_for_item_body = AsyncMock(return_value={"hit": False})
     write_result = MagicMock()
     write_result.status = "slug_collision"
     write_result.note_id = ""

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -699,6 +699,10 @@ class TestSweepWriteErrorMarksReadinessDegraded:
                     ],
                 )
 
+            async def task_create_body(self, **kwargs: Any) -> dict[str, Any]:
+                del kwargs
+                return {"task_id": "noop-task"}
+
             async def task_complete(self, **kwargs: Any) -> Any:
                 import json as _json
 
@@ -773,6 +777,10 @@ class TestSweepWriteErrorMarksReadinessDegraded:
                         _mcp_types.TextContent(type="text", text=txt),
                     ],
                 )
+
+            async def task_create_body(self, **kwargs: Any) -> dict[str, Any]:
+                del kwargs
+                return {"task_id": "noop-task"}
 
             async def task_complete(self, **kwargs: Any) -> Any:
                 import json as _json
@@ -852,6 +860,10 @@ class TestSweepWriteErrorMarksReadinessDegraded:
                         _mcp_types.TextContent(type="text", text=txt),
                     ],
                 )
+
+            async def task_create_body(self, **kwargs: Any) -> dict[str, Any]:
+                del kwargs
+                return {"task_id": "noop-task"}
 
             async def task_complete(self, **kwargs: Any) -> Any: ...
 
@@ -935,6 +947,10 @@ class TestScheduledFireInvokesRepairSweep:
                         _mcp_types.TextContent(type="text", text=txt),
                     ],
                 )
+
+            async def task_create_body(self, **kwargs: Any) -> dict[str, Any]:
+                del kwargs
+                return {"task_id": "noop-task"}
 
             async def task_complete(self, **kwargs: Any) -> Any:
                 import json as _json
@@ -1036,6 +1052,10 @@ class TestNegativeExampleMaxTitleCharsWired:
                         _mcp_types.TextContent(type="text", text=txt),
                     ],
                 )
+
+            async def task_create_body(self, **kwargs: Any) -> dict[str, Any]:
+                del kwargs
+                return {"task_id": "noop-task"}
 
             async def task_complete(self, **kwargs: Any) -> Any:
                 import json as _json
@@ -1322,6 +1342,10 @@ class TestManualRunDispatchesToRunModule:
                     ],
                 )
 
+            async def task_create_body(self, **kwargs: Any) -> dict[str, Any]:
+                del kwargs
+                return {"task_id": "manual-task"}
+
             async def task_complete(self, **kwargs: Any) -> Any:
                 import json as _json
 
@@ -1427,6 +1451,10 @@ class TestBackfillRunDispatchesToRunModule:
                         ),
                     ],
                 )
+
+            async def task_create_body(self, **kwargs: Any) -> dict[str, Any]:
+                del kwargs
+                return {"task_id": "bf-task"}
 
             async def task_complete(self, **kwargs: Any) -> Any:
                 import json as _json

--- a/tests/unit/test_telemetry_wiring.py
+++ b/tests/unit/test_telemetry_wiring.py
@@ -1172,15 +1172,20 @@ class TestInfluxLithosWriteSpan:
                 ),
                 patch("influx.service.post_run_webhook_hook"),
             ):
-                mock_client = AsyncMock()
+                mock_client = MagicMock()
                 mock_client_cls.return_value = mock_client
                 mock_client_cls_run.return_value = mock_client
                 # task_create returns a task_id
-                mock_client.task_create.return_value = MagicMock(
-                    content=[MagicMock(text='{"task_id": "task-1"}')]
+                mock_client.task_create_body = AsyncMock(
+                    return_value={"task_id": "task-1"}
                 )
-                mock_client.cache_lookup_for_item.return_value = mock_cache_result
-                mock_client.write_note.return_value = mock_write_result
+                mock_client.cache_lookup_for_item_body = AsyncMock(
+                    return_value={"hit": False}
+                )
+                mock_client.list_archive_terminal_arxiv_ids = AsyncMock(
+                    return_value=set()
+                )
+                mock_client.write_note = AsyncMock(return_value=mock_write_result)
                 mock_client.close = AsyncMock()
                 mock_client.task_complete = AsyncMock()
 
@@ -1215,9 +1220,6 @@ class TestInfluxLithosWriteSpan:
         mock_write_result = MagicMock()
         mock_write_result.status = "created"
         mock_write_result.note_id = "note-456"
-
-        mock_cache_result = MagicMock()
-        mock_cache_result.content = [MagicMock(text='{"hit": false}')]
 
         async def fake_provider(
             profile: str, kind: Any, run_range: Any, prompt: str
@@ -1263,14 +1265,15 @@ class TestInfluxLithosWriteSpan:
             ),
             patch("influx.service.post_run_webhook_hook"),
         ):
-            mock_client = AsyncMock()
+            mock_client = MagicMock()
             mock_client_cls.return_value = mock_client
             mock_client_cls_run.return_value = mock_client
-            mock_client.task_create.return_value = MagicMock(
-                content=[MagicMock(text='{"task_id": "task-1"}')]
+            mock_client.task_create_body = AsyncMock(return_value={"task_id": "task-1"})
+            mock_client.cache_lookup_for_item_body = AsyncMock(
+                return_value={"hit": False}
             )
-            mock_client.cache_lookup_for_item.return_value = mock_cache_result
-            mock_client.write_note.return_value = mock_write_result
+            mock_client.list_archive_terminal_arxiv_ids = AsyncMock(return_value=set())
+            mock_client.write_note = AsyncMock(return_value=mock_write_result)
             mock_client.close = AsyncMock()
             mock_client.task_complete = AsyncMock()
 
@@ -1300,9 +1303,7 @@ class TestInfluxLithosRetrieveSpan:
 
         # Mock the LithosClient
         mock_client = AsyncMock()
-        mock_client.retrieve.return_value = MagicMock(
-            content=[MagicMock(text='{"results": []}')]
-        )
+        mock_client.retrieve_body.return_value = {"results": []}
 
         token = current_run_id.set("test-run-retrieve")
         try:
@@ -1337,9 +1338,7 @@ class TestInfluxLithosRetrieveSpan:
         assert not disabled_tracer.enabled
 
         mock_client = AsyncMock()
-        mock_client.retrieve.return_value = MagicMock(
-            content=[MagicMock(text='{"results": []}')]
-        )
+        mock_client.retrieve_body.return_value = {"results": []}
 
         with patch("influx.lcma.get_tracer", return_value=disabled_tracer):
             from influx.lcma import after_write
@@ -1355,7 +1354,7 @@ class TestInfluxLithosRetrieveSpan:
             )
 
         # Retrieve still happened
-        mock_client.retrieve.assert_awaited_once()
+        mock_client.retrieve_body.assert_awaited_once()
 
 
 # ── (9) influx.archive.download span (US-006) ───────────────────────────


### PR DESCRIPTION
## Summary
- add LithosClient helpers that decode MCP text payloads into validated JSON objects with consistent malformed-response errors
- migrate run, repair, feedback, and LCMA call sites to the centralized helpers instead of open-coded JSON parsing
- update and extend unit coverage for the new decode path and the helperized call sites

## Testing
- uv run pytest tests/unit/test_lithos_client.py tests/unit/test_run_module.py tests/unit/test_repair_sweep.py tests/unit/test_repair_hook_rollback.py tests/unit/test_lcma_wiring.py tests/unit/test_rejection_rate_logging.py tests/unit/test_scheduler.py -q
- uv run ruff check src/influx/lithos_client.py src/influx/run.py src/influx/lcma.py src/influx/repair.py src/influx/feedback.py tests/unit/test_lithos_client.py tests/unit/test_run_module.py tests/unit/test_repair_sweep.py tests/unit/test_repair_hook_rollback.py tests/unit/test_lcma_wiring.py tests/unit/test_rejection_rate_logging.py tests/unit/test_scheduler.py
- uv run ruff format --check src/influx/lithos_client.py src/influx/run.py src/influx/lcma.py src/influx/repair.py src/influx/feedback.py tests/unit/test_lithos_client.py tests/unit/test_run_module.py tests/unit/test_repair_sweep.py tests/unit/test_repair_hook_rollback.py tests/unit/test_lcma_wiring.py tests/unit/test_rejection_rate_logging.py tests/unit/test_scheduler.py
- uv run pyright src/influx/lithos_client.py src/influx/run.py src/influx/lcma.py src/influx/repair.py src/influx/feedback.py

Fixes #106