### PR TITLE
Back off and retry on filter model 429s

### DIFF
--- a/src/influx/filter.py
+++ b/src/influx/filter.py
@@ -36,7 +36,10 @@ from __future__ import annotations
 import json
 import logging
 import os
+import time
 from collections.abc import Awaitable, Callable
+from datetime import UTC
+from email.utils import parsedate_to_datetime
 from typing import Any
 
 from pydantic import ValidationError
@@ -81,6 +84,150 @@ class FilterScorerError(RuntimeError):
 
 
 _log = logging.getLogger(__name__)
+
+_RETRY_AFTER_MAX_SECONDS = 300.0
+
+
+def _sleep(seconds: float) -> None:
+    """Sleep wrapper for monkeypatching in tests."""
+    time.sleep(seconds)
+
+
+def _header_value(headers: dict[str, str], name: str) -> str | None:
+    """Return an HTTP header value using case-insensitive lookup."""
+    name_lower = name.lower()
+    for key, value in headers.items():
+        if key.lower() == name_lower:
+            return value
+    return None
+
+
+def _parse_retry_after_seconds(value: str) -> float | None:
+    """Parse RFC 7231 ``Retry-After`` as seconds or HTTP-date."""
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        seconds = float(value)
+    except ValueError:
+        try:
+            retry_at = parsedate_to_datetime(value)
+        except (TypeError, ValueError, IndexError):
+            return None
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=UTC)
+        seconds = retry_at.timestamp() - time.time()
+    if seconds < 0:
+        return 0.0
+    return min(seconds, _RETRY_AFTER_MAX_SECONDS)
+
+
+def _filter_429_delay(headers: dict[str, str], config: AppConfig, attempt: int) -> float:
+    """Return the backoff delay for a filter-model 429 response."""
+    retry_after = _header_value(headers, "Retry-After")
+    if retry_after is not None:
+        parsed = _parse_retry_after_seconds(retry_after)
+        if parsed is not None:
+            return parsed
+    return float(config.resilience.backoff_base_seconds * (2**attempt))
+
+
+def _call_filter_model_with_retry(
+    *,
+    config: AppConfig,
+    profile: str,
+    url: str,
+    body: dict[str, Any],
+    headers: dict[str, str],
+    attempts: int,
+) -> FilterResponse:
+    """POST to the configured filter model and parse the response with retries."""
+    last_error: Exception | None = None
+    for attempt in range(attempts):
+        try:
+            result = guarded_post_json_fetch(
+                url,
+                body,
+                headers=headers,
+                allow_private_ips=config.security.allow_private_ips,
+                max_response_bytes=config.storage.max_download_bytes,
+                timeout_seconds=config.models["filter"].request_timeout,
+            )
+        except NetworkError as exc:
+            last_error = exc
+            if attempt + 1 >= attempts:
+                break
+            delay = float(config.resilience.backoff_base_seconds * (2**attempt))
+            _log.warning(
+                "filter HTTP error for profile %r on attempt %d/%d: %s; retrying in %.1fs",
+                profile,
+                attempt + 1,
+                attempts,
+                exc,
+                delay,
+            )
+            _sleep(delay)
+            continue
+
+        if result.status_code == 429:
+            last_error = FilterScorerError("filter slot HTTP 429")
+            if attempt + 1 >= attempts:
+                break
+            delay = _filter_429_delay(result.headers, config, attempt)
+            _log.warning(
+                "filter slot HTTP 429 for profile %r on attempt %d/%d; backing off %.1fs",
+                profile,
+                attempt + 1,
+                attempts,
+                delay,
+            )
+            _sleep(delay)
+            continue
+
+        if result.status_code >= 500:
+            last_error = FilterScorerError(f"filter slot HTTP {result.status_code}")
+            if attempt + 1 >= attempts:
+                break
+            delay = float(config.resilience.backoff_base_seconds * (2**attempt))
+            _log.warning(
+                "filter slot HTTP %d for profile %r on attempt %d/%d; retrying in %.1fs",
+                result.status_code,
+                profile,
+                attempt + 1,
+                attempts,
+                delay,
+            )
+            _sleep(delay)
+            continue
+
+        if result.status_code >= 400:
+            raise FilterScorerError(f"filter slot HTTP {result.status_code}")
+
+        try:
+            resp_json = json.loads(result.body.decode("utf-8"))
+            content_str: str = resp_json["choices"][0]["message"]["content"]
+            parsed = json.loads(content_str)
+            return FilterResponse.model_validate(parsed)
+        except (
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+            KeyError,
+            IndexError,
+            TypeError,
+            ValidationError,
+            ValueError,
+        ) as exc:
+            last_error = exc
+            _log.warning(
+                "filter response parse failure for profile %r on attempt %d/%d: %s",
+                profile,
+                attempt + 1,
+                attempts,
+                exc,
+            )
+            continue
+
+    raise FilterScorerError(f"filter failed after {attempts} attempts") from last_error
 
 
 def make_default_arxiv_filter_scorer(
@@ -160,76 +307,23 @@ def make_default_arxiv_filter_scorer(
         if slot.json_mode:
             body["response_format"] = {"type": "json_object"}
 
-        attempts = slot.max_retries + 1
-        last_error: Exception | None = None
-        for attempt in range(attempts):
-            try:
-                result = guarded_post_json_fetch(
-                    url,
-                    body,
-                    headers=headers,
-                    allow_private_ips=config.security.allow_private_ips,
-                    max_response_bytes=config.storage.max_download_bytes,
-                    timeout_seconds=slot.request_timeout,
-                )
-            except NetworkError as exc:
-                last_error = exc
-                _log.warning(
-                    "filter HTTP error for profile %r on attempt %d/%d: %s",
-                    profile,
-                    attempt + 1,
-                    attempts,
-                    exc,
-                )
-                continue
-
-            if result.status_code >= 400:
-                last_error = FilterScorerError(f"filter slot HTTP {result.status_code}")
-                _log.warning(
-                    "filter slot HTTP %d for profile %r on attempt %d/%d",
-                    result.status_code,
-                    profile,
-                    attempt + 1,
-                    attempts,
-                )
-                continue
-
-            try:
-                resp_json = json.loads(result.body.decode("utf-8"))
-                content_str: str = resp_json["choices"][0]["message"]["content"]
-                parsed = json.loads(content_str)
-                response = FilterResponse.model_validate(parsed)
-                return {
-                    r.id: ArxivScoreResult(
-                        score=r.score,
-                        confidence=1.0,
-                        reason=r.reason,
-                        filter_tags=tuple(r.tags),
-                    )
-                    for r in response.results
-                }
-            except (
-                UnicodeDecodeError,
-                json.JSONDecodeError,
-                KeyError,
-                IndexError,
-                TypeError,
-                ValidationError,
-                ValueError,
-            ) as exc:
-                last_error = exc
-                _log.warning(
-                    "filter response parse failure for profile %r on attempt %d/%d: %s",
-                    profile,
-                    attempt + 1,
-                    attempts,
-                    exc,
-                )
-                continue
-
-        raise FilterScorerError(f"filter failed after {attempts} attempts") from (
-            last_error
+        response = _call_filter_model_with_retry(
+            config=config,
+            profile=profile,
+            url=url,
+            body=body,
+            headers=headers,
+            attempts=slot.max_retries + 1,
         )
+        return {
+            r.id: ArxivScoreResult(
+                score=r.score,
+                confidence=1.0,
+                reason=r.reason,
+                filter_tags=tuple(r.tags),
+            )
+            for r in response.results
+        }
 
     return _scorer
 
@@ -294,64 +388,25 @@ def make_default_batch_scorer(config: AppConfig) -> BatchScorer | None:
             body["response_format"] = {"type": "json_object"}
 
         by_id: dict[str, Candidate] = {c.item_id: c for c in candidates}
-        attempts = slot.max_retries + 1
-        last_error: Exception | None = None
-        for attempt in range(attempts):
-            try:
-                result = guarded_post_json_fetch(
-                    url,
-                    body,
-                    headers=headers,
-                    allow_private_ips=config.security.allow_private_ips,
-                    max_response_bytes=config.storage.max_download_bytes,
-                    timeout_seconds=slot.request_timeout,
-                )
-            except NetworkError as exc:
-                last_error = exc
-                _log.warning(
-                    "filter HTTP error for profile %r on attempt %d/%d: %s",
-                    profile,
-                    attempt + 1,
-                    attempts,
-                    exc,
-                )
-                continue
-
-            if result.status_code >= 400:
-                last_error = FilterScorerError(f"filter slot HTTP {result.status_code}")
-                continue
-
-            try:
-                resp_json = json.loads(result.body.decode("utf-8"))
-                content_str: str = resp_json["choices"][0]["message"]["content"]
-                parsed = json.loads(content_str)
-                response = FilterResponse.model_validate(parsed)
-                return {
-                    r.id: ScoredCandidate(
-                        candidate=by_id[r.id],
-                        score=r.score,
-                        confidence=1.0,
-                        reason=r.reason,
-                        filter_tags=tuple(r.tags),
-                    )
-                    for r in response.results
-                    if r.id in by_id
-                }
-            except (
-                UnicodeDecodeError,
-                json.JSONDecodeError,
-                KeyError,
-                IndexError,
-                TypeError,
-                ValidationError,
-                ValueError,
-            ) as exc:
-                last_error = exc
-                continue
-
-        raise FilterScorerError(f"filter failed after {attempts} attempts") from (
-            last_error
+        response = _call_filter_model_with_retry(
+            config=config,
+            profile=profile,
+            url=url,
+            body=body,
+            headers=headers,
+            attempts=slot.max_retries + 1,
         )
+        return {
+            r.id: ScoredCandidate(
+                candidate=by_id[r.id],
+                score=r.score,
+                confidence=1.0,
+                reason=r.reason,
+                filter_tags=tuple(r.tags),
+            )
+            for r in response.results
+            if r.id in by_id
+        }
 
     return _scorer
 

--- a/src/influx/filter.py
+++ b/src/influx/filter.py
@@ -122,7 +122,11 @@ def _parse_retry_after_seconds(value: str) -> float | None:
     return min(seconds, _RETRY_AFTER_MAX_SECONDS)
 
 
-def _filter_429_delay(headers: dict[str, str], config: AppConfig, attempt: int) -> float:
+def _filter_429_delay(
+    headers: dict[str, str],
+    config: AppConfig,
+    attempt: int,
+) -> float:
     """Return the backoff delay for a filter-model 429 response."""
     retry_after = _header_value(headers, "Retry-After")
     if retry_after is not None:
@@ -159,7 +163,8 @@ def _call_filter_model_with_retry(
                 break
             delay = float(config.resilience.backoff_base_seconds * (2**attempt))
             _log.warning(
-                "filter HTTP error for profile %r on attempt %d/%d: %s; retrying in %.1fs",
+                "filter HTTP error for profile %r on attempt %d/%d: %s; "
+                "retrying in %.1fs",
                 profile,
                 attempt + 1,
                 attempts,
@@ -175,7 +180,8 @@ def _call_filter_model_with_retry(
                 break
             delay = _filter_429_delay(result.headers, config, attempt)
             _log.warning(
-                "filter slot HTTP 429 for profile %r on attempt %d/%d; backing off %.1fs",
+                "filter slot HTTP 429 for profile %r on attempt %d/%d; "
+                "backing off %.1fs",
                 profile,
                 attempt + 1,
                 attempts,
@@ -190,7 +196,8 @@ def _call_filter_model_with_retry(
                 break
             delay = float(config.resilience.backoff_base_seconds * (2**attempt))
             _log.warning(
-                "filter slot HTTP %d for profile %r on attempt %d/%d; retrying in %.1fs",
+                "filter slot HTTP %d for profile %r on attempt %d/%d; "
+                "retrying in %.1fs",
                 result.status_code,
                 profile,
                 attempt + 1,

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -38,7 +38,6 @@ from influx.extraction.article import extract_article
 from influx.filter import FilterScorerError, _call_filter_model_with_retry
 from influx.http_client import guarded_fetch as _guarded_fetch
 from influx.renderer import render
-from influx.schemas import FilterResponse
 from influx.slugs import slugify_feed_name
 from influx.source import Candidate, ScoredCandidate
 from influx.storage import download_archive

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -35,9 +35,8 @@ from influx.cascade import Acquired, Cascade
 from influx.coordinator import RunKind
 from influx.errors import ExtractionError, NetworkError
 from influx.extraction.article import extract_article
-from influx.filter import FilterScorerError
+from influx.filter import FilterScorerError, _call_filter_model_with_retry
 from influx.http_client import guarded_fetch as _guarded_fetch
-from influx.http_client import guarded_post_json_fetch
 from influx.renderer import render
 from influx.schemas import FilterResponse
 from influx.slugs import slugify_feed_name
@@ -413,21 +412,15 @@ async def _score_rss_items(
         last_error: Exception | None = None
         for _attempt in range(attempts):
             try:
-                response = guarded_post_json_fetch(
-                    url,
-                    body,
+                response = _call_filter_model_with_retry(
+                    config=config,
+                    profile=profile,
+                    url=url,
+                    body=body,
                     headers=headers,
-                    allow_private_ips=config.security.allow_private_ips,
-                    max_response_bytes=config.storage.max_download_bytes,
-                    timeout_seconds=slot.request_timeout,
+                    attempts=attempts,
                 )
-                if response.status_code >= 400:
-                    last_error = FilterScorerError(f"HTTP {response.status_code}")
-                    continue
-                envelope = json.loads(response.body.decode("utf-8"))
-                content = envelope["choices"][0]["message"]["content"]
-                parsed = FilterResponse.model_validate(json.loads(content))
-                all_scores.update({result.id: result for result in parsed.results})
+                all_scores.update({result.id: result for result in response.results})
                 break
             except Exception as exc:
                 last_error = exc

--- a/tests/integration/test_arxiv_pipeline_end_to_end.py
+++ b/tests/integration/test_arxiv_pipeline_end_to_end.py
@@ -740,6 +740,78 @@ class TestDefaultFilterScorerEndToEnd:
         write_calls = [c for c in fake_lithos.calls if c[0] == "lithos_write"]
         assert write_calls == []
 
+    def test_default_scorer_429_backs_off_and_recovers(
+        self,
+        fake_lithos: FakeLithosServer,
+        fake_lithos_url: str,
+    ) -> None:
+        """A 429 from the filter model honours Retry-After and succeeds on retry."""
+        config = _make_config_with_filter(fake_lithos_url).model_copy(
+            update={
+                "models": {
+                    "filter": ModelSlotConfig(
+                        provider="openai",
+                        model="gpt-test",
+                        max_retries=1,
+                        json_mode=True,
+                    ),
+                },
+            }
+        )
+        app = create_app(config)
+        assert app.state.item_provider is not None
+
+        filter_calls = {"count": 0}
+        sleeps: list[float] = []
+
+        def fake_filter_post(*args: object, **kwargs: object) -> FetchResult:
+            del args, kwargs
+            filter_calls["count"] += 1
+            if filter_calls["count"] == 1:
+                return FetchResult(
+                    body=b'{"error":{"message":"rate limited"}}',
+                    status_code=429,
+                    content_type="application/json",
+                    final_url="https://api.openai.invalid/v1/chat/completions",
+                    headers={"Retry-After": "11"},
+                )
+            return _filter_fetch_result(_filter_response(_ARXIV_ID, 7))
+
+        with (
+            patch(
+                "influx.sources.arxiv.guarded_fetch",
+                return_value=_atom_fetch_result(),
+            ),
+            patch(
+                "influx.extraction.html.guarded_fetch",
+            ) as mock_html,
+            patch(
+                "influx.filter.guarded_post_json_fetch",
+                side_effect=fake_filter_post,
+            ),
+            patch(
+                "influx.filter._sleep",
+                side_effect=lambda seconds: sleeps.append(seconds),
+            ),
+        ):
+            import asyncio
+
+            asyncio.run(
+                run_profile(
+                    "ai-robotics",
+                    RunKind.MANUAL,
+                    config=config,
+                    item_provider=app.state.item_provider,
+                )
+            )
+
+            assert filter_calls["count"] == 2
+            assert sleeps == [11.0]
+            assert mock_html.call_count == 0
+
+        write_calls = [c for c in fake_lithos.calls if c[0] == "lithos_write"]
+        assert len(write_calls) == 1
+
     def test_default_scorer_missing_provider_skips_batch(
         self,
         fake_lithos: FakeLithosServer,

--- a/tests/integration/test_otel_metrics.py
+++ b/tests/integration/test_otel_metrics.py
@@ -102,6 +102,8 @@ def _mock_lithos_client() -> AsyncMock:
     client = AsyncMock()
     client.task_create_body.return_value = {"task_id": "task-1"}
     client.cache_lookup_for_item_body.return_value = {"hit": False}
+    client.list_notes_body.return_value = {"items": []}
+    client.read_note.return_value = {}
     write_result = MagicMock()
     write_result.status = "created"
     write_result.note_id = "note-123"
@@ -216,18 +218,11 @@ async def _run_arxiv_scenario(meter: InfluxMeter, config: Any) -> None:
             return_value=Tier3Extraction(claims=["claim1"], builds_on=["b1"]),
         ),
         patch("influx.run.LithosClient", return_value=mock_client),
-        patch("influx.run.LithosClient", return_value=mock_client),
         patch(
             "influx.run.build_negative_examples_block",
             new_callable=AsyncMock,
             return_value="",
         ),
-        patch(
-            "influx.run.build_negative_examples_block",
-            new_callable=AsyncMock,
-            return_value="",
-        ),
-        patch("influx.run.repair_sweep", new_callable=AsyncMock),
         patch("influx.run.repair_sweep", new_callable=AsyncMock),
         patch("influx.service.post_run_webhook_hook"),
     ):
@@ -406,18 +401,11 @@ class TestOtelDisabledZeroMetrics:
                 return_value=Tier3Extraction(claims=["claim1"], builds_on=["b1"]),
             ),
             patch("influx.run.LithosClient", return_value=mock_client),
-            patch("influx.run.LithosClient", return_value=mock_client),
             patch(
                 "influx.run.build_negative_examples_block",
                 new_callable=AsyncMock,
                 return_value="",
             ),
-            patch(
-                "influx.run.build_negative_examples_block",
-                new_callable=AsyncMock,
-                return_value="",
-            ),
-            patch("influx.run.repair_sweep", new_callable=AsyncMock),
             patch("influx.run.repair_sweep", new_callable=AsyncMock),
             patch("influx.service.post_run_webhook_hook"),
         ):

--- a/tests/integration/test_otel_spans.py
+++ b/tests/integration/test_otel_spans.py
@@ -159,6 +159,8 @@ def _mock_lithos_client() -> AsyncMock:
     client = AsyncMock()
     client.task_create_body.return_value = {"task_id": "task-1"}
     client.cache_lookup_for_item_body.return_value = {"hit": False}
+    client.list_notes_body.return_value = {"items": []}
+    client.read_note.return_value = {}
     write_result = MagicMock()
     write_result.status = "created"
     write_result.note_id = "note-123"
@@ -240,18 +242,11 @@ async def _run_arxiv_scenario(
         ),
         # Scheduler + Run infrastructure (#58 dispatch)
         patch("influx.run.LithosClient", return_value=mock_client),
-        patch("influx.run.LithosClient", return_value=mock_client),
         patch(
             "influx.run.build_negative_examples_block",
             new_callable=AsyncMock,
             return_value="",
         ),
-        patch(
-            "influx.run.build_negative_examples_block",
-            new_callable=AsyncMock,
-            return_value="",
-        ),
-        patch("influx.run.repair_sweep", new_callable=AsyncMock),
         patch("influx.run.repair_sweep", new_callable=AsyncMock),
         # lcma_after_write runs normally — produces influx.lithos.retrieve span
         # lcma_resolve_builds_on runs normally — "b1" has no arXiv ref, no-ops
@@ -473,18 +468,11 @@ class TestOtelDisabledZeroSpans:
             ),
             # Scheduler + Run infrastructure (#58 dispatch)
             patch("influx.run.LithosClient", return_value=mock_client),
-            patch("influx.run.LithosClient", return_value=mock_client),
             patch(
                 "influx.run.build_negative_examples_block",
                 new_callable=AsyncMock,
                 return_value="",
             ),
-            patch(
-                "influx.run.build_negative_examples_block",
-                new_callable=AsyncMock,
-                return_value="",
-            ),
-            patch("influx.run.repair_sweep", new_callable=AsyncMock),
             patch("influx.run.repair_sweep", new_callable=AsyncMock),
             patch("influx.service.post_run_webhook_hook"),
         ):

--- a/tests/integration/test_rss_to_lithos.py
+++ b/tests/integration/test_rss_to_lithos.py
@@ -23,6 +23,7 @@ from typing import Literal
 
 import pytest
 
+from influx import filter as filter_module
 from influx.config import (
     AppConfig,
     FilterTuningConfig,
@@ -38,7 +39,6 @@ from influx.config import (
     SecurityConfig,
     StorageConfig,
 )
-from influx import filter as filter_module
 from influx.slugs import slugify_feed_name
 from influx.sources import rss as rss_module
 from influx.sources.rss import RssFeedItem, build_rss_note_item, parse_feed

--- a/tests/integration/test_rss_to_lithos.py
+++ b/tests/integration/test_rss_to_lithos.py
@@ -38,6 +38,7 @@ from influx.config import (
     SecurityConfig,
     StorageConfig,
 )
+from influx import filter as filter_module
 from influx.slugs import slugify_feed_name
 from influx.sources import rss as rss_module
 from influx.sources.rss import RssFeedItem, build_rss_note_item, parse_feed
@@ -239,7 +240,7 @@ async def test_score_rss_items_chunks_by_filter_batch_size(
         return _filter_response_for(candidate_ids)
 
     monkeypatch.setattr(
-        rss_module,
+        filter_module,
         "guarded_post_json_fetch",
         fake_post_json_fetch,
     )
@@ -282,7 +283,7 @@ async def test_score_rss_items_skips_failed_chunk_but_keeps_other_scores(
         return _filter_response_for(candidate_ids)
 
     monkeypatch.setattr(
-        rss_module,
+        filter_module,
         "guarded_post_json_fetch",
         fake_post_json_fetch,
     )
@@ -305,6 +306,63 @@ async def test_score_rss_items_skips_failed_chunk_but_keeps_other_scores(
         url_hash("https://example.com/post-4"),
     }
     assert len(recorded_errors) == 1
+
+
+async def test_score_rss_items_honours_retry_after_on_429(
+    archive_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _make_filter_config(archive_dir=archive_dir, batch_size=2).model_copy(
+        update={
+            "models": {
+                "filter": ModelSlotConfig(
+                    provider="test",
+                    model="test-filter",
+                    max_retries=1,
+                    json_mode=True,
+                ),
+            },
+        }
+    )
+    items = [
+        _make_item(url="https://example.com/post-0", title="Post 0"),
+        _make_item(url="https://example.com/post-1", title="Post 1"),
+    ]
+    calls = {"count": 0}
+    sleeps: list[float] = []
+
+    def fake_post_json_fetch(
+        url: str,
+        body: dict[str, object],
+        **kwargs: object,
+    ) -> SimpleNamespace:
+        candidate_ids = _candidate_ids_from_filter_body(body)
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return SimpleNamespace(
+                status_code=429,
+                body=b'{"error":{"message":"rate limited"}}',
+                headers={"Retry-After": "7"},
+            )
+        return _filter_response_for(candidate_ids)
+
+    monkeypatch.setattr(
+        filter_module,
+        "guarded_post_json_fetch",
+        fake_post_json_fetch,
+    )
+    monkeypatch.setattr(filter_module, "_sleep", lambda seconds: sleeps.append(seconds))
+
+    scores = await rss_module._score_rss_items(
+        items=items,
+        profile="test-profile",
+        filter_prompt="score these",
+        config=config,
+    )
+
+    assert calls["count"] == 2
+    assert sleeps == [7.0]
+    assert set(scores) == {_rss_filter_id_for(item) for item in items}
 
 
 def _rss_filter_id_for(item: RssFeedItem) -> str:


### PR DESCRIPTION
## Summary
- add shared filter-model retry handling with 429  support and exponential backoff for transient failures
- route RSS filter scoring through the shared retry path so rate limits no longer immediately drop staged RSS chunks
- add regression coverage for RSS and default filter scorer recovery after a 429

## Testing
- ============================= test session starts ==============================
platform linux -- Python 3.12.12, pytest-9.0.3, pluggy-1.6.0
rootdir: /tmp/influx-filter-429-worktree
configfile: pyproject.toml
plugins: anyio-4.13.0, asyncio-1.3.0, cov-7.1.0, respx-0.23.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 16 items / 13 deselected / 3 selected

tests/integration/test_rss_to_lithos.py ...                              [100%]

======================= 3 passed, 13 deselected in 0.35s =======================
- ============================= test session starts ==============================
platform linux -- Python 3.12.12, pytest-9.0.3, pluggy-1.6.0
rootdir: /tmp/influx-filter-429-worktree
configfile: pyproject.toml
plugins: anyio-4.13.0, asyncio-1.3.0, cov-7.1.0, respx-0.23.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 11 items / 9 deselected / 2 selected

tests/integration/test_arxiv_pipeline_end_to_end.py ..                   [100%]

=============================== warnings summary ===============================
tests/integration/test_arxiv_pipeline_end_to_end.py::TestDefaultFilterScorerEndToEnd::test_default_scorer_http_failure_skips_batch
  /tmp/influx-filter-429-worktree/.venv/lib/python3.12/site-packages/websockets/legacy/__init__.py:6: DeprecationWarning: websockets.legacy is deprecated; see https://websockets.readthedocs.io/en/stable/howto/upgrade.html for upgrade instructions
    warnings.warn(  # deprecated in 14.0 - 2024-11-09

tests/integration/test_arxiv_pipeline_end_to_end.py::TestDefaultFilterScorerEndToEnd::test_default_scorer_http_failure_skips_batch
  /tmp/influx-filter-429-worktree/.venv/lib/python3.12/site-packages/uvicorn/protocols/websockets/websockets_impl.py:17: DeprecationWarning: websockets.server.WebSocketServerProtocol is deprecated
    from websockets.server import WebSocketServerProtocol

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================= 2 passed, 9 deselected, 2 warnings in 4.01s ==================
