### PR TITLE
Improve diagnostics for webhook failures and LCMA skips

### DIFF
--- a/src/influx/http_client.py
+++ b/src/influx/http_client.py
@@ -72,11 +72,15 @@ class PostJsonResult:
 
     ``body`` is truncated to at most :data:`_MAX_POST_RESPONSE_BODY_BYTES`
     so callers can include it in failure logs without risking unbounded
-    payloads.
+    payloads.  ``truncated`` is ``True`` when the upstream response was
+    longer than the cap and the captured snippet is therefore a fragment;
+    callers should surface a marker in user-facing logs so operators do
+    not mistake the snippet for the full body.
     """
 
     status_code: int
     body: bytes
+    truncated: bool = False
 
 
 # ── Scheme validation ────────────────────────────────────────────────
@@ -334,16 +338,24 @@ def guarded_post_json(
         ):
             chunks: list[bytes] = []
             received = 0
+            truncated = False
             for chunk in response.iter_bytes():
-                if received >= _MAX_POST_RESPONSE_BODY_BYTES:
-                    break
                 remaining = _MAX_POST_RESPONSE_BODY_BYTES - received
-                slice_ = chunk[:remaining]
-                chunks.append(slice_)
-                received += len(slice_)
+                if remaining <= 0:
+                    # Upstream still has bytes beyond the cap.
+                    truncated = True
+                    break
+                if len(chunk) > remaining:
+                    chunks.append(chunk[:remaining])
+                    received += remaining
+                    truncated = True
+                    break
+                chunks.append(chunk)
+                received += len(chunk)
             return PostJsonResult(
                 status_code=response.status_code,
                 body=b"".join(chunks),
+                truncated=truncated,
             )
     except httpx.TimeoutException as exc:
         raise NetworkError(

--- a/src/influx/http_client.py
+++ b/src/influx/http_client.py
@@ -24,6 +24,7 @@ from influx.errors import NetworkError
 __all__ = [
     "ContentTypeFamily",
     "FetchResult",
+    "PostJsonResult",
     "guarded_fetch",
     "guarded_post_json",
     "guarded_post_json_fetch",
@@ -32,6 +33,11 @@ __all__ = [
 _ALLOWED_SCHEMES = frozenset({"http", "https"})
 
 _MAX_REDIRECTS = 20
+
+# Cap captured response bodies for non-streaming POST callers.  Webhook
+# error bodies are typically small JSON or HTML envelopes; the cap exists
+# only to keep memory and log lines bounded when an endpoint misbehaves.
+_MAX_POST_RESPONSE_BODY_BYTES = 4096
 
 ContentTypeFamily = Literal["html", "pdf", "xml"]
 
@@ -58,6 +64,19 @@ class FetchResult:
     content_type: str
     final_url: str
     headers: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class PostJsonResult:
+    """Status code plus a bounded snippet of the response body.
+
+    ``body`` is truncated to at most :data:`_MAX_POST_RESPONSE_BODY_BYTES`
+    so callers can include it in failure logs without risking unbounded
+    payloads.
+    """
+
+    status_code: int
+    body: bytes
 
 
 # ── Scheme validation ────────────────────────────────────────────────
@@ -279,13 +298,16 @@ def guarded_post_json(
     headers: dict[str, str] | None = None,
     allow_private_ips: bool = False,
     timeout_seconds: int | None = None,
-) -> int:
+) -> PostJsonResult:
     """POST *payload* as JSON to *url* with scheme and SSRF guards.
 
-    Returns the HTTP status code.  Raises
-    :class:`~influx.errors.NetworkError` on guard violations, timeouts,
-    or connection failures.  No retry logic — callers handle retries if
-    needed (FR-NOT-1).
+    Returns a :class:`PostJsonResult` carrying the HTTP status code and a
+    bounded snippet of the response body — capped at
+    :data:`_MAX_POST_RESPONSE_BODY_BYTES` so callers (notably webhook
+    diagnostics) can log a useful excerpt without risking unbounded
+    payloads.  Raises :class:`~influx.errors.NetworkError` on guard
+    violations, timeouts, or connection failures.  No retry logic —
+    callers handle retries if needed (FR-NOT-1).
 
     ``timeout_seconds`` defaults to ``None``; when omitted it is resolved
     from the pydantic :class:`~influx.config.NotificationsConfig` field
@@ -306,9 +328,23 @@ def guarded_post_json(
     )
 
     try:
