### PR TITLE
Terminalize unsupported repair sources

### DIFF
--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -1038,6 +1038,21 @@ async def _process_sweep_note(
                 note["tags"] = list(current_tags)
         except (ExtractionError, LCMAError, LithosError) as exc:
             _restore_note(note, snapshot)
+            if (
+                isinstance(exc, ExtractionError)
+                and getattr(exc, "stage", "") == "unsupported_source"
+            ):
+                restored_tags = list(note.get("tags", []))
+                if not any(tag.startswith("text:") for tag in restored_tags):
+                    restored_tags.append("text:abstract-only")
+                if "influx:text-terminal" not in restored_tags:
+                    restored_tags.append("influx:text-terminal")
+                if "influx:archive-missing" not in restored_tags:
+                    restored_tags = [
+                        tag for tag in restored_tags if tag != "influx:repair-needed"
+                    ]
+                current_tags = restored_tags
+                note["tags"] = list(current_tags)
             _log_stage_failure(
                 "text_extraction",
                 note=note,

--- a/tests/unit/test_repair_sweep.py
+++ b/tests/unit/test_repair_sweep.py
@@ -1349,3 +1349,62 @@ class TestSweepTextExtractionRetry:
         rewritten = self._last_write_args(client)
         assert not any(t.startswith("text:") for t in rewritten["tags"])
         assert "influx:repair-needed" in rewritten["tags"]
+
+    async def test_unsupported_source_becomes_terminal_and_leaves_sweep(self) -> None:
+        items = [{"id": "n1", "title": "Paper"}]
+        note = self._note_textless("n1")
+
+        def hook(note: dict[str, object]) -> str:
+            del note
+            raise ExtractionError(
+                "text_extraction retry: source '' not supported",
+                stage="unsupported_source",
+            )
+
+        config = _make_config()
+        client = _make_client(list_items=items, read_responses=[note])
+
+        await sweep(
+            "ai-robotics",
+            client=client,
+            config=config,
+            hooks=SweepHooks(text_extraction=hook),
+        )
+
+        rewritten = self._last_write_args(client)
+        assert "text:abstract-only" in rewritten["tags"]
+        assert "influx:text-terminal" in rewritten["tags"]
+        assert "influx:repair-needed" not in rewritten["tags"]
+
+    async def test_unsupported_source_keeps_repair_needed_when_archive_missing(
+        self,
+    ) -> None:
+        items = [{"id": "n1", "title": "Paper"}]
+        note = self._note_textless("n1")
+        note["tags"] = list(note["tags"]) + ["influx:archive-missing"]
+        note["content"] = str(note["content"]).replace(
+            "path: arxiv/2026/04/x.pdf\n\n",
+            "",
+        )
+
+        def hook(note: dict[str, object]) -> str:
+            del note
+            raise ExtractionError(
+                "text_extraction retry: source '' not supported",
+                stage="unsupported_source",
+            )
+
+        config = _make_config()
+        client = _make_client(list_items=items, read_responses=[note])
+
+        await sweep(
+            "ai-robotics",
+            client=client,
+            config=config,
+            hooks=SweepHooks(text_extraction=hook),
+        )
+
+        rewritten = self._last_write_args(client)
+        assert "text:abstract-only" in rewritten["tags"]
+        assert "influx:text-terminal" in rewritten["tags"]
+        assert "influx:repair-needed" in rewritten["tags"]


### PR DESCRIPTION
## Summary
- stop requeueing unsupported text extraction repairs forever by marking them terminal
- keep repair-needed only when archive recovery is still outstanding
- add sweep coverage for unsupported-source terminalization and archive-missing retention

## Testing
- uv run pytest tests/unit/test_repair_sweep.py -q
- uv run ruff check src/influx/repair.py tests/unit/test_repair_sweep.py
- uv run ruff format --check src/influx/repair.py tests/unit/test_repair_sweep.py

Fixes #111