### PR TITLE
refactor: deduplicate repair sweep stage execution

### DIFF
--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -1036,9 +1036,7 @@ def _run_archive_retry(
         return current_tags, downloaded_path, True
     except (ExtractionError, LithosError) as exc:
         failure_stage = (
-            getattr(exc, "stage", "")
-            or getattr(exc, "kind", "")
-            or "archive_failed"
+            getattr(exc, "stage", "") or getattr(exc, "kind", "") or "archive_failed"
         )
         new_tags = _apply_counted_failure(
             note=note,
@@ -1073,9 +1071,7 @@ def _terminate_unsupported_text_source(note: dict[str, Any]) -> list[str]:
     if "influx:text-terminal" not in restored_tags:
         restored_tags.append("influx:text-terminal")
     if "influx:archive-missing" not in restored_tags:
-        restored_tags = [
-            tag for tag in restored_tags if tag != "influx:repair-needed"
-        ]
+        restored_tags = [tag for tag in restored_tags if tag != "influx:repair-needed"]
     note["tags"] = list(restored_tags)
     return restored_tags
 

--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -13,10 +13,12 @@ implementations ship with PRD 07.
 
 from __future__ import annotations
 
+import contextlib
 import copy
 import enum
 import json
 import logging
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -24,6 +26,7 @@ from influx import metrics
 from influx.errors import ExtractionError, LCMAError, LithosError
 from influx.notes import merge_tags
 from influx.repair_counters import (
+    CountedStage,
     classify_failure,
     record_counted_failure,
 )
@@ -489,6 +492,102 @@ def _log_stage_failure(
     )
 
 
+# ── Shared per-stage execution envelope ───────────────────────────
+
+
+@contextlib.contextmanager
+def _stage_attempt(
+    note: dict[str, Any],
+    *,
+    profile: str,
+    kind: str,
+    span_name: str,
+    sync_tags: list[str] | None = None,
+) -> Iterator[None]:
+    """Common per-stage hook-call envelope.
+
+    Increments the per-kind candidate metric, opens an OTEL span tagged
+    with note id / profile / run id, and snapshots the live note dict so
+    a hook that mutates it and then raises does NOT leak partial state
+    into the rewrite (finding #1).  When *sync_tags* is supplied,
+    ``note["tags"]`` is set to a copy of it before the snapshot so the
+    snapshot reflects the latest stage-output tag state callers expect
+    rolled back on failure.
+
+    On any exception the snapshot is restored before re-raising so the
+    caller can compute counted-failure advancement / source-specific
+    recovery against the rolled-back note state.
+    """
+    if sync_tags is not None:
+        note["tags"] = list(sync_tags)
+    metrics.repair_candidates().add(1, {"profile": profile, "kind": kind})
+    snapshot = _snapshot_note(note)
+    tracer = get_tracer()
+    try:
+        with tracer.span(
+            span_name,
+            attributes={
+                "influx.note_id": note.get("id", ""),
+                "influx.profile": profile,
+                "influx.run_id": current_run_id.get() or "",
+            },
+        ):
+            yield
+    except BaseException:
+        _restore_note(note, snapshot)
+        raise
+
+
+def _apply_counted_failure(
+    *,
+    note: dict[str, Any],
+    current_tags: list[str],
+    exc: BaseException,
+    profile: str,
+    stage: CountedStage,
+    failure_stage: str,
+) -> list[str]:
+    """Advance the per-stage counter and emit terminal-flip logging.
+
+    No-op for transient failures (returns *current_tags* unchanged).
+    For counted failures, mutates ``note["content"]`` with the bumped
+    ``## Repair`` section and, when the cap is just crossed, also writes
+    ``note["tags"]`` and emits a structured WARNING so operators see the
+    stage flip in logs.  The ``<stage>_attempts`` log field is named per
+    *stage* so existing log-filter rules keep matching.
+    """
+    if classify_failure(exc) != "counted":
+        return current_tags
+    advance = record_counted_failure(
+        content=str(note.get("content", "")),
+        tags=current_tags,
+        stage=stage,
+        failure_stage=failure_stage,
+        failure_error=str(exc),
+    )
+    note["content"] = advance.new_content
+    if advance.terminal_tag_added:
+        note["tags"] = list(advance.new_tags)
+        logger.warning(
+            "sweep: %s marked terminal after %d counted failures for %s",
+            stage,
+            advance.attempts,
+            note.get("id", "?"),
+            extra={
+                "sweep_stage": f"{stage}_terminal_flip",
+                "note_id": note.get("id"),
+                "profile": profile,
+                "run_id": current_run_id.get() or "",
+                f"{stage}_attempts": advance.attempts,
+                "exc_type": type(exc).__name__,
+                "stage": getattr(exc, "stage", None),
+                "kind": getattr(exc, "kind", None) or failure_stage,
+                "detail": getattr(exc, "detail", None),
+            },
+        )
+    return advance.new_tags
+
+
 # ── Abstract-only re-extraction stage (§5.2) ──────────────────────
 
 
@@ -763,6 +862,27 @@ async def _sweep_resolve_version_conflict(
     return status
 
 
+async def _attempt_sweep_write(
+    client: LithosClient,
+    args: dict[str, Any],
+    *,
+    pending_tags: list[str],
+    note_id: str,
+) -> str:
+    """Single rewrite attempt with FR-MCP-7 version-conflict retry.
+
+    Returns the final response status (after one re-read + retry on
+    ``version_conflict``).  Raises :class:`SweepWriteError` on
+    transport failure or unresolved conflict.
+    """
+    status = await _sweep_call_write(client, args, note_id)
+    if status == "version_conflict":
+        status = await _sweep_resolve_version_conflict(
+            client, args, pending_tags, note_id
+        )
+    return status
+
+
 async def _rewrite_sweep_note(
     client: LithosClient,
     note: dict[str, Any],
@@ -825,38 +945,34 @@ async def _rewrite_sweep_note(
     if version is not None:
         base_args["expected_version"] = version
 
-    # ── Attempt 1: original content + tags. ───────────────────────
-    status = await _sweep_call_write(client, base_args, note_id)
-    if status == "version_conflict":
-        status = await _sweep_resolve_version_conflict(
-            client, base_args, list(tags), note_id
-        )
+    # Attempt 1: original content + tags.
+    status = await _attempt_sweep_write(
+        client, base_args, pending_tags=list(tags), note_id=note_id
+    )
     if status != "content_too_large":
         return
 
-    # ── Attempt 2: drop Tier 2 (## Full Text) and retry. ─────────
-    tier2_args = dict(base_args)
-    tier2_args["content"] = _drop_tier2(base_args["content"])
-    status = await _sweep_call_write(client, tier2_args, note_id)
-    if status == "version_conflict":
-        status = await _sweep_resolve_version_conflict(
-            client, tier2_args, list(tags), note_id
-        )
+    # Attempt 2: drop ## Full Text (Tier 2) and retry.
+    tier2_args = {**base_args, "content": _drop_tier2(base_args["content"])}
+    status = await _attempt_sweep_write(
+        client, tier2_args, pending_tags=list(tags), note_id=note_id
+    )
     if status != "content_too_large":
         return
 
-    # ── Attempt 3: drop Tier 2 + Tier 3, ensure repair-needed. ───
-    tier1_args = dict(base_args)
-    tier1_args["content"] = _drop_tier2_and_tier3(base_args["content"])
+    # Attempt 3: drop Tier 2 + Tier 3 and ensure influx:repair-needed
+    # so the note re-enters the sweep on a later run.
     repair_tags = list(tags)
     if "influx:repair-needed" not in repair_tags:
         repair_tags.append("influx:repair-needed")
-    tier1_args["tags"] = repair_tags
-    status = await _sweep_call_write(client, tier1_args, note_id)
-    if status == "version_conflict":
-        status = await _sweep_resolve_version_conflict(
-            client, tier1_args, list(repair_tags), note_id
-        )
+    tier1_args = {
+        **base_args,
+        "content": _drop_tier2_and_tier3(base_args["content"]),
+        "tags": repair_tags,
+    }
+    status = await _attempt_sweep_write(
+        client, tier1_args, pending_tags=repair_tags, note_id=note_id
+    )
     if status != "content_too_large":
         return
 
@@ -877,6 +993,182 @@ def _get_profile_thresholds(
             return p.thresholds.full_text, p.thresholds.deep_extract
     # Fallback defaults from ProfileThresholds.
     return 8, 9
+
+
+def _run_archive_retry(
+    note: dict[str, Any],
+    *,
+    profile: str,
+    current_tags: list[str],
+    archive_path: str | None,
+    hook: ArchiveDownloadHook,
+) -> tuple[list[str], str | None, bool]:
+    """Run the archive-download retry stage (FR-REP-1).
+
+    Returns ``(tags, archive_path, succeeded)``.  On failure the tag
+    list reflects any counted-failure terminal flip and the archive
+    path is left at its prior value; callers feed the returned path
+    back into :func:`compute_clearing` and the abstract-only
+    re-extraction eligibility re-check.
+    """
+    try:
+        with _stage_attempt(
+            note,
+            profile=profile,
+            kind="archive",
+            span_name="influx.repair.archive",
+        ):
+            downloaded_path = hook(note)
+        # Patch ## Archive with the freshly downloaded path (idempotent —
+        # only inserts when no path: line is already present).
+        content = str(note.get("content", ""))
+        marker = "## Archive\n"
+        idx = content.find(marker)
+        if idx >= 0:
+            insert_pos = idx + len(marker)
+            rest = content[insert_pos:]
+            if not rest.startswith("path:"):
+                note["content"] = (
+                    content[:insert_pos]
+                    + f"path: {downloaded_path}\n"
+                    + content[insert_pos:]
+                )
+        return current_tags, downloaded_path, True
+    except (ExtractionError, LithosError) as exc:
+        failure_stage = (
+            getattr(exc, "stage", "")
+            or getattr(exc, "kind", "")
+            or "archive_failed"
+        )
+        new_tags = _apply_counted_failure(
+            note=note,
+            current_tags=current_tags,
+            exc=exc,
+            profile=profile,
+            stage="archive",
+            failure_stage=failure_stage,
+        )
+        _log_stage_failure(
+            "archive_download",
+            note=note,
+            profile=profile,
+            exc=exc,
+        )
+        return new_tags, archive_path, False
+
+
+def _terminate_unsupported_text_source(note: dict[str, Any]) -> list[str]:
+    """Mark text extraction terminal when the note's source is unsupported.
+
+    Without a per-source resolver the text-extraction hook raises
+    ``ExtractionError(stage="unsupported_source")`` every pass and the
+    note loops forever.  We pin Tier 1 quality to ``text:abstract-only``,
+    add ``influx:text-terminal`` so later sweeps skip the stage, and
+    drop ``influx:repair-needed`` (when no other repair condition holds)
+    so the note exits the sweep entirely.
+    """
+    restored_tags = list(note.get("tags", []))
+    if not any(tag.startswith("text:") for tag in restored_tags):
+        restored_tags.append("text:abstract-only")
+    if "influx:text-terminal" not in restored_tags:
+        restored_tags.append("influx:text-terminal")
+    if "influx:archive-missing" not in restored_tags:
+        restored_tags = [
+            tag for tag in restored_tags if tag != "influx:repair-needed"
+        ]
+    note["tags"] = list(restored_tags)
+    return restored_tags
+
+
+def _run_text_extraction_retry(
+    note: dict[str, Any],
+    *,
+    profile: str,
+    current_tags: list[str],
+    hook: TextExtractionHook,
+) -> list[str]:
+    """Run the text-extraction retry stage (FR-REP-1 stage 2).
+
+    Distinct from the abstract-only re-extraction stage below, which
+    upgrades ``text:abstract-only`` against an existing archive.  No
+    new terminal tag is introduced for normal failures (out of scope
+    for issue #24); ``unsupported_source`` failures are flipped to
+    terminal so the note exits the sweep instead of looping.
+    """
+    try:
+        with _stage_attempt(
+            note,
+            profile=profile,
+            kind="text_extraction",
+            span_name="influx.repair.text_extraction",
+            sync_tags=current_tags,
+        ):
+            new_text_tag = hook(note)
+        new_tags = list(current_tags)
+        if new_text_tag and not any(t.startswith("text:") for t in new_tags):
+            new_tags.append(new_text_tag)
+            note["tags"] = list(new_tags)
+        return new_tags
+    except (ExtractionError, LCMAError, LithosError) as exc:
+        new_tags = current_tags
+        if (
+            isinstance(exc, ExtractionError)
+            and getattr(exc, "stage", "") == "unsupported_source"
+        ):
+            new_tags = _terminate_unsupported_text_source(note)
+        _log_stage_failure(
+            "text_extraction",
+            note=note,
+            profile=profile,
+            exc=exc,
+        )
+        return new_tags
+
+
+def _run_tier_retry(
+    note: dict[str, Any],
+    *,
+    profile: str,
+    current_tags: list[str],
+    hook: Tier2EnrichHook | Tier3ExtractHook,
+    stage: CountedStage,
+    log_subject: str,
+) -> list[str]:
+    """Run a Tier 2 / Tier 3 retry stage.
+
+    Both tiers share the same shape — counted-failure cap, terminal-tag
+    flip, hook-mutation rollback — so they delegate to a single helper
+    parameterised on *stage* (``"tier2"`` / ``"tier3"``) and the log
+    subject used for the per-stage failure WARN line.
+    """
+    try:
+        with _stage_attempt(
+            note,
+            profile=profile,
+            kind=stage,
+            span_name=f"influx.repair.{stage}",
+            sync_tags=current_tags,
+        ):
+            hook(note)
+        # Sync any tag/content mutations the hook applied to the note
+        # dict back into the working tag set.
+        return list(note.get("tags", current_tags))
+    except (ExtractionError, LCMAError, LithosError) as exc:
+        new_tags = _apply_counted_failure(
+            note=note,
+            current_tags=current_tags,
+            exc=exc,
+            profile=profile,
+            stage=stage,
+            failure_stage=getattr(exc, "stage", "") or "",
+        )
+        _log_stage_failure(
+            log_subject,
+            note=note,
+            profile=profile,
+            exc=exc,
+        )
+        return new_tags
 
 
 async def _process_sweep_note(
@@ -932,146 +1224,33 @@ async def _process_sweep_note(
 
     # ── Execute selected stages ─────────────────────────────────
     current_tags = list(tags)
-
-    # Archive retry.
     archive_succeeded = False
+
     if stages.archive_retry and hooks.archive_download:
-        # Snapshot before the hook so a raise rolls back any partial
-        # in-place note mutations the hook applied (finding #1).
-        snapshot = _snapshot_note(note)
-        metrics.repair_candidates().add(1, {"profile": profile, "kind": "archive"})
-        tracer = get_tracer()
-        try:
-            with tracer.span(
-                "influx.repair.archive",
-                attributes={
-                    "influx.note_id": note.get("id", ""),
-                    "influx.profile": profile,
-                    "influx.run_id": current_run_id.get() or "",
-                },
-            ):
-                downloaded_path = hooks.archive_download(note)
-            archive_path = downloaded_path
-            archive_succeeded = True
-            # Update ## Archive in note content with the new path.
-            content = str(note.get("content", ""))
-            marker = "## Archive\n"
-            idx = content.find(marker)
-            if idx >= 0:
-                insert_pos = idx + len(marker)
-                rest = content[insert_pos:]
-                if not rest.startswith("path:"):
-                    note["content"] = (
-                        content[:insert_pos]
-                        + f"path: {downloaded_path}\n"
-                        + content[insert_pos:]
-                    )
-        except (ExtractionError, LithosError) as exc:
-            # Hook raises are per-stage failures, not fatal aborts.
-            # Restore the note dict so partial in-place mutations from
-            # the failing hook are NOT persisted (finding #1).
-            _restore_note(note, snapshot)
-            if classify_failure(exc) == "counted":
-                kind = (
-                    getattr(exc, "stage", "")
-                    or getattr(exc, "kind", "")
-                    or "archive_failed"
-                )
-                advance = record_counted_failure(
-                    content=str(note.get("content", "")),
-                    tags=current_tags,
-                    stage="archive",
-                    failure_stage=kind,
-                    failure_error=str(exc),
-                )
-                note["content"] = advance.new_content
-                current_tags = advance.new_tags
-                if advance.terminal_tag_added:
-                    note["tags"] = list(current_tags)
-                    logger.warning(
-                        "sweep: archive marked terminal after %d failures for %s",
-                        advance.attempts,
-                        note.get("id", "?"),
-                        extra={
-                            "sweep_stage": "archive_terminal_flip",
-                            "note_id": note.get("id"),
-                            "profile": profile,
-                            "run_id": current_run_id.get() or "",
-                            "archive_attempts": advance.attempts,
-                            "exc_type": type(exc).__name__,
-                            "kind": kind,
-                            "detail": getattr(exc, "detail", None),
-                        },
-                    )
-            _log_stage_failure(
-                "archive_download",
-                note=note,
-                profile=profile,
-                exc=exc,
-            )
-
-    # Text extraction retry (FR-REP-1 stage 2).  Runs when the note
-    # carries no ``text:*`` tag at all — distinct from the abstract-
-    # only re-extraction stage below, which upgrades ``text:abstract-
-    # only`` against an existing archive.  No new terminal tag is
-    # introduced here (out of scope for #24); failures roll back the
-    # in-place note mutations and re-enter the sweep next pass.
-    if stages.text_extraction_retry and hooks.text_extraction:
-        note["tags"] = list(current_tags)
-        snapshot = _snapshot_note(note)
-        metrics.repair_candidates().add(
-            1, {"profile": profile, "kind": "text_extraction"}
+        current_tags, archive_path, archive_succeeded = _run_archive_retry(
+            note,
+            profile=profile,
+            current_tags=current_tags,
+            archive_path=archive_path,
+            hook=hooks.archive_download,
         )
-        tracer = get_tracer()
-        try:
-            with tracer.span(
-                "influx.repair.text_extraction",
-                attributes={
-                    "influx.note_id": note.get("id", ""),
-                    "influx.profile": profile,
-                    "influx.run_id": current_run_id.get() or "",
-                },
-            ):
-                new_text_tag = hooks.text_extraction(note)
-            if new_text_tag and not any(t.startswith("text:") for t in current_tags):
-                current_tags.append(new_text_tag)
-                note["tags"] = list(current_tags)
-        except (ExtractionError, LCMAError, LithosError) as exc:
-            _restore_note(note, snapshot)
-            if (
-                isinstance(exc, ExtractionError)
-                and getattr(exc, "stage", "") == "unsupported_source"
-            ):
-                restored_tags = list(note.get("tags", []))
-                if not any(tag.startswith("text:") for tag in restored_tags):
-                    restored_tags.append("text:abstract-only")
-                if "influx:text-terminal" not in restored_tags:
-                    restored_tags.append("influx:text-terminal")
-                if "influx:archive-missing" not in restored_tags:
-                    restored_tags = [
-                        tag for tag in restored_tags if tag != "influx:repair-needed"
-                    ]
-                current_tags = restored_tags
-                note["tags"] = list(current_tags)
-            _log_stage_failure(
-                "text_extraction",
-                note=note,
-                profile=profile,
-                exc=exc,
-            )
 
-    # Abstract-only re-extraction.
-    # Re-evaluate eligibility if archive just succeeded this pass
-    # (initial selection used archive_succeeded_this_pass=False).
-    run_abstract_reextraction = stages.abstract_only_reextraction
-    if (
-        not run_abstract_reextraction
-        and archive_succeeded
+    if stages.text_extraction_retry and hooks.text_extraction:
+        current_tags = _run_text_extraction_retry(
+            note,
+            profile=profile,
+            current_tags=current_tags,
+            hook=hooks.text_extraction,
+        )
+
+    # Re-evaluate abstract-only re-extraction eligibility now that the
+    # archive download outcome is known (initial selection above used
+    # archive_succeeded_this_pass=False).
+    run_abstract_reextraction = stages.abstract_only_reextraction or (
+        archive_succeeded
         and "text:abstract-only" in set(tags)
         and "influx:text-terminal" not in set(tags)
-    ):
-        run_abstract_reextraction = True
-
+    )
     if (
         run_abstract_reextraction
         and hooks.re_extract_archive
@@ -1084,141 +1263,42 @@ async def _process_sweep_note(
             hook=hooks.re_extract_archive,
         )
 
-    # Tier 2 retry.
     if stages.tier2_retry and hooks.tier2_enrich:
-        # Expose any tag mutations from earlier stages so the hook sees
-        # the latest tag set on the note dict.
-        note["tags"] = list(current_tags)
-        # Snapshot AFTER updating tags so an exception rolls back to
-        # the expected pre-hook state — including the latest current_tags
-        # rather than whatever was on the note before this stage ran.
-        snapshot = _snapshot_note(note)
-        metrics.repair_candidates().add(1, {"profile": profile, "kind": "tier2"})
-        tracer = get_tracer()
-        try:
-            with tracer.span(
-                "influx.repair.tier2",
-                attributes={
-                    "influx.note_id": note.get("id", ""),
-                    "influx.profile": profile,
-                    "influx.run_id": current_run_id.get() or "",
-                },
-            ):
-                hooks.tier2_enrich(note)
-            # Sync any tag/content mutations the hook applied to the
-            # note dict back into the local working set.
-            current_tags = list(note.get("tags", current_tags))
-        except (ExtractionError, LCMAError, LithosError) as exc:
-            # Per-stage failure: roll back any partial in-place
-            # mutations from the failing hook (finding #1).  Do NOT
-            # sync hook mutations into ``current_tags``.
-            _restore_note(note, snapshot)
-            if classify_failure(exc) == "counted":
-                advance = record_counted_failure(
-                    content=str(note.get("content", "")),
-                    tags=current_tags,
-                    stage="tier2",
-                    failure_stage=getattr(exc, "stage", "") or "",
-                    failure_error=str(exc),
-                )
-                note["content"] = advance.new_content
-                current_tags = advance.new_tags
-                if advance.terminal_tag_added:
-                    note["tags"] = list(current_tags)
-                    logger.warning(
-                        "sweep: tier2 marked terminal after %d counted failures for %s",
-                        advance.attempts,
-                        note.get("id", "?"),
-                        extra={
-                            "sweep_stage": "tier2_terminal_flip",
-                            "note_id": note.get("id"),
-                            "profile": profile,
-                            "run_id": current_run_id.get() or "",
-                            "tier2_attempts": advance.attempts,
-                            "exc_type": type(exc).__name__,
-                            "stage": getattr(exc, "stage", None),
-                            "detail": getattr(exc, "detail", None),
-                        },
-                    )
-            _log_stage_failure(
-                "tier2_enrichment",
-                note=note,
-                profile=profile,
-                exc=exc,
-            )
+        current_tags = _run_tier_retry(
+            note,
+            profile=profile,
+            current_tags=current_tags,
+            hook=hooks.tier2_enrich,
+            stage="tier2",
+            log_subject="tier2_enrichment",
+        )
 
-    # Tier 3 retry.
     if stages.tier3_retry and hooks.tier3_extract:
-        note["tags"] = list(current_tags)
-        snapshot = _snapshot_note(note)
-        metrics.repair_candidates().add(1, {"profile": profile, "kind": "tier3"})
-        tracer = get_tracer()
-        try:
-            with tracer.span(
-                "influx.repair.tier3",
-                attributes={
-                    "influx.note_id": note.get("id", ""),
-                    "influx.profile": profile,
-                    "influx.run_id": current_run_id.get() or "",
-                },
-            ):
-                hooks.tier3_extract(note)
-            current_tags = list(note.get("tags", current_tags))
-        except (ExtractionError, LCMAError, LithosError) as exc:
-            _restore_note(note, snapshot)
-            if classify_failure(exc) == "counted":
-                advance = record_counted_failure(
-                    content=str(note.get("content", "")),
-                    tags=current_tags,
-                    stage="tier3",
-                    failure_stage=getattr(exc, "stage", "") or "",
-                    failure_error=str(exc),
-                )
-                note["content"] = advance.new_content
-                current_tags = advance.new_tags
-                if advance.terminal_tag_added:
-                    note["tags"] = list(current_tags)
-                    logger.warning(
-                        "sweep: tier3 marked terminal after %d counted failures for %s",
-                        advance.attempts,
-                        note.get("id", "?"),
-                        extra={
-                            "sweep_stage": "tier3_terminal_flip",
-                            "note_id": note.get("id"),
-                            "profile": profile,
-                            "run_id": current_run_id.get() or "",
-                            "tier3_attempts": advance.attempts,
-                            "exc_type": type(exc).__name__,
-                            "stage": getattr(exc, "stage", None),
-                            "detail": getattr(exc, "detail", None),
-                        },
-                    )
-            _log_stage_failure(
-                "tier3_extraction",
-                note=note,
-                profile=profile,
-                exc=exc,
-            )
+        current_tags = _run_tier_retry(
+            note,
+            profile=profile,
+            current_tags=current_tags,
+            hook=hooks.tier3_extract,
+            stage="tier3",
+            log_subject="tier3_extraction",
+        )
 
     # ── Compute and apply clearing ──────────────────────────────
-    post_archive_path = archive_path
-
     clearing = compute_clearing(
         tags=current_tags,
-        archive_path=post_archive_path,
+        archive_path=archive_path,
         max_profile_score=max_profile_score,
         full_text_threshold=ft_thresh,
         deep_extract_threshold=de_thresh,
     )
-
     if clearing.clear_archive_missing:
         current_tags = [t for t in current_tags if t != "influx:archive-missing"]
     if clearing.clear_repair_needed:
         current_tags = [t for t in current_tags if t != "influx:repair-needed"]
 
-    # Apply rejection guard (FR-NOTE-6, AC-M3-6): ensure the final
-    # tag set preserves influx:rejected:<profile> tags and does NOT
-    # re-add profile:<name> for rejected profiles.
+    # Apply rejection guard (FR-NOTE-6, AC-M3-6): preserve any
+    # influx:rejected:<profile> tags and do NOT re-add profile:<name>
+    # for rejected profiles.
     current_tags = merge_tags(existing_tags=tags, new_tags=current_tags)
 
     # ── Rewrite (§5.4 retry-order advancement) ──────────────────

--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -204,6 +204,30 @@ def _find_tag(tags: list[str], prefix: str) -> str | None:
     return None
 
 
+def _note_tags(note: dict[str, object]) -> list[str]:
+    """Read and cast the note's tag list defensively (Lithos returns ``Any``)."""
+    raw = note.get("tags", [])
+    return list(raw) if isinstance(raw, list) else []
+
+
+def _require_arxiv_source(note: dict[str, object], *, stage_label: str) -> None:
+    """Raise ``ExtractionError(stage="unsupported_source")`` for non-arxiv notes.
+
+    The current sweep-side hooks only know how to retry archive download
+    and text extraction for arxiv notes; other sources surface this
+    sentinel which the sweep classifies as transient (and which
+    :func:`influx.repair._terminate_unsupported_text_source` flips to
+    terminal so the note exits the sweep instead of looping).
+    """
+    source = _find_tag(_note_tags(note), _SOURCE_TAG_PREFIX) or ""
+    if source != "arxiv":
+        raise ExtractionError(
+            f"{stage_label}: source {source!r} not supported",
+            stage="unsupported_source",
+            detail=f"note id={note.get('id', '?')}",
+        )
+
+
 def _parse_year_month_from_note_path(note_path: str) -> tuple[int, int] | None:
     """Pull ``(year, month)`` from a Lithos note path like ``papers/arxiv/2026/04``."""
     m = _NOTE_PATH_RE.search(note_path)
@@ -240,9 +264,7 @@ def _resolve_arxiv_download_args(
     missing fields needed to retry — the sweep treats this as transient
     so an operator hand-fix lands the next pass.
     """
-    raw_tags = note.get("tags", [])
-    tags: list[str] = list(raw_tags) if isinstance(raw_tags, list) else []
-    arxiv_id = _find_tag(tags, _ARXIV_ID_TAG_PREFIX)
+    arxiv_id = _find_tag(_note_tags(note), _ARXIV_ID_TAG_PREFIX)
     if not arxiv_id:
         raise ExtractionError(
             "Cannot retry archive download: no arxiv-id tag on note",
@@ -295,15 +317,7 @@ def _make_archive_download_hook(config: AppConfig) -> ArchiveDownloadHook:
     """
 
     def hook(note: dict[str, object]) -> str:
-        raw_tags = note.get("tags", [])
-        tags: list[str] = list(raw_tags) if isinstance(raw_tags, list) else []
-        source = _find_tag(tags, _SOURCE_TAG_PREFIX) or ""
-        if source != "arxiv":
-            raise ExtractionError(
-                f"archive_download retry: source {source!r} not supported",
-                stage="unsupported_source",
-                detail=f"note id={note.get('id', '?')}",
-            )
+        _require_arxiv_source(note, stage_label="archive_download retry")
 
         kwargs = _resolve_arxiv_download_args(note, config)
         result = download_archive(**kwargs)  # type: ignore[arg-type]
@@ -345,17 +359,9 @@ def _make_text_extraction_hook(config: AppConfig) -> TextExtractionHook:
     """
 
     def hook(note: dict[str, object]) -> str:
-        raw_tags = note.get("tags", [])
-        tags: list[str] = list(raw_tags) if isinstance(raw_tags, list) else []
-        source = _find_tag(tags, _SOURCE_TAG_PREFIX) or ""
-        if source != "arxiv":
-            raise ExtractionError(
-                f"text_extraction retry: source {source!r} not supported",
-                stage="unsupported_source",
-                detail=f"note id={note.get('id', '?')}",
-            )
+        _require_arxiv_source(note, stage_label="text_extraction retry")
 
-        arxiv_id = _find_tag(tags, _ARXIV_ID_TAG_PREFIX)
+        arxiv_id = _find_tag(_note_tags(note), _ARXIV_ID_TAG_PREFIX)
         if not arxiv_id:
             raise ExtractionError(
                 "Cannot retry text extraction: no arxiv-id tag on note",
@@ -430,8 +436,7 @@ def _make_tier2_enrich_hook(config: AppConfig) -> Tier2EnrichHook:
 
     def hook(note: dict[str, object]) -> None:
         content: str = str(note.get("content", ""))
-        raw_tags = note.get("tags", [])
-        tags: list[str] = list(raw_tags) if isinstance(raw_tags, list) else []
+        tags: list[str] = _note_tags(note)
 
         # Find archive path from note content.
         try:
@@ -478,8 +483,7 @@ def _make_tier3_extract_hook(config: AppConfig) -> Tier3ExtractHook:
 
     def hook(note: dict[str, object]) -> None:
         content: str = str(note.get("content", ""))
-        raw_tags = note.get("tags", [])
-        tags: list[str] = list(raw_tags) if isinstance(raw_tags, list) else []
+        tags: list[str] = _note_tags(note)
 
         # Extract full text from note content.
         full_text = _extract_full_text_body(content)


### PR DESCRIPTION
## Summary

Collapses the four near-duplicate retry-stage blocks in
`_process_sweep_note` (archive, text extraction, tier 2, tier 3) onto
shared helpers, and dedupes the smaller patterns in `repair_hooks.py`.

The repair path is one of the highest-risk areas in the codebase for
subtle resilience regressions — a fix to one stage has been easy to
miss in the others.  After this change each stage declares only its
differences and the cross-cutting concerns (metric, span, snapshot,
rollback, counted-failure cap, terminal-tag flip, structured logging)
live in one place.

## What changed

**`src/influx/repair.py`**

- `_stage_attempt(note, *, profile, kind, span_name, sync_tags=...)` —
  context manager that bundles the metric increment, trace span, and
  hook-call snapshot/rollback envelope every counted stage shares.
- `_apply_counted_failure(...)` — the canonical
  classify / bump / log-terminal-flip sequence used after archive,
  tier 2, and tier 3 failures.  Single source of truth for the
  `*_terminal_flip` warning shape.
- `_run_archive_retry`, `_run_text_extraction_retry`, `_run_tier_retry`
  — small per-stage executors that delegate to the helpers above and
  return the new tag list.  Tier 2 and Tier 3 share `_run_tier_retry`
  parameterised on stage name + log subject (the one axis they
  actually differ on).
- `_terminate_unsupported_text_source` — names the inline tag-rewriting
  recovery used when a source has no per-source resolver yet.
- `_attempt_sweep_write` — folds the three repeated
  `_sweep_call_write` + version-conflict resolution blocks in
  `_rewrite_sweep_note` into one helper.
- `_process_sweep_note` itself drops from ~340 lines to ~135 and now
  reads as a linear stage sequence.

**`src/influx/repair_hooks.py`**

- `_note_tags(note)` replaces the four duplicated
  `raw = note.get("tags", []); list(raw) if isinstance(raw, list) else []`
  snippets.
- `_require_arxiv_source(note, *, stage_label)` replaces the duplicated
  source-check block in the archive-download and text-extraction hooks.

## Behaviour

No functional changes.  Structured log fields are preserved exactly:
`archive_terminal_flip` still carries `archive_attempts` + `kind`;
`tier{2,3}_terminal_flip` still carries `tier{2,3}_attempts` + `stage`.
Per-stage failure WARN log subjects (`tier2_enrichment`,
`tier3_extraction`, `text_extraction`, `archive_download`) are
unchanged.

## Test plan

- [x] `uv run pytest tests/unit tests/integration -k repair` — 303 passed
- [x] `uv run ruff check src/influx/repair.py src/influx/repair_hooks.py` — clean
- [x] `uv run mypy src/influx/repair.py src/influx/repair_hooks.py` — no new errors
- [x] Full suite `uv run pytest tests/unit tests/integration` — only pre-existing test-isolation flakes (unrelated `rss_to_lithos` / `otel_spans` tests pass on their own and on `main`)

Closes #107