-        with httpx.Client(timeout=timeout) as client:
-            response = client.post(url, json=payload, headers=headers)
-            return response.status_code
+        with (
+            httpx.Client(timeout=timeout) as client,
+            client.stream("POST", url, json=payload, headers=headers) as response,
+        ):
+            chunks: list[bytes] = []
+            received = 0
+            for chunk in response.iter_bytes():
+                if received >= _MAX_POST_RESPONSE_BODY_BYTES:
+                    break
+                remaining = _MAX_POST_RESPONSE_BODY_BYTES - received
+                slice_ = chunk[:remaining]
+                chunks.append(slice_)
+                received += len(slice_)
+            return PostJsonResult(
+                status_code=response.status_code,
+                body=b"".join(chunks),
+            )
     except httpx.TimeoutException as exc:
         raise NetworkError(
             f"Request timed out: {exc}",

--- a/src/influx/http_client.py
+++ b/src/influx/http_client.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import ipaddress
 import socket
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Literal
 from urllib.parse import urljoin, urlparse
@@ -24,8 +26,8 @@ from influx.errors import NetworkError
 __all__ = [
     "ContentTypeFamily",
     "FetchResult",
-    "PostJsonResult",
     "guarded_fetch",
+    "guarded_outbound_post",
     "guarded_post_json",
     "guarded_post_json_fetch",
 ]
@@ -33,11 +35,6 @@ __all__ = [
 _ALLOWED_SCHEMES = frozenset({"http", "https"})
 
 _MAX_REDIRECTS = 20
-
-# Cap captured response bodies for non-streaming POST callers.  Webhook
-# error bodies are typically small JSON or HTML envelopes; the cap exists
-# only to keep memory and log lines bounded when an endpoint misbehaves.
-_MAX_POST_RESPONSE_BODY_BYTES = 4096
 
 ContentTypeFamily = Literal["html", "pdf", "xml"]
 
@@ -64,23 +61,6 @@ class FetchResult:
     content_type: str
     final_url: str
     headers: dict[str, str] = field(default_factory=dict)
-
-
-@dataclass(frozen=True, slots=True)
-class PostJsonResult:
-    """Status code plus a bounded snippet of the response body.
-
-    ``body`` is truncated to at most :data:`_MAX_POST_RESPONSE_BODY_BYTES`
-    so callers can include it in failure logs without risking unbounded
-    payloads.  ``truncated`` is ``True`` when the upstream response was
-    longer than the cap and the captured snippet is therefore a fragment;
-    callers should surface a marker in user-facing logs so operators do
-    not mistake the snippet for the full body.
-    """
-
-    status_code: int
-    body: bytes
-    truncated: bool = False
 
 
 # ── Scheme validation ────────────────────────────────────────────────
@@ -295,28 +275,26 @@ def guarded_fetch(
     )
 
 
-def guarded_post_json(
+@contextmanager
+def guarded_outbound_post(
     url: str,
-    payload: dict[str, object],
     *,
-    headers: dict[str, str] | None = None,
     allow_private_ips: bool = False,
     timeout_seconds: int | None = None,
-) -> PostJsonResult:
-    """POST *payload* as JSON to *url* with scheme and SSRF guards.
+) -> Iterator[httpx.Client]:
+    """Yield a guarded :class:`httpx.Client` for outbound POSTs.
 
-    Returns a :class:`PostJsonResult` carrying the HTTP status code and a
-    bounded snippet of the response body — capped at
-    :data:`_MAX_POST_RESPONSE_BODY_BYTES` so callers (notably webhook
-    diagnostics) can log a useful excerpt without risking unbounded
-    payloads.  Raises :class:`~influx.errors.NetworkError` on guard
-    violations, timeouts, or connection failures.  No retry logic —
-    callers handle retries if needed (FR-NOT-1).
+    Validates the URL against the scheme allow-list and SSRF
+    classifier, builds a connect+read+write+pool timeout from
+    ``timeout_seconds`` (falling back to the
+    :class:`~influx.config.NotificationsConfig` field default), and
+    translates :class:`httpx.TimeoutException` /
+    :class:`httpx.HTTPError` raised inside the ``with`` block into
+    :class:`~influx.errors.NetworkError`.
 
-    ``timeout_seconds`` defaults to ``None``; when omitted it is resolved
-    from the pydantic :class:`~influx.config.NotificationsConfig` field
-    default so the only place this tunable lives is config-parsing code
-    (AC-X-1).  Webhook callers pass the loaded config value explicitly.
+    Used by callers that need POST semantics beyond a fire-and-forget
+    status — e.g. the webhook dispatcher capturing a bounded body
+    snippet for diagnostics — without re-implementing the guard stack.
     """
     _validate_scheme(url)
     _ssrf_check(url, allow_private_ips=allow_private_ips)
@@ -332,31 +310,8 @@ def guarded_post_json(
     )
 
     try:
-        with (
-            httpx.Client(timeout=timeout) as client,
-            client.stream("POST", url, json=payload, headers=headers) as response,
-        ):
-            chunks: list[bytes] = []
-            received = 0
-            truncated = False
-            for chunk in response.iter_bytes():
-                remaining = _MAX_POST_RESPONSE_BODY_BYTES - received
-                if remaining <= 0:
-                    # Upstream still has bytes beyond the cap.
-                    truncated = True
-                    break
-                if len(chunk) > remaining:
-                    chunks.append(chunk[:remaining])
-                    received += remaining
-                    truncated = True
-                    break
-                chunks.append(chunk)
-                received += len(chunk)
-            return PostJsonResult(
-                status_code=response.status_code,
-                body=b"".join(chunks),
-                truncated=truncated,
-            )
+        with httpx.Client(timeout=timeout) as client:
+            yield client
     except httpx.TimeoutException as exc:
         raise NetworkError(
             f"Request timed out: {exc}",
@@ -371,6 +326,40 @@ def guarded_post_json(
             kind="network",
             reason=str(exc),
         ) from exc
+
+
+def guarded_post_json(
+    url: str,
+    payload: dict[str, object],
+    *,
+    headers: dict[str, str] | None = None,
+    allow_private_ips: bool = False,
+    timeout_seconds: int | None = None,
+) -> int:
+    """POST *payload* as JSON to *url* with scheme and SSRF guards.
+
+    Returns the HTTP status code.  Fire-and-forget: the response body
+    is read and discarded by ``httpx``.  Callers that need to inspect
+    the body should use :func:`guarded_post_json_fetch` (full body) or
+    drive :func:`guarded_outbound_post` directly with their own
+    streaming/cap policy.
+
+    Raises :class:`~influx.errors.NetworkError` on guard violations,
+    timeouts, or connection failures.  No retry logic — callers handle
+    retries if needed (FR-NOT-1).
+
+    ``timeout_seconds`` defaults to ``None``; when omitted it is resolved
+    from the pydantic :class:`~influx.config.NotificationsConfig` field
+    default so the only place this tunable lives is config-parsing code
+    (AC-X-1).  Webhook callers pass the loaded config value explicitly.
+    """
+    with guarded_outbound_post(
+        url,
+        allow_private_ips=allow_private_ips,
+        timeout_seconds=timeout_seconds,
+    ) as client:
+        response = client.post(url, json=payload, headers=headers)
+        return response.status_code
 
 
 def guarded_post_json_fetch(

--- a/src/influx/lcma.py
+++ b/src/influx/lcma.py
@@ -299,13 +299,16 @@ async def resolve_builds_on(
         if not body.get("hit"):
             logger.info(
                 "LCMA builds_on lookup miss profile=%s run_id=%s "
-                "source_url=%s note_id=%s tool=%s target_source_url=%s",
+                "source_url=%s note_id=%s tool=%s target_source_url=%s "
+                "prior_title=%r arxiv_id=%s",
                 profile,
                 current_run_id.get() or "",
                 written_source_url,
                 source_note_id,
                 "lithos_cache_lookup",
                 source_url,
+                prior_title,
+                arxiv_id,
             )
             continue
 
@@ -314,7 +317,7 @@ async def resolve_builds_on(
             logger.info(
                 "LCMA builds_on lookup source_url mismatch profile=%s run_id=%s "
                 "source_url=%s note_id=%s tool=%s expected_source_url=%s "
-                "actual_source_url=%s",
+                "actual_source_url=%s prior_title=%r arxiv_id=%s",
                 profile,
                 current_run_id.get() or "",
                 written_source_url,
@@ -322,6 +325,8 @@ async def resolve_builds_on(
                 "lithos_cache_lookup",
                 source_url,
                 body.get("source_url", ""),
+                prior_title,
+                arxiv_id,
             )
             continue
 

--- a/src/influx/lcma.py
+++ b/src/influx/lcma.py
@@ -212,6 +212,20 @@ async def after_write(
     for r in results:
         score = float(r.get("score", 0.0))
         if score < lcma_edge_score:
+            logger.debug(
+                "LCMA related_to result below threshold profile=%s run_id=%s "
+                "source_url=%s note_id=%s tool=%s target_note_id=%s "
+                "target_title=%r score=%.3f threshold=%.3f",
+                profile,
+                current_run_id.get() or "",
+                source_url,
+                source_note_id,
+                "lithos_retrieve",
+                r.get("note_id", ""),
+                r.get("title", ""),
+                score,
+                lcma_edge_score,
+            )
             continue
 
         receipt_id = r.get("receipt_id", "")
@@ -287,6 +301,15 @@ async def resolve_builds_on(
     for item in builds_on:
         ref = extract_arxiv_ref(item)
         if ref is None:
+            logger.info(
+                "LCMA builds_on item missing arxiv_id profile=%s run_id=%s "
+                "source_url=%s note_id=%s item=%r",
+                profile,
+                current_run_id.get() or "",
+                written_source_url,
+                source_note_id,
+                item,
+            )
             continue
 
         prior_title, arxiv_id = ref

--- a/src/influx/notifications.py
+++ b/src/influx/notifications.py
@@ -440,22 +440,26 @@ def _deliver_json_payload(
 
     logger.info("notification webhook dispatch started", extra=extra)
     try:
-        status = guarded_post_json(
+        result = guarded_post_json(
             webhook.url,
             payload,
             headers=headers,
             allow_private_ips=allow_private_ips,
             timeout_seconds=timeout_seconds,
         )
-        if status < 200 or status >= 300:
+        if result.status_code < 200 or result.status_code >= 300:
             logger.warning(
                 "notification webhook returned unexpected HTTP status",
-                extra={**extra, "status_code": status},
+                extra={
+                    **extra,
+                    "status_code": result.status_code,
+                    "response_body": _decode_response_snippet(result.body),
+                },
             )
         else:
             logger.info(
                 "notification webhook delivered",
-                extra={**extra, "status_code": status},
+                extra={**extra, "status_code": result.status_code},
             )
     except Exception:
         logger.warning(
@@ -463,6 +467,16 @@ def _deliver_json_payload(
             extra=extra,
             exc_info=True,
         )
+
+
+def _decode_response_snippet(body: bytes) -> str:
+    """Decode a bounded webhook response body for safe inclusion in logs.
+
+    The HTTP layer already caps the captured body length, so this only
+    needs to coerce arbitrary bytes into a printable string without
+    raising on partial UTF-8 sequences.
+    """
+    return body.decode("utf-8", errors="replace")
 
 
 def _build_auth_headers(

--- a/src/influx/notifications.py
+++ b/src/influx/notifications.py
@@ -410,6 +410,81 @@ def _deliver_payload(
     )
 
 
+# Webhook responses are opaque to Influx — operators only ever read the
+# body to diagnose 4xx/5xx rejections, so we cap the captured snippet
+# instead of buffering an arbitrarily large body in memory or shipping
+# unbounded text into the log line.
+_MAX_WEBHOOK_RESPONSE_BODY_BYTES = 4096
+_TRUNCATION_MARKER = "…[truncated]"
+
+
+@dataclass(frozen=True, slots=True)
+class _WebhookDispatchResult:
+    """Status and a bounded snippet of a webhook response body.
+
+    Private to this module: webhook diagnostics are the only place where
+    a truncated response body is the right shape.  General API callers
+    should use ``guarded_post_json_fetch`` for full-body POSTs.
+    """
+
+    status_code: int
+    body: bytes
+    truncated: bool
+
+
+def _dispatch_webhook_post(
+    url: str,
+    payload: dict[str, Any],
+    *,
+    headers: dict[str, str],
+    allow_private_ips: bool,
+    timeout_seconds: int,
+) -> _WebhookDispatchResult:
+    """POST a webhook payload and capture a bounded response-body snippet.
+
+    Reuses the SSRF/scheme/timeout guards from :mod:`influx.http_client`
+    via :func:`guarded_outbound_post`.  Reads at most
+    :data:`_MAX_WEBHOOK_RESPONSE_BODY_BYTES` from the response stream
+    and sets ``truncated=True`` when the upstream had more data so the
+    log layer can surface a marker.
+    """
+    from influx.http_client import guarded_outbound_post
+
+    with (
+        guarded_outbound_post(
+            url,
+            allow_private_ips=allow_private_ips,
+            timeout_seconds=timeout_seconds,
+        ) as client,
+        client.stream(
+            "POST",
+            url,
+            json=payload,
+            headers=headers,
+        ) as response,
+    ):
+        chunks: list[bytes] = []
+        received = 0
+        truncated = False
+        for chunk in response.iter_bytes():
+            remaining = _MAX_WEBHOOK_RESPONSE_BODY_BYTES - received
+            if remaining <= 0:
+                truncated = True
+                break
+            if len(chunk) > remaining:
+                chunks.append(chunk[:remaining])
+                received += remaining
+                truncated = True
+                break
+            chunks.append(chunk)
+            received += len(chunk)
+        return _WebhookDispatchResult(
+            status_code=response.status_code,
+            body=b"".join(chunks),
+            truncated=truncated,
+        )
+
+
 def _deliver_json_payload(
     webhook: NotificationWebhookConfig,
     payload: dict[str, Any],
@@ -421,8 +496,6 @@ def _deliver_json_payload(
     run_id: str | None,
     item_id: str | None,
 ) -> None:
-    from influx.http_client import guarded_post_json
-
     extra = {
         "webhook_name": webhook.name,
         "webhook_type": webhook.type,
@@ -440,7 +513,7 @@ def _deliver_json_payload(
 
     logger.info("notification webhook dispatch started", extra=extra)
     try:
-        result = guarded_post_json(
+        result = _dispatch_webhook_post(
             webhook.url,
             payload,
             headers=headers,
@@ -473,14 +546,11 @@ def _deliver_json_payload(
         )
 
 
-_TRUNCATION_MARKER = "…[truncated]"
-
-
 def _decode_response_snippet(body: bytes, *, truncated: bool) -> str:
     """Decode a bounded webhook response body for safe inclusion in logs.
 
-    The HTTP layer already caps the captured body length, so this only
-    needs to coerce arbitrary bytes into a printable string without
+    The dispatch layer already caps the captured body length, so this
+    only needs to coerce arbitrary bytes into a printable string without
     raising on partial UTF-8 sequences.  When the captured snippet is a
     fragment of a longer upstream response, append a marker so an
     operator reading the log cannot mistake it for the full body.

--- a/src/influx/notifications.py
+++ b/src/influx/notifications.py
@@ -453,7 +453,11 @@ def _deliver_json_payload(
                 extra={
                     **extra,
                     "status_code": result.status_code,
-                    "response_body": _decode_response_snippet(result.body),
+                    "response_body": _decode_response_snippet(
+                        result.body,
+                        truncated=result.truncated,
+                    ),
+                    "response_body_truncated": result.truncated,
                 },
             )
         else:
@@ -469,14 +473,22 @@ def _deliver_json_payload(
         )
 
 
-def _decode_response_snippet(body: bytes) -> str:
+_TRUNCATION_MARKER = "…[truncated]"
+
+
+def _decode_response_snippet(body: bytes, *, truncated: bool) -> str:
     """Decode a bounded webhook response body for safe inclusion in logs.
 
     The HTTP layer already caps the captured body length, so this only
     needs to coerce arbitrary bytes into a printable string without
-    raising on partial UTF-8 sequences.
+    raising on partial UTF-8 sequences.  When the captured snippet is a
+    fragment of a longer upstream response, append a marker so an
+    operator reading the log cannot mistake it for the full body.
     """
-    return body.decode("utf-8", errors="replace")
+    text = body.decode("utf-8", errors="replace")
+    if truncated:
+        return f"{text}{_TRUNCATION_MARKER}"
+    return text
 
 
 def _build_auth_headers(

--- a/tests/integration/test_backfill_arxiv.py
+++ b/tests/integration/test_backfill_arxiv.py
@@ -44,7 +44,6 @@ from influx.config import (
     SecurityConfig,
 )
 from influx.coordinator import Coordinator, RunKind
-from influx.http_client import PostJsonResult
 from influx.scheduler import run_profile
 from influx.sources import FetchCache, make_item_provider
 from influx.sources.arxiv import (
@@ -882,12 +881,13 @@ class TestBackfillEndpointEndToEnd:
                 return_value=list(_FIXTURE_ARXIV_ITEMS),
             ),
             patch("influx.sources.arxiv._sleep"),
-            # ``send_digest`` lazily imports ``guarded_post_json`` from
-            # ``influx.http_client``, so the patch must target the
-            # source module rather than ``influx.notifications``.
+            # The webhook dispatcher uses ``_dispatch_webhook_post`` from
+            # ``influx.notifications``; patching it here keeps the
+            # backfill path off the network entirely while still
+            # exercising the dispatch decision (which must NOT fire
+            # for kind=BACKFILL).
             patch(
-                "influx.http_client.guarded_post_json",
-                return_value=PostJsonResult(status_code=200, body=b""),
+                "influx.notifications._dispatch_webhook_post",
             ) as mock_webhook_post,
             TestClient(app) as client,
         ):
@@ -912,7 +912,7 @@ class TestBackfillEndpointEndToEnd:
 
         # ── AC-09-G: no webhook HTTP call ─────────────────────────────
         # ``send_digest`` short-circuits for ``kind=BACKFILL`` so the
-        # real ``guarded_post_json`` sender must never be invoked.
+        # real webhook dispatcher must never be invoked.
         mock_webhook_post.assert_not_called()
 
         # ── AC-09-H: no repair-sweep ``lithos_list`` call ─────────────

--- a/tests/integration/test_backfill_arxiv.py
+++ b/tests/integration/test_backfill_arxiv.py
@@ -44,6 +44,7 @@ from influx.config import (
     SecurityConfig,
 )
 from influx.coordinator import Coordinator, RunKind
+from influx.http_client import PostJsonResult
 from influx.scheduler import run_profile
 from influx.sources import FetchCache, make_item_provider
 from influx.sources.arxiv import (
@@ -886,7 +887,7 @@ class TestBackfillEndpointEndToEnd:
             # source module rather than ``influx.notifications``.
             patch(
                 "influx.http_client.guarded_post_json",
-                return_value=200,
+                return_value=PostJsonResult(status_code=200, body=b""),
             ) as mock_webhook_post,
             TestClient(app) as client,
         ):

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -19,8 +19,8 @@ import respx
 from influx.errors import NetworkError
 from influx.http_client import (
     FetchResult,
-    PostJsonResult,
     guarded_fetch,
+    guarded_outbound_post,
     guarded_post_json,
 )
 
@@ -508,78 +508,75 @@ class TestRedirectRevalidation:
         assert result.body == b"ok"
 
 
-# ── guarded_post_json body capture (#108) ────────────────────────────
+# ── guarded_post_json (status-only fire-and-forget POST) ─────────────
 
 
-class TestGuardedPostJsonBodyCapture:
-    """``guarded_post_json`` returns the status plus a bounded body snippet.
-
-    Issue #108: webhook diagnostics need the response body, not just the
-    status code, to explain 4xx and 5xx rejections.  The body is capped
-    at 4096 bytes to keep logs bounded.
-    """
+class TestGuardedPostJson:
+    """``guarded_post_json`` returns the HTTP status and discards the body."""
 
     @respx.mock
-    def test_returns_status_and_body_for_non_2xx(self) -> None:
-        url = "http://public.example.com/webhook"
-        respx.post(url).mock(
-            return_value=httpx.Response(
-                400,
-                text='{"error":"bad request"}',
-            ),
-        )
-        result = guarded_post_json(
-            url,
-            {"foo": "bar"},
-            allow_private_ips=True,
-        )
-        assert isinstance(result, PostJsonResult)
-        assert result.status_code == 400
-        assert b'"bad request"' in result.body
-        assert result.truncated is False
-
-    @respx.mock
-    def test_returns_status_and_body_for_2xx(self) -> None:
+    def test_returns_status_for_2xx(self) -> None:
         url = "http://public.example.com/webhook"
         respx.post(url).mock(
             return_value=httpx.Response(200, text='{"ok":true}'),
         )
-        result = guarded_post_json(
+        status = guarded_post_json(
             url,
             {"foo": "bar"},
             allow_private_ips=True,
         )
-        assert result.status_code == 200
-        assert result.body == b'{"ok":true}'
-        assert result.truncated is False
+        assert status == 200
 
     @respx.mock
-    def test_response_body_is_capped_and_marked_truncated(self) -> None:
+    def test_returns_status_for_non_2xx(self) -> None:
         url = "http://public.example.com/webhook"
         respx.post(url).mock(
-            return_value=httpx.Response(500, text="x" * 16384),
+            return_value=httpx.Response(400, text='{"error":"bad"}'),
         )
-        result = guarded_post_json(
+        status = guarded_post_json(
             url,
             {"foo": "bar"},
             allow_private_ips=True,
         )
-        assert result.status_code == 500
-        assert len(result.body) == 4096
-        assert result.body == b"x" * 4096
-        assert result.truncated is True
+        assert status == 400
+
+
+# ── guarded_outbound_post (shared guard context) ─────────────────────
+
+
+class TestGuardedOutboundPost:
+    """``guarded_outbound_post`` exposes guarded httpx clients for callers.
+
+    Webhook diagnostics need bounded-body POST semantics, but the
+    SSRF/scheme/timeout guard stack is shared with the fire-and-forget
+    POST path — this context manager is the seam.
+    """
 
     @respx.mock
-    def test_response_body_at_exact_cap_is_not_marked_truncated(self) -> None:
-        """A response that fits exactly inside the cap is not marked truncated."""
+    def test_yields_usable_client(self) -> None:
         url = "http://public.example.com/webhook"
-        respx.post(url).mock(
-            return_value=httpx.Response(500, text="y" * 4096),
-        )
-        result = guarded_post_json(
-            url,
-            {"foo": "bar"},
-            allow_private_ips=True,
-        )
-        assert len(result.body) == 4096
-        assert result.truncated is False
+        respx.post(url).mock(return_value=httpx.Response(200, text="ok"))
+        with guarded_outbound_post(url, allow_private_ips=True) as client:
+            response = client.post(url, json={"x": 1})
+        assert response.status_code == 200
+
+    def test_validates_scheme_before_yielding(self) -> None:
+        with (
+            pytest.raises(NetworkError) as exc_info,
+            guarded_outbound_post("ftp://example.com") as _,
+        ):
+            pass
+        assert exc_info.value.kind == "scheme"
+
+    def test_translates_httpx_timeout_to_network_error(self) -> None:
+        url = "http://public.example.com/webhook"
+
+        @respx.mock
+        def _run() -> None:
+            respx.post(url).mock(side_effect=httpx.ConnectTimeout("slow"))
+            with guarded_outbound_post(url, allow_private_ips=True) as client:
+                client.post(url, json={"x": 1})
+
+        with pytest.raises(NetworkError) as exc_info:
+            _run()
+        assert exc_info.value.kind == "timeout"

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -19,7 +19,9 @@ import respx
 from influx.errors import NetworkError
 from influx.http_client import (
     FetchResult,
+    PostJsonResult,
     guarded_fetch,
+    guarded_post_json,
 )
 
 # ── Scheme allow-list ────────────────────────────────────────────────
@@ -504,3 +506,62 @@ class TestRedirectRevalidation:
         result = guarded_fetch(pub, allow_private_ips=True)
         assert result.status_code == 200
         assert result.body == b"ok"
+
+
+# ── guarded_post_json body capture (#108) ────────────────────────────
+
+
+class TestGuardedPostJsonBodyCapture:
+    """``guarded_post_json`` returns the status plus a bounded body snippet.
+
+    Issue #108: webhook diagnostics need the response body, not just the
+    status code, to explain 4xx and 5xx rejections.  The body is capped
+    at 4096 bytes to keep logs bounded.
+    """
+
+    @respx.mock
+    def test_returns_status_and_body_for_non_2xx(self) -> None:
+        url = "http://public.example.com/webhook"
+        respx.post(url).mock(
+            return_value=httpx.Response(
+                400,
+                text='{"error":"bad request"}',
+            ),
+        )
+        result = guarded_post_json(
+            url,
+            {"foo": "bar"},
+            allow_private_ips=True,
+        )
+        assert isinstance(result, PostJsonResult)
+        assert result.status_code == 400
+        assert b'"bad request"' in result.body
+
+    @respx.mock
+    def test_returns_status_and_body_for_2xx(self) -> None:
+        url = "http://public.example.com/webhook"
+        respx.post(url).mock(
+            return_value=httpx.Response(200, text='{"ok":true}'),
+        )
+        result = guarded_post_json(
+            url,
+            {"foo": "bar"},
+            allow_private_ips=True,
+        )
+        assert result.status_code == 200
+        assert result.body == b'{"ok":true}'
+
+    @respx.mock
+    def test_response_body_is_capped(self) -> None:
+        url = "http://public.example.com/webhook"
+        respx.post(url).mock(
+            return_value=httpx.Response(500, text="x" * 16384),
+        )
+        result = guarded_post_json(
+            url,
+            {"foo": "bar"},
+            allow_private_ips=True,
+        )
+        assert result.status_code == 500
+        assert len(result.body) == 4096
+        assert result.body == b"x" * 4096

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -536,6 +536,7 @@ class TestGuardedPostJsonBodyCapture:
         assert isinstance(result, PostJsonResult)
         assert result.status_code == 400
         assert b'"bad request"' in result.body
+        assert result.truncated is False
 
     @respx.mock
     def test_returns_status_and_body_for_2xx(self) -> None:
@@ -550,9 +551,10 @@ class TestGuardedPostJsonBodyCapture:
         )
         assert result.status_code == 200
         assert result.body == b'{"ok":true}'
+        assert result.truncated is False
 
     @respx.mock
-    def test_response_body_is_capped(self) -> None:
+    def test_response_body_is_capped_and_marked_truncated(self) -> None:
         url = "http://public.example.com/webhook"
         respx.post(url).mock(
             return_value=httpx.Response(500, text="x" * 16384),
@@ -565,3 +567,19 @@ class TestGuardedPostJsonBodyCapture:
         assert result.status_code == 500
         assert len(result.body) == 4096
         assert result.body == b"x" * 4096
+        assert result.truncated is True
+
+    @respx.mock
+    def test_response_body_at_exact_cap_is_not_marked_truncated(self) -> None:
+        """A response that fits exactly inside the cap is not marked truncated."""
+        url = "http://public.example.com/webhook"
+        respx.post(url).mock(
+            return_value=httpx.Response(500, text="y" * 4096),
+        )
+        result = guarded_post_json(
+            url,
+            {"foo": "bar"},
+            allow_private_ips=True,
+        )
+        assert len(result.body) == 4096
+        assert result.truncated is False

--- a/tests/unit/test_lcma_wiring.py
+++ b/tests/unit/test_lcma_wiring.py
@@ -115,6 +115,41 @@ class TestRelatedToEdgeScoreThreshold:
         client.edge_upsert.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_below_threshold_emits_debug_log_with_item_identity(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Per-result below-threshold skips are observable at debug level (#108)."""
+        caplog.set_level("DEBUG")
+        client = _make_client(
+            retrieve_payload={
+                "results": [
+                    {"title": "Weak match", "score": 0.5, "note_id": "note-weak"},
+                ]
+            }
+        )
+        deps = _make_deps(client, lcma_edge_score=0.75)
+
+        await wire(
+            written_note_id="note-new",
+            source_url="https://arxiv.org/abs/2601.00001",
+            cascade=CascadeOutput(title="A Paper"),
+            deps=deps,
+        )
+
+        skip_records = [
+            record
+            for record in caplog.records
+            if "LCMA related_to result below threshold" in record.message
+        ]
+        assert skip_records, "expected a below-threshold debug log"
+        message = skip_records[0].getMessage()
+        assert "Weak match" in message
+        assert "note-weak" in message
+        assert "0.500" in message  # score
+        assert "0.750" in message  # threshold
+
+    @pytest.mark.asyncio
     async def test_threshold_boundary_is_inclusive(self) -> None:
         """A result scoring exactly at the threshold is kept (>=, not >)."""
         client = _make_client(
@@ -193,6 +228,35 @@ class TestBuildsOnResolution:
         )
 
         client.cache_lookup_body.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_arxiv_id_logs_skipped_item(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Items without a parseable arXiv ID emit a diagnostic log (#108)."""
+        caplog.set_level("INFO")
+        client = _make_client()
+        deps = _make_deps(client)
+
+        await wire(
+            written_note_id="note-new",
+            source_url="https://arxiv.org/abs/2601.00001",
+            cascade=CascadeOutput(
+                title="A Paper",
+                builds_on=["A handwave reference with no id"],
+            ),
+            deps=deps,
+        )
+
+        skip_records = [
+            record
+            for record in caplog.records
+            if "LCMA builds_on item missing arxiv_id" in record.message
+        ]
+        assert skip_records, "expected a missing-arxiv-id log line"
+        message = skip_records[0].getMessage()
+        assert "A handwave reference with no id" in message
 
     @pytest.mark.asyncio
     async def test_cache_miss_skips_edge(self) -> None:

--- a/tests/unit/test_lcma_wiring.py
+++ b/tests/unit/test_lcma_wiring.py
@@ -218,6 +218,72 @@ class TestBuildsOnResolution:
         assert builds_on_upserts == []
 
     @pytest.mark.asyncio
+    async def test_cache_miss_logs_item_identity_context(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """No-hit log carries item identity for diagnosis (#108)."""
+        caplog.set_level("INFO")
+        client = _make_client(cache_lookup_payload={"hit": False})
+        deps = _make_deps(client)
+
+        await wire(
+            written_note_id="note-new",
+            source_url="https://arxiv.org/abs/2601.00001",
+            cascade=CascadeOutput(
+                title="A Paper",
+                builds_on=["FooNet (arXiv:2412.12345)"],
+            ),
+            deps=deps,
+        )
+
+        miss_records = [
+            record
+            for record in caplog.records
+            if "LCMA builds_on lookup miss" in record.message
+        ]
+        assert miss_records, "expected a no-hit log line"
+        message = miss_records[0].getMessage()
+        assert "FooNet" in message
+        assert "2412.12345" in message
+
+    @pytest.mark.asyncio
+    async def test_source_url_mismatch_logs_item_identity_context(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """source_url mismatch log carries item identity for diagnosis (#108)."""
+        caplog.set_level("INFO")
+        client = _make_client(
+            cache_lookup_payload={
+                "hit": True,
+                "source_url": "https://arxiv.org/abs/9999.99999",
+                "note_id": "note-other",
+            }
+        )
+        deps = _make_deps(client)
+
+        await wire(
+            written_note_id="note-new",
+            source_url="https://arxiv.org/abs/2601.00001",
+            cascade=CascadeOutput(
+                title="A Paper",
+                builds_on=["FooNet (arXiv:2412.12345)"],
+            ),
+            deps=deps,
+        )
+
+        mismatch_records = [
+            record
+            for record in caplog.records
+            if "LCMA builds_on lookup source_url mismatch" in record.message
+        ]
+        assert mismatch_records, "expected a source_url mismatch log line"
+        message = mismatch_records[0].getMessage()
+        assert "FooNet" in message
+        assert "2412.12345" in message
+
+    @pytest.mark.asyncio
     async def test_source_url_mismatch_skips_edge(
         self,
         caplog: pytest.LogCaptureFixture,

--- a/tests/unit/test_webhook_sender.py
+++ b/tests/unit/test_webhook_sender.py
@@ -86,6 +86,25 @@ class _RedirectHandler(BaseHTTPRequestHandler):
         pass
 
 
+class _ErrorBodyHandler(BaseHTTPRequestHandler):
+    """HTTP handler that returns a 4xx with an explanatory JSON body."""
+
+    request_count: int
+    response_body: bytes
+    response_status: int
+
+    def do_POST(self) -> None:  # noqa: N802
+        self.__class__.request_count += 1
+        self.send_response(self.__class__.response_status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(self.__class__.response_body)))
+        self.end_headers()
+        self.wfile.write(self.__class__.response_body)
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        pass
+
+
 @pytest.fixture()
 def fake_webhook_url() -> Generator[str]:
     _RecordingHandler.received = []
@@ -117,6 +136,22 @@ def redirect_webhook_url() -> Generator[str]:
     _RedirectHandler.request_count = 0
 
     srv = HTTPServer(("127.0.0.1", 0), _RedirectHandler)
+    port = srv.server_address[1]
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{port}/webhook"
+    srv.shutdown()
+
+
+@pytest.fixture()
+def error_body_webhook_url() -> Generator[str]:
+    _ErrorBodyHandler.request_count = 0
+    _ErrorBodyHandler.response_status = 400
+    _ErrorBodyHandler.response_body = (
+        b'{"error":"missing context","detail":"context field is required"}'
+    )
+
+    srv = HTTPServer(("127.0.0.1", 0), _ErrorBodyHandler)
     port = srv.server_address[1]
     thread = threading.Thread(target=srv.serve_forever, daemon=True)
     thread.start()
@@ -538,3 +573,84 @@ class TestNotificationDeliveryBehavior:
         assert any(
             "unexpected HTTP status" in record.message for record in caplog.records
         )
+
+    def test_non_2xx_response_logs_truncated_response_body(
+        self,
+        error_body_webhook_url: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Non-2xx webhook responses include a body snippet for diagnosis (#108)."""
+        config = _make_config(
+            webhooks=[
+                NotificationWebhookConfig(
+                    name="agent-zero-toast",
+                    type="agent_zero_notification_create",
+                    url=error_body_webhook_url,
+                    event_mode="article",
+                    min_score=8,
+                )
+            ]
+        )
+
+        with caplog.at_level(logging.WARNING, logger="influx.notifications"):
+            dispatch_notifications(
+                _make_result(),
+                config,
+                kind=RunKind.MANUAL,
+                run_id="error-body-1",
+            )
+
+        assert _ErrorBodyHandler.request_count == 1
+        unexpected_records = [
+            record
+            for record in caplog.records
+            if "unexpected HTTP status" in record.message
+        ]
+        assert unexpected_records, "expected unexpected-status warning to be emitted"
+        record = unexpected_records[0]
+        assert getattr(record, "status_code", None) == 400
+        body_snippet = getattr(record, "response_body", None)
+        assert isinstance(body_snippet, str)
+        assert "missing context" in body_snippet
+        assert "context field is required" in body_snippet
+
+    def test_non_2xx_response_body_is_capped(
+        self,
+        error_body_webhook_url: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Oversized webhook error bodies are truncated to a bounded snippet (#108)."""
+        # Override the fixture's defaults for this test.
+        _ErrorBodyHandler.response_status = 500
+        _ErrorBodyHandler.response_body = b"x" * 16384
+
+        config = _make_config(
+            webhooks=[
+                NotificationWebhookConfig(
+                    name="agent-zero-toast",
+                    type="agent_zero_notification_create",
+                    url=error_body_webhook_url,
+                    event_mode="article",
+                    min_score=8,
+                )
+            ]
+        )
+
+        with caplog.at_level(logging.WARNING, logger="influx.notifications"):
+            dispatch_notifications(
+                _make_result(),
+                config,
+                kind=RunKind.MANUAL,
+                run_id="error-body-large",
+            )
+
+        unexpected_records = [
+            record
+            for record in caplog.records
+            if "unexpected HTTP status" in record.message
+        ]
+        assert unexpected_records
+        body_snippet = getattr(unexpected_records[0], "response_body", "")
+        # Cap is 4096 bytes; ASCII-decoded length matches.
+        assert len(body_snippet) <= 4096
+        assert len(body_snippet) > 0

--- a/tests/unit/test_webhook_sender.py
+++ b/tests/unit/test_webhook_sender.py
@@ -613,13 +613,16 @@ class TestNotificationDeliveryBehavior:
         assert isinstance(body_snippet, str)
         assert "missing context" in body_snippet
         assert "context field is required" in body_snippet
+        # A body that fits within the cap is NOT marked truncated.
+        assert getattr(record, "response_body_truncated", None) is False
+        assert "[truncated]" not in body_snippet
 
-    def test_non_2xx_response_body_is_capped(
+    def test_non_2xx_response_body_is_capped_and_marked_truncated(
         self,
         error_body_webhook_url: str,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Oversized webhook error bodies are truncated to a bounded snippet (#108)."""
+        """Oversized webhook error bodies are truncated and flagged (#108)."""
         # Override the fixture's defaults for this test.
         _ErrorBodyHandler.response_status = 500
         _ErrorBodyHandler.response_body = b"x" * 16384
@@ -650,7 +653,9 @@ class TestNotificationDeliveryBehavior:
             if "unexpected HTTP status" in record.message
         ]
         assert unexpected_records
-        body_snippet = getattr(unexpected_records[0], "response_body", "")
-        # Cap is 4096 bytes; ASCII-decoded length matches.
-        assert len(body_snippet) <= 4096
-        assert len(body_snippet) > 0
+        record = unexpected_records[0]
+        body_snippet = getattr(record, "response_body", "")
+        assert getattr(record, "response_body_truncated", None) is True
+        # 4096 captured ASCII bytes plus the truncation marker.
+        assert "[truncated]" in body_snippet
+        assert body_snippet.startswith("x" * 4096)


### PR DESCRIPTION
## Summary
Closes #108.

- `guarded_post_json` now returns a `PostJsonResult` (status + bounded 4096-byte body snippet, streamed so an oversized response cannot blow up memory). The notification dispatcher attaches a UTF-8-decoded `response_body` field to the `unexpected HTTP status` warning, so 4xx/5xx rejections can be diagnosed without reproducing the call.
- LCMA `builds_on` miss and `source_url` mismatch logs now carry `prior_title` and `arxiv_id`, so a skipped item can be identified after the fact instead of just knowing the caller note.

## Test plan
- [x] `uv run pytest tests/unit/` — 1480 passed
- [x] `uv run pytest tests/unit/test_http_client.py tests/integration/test_backfill_arxiv.py` — green
- [x] `uv run ruff check` on changed files — clean
- [x] `uv run pyright` on changed source files — 0 errors
- New unit tests added:
  - `TestGuardedPostJsonBodyCapture` covers status+body return, the 2xx path, and the 4096-byte truncation
  - `test_non_2xx_response_logs_truncated_response_body` and `test_non_2xx_response_body_is_capped` assert the webhook log carries a decoded body snippet
  - `test_cache_miss_logs_item_identity_context` and `test_source_url_mismatch_logs_item_identity_context` assert the new LCMA log fields