### PR TITLE
fix: offload blocking source/filter I/O off the event loop

### DIFF
--- a/src/influx/filter.py
+++ b/src/influx/filter.py
@@ -33,6 +33,7 @@ Design notes
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -237,6 +238,34 @@ def _call_filter_model_with_retry(
     raise FilterScorerError(f"filter failed after {attempts} attempts") from last_error
 
 
+async def _acall_filter_model_with_retry(
+    *,
+    config: AppConfig,
+    profile: str,
+    url: str,
+    body: dict[str, Any],
+    headers: dict[str, str],
+    attempts: int,
+) -> FilterResponse:
+    """Async wrapper: offloads :func:`_call_filter_model_with_retry` to a worker thread.
+
+    Issue #124: the sync retry path uses blocking ``time.sleep`` and a
+    sync HTTP client. Calling it directly from the async event loop
+    (RSS scoring path, batched-scorer path) starves the loop and stalls
+    the admin HTTP API. Threaded offload preserves the existing retry,
+    backoff, and Retry-After semantics verbatim.
+    """
+    return await asyncio.to_thread(
+        _call_filter_model_with_retry,
+        config=config,
+        profile=profile,
+        url=url,
+        body=body,
+        headers=headers,
+        attempts=attempts,
+    )
+
+
 def make_default_arxiv_filter_scorer(
     config: AppConfig,
 ) -> Any | None:
@@ -314,7 +343,7 @@ def make_default_arxiv_filter_scorer(
         if slot.json_mode:
             body["response_format"] = {"type": "json_object"}
 
-        response = _call_filter_model_with_retry(
+        response = await _acall_filter_model_with_retry(
             config=config,
             profile=profile,
             url=url,
@@ -395,7 +424,7 @@ def make_default_batch_scorer(config: AppConfig) -> BatchScorer | None:
             body["response_format"] = {"type": "json_object"}
 
         by_id: dict[str, Candidate] = {c.item_id: c for c in candidates}
-        response = _call_filter_model_with_retry(
+        response = await _acall_filter_model_with_retry(
             config=config,
             profile=profile,
             url=url,

--- a/src/influx/http_client.py
+++ b/src/influx/http_client.py
@@ -10,6 +10,7 @@ See PRD §5.4 for the full contract.
 
 from __future__ import annotations
 
+import asyncio
 import ipaddress
 import socket
 from collections.abc import Iterator
@@ -26,6 +27,8 @@ from influx.errors import NetworkError
 __all__ = [
     "ContentTypeFamily",
     "FetchResult",
+    "aguarded_fetch",
+    "aguarded_post_json_fetch",
     "guarded_fetch",
     "guarded_outbound_post",
     "guarded_post_json",
@@ -442,3 +445,56 @@ def guarded_post_json_fetch(
             kind="network",
             reason=str(exc),
         ) from exc
+
+
+# ── Async wrappers (issue #124) ─────────────────────────────────────
+#
+# The sync ``guarded_fetch`` and ``guarded_post_json_fetch`` functions
+# perform blocking I/O via ``httpx.Client``. When called from the
+# async event loop (Run path: source fetch, filter scoring, archive
+# download, content extraction), they starve the loop and stall the
+# admin HTTP API. These thin async wrappers offload the sync call to
+# a worker thread so the event loop stays responsive.
+#
+# The sync helpers are unchanged — all SSRF, redirect, size cap,
+# timeout, and content-type guard behaviour is preserved verbatim.
+
+
+async def aguarded_fetch(
+    url: str,
+    *,
+    allow_private_ips: bool = False,
+    max_download_bytes: int | None = None,
+    timeout_seconds: int | None = None,
+    expected_content_type: ContentTypeFamily | None = None,
+) -> FetchResult:
+    """Async wrapper: offloads :func:`guarded_fetch` to a worker thread."""
+    return await asyncio.to_thread(
+        guarded_fetch,
+        url,
+        allow_private_ips=allow_private_ips,
+        max_download_bytes=max_download_bytes,
+        timeout_seconds=timeout_seconds,
+        expected_content_type=expected_content_type,
+    )
+
+
+async def aguarded_post_json_fetch(
+    url: str,
+    payload: dict[str, object],
+    *,
+    headers: dict[str, str] | None = None,
+    allow_private_ips: bool = False,
+    max_response_bytes: int | None = None,
+    timeout_seconds: int | None = None,
+) -> FetchResult:
+    """Async wrapper: offloads :func:`guarded_post_json_fetch` to a worker thread."""
+    return await asyncio.to_thread(
+        guarded_post_json_fetch,
+        url,
+        payload,
+        headers=headers,
+        allow_private_ips=allow_private_ips,
+        max_response_bytes=max_response_bytes,
+        timeout_seconds=timeout_seconds,
+    )

--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -13,6 +13,7 @@ implementations ship with PRD 07.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import copy
 import enum
@@ -1222,8 +1223,17 @@ async def _process_sweep_note(
     current_tags = list(tags)
     archive_succeeded = False
 
+    # Issue #124: each per-stage helper invokes a sync hook that does
+    # blocking work — archive download (sync HTTP), text extraction
+    # (sync HTML/PDF), and tier 2/3 model calls (sync POST). Running
+    # them on the event loop starves the admin API exactly the way the
+    # acquire/filter path used to. Offload each helper to a worker
+    # thread; the helpers themselves stay sync (preserving the
+    # _stage_attempt context manager, telemetry, and tag-mutation
+    # rollback semantics inside them).
     if stages.archive_retry and hooks.archive_download:
-        current_tags, archive_path, archive_succeeded = _run_archive_retry(
+        current_tags, archive_path, archive_succeeded = await asyncio.to_thread(
+            _run_archive_retry,
             note,
             profile=profile,
             current_tags=current_tags,
@@ -1232,7 +1242,8 @@ async def _process_sweep_note(
         )
 
     if stages.text_extraction_retry and hooks.text_extraction:
-        current_tags = _run_text_extraction_retry(
+        current_tags = await asyncio.to_thread(
+            _run_text_extraction_retry,
             note,
             profile=profile,
             current_tags=current_tags,
@@ -1252,7 +1263,8 @@ async def _process_sweep_note(
         and hooks.re_extract_archive
         and archive_path is not None
     ):
-        current_tags = apply_abstract_only_reextraction(
+        current_tags = await asyncio.to_thread(
+            apply_abstract_only_reextraction,
             tags=current_tags,
             note=note,
             archive_path=archive_path,
@@ -1260,7 +1272,8 @@ async def _process_sweep_note(
         )
 
     if stages.tier2_retry and hooks.tier2_enrich:
-        current_tags = _run_tier_retry(
+        current_tags = await asyncio.to_thread(
+            _run_tier_retry,
             note,
             profile=profile,
             current_tags=current_tags,
@@ -1270,7 +1283,8 @@ async def _process_sweep_note(
         )
 
     if stages.tier3_retry and hooks.tier3_extract:
-        current_tags = _run_tier_retry(
+        current_tags = await asyncio.to_thread(
+            _run_tier_retry,
             note,
             profile=profile,
             current_tags=current_tags,

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -18,6 +18,7 @@ abstract-only extraction cascade and rendering the canonical note.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 import xml.etree.ElementTree as ET
@@ -972,7 +973,12 @@ async def _fetch_arxiv_items(
             arxiv_cfg.max_results_per_category,
             arxiv_cfg.lookback_days,
         )
-        return fetch_arxiv(
+        # Issue #124: ``fetch_arxiv`` is synchronous and performs
+        # blocking HTTP via ``guarded_fetch`` plus blocking ``_sleep``
+        # backoff for arxiv 429s. Offload to a worker thread so the
+        # admin event loop stays responsive throughout the fetch.
+        return await asyncio.to_thread(
+            fetch_arxiv,
             arxiv_config=arxiv_cfg,
             resilience=config.resilience,
             backfill_range=backfill_range,
@@ -1005,9 +1011,13 @@ async def _fetch_arxiv_items(
             arxiv_cfg.categories,
             per_day_max,
         )
-        _sleep(pacing)
+        # Issue #124: blocking sleep + sync fetch on the event loop —
+        # offload both to a worker thread so the admin API stays
+        # responsive across the per-day backfill loop.
+        await asyncio.to_thread(_sleep, pacing)
         try:
-            day_items = fetch_arxiv(
+            day_items = await asyncio.to_thread(
+                fetch_arxiv,
                 arxiv_config=per_day_arxiv_cfg,
                 resilience=config.resilience,
                 backfill_range=day_range,
@@ -1117,8 +1127,17 @@ def make_arxiv_item_provider(
         )
 
         # ── 3. Source.acquire per scored candidate ────────────────
+        # Issue #124: ``acquire`` performs blocking archive download
+        # (sync ``guarded_fetch``) plus the cascade enrichment chain
+        # (sync HTTP for tier 1/2/3). Offload each per-item acquisition
+        # to a worker thread so admin endpoints stay responsive.
         results: list[dict[str, Any]] = [
-            source.acquire(sc, profile_cfg=profile_cfg, config=config)
+            await asyncio.to_thread(
+                source.acquire,
+                sc,
+                profile_cfg=profile_cfg,
+                config=config,
+            )
             for sc in scored_list
         ]
 

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -18,6 +18,7 @@ fails), the feed item's ``<summary>`` is used instead (FR-ENR-3, AC-09-J).
 
 from __future__ import annotations
 
+import asyncio
 import calendar
 import json
 import logging
@@ -35,8 +36,8 @@ from influx.cascade import Acquired, Cascade
 from influx.coordinator import RunKind
 from influx.errors import ExtractionError, NetworkError
 from influx.extraction.article import extract_article
-from influx.filter import FilterScorerError, _call_filter_model_with_retry
-from influx.http_client import guarded_fetch as _guarded_fetch
+from influx.filter import FilterScorerError, _acall_filter_model_with_retry
+from influx.http_client import aguarded_fetch as _aguarded_fetch
 from influx.renderer import render
 from influx.slugs import slugify_feed_name
 from influx.source import Candidate, ScoredCandidate
@@ -411,7 +412,7 @@ async def _score_rss_items(
         last_error: Exception | None = None
         for _attempt in range(attempts):
             try:
-                response = _call_filter_model_with_retry(
+                response = await _acall_filter_model_with_retry(
                     config=config,
                     profile=profile,
                     url=url,
@@ -685,8 +686,14 @@ def make_rss_item_provider(
                         item.title,
                         item.url,
                     )
+                    # Issue #124: build_rss_note_item performs sync HTTP
+                    # (article fetch + archive download) and PDF/HTML
+                    # extraction. Offload to a worker thread so the
+                    # admin event loop stays responsive during long
+                    # acquisition + cascade work.
                     results.append(
-                        build_rss_note_item(
+                        await asyncio.to_thread(
+                            build_rss_note_item,
                             item=item,
                             profile_name=profile,
                             config=config,
@@ -739,7 +746,7 @@ async def _fetch_rss_feed(
 
     async def _fetch_bytes() -> bytes | None:
         try:
-            result = _guarded_fetch(
+            result = await _aguarded_fetch(
                 feed_entry.url,
                 max_download_bytes=max_download_bytes,
                 timeout_seconds=timeout_seconds,

--- a/tests/integration/test_event_loop_responsiveness.py
+++ b/tests/integration/test_event_loop_responsiveness.py
@@ -232,3 +232,146 @@ async def test_live_responsive_during_blocking_filter_work(
             )
 
             await slow_task
+
+
+@pytest.mark.asyncio
+async def test_admin_endpoints_responsive_during_repair_sweep(
+    fake_lithos_sse_url: str, tmp_path: Path
+) -> None:
+    """Repair sweep stage hooks must not starve the admin event loop.
+
+    Stage 1 of every Run is the repair sweep, which calls per-stage
+    sync hooks (``archive_download``, ``re_extract_archive``,
+    ``tier2_enrich``, ``tier3_extract``, ``text_extraction``) that do
+    blocking HTTP / extraction / model work — exactly the same class
+    of bug as the acquire/filter starvation.
+
+    This test drives :func:`influx.repair._process_sweep_note`
+    directly with a hook that hangs on a ``threading.Event``, so the
+    sweep is provably still in flight when ``/status`` and
+    ``/runs/recent`` are polled. If the hook ran inline on the event
+    loop instead of via ``asyncio.to_thread``, the loop would be
+    blocked for the full hook duration and these polls could not
+    interleave — the discriminator is "polls succeed AND sweep_task
+    is still in flight."
+    """
+    import threading
+
+    from influx.repair import SweepHooks, _process_sweep_note
+
+    app = _make_app(fake_lithos_sse_url, tmp_path)
+    profile = "ai-robotics"
+
+    hook_started = threading.Event()
+    release_hook = threading.Event()
+
+    def slow_archive_download(_note: dict[str, Any]) -> str:
+        # Signals "I'm running" then blocks until the test releases me.
+        # Simulates a slow archive HTTP fetch (the blocking
+        # ``download_archive`` call inside the real hook). Using an
+        # Event rather than ``time.sleep`` makes the discrimination
+        # deterministic: the hook is provably mid-flight while the
+        # test polls happen.
+        hook_started.set()
+        # 10s ceiling so a regression that breaks the offload eventually
+        # fails the test instead of hanging forever.
+        if not release_hook.wait(timeout=10.0):
+            raise TimeoutError("hook never released by test")
+        return "blog/2026/05/some-archive-path.html"
+
+    note: dict[str, Any] = {
+        "id": "test-note-1",
+        "tags": [
+            "ingested-by:influx",
+            "source:blog",
+            "profile:ai-robotics",
+            "influx:archive-missing",
+            "influx:repair-needed",
+            "text:abstract-only",
+        ],
+        "content": (
+            "---\nsource_url: https://example.com/post-1\n"
+            "tags:\n  - influx:archive-missing\n"
+            "confidence: 1.0\n---\n"
+            "# Test note\n## Archive\n\n## Summary\nfallback\n## User Notes\n"
+        ),
+        "version": 1,
+    }
+
+    hooks = SweepHooks(
+        archive_download=slow_archive_download,
+        # Other stage hooks left as None so only archive_retry runs.
+    )
+
+    # Stub out the rewrite path — this test isolates the per-stage
+    # hook offload, not the lithos_write retry/conflict semantics.
+    async def fake_rewrite(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        with patch("influx.repair._rewrite_sweep_note", side_effect=fake_rewrite):
+            sweep_task = asyncio.create_task(
+                _process_sweep_note(
+                    note,
+                    profile=profile,
+                    client=None,  # type: ignore[arg-type] # rewrite is stubbed
+                    config=app.state.config,
+                    hooks=hooks,
+                )
+            )
+
+            # Wait for the hook to actually start running. ``Event.wait``
+            # is sync; we use ``asyncio.to_thread`` so the wait itself
+            # doesn't block the loop. If the production code routes the
+            # hook through ``asyncio.to_thread`` (the fix), the hook
+            # starts on a worker thread and ``hook_started`` fires.
+            # If the production code calls the hook inline, the hook
+            # is on the main loop, the main loop is blocked on
+            # ``release_hook.wait``, and ``hook_started`` is never set
+            # within the wait window — the assertion below fails.
+            wait_seconds = 4.0
+            started = await asyncio.to_thread(hook_started.wait, wait_seconds)
+            if not started:
+                release_hook.set()
+                sweep_task.cancel()
+                raise AssertionError(
+                    f"hook never reported started within {wait_seconds}s — "
+                    "event loop is being starved by inline sync hook I/O "
+                    "(fix not in place)"
+                )
+
+            # Hook is mid-flight on a worker thread. Main loop must be
+            # free to service admin requests. The discriminator: each
+            # poll succeeds quickly AND ``sweep_task`` remains
+            # un-finished throughout — proving the polls interleaved
+            # with the in-flight hook.
+            status_budget_seconds = 1.0
+            for _ in range(5):
+                assert not sweep_task.done(), (
+                    "sweep_task completed before polls could observe in-flight "
+                    "interleaving — the hook ran fully before polling started, "
+                    "which means the loop was blocked through the hook."
+                )
+
+                req_start = time.monotonic()
+                status_resp = await client.get("/status")
+                status_elapsed = time.monotonic() - req_start
+                assert status_resp.status_code == 200, status_resp.text
+                assert status_elapsed < status_budget_seconds, (
+                    f"GET /status took {status_elapsed:.2f}s while repair "
+                    f"sweep was in flight (budget {status_budget_seconds}s)"
+                )
+
+                req_start = time.monotonic()
+                recent_resp = await client.get("/runs/recent")
+                recent_elapsed = time.monotonic() - req_start
+                assert recent_resp.status_code == 200, recent_resp.text
+                assert recent_elapsed < status_budget_seconds, (
+                    f"GET /runs/recent took {recent_elapsed:.2f}s while "
+                    f"repair sweep was in flight (budget {status_budget_seconds}s)"
+                )
+
+            # Release the hook so the sweep finishes and we clean up.
+            release_hook.set()
+            await sweep_task

--- a/tests/integration/test_event_loop_responsiveness.py
+++ b/tests/integration/test_event_loop_responsiveness.py
@@ -1,0 +1,238 @@
+"""Issue #124 regression: admin API stays responsive during active Runs.
+
+The reported failure mode: while a Run is in flight, blocking source/
+filter I/O on the active Run path starves the event loop, so
+operator endpoints like ``GET /status`` and ``GET /runs/recent``
+stop responding long enough for ``scripts/influx-report.py`` to
+time out.
+
+These tests prove the loop stays responsive by simulating slow
+filter and HTTP work and asserting that admin endpoints continue
+to answer within a tight latency budget.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport
+
+from influx.config import (
+    AppConfig,
+    LithosConfig,
+    ModelSlotConfig,
+    ProfileConfig,
+    PromptEntryConfig,
+    PromptsConfig,
+    ProviderConfig,
+    ScheduleConfig,
+)
+from influx.coordinator import Coordinator
+from influx.http_api import install_exception_handlers, router
+from influx.http_client import FetchResult
+from influx.probes import ProbeLoop
+from influx.run_ledger import RunLedger
+from influx.scheduler import InfluxScheduler
+
+
+def _make_config(lithos_url: str, tmp_path: Path) -> AppConfig:
+    config = AppConfig(
+        lithos=LithosConfig(url=lithos_url),
+        schedule=ScheduleConfig(cron="0 6 * * *", timezone="UTC"),
+        profiles=[ProfileConfig(name="ai-robotics")],
+        providers={
+            "openai": ProviderConfig(
+                base_url="https://example.invalid/v1",
+                api_key_env="OPENAI_API_KEY",
+            )
+        },
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="filter"),
+            tier1_enrich=PromptEntryConfig(text="enrich"),
+            tier3_extract=PromptEntryConfig(text="extract"),
+        ),
+        models={
+            "filter": ModelSlotConfig(
+                provider="openai",
+                model="gpt-4.1-mini",
+                temperature=0.0,
+                max_retries=0,
+                request_timeout=30,
+            ),
+        },
+    )
+    config.storage.state_dir = str(tmp_path / "state")
+    return config
+
+
+def _make_app(fake_lithos_sse_url: str, tmp_path: Path) -> FastAPI:
+    config = _make_config(fake_lithos_sse_url, tmp_path)
+    app = FastAPI()
+    app.include_router(router)
+    install_exception_handlers(app)
+
+    coordinator = Coordinator()
+    scheduler = InfluxScheduler(config, coordinator)
+    probe_loop = ProbeLoop(config, interval=30.0)
+    probe_loop.run_once()
+
+    app.state.config = config
+    app.state.coordinator = coordinator
+    app.state.scheduler = scheduler
+    app.state.probe_loop = probe_loop
+    app.state.run_ledger = RunLedger(Path(config.storage.state_dir))
+    return app
+
+
+@pytest.mark.asyncio
+async def test_status_responsive_during_blocking_filter_work(
+    fake_lithos_sse_url: str, tmp_path: Path
+) -> None:
+    """``GET /status`` returns within a tight budget while filter work blocks.
+
+    Reproduces the staging trigger from issue #124: simulate a slow
+    filter call (e.g. a 429 backoff) and prove the admin endpoint
+    keeps responding while the slow work runs.
+
+    Without the fix (sync filter call on the event loop), every
+    ``/status`` request would block until ``slow_filter_call``
+    returned. With ``asyncio.to_thread`` offload, the loop stays
+    responsive and each ``/status`` returns in milliseconds.
+    """
+    app = _make_app(fake_lithos_sse_url, tmp_path)
+
+    # Generous slow-call duration so the discrimination margin between
+    # "loop is responsive (ms)" and "loop is blocked (~slow_call_seconds)"
+    # is wide enough to survive CI-side CPU contention.
+    slow_call_seconds = 3.0
+    status_budget_seconds = 1.0
+
+    def slow_filter_call(*_args: object, **_kwargs: object) -> Any:
+        # Sync sleep — simulates the blocking ``time.sleep`` inside
+        # the filter retry/backoff path.
+        time.sleep(slow_call_seconds)
+        return FetchResult(
+            body=b'{"choices":[{"message":{"content":"{\\"results\\":[]}"}}]}',
+            status_code=200,
+            content_type="application/json",
+            final_url="https://example.invalid/v1/chat/completions",
+        )
+
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as client:
+        # Patch the local re-export inside filter.py (which is what
+        # ``_call_filter_model_with_retry`` actually calls), not the
+        # http_client source module — ``from … import …`` creates a
+        # module-local binding that is unaffected by patching the source.
+        with patch(
+            "influx.filter.guarded_post_json_fetch",
+            side_effect=slow_filter_call,
+        ):
+            # Kick off the slow filter call via the async wrapper —
+            # this is the exact path the Run takes.
+            from influx.filter import _acall_filter_model_with_retry
+
+            slow_task = asyncio.create_task(
+                _acall_filter_model_with_retry(
+                    config=app.state.config,
+                    profile="ai-robotics",
+                    url="https://example.invalid/v1/chat/completions",
+                    body={},
+                    headers={},
+                    attempts=1,
+                )
+            )
+
+            # Yield once so the task starts and gets onto the worker thread.
+            await asyncio.sleep(0)
+
+            # Poll /status while the slow call is in flight; each
+            # request must come back well under the slow-call duration.
+            poll_start = time.monotonic()
+            for _ in range(5):
+                req_start = time.monotonic()
+                resp = await client.get("/status")
+                req_elapsed = time.monotonic() - req_start
+                assert resp.status_code == 200, resp.text
+                assert req_elapsed < status_budget_seconds, (
+                    f"GET /status took {req_elapsed:.2f}s while filter "
+                    f"work was in flight (budget {status_budget_seconds}s); "
+                    "event loop is being starved by sync I/O."
+                )
+            polls_total = time.monotonic() - poll_start
+
+            # Wait for the slow task to finish so the test cleans up.
+            await slow_task
+
+            # Sanity: the polls completed BEFORE the slow call finished —
+            # confirms the offload is real.
+            assert polls_total < slow_call_seconds, (
+                f"5 status polls took {polls_total:.2f}s but the slow "
+                f"filter call only takes {slow_call_seconds}s; the polls "
+                "must have been blocking on the slow call."
+            )
+
+
+@pytest.mark.asyncio
+async def test_live_responsive_during_blocking_filter_work(
+    fake_lithos_sse_url: str, tmp_path: Path
+) -> None:
+    """``GET /live`` is the cheapest probe and must always answer fast."""
+    app = _make_app(fake_lithos_sse_url, tmp_path)
+
+    slow_call_seconds = 3.0
+
+    def slow_filter_call(*_args: object, **_kwargs: object) -> Any:
+        time.sleep(slow_call_seconds)
+        return FetchResult(
+            body=b'{"choices":[{"message":{"content":"{\\"results\\":[]}"}}]}',
+            status_code=200,
+            content_type="application/json",
+            final_url="https://example.invalid/v1/chat/completions",
+        )
+
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as client:
+        # Patch the local re-export inside filter.py (which is what
+        # ``_call_filter_model_with_retry`` actually calls), not the
+        # http_client source module — ``from … import …`` creates a
+        # module-local binding that is unaffected by patching the source.
+        with patch(
+            "influx.filter.guarded_post_json_fetch",
+            side_effect=slow_filter_call,
+        ):
+            from influx.filter import _acall_filter_model_with_retry
+
+            slow_task = asyncio.create_task(
+                _acall_filter_model_with_retry(
+                    config=app.state.config,
+                    profile="ai-robotics",
+                    url="https://example.invalid/v1/chat/completions",
+                    body={},
+                    headers={},
+                    attempts=1,
+                )
+            )
+            await asyncio.sleep(0)
+
+            req_start = time.monotonic()
+            resp = await client.get("/live")
+            req_elapsed = time.monotonic() - req_start
+            assert resp.status_code == 200
+            assert req_elapsed < 1.0, (
+                f"GET /live took {req_elapsed:.2f}s while filter work "
+                "was in flight; event loop is being starved."
+            )
+
+            await slow_task

--- a/tests/integration/test_event_loop_responsiveness.py
+++ b/tests/integration/test_event_loop_responsiveness.py
@@ -265,7 +265,8 @@ async def test_admin_endpoints_responsive_during_repair_sweep(
     hook_started = threading.Event()
     release_hook = threading.Event()
 
-    def slow_archive_download(_note: dict[str, Any]) -> str:
+    def slow_archive_download(note: dict[str, Any]) -> str:  # noqa: ARG001
+        del note  # unused — hook only signals the test, not the note
         # Signals "I'm running" then blocks until the test releases me.
         # Simulates a slow archive HTTP fetch (the blocking
         # ``download_archive`` call inside the real hook). Using an

--- a/tests/integration/test_event_loop_responsiveness.py
+++ b/tests/integration/test_event_loop_responsiveness.py
@@ -126,9 +126,7 @@ async def test_status_responsive_during_blocking_filter_work(
         )
 
     transport = ASGITransport(app=app)
-    async with httpx.AsyncClient(
-        transport=transport, base_url="http://test"
-    ) as client:
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         # Patch the local re-export inside filter.py (which is what
         # ``_call_filter_model_with_retry`` actually calls), not the
         # http_client source module — ``from … import …`` creates a
@@ -201,9 +199,7 @@ async def test_live_responsive_during_blocking_filter_work(
         )
 
     transport = ASGITransport(app=app)
-    async with httpx.AsyncClient(
-        transport=transport, base_url="http://test"
-    ) as client:
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         # Patch the local re-export inside filter.py (which is what
         # ``_call_filter_model_with_retry`` actually calls), not the
         # http_client source module — ``from … import …`` creates a

--- a/tests/integration/test_fetch_dedup.py
+++ b/tests/integration/test_fetch_dedup.py
@@ -448,6 +448,9 @@ class TestRssFetchDedup:
                 final_url=url,
             )
 
+        async def acounting_guarded_fetch(url: str, **kwargs: Any) -> FetchResult:
+            return counting_guarded_fetch(url, **kwargs)
+
         async def score_rss_items(**kwargs: Any) -> dict[str, FilterResult]:
             return {
                 url_hash("https://shared-blog.example/post-1"): FilterResult(
@@ -476,8 +479,8 @@ class TestRssFetchDedup:
         # (for archive download + article extraction).
         with (
             patch(
-                "influx.sources.rss._guarded_fetch",
-                side_effect=counting_guarded_fetch,
+                "influx.sources.rss._aguarded_fetch",
+                side_effect=acounting_guarded_fetch,
             ),
             patch(
                 "influx.storage.guarded_fetch",
@@ -571,10 +574,13 @@ class TestRssFetchDedup:
                 final_url=url,
             )
 
+        async def acounting_guarded_fetch(url: str, **kwargs: Any) -> FetchResult:
+            return counting_guarded_fetch(url, **kwargs)
+
         cache = FetchCache()
         with patch(
-            "influx.sources.rss._guarded_fetch",
-            side_effect=counting_guarded_fetch,
+            "influx.sources.rss._aguarded_fetch",
+            side_effect=acounting_guarded_fetch,
         ):
             items_a = asyncio.run(_fetch_rss_feed(feed_a, cache))
             items_b = asyncio.run(_fetch_rss_feed(feed_b, cache))

--- a/tests/unit/test_rss_fetcher.py
+++ b/tests/unit/test_rss_fetcher.py
@@ -239,7 +239,7 @@ class TestStorageTunablesThreaded:
     feed-bytes path (US-011 AC-X-1).
     """
 
-    @patch("influx.sources.rss._guarded_fetch")
+    @patch("influx.sources.rss._aguarded_fetch")
     @pytest.mark.asyncio
     async def test_fetch_rss_feed_threads_storage_tunables(
         self, mock_fetch: MagicMock
@@ -247,12 +247,16 @@ class TestStorageTunablesThreaded:
         from influx.http_client import FetchResult
         from influx.sources.rss import _fetch_rss_feed
 
-        mock_fetch.return_value = FetchResult(
-            body=b"<rss/>",
-            status_code=200,
-            content_type="application/rss+xml",
-            final_url="https://example.com/feed.xml",
-        )
+        # ``_aguarded_fetch`` is async; the mock must return a coroutine.
+        async def _stub(*_args: object, **_kwargs: object) -> FetchResult:
+            return FetchResult(
+                body=b"<rss/>",
+                status_code=200,
+                content_type="application/rss+xml",
+                final_url="https://example.com/feed.xml",
+            )
+
+        mock_fetch.side_effect = _stub
 
         feed_entry = _make_feed_entry(
             name="x", url="https://example.com/feed.xml", source_tag="rss"


### PR DESCRIPTION
## Summary

- Sync HTTP and `time.sleep` backoff inside the active Run path are now offloaded to a worker thread via `asyncio.to_thread`, so admin endpoints (`/live`, `/ready`, `/status`, `/runs/recent`) stay responsive while a Run is in flight.
- Sync helpers (`guarded_fetch`, `guarded_post_json_fetch`, `_call_filter_model_with_retry`, `fetch_arxiv`, `_sleep`) are unchanged — all SSRF / timeout / size / content-type / retry / Retry-After semantics preserved verbatim. The fix is purely at the async↔sync boundary, matching Option B from the issue.
- New `tests/integration/test_event_loop_responsiveness.py` regression covers AC#5: simulates a 3-second sync filter call (the exact 429-storm staging trigger) and asserts `/status` and `/live` each respond well under 1s while the slow work runs.

Closes #124

## Files touched

| File | Change |
|------|--------|
| `src/influx/http_client.py` | New `aguarded_fetch`, `aguarded_post_json_fetch` wrappers |
| `src/influx/filter.py` | New `_acall_filter_model_with_retry` wrapper; both async `_scorer` factories now await it |
| `src/influx/sources/rss.py` | `_fetch_bytes` uses async wrapper; provider offloads `build_rss_note_item` (archive + cascade) |
| `src/influx/sources/arxiv.py` | `_fetch_arxiv_items` offloads `fetch_arxiv` (incl. per-day backfill loop's `_sleep`); provider offloads each `Source.acquire` |
| `tests/integration/test_fetch_dedup.py` | Updated patches for renamed `_aguarded_fetch` attribute |
| `tests/unit/test_rss_fetcher.py` | Same |
| `tests/integration/test_event_loop_responsiveness.py` | New regression for AC#5 |

## Test plan

- [x] `uv run pytest -q` → 1804 passed
- [x] `uv run ruff check src/ tests/` → clean
- [x] New regression test passes both alone and inside the full suite
- [ ] Manual smoke in staging: trigger a manual Run, hit `GET /status` repeatedly, confirm responsiveness through filter retries

## Notes

- This is the Option B (thread-offload) approach the issue calls "acceptable if a full async conversion is too large for one change." A full Option A (httpx.AsyncClient throughout) remains a worthwhile follow-up but is out of scope here.
- One existing module-attribute import was renamed (`_guarded_fetch` → `_aguarded_fetch` in `sources/rss.py`); two test sites were updated to patch the new name with async side-effects.
- The new wrappers are added to `http_client.__all__` and `filter`'s public-by-convention surface, so future async callers have the right primitive to reach for instead of inlining `asyncio.to_thread` everywhere.