### PR TITLE
fix: add source_url fallback to pre-write dedup (#128)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -103,7 +103,7 @@ _Avoid_: probes (one input to Health), readiness (one output of Health).
 - A **Profile** has many **Runs** over time; at most one Run per Profile is active at once (enforced by the **Coordinator**).
 - A **Run** consumes a **RunPlan** and produces a **RunOutcome**; its history lives in the **RunLedger**.
 - A **Run**'s Acquire stage walks: **Source**.fetch_candidates → **Filter** → **Source**.acquire → **Acquired**.
-- A **Run**'s Ingest stage walks: cache_lookup → **Cascade**.enrich → **Renderer** → **LithosClient**.write_note → **LcmaWiring**.wire.
+- A **Run**'s Ingest stage walks: cache_lookup → **Cascade**.enrich → **Renderer** → **LithosClient**.write_note → **LcmaWiring**.wire. The cache_lookup step is two-stage: a primary `compose_dedup_query` lookup (title + first sentence of summary) followed, on miss, by a defensive exact-`source_url` fallback (#128). Either hit is treated as a cache hit for the rest of the per-item flow — so notes already present under the same URL never silently fall through to a write-time `duplicate` rejection.
 - A **Cascade** consults **RepairCounters** before each tier and after counted failures.
 - A **LithosClient** owns **WriteResult** parsing and **Squatter-shape dispatch** internally.
 - **Health** latches are flipped by Run stages and read by the scheduler before starting a new Run.

--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -657,6 +657,30 @@ class LithosClient:
         query = compose_dedup_query(title, abstract_or_summary)
         return await self.cache_lookup(query=query, source_url=source_url)
 
+    async def cache_lookup_by_url_body(
+        self,
+        *,
+        source_url: str,
+    ) -> dict[str, Any]:
+        """Source-URL-only cache lookup (issue #128).
+
+        Sends ``query=source_url`` so the Lithos server matches on
+        the exact URL.  Used as a defensive fallback after the primary
+        title-based dedup query misses, and as the canonical chokepoint
+        for any caller that needs to ask "do you have a note for this
+        exact source_url?" (e.g. ``content_too_large`` recovery).
+
+        Raises ``LithosError("missing_lookup_arg")`` before any RPC
+        when *source_url* is empty.
+        """
+        if not source_url:
+            raise LithosError(
+                "missing_lookup_arg",
+                operation="cache_lookup",
+                detail="source_url is required",
+            )
+        return await self.cache_lookup_body(query=source_url, source_url=source_url)
+
     async def cache_lookup_for_item_body(
         self,
         *,
@@ -954,17 +978,12 @@ class LithosClient:
     async def _check_existing_note(self, source_url: str) -> dict[str, Any] | None:
         """Check whether an Influx-authored note exists for *source_url*.
 
-        Uses ``lithos_cache_lookup`` with the source URL.  Returns the
-        existing note dict if found, ``None`` otherwise.  The detection
-        mechanism is a cache lookup by ``source_url`` — implementation-
-        defined per AC of US-010.
+        Thin wrapper over :meth:`cache_lookup_by_url_body`: returns the
+        decoded body when ``hit`` is true, ``None`` otherwise.  The
+        detection mechanism is a cache lookup by ``source_url`` —
+        implementation-defined per AC of US-010.
         """
-        result = await self.call_tool(
-            "lithos_cache_lookup",
-            {"query": source_url, "source_url": source_url},
-        )
-        text = result.content[0].text  # type: ignore[union-attr]
-        body = json.loads(text)
+        body = await self.cache_lookup_by_url_body(source_url=source_url)
         if body.get("hit"):
             return body
         return None

--- a/src/influx/metrics.py
+++ b/src/influx/metrics.py
@@ -38,6 +38,7 @@ __all__ = [
     "articles_filtered",
     "articles_inspected",
     "cache_hits",
+    "cache_hits_via_url_fallback",
     "candidates_fetched",
     "lithos_writes",
     "llm_validation_failures",
@@ -163,6 +164,28 @@ def cache_hits() -> Any:
     return get_meter().counter(
         "influx_cache_hits_total",
         description="Lithos cache hits during the scheduler write loop.",
+    )
+
+
+def cache_hits_via_url_fallback() -> Any:
+    """Counter of pre-write dedup cache hits resolved by source-URL fallback (#128).
+
+    Increments when the primary ``compose_dedup_query``-based cache
+    lookup misses but a follow-up exact-``source_url`` lookup hits —
+    i.e. a note for the same URL is already in Lithos but its title
+    or first-sentence abstract drifted enough for the text query to
+    miss.  Sustained non-zero in steady state indicates either Lithos
+    server-side dedup needs strengthening or upstream feeds are
+    rewriting titles/summaries between runs.
+
+    Labels: ``profile``, ``source``.
+    """
+    return get_meter().counter(
+        "influx_cache_hits_via_url_fallback_total",
+        description=(
+            "pre-write dedup cache hits that required a source_url "
+            "fallback lookup after the primary title-based query missed"
+        ),
     )
 
 

--- a/src/influx/run.py
+++ b/src/influx/run.py
@@ -474,19 +474,46 @@ async def _run_ingest_stage(
             abstract_or_summary=item.get("abstract_or_summary"),
         )
         cache_hit = bool(cache_body.get("hit"))
+        cache_hit_reason: str | None = "primary" if cache_hit else None
+
+        # #128: defensive source_url-only fallback when the primary
+        # title+abstract dedup misses.  Catches notes whose source_url
+        # is already in Lithos but whose title/first-sentence abstract
+        # drifted between runs (translation, punctuation, profile-
+        # specific summary edits) — those used to fall through to
+        # ``write_note`` and be rejected as ``duplicate`` at write time.
+        if not cache_hit and source_url:
+            fallback_body = await client.cache_lookup_by_url_body(source_url=source_url)
+            if bool(fallback_body.get("hit")):
+                cache_hit = True
+                cache_hit_reason = "source_url_fallback"
+                metrics.cache_hits_via_url_fallback().add(
+                    1, {"profile": profile, "source": item_source}
+                )
+
         if cache_hit:
             metrics.cache_hits().add(1, {"profile": profile, "source": item_source})
             logger.info(
-                "article cache hit profile=%s source_url=%s title=%r kind=%s action=%s",
+                "article cache hit profile=%s source_url=%s title=%r "
+                "kind=%s action=%s reason=%s",
                 profile,
                 source_url,
                 title,
                 plan.kind.value,
                 "skip" if plan.skip_cache_hits else "merge-profile",
+                cache_hit_reason,
             )
             if plan.skip_cache_hits:
                 continue
             # Multi-profile merge — fall through to write path.
+        else:
+            logger.info(
+                "article cache miss profile=%s source_url=%s title=%r kind=%s",
+                profile,
+                source_url,
+                title,
+                plan.kind.value,
+            )
 
         with tracer.span(
             "influx.lithos.write",
@@ -515,13 +542,15 @@ async def _run_ingest_stage(
         if write_result.status in ("created", "updated"):
             logger.info(
                 "article write completed profile=%s source_url=%s "
-                "title=%r status=%s note_id=%s cache_hit=%s",
+                "title=%r status=%s note_id=%s cache_hit=%s "
+                "cache_hit_reason=%s",
                 profile,
                 source_url,
                 title,
                 write_result.status,
                 write_result.note_id,
                 str(cache_hit).lower(),
+                cache_hit_reason or "none",
             )
             try:
                 related_in_lithos = await lcma_wire(
@@ -559,7 +588,7 @@ async def _run_ingest_stage(
         elif not cache_hit:
             logger.warning(
                 "article write skipped profile=%s source_url=%s title=%r "
-                "status=%s detail=%r cache_hit=false",
+                "status=%s detail=%r cache_hit=false cache_hit_reason=none",
                 profile,
                 source_url,
                 title,
@@ -574,6 +603,7 @@ async def _run_ingest_stage(
                     "run_id": current_run_id.get() or "",
                     "tags": list(item.get("tags", [])),
                     "cache_hit": False,
+                    "cache_hit_reason": "none",
                 },
             )
             if write_result.status == "slug_collision":

--- a/tests/contract/test_lithos_client.py
+++ b/tests/contract/test_lithos_client.py
@@ -607,6 +607,70 @@ class TestCacheLookupChokepoint:
             await client.close()
 
 
+# ── Source-URL cache lookup chokepoint (#128) ─────────────────────
+
+
+class TestCacheLookupByUrlBody:
+    """``cache_lookup_by_url_body`` is the canonical URL-only chokepoint (#128)."""
+
+    async def test_empty_source_url_raises_before_rpc(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+    ) -> None:
+        """Empty source_url raises LithosError; zero RPCs sent."""
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            with pytest.raises(LithosError, match="missing_lookup_arg"):
+                await client.cache_lookup_by_url_body(source_url="")
+            lookup_calls = [
+                c for c in fake_lithos_server.calls if c[0] == "lithos_cache_lookup"
+            ]
+            assert len(lookup_calls) == 0
+        finally:
+            await client.close()
+
+    async def test_sends_url_as_both_query_and_source_url(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+    ) -> None:
+        """The URL is forwarded as both query and source_url for exact match."""
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            url = "https://arxiv.org/abs/1706.03762"
+            fake_lithos_server.cache_lookup_responses.append(
+                '{"hit": true, "stale_exists": false}'
+            )
+            body = await client.cache_lookup_by_url_body(source_url=url)
+            assert body == {"hit": True, "stale_exists": False}
+            lookup_calls = [
+                c for c in fake_lithos_server.calls if c[0] == "lithos_cache_lookup"
+            ]
+            assert len(lookup_calls) == 1
+            assert lookup_calls[0][1] == {"query": url, "source_url": url}
+        finally:
+            await client.close()
+
+    async def test_decodes_miss_body_unchanged(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+    ) -> None:
+        """A miss response is decoded verbatim (no hit-only filtering)."""
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            body = await client.cache_lookup_by_url_body(
+                source_url="https://example.com/missing"
+            )
+            assert body == {"hit": False, "stale_exists": False}
+        finally:
+            await client.close()
+
+
 # ── List wrapper (FR-MCP-5) ────────────────────────────────────────
 
 

--- a/tests/integration/test_backfill_arxiv.py
+++ b/tests/integration/test_backfill_arxiv.py
@@ -270,8 +270,12 @@ class TestBackfillCacheLookupSkip:
         # Queue Lithos: feedback
         fake_lithos.list_responses.append(json.dumps({"items": []}))
 
-        # First item: cache miss (will be written)
-        # Second item: cache hit (should be skipped)
+        # First item: primary miss + source_url fallback miss (#128) →
+        # genuine cache miss → will be written.
+        # Second item: primary hit → no fallback runs → skipped on backfill.
+        fake_lithos.cache_lookup_responses.append(
+            json.dumps({"hit": False, "stale_exists": False})
+        )
         fake_lithos.cache_lookup_responses.append(
             json.dumps({"hit": False, "stale_exists": False})
         )
@@ -299,9 +303,10 @@ class TestBackfillCacheLookupSkip:
         assert len(write_calls) == 1
         assert write_calls[0][1]["title"] == "Backfill Paper Alpha"
 
-        # Verify: TWO cache_lookup calls (both items checked).
+        # Verify: THREE cache_lookup calls — item 1 does primary + source_url
+        # fallback (#128) on a miss, item 2 does only primary on a hit.
         cache_calls = [c for c in fake_lithos.calls if c[0] == "lithos_cache_lookup"]
-        assert len(cache_calls) == 2
+        assert len(cache_calls) == 3
 
     def test_all_cache_hits_produce_zero_writes(
         self,

--- a/tests/integration/test_lcma_edges_end_to_end.py
+++ b/tests/integration/test_lcma_edges_end_to_end.py
@@ -440,11 +440,16 @@ class TestBuildsOnResolver:
         fake_lithos.retrieve_responses.append(_json.dumps({"results": []}))
 
         # Queue a cache_lookup hit for the builds_on arXiv URL.
-        # First cache_lookup is the per-item dedup check (miss).
+        # First cache_lookup is the per-item dedup check (primary miss).
         fake_lithos.cache_lookup_responses.append(
             _json.dumps({"hit": False, "stale_exists": False})
         )
-        # Second cache_lookup is the builds_on resolver (hit).
+        # Second cache_lookup is the per-item dedup source_url fallback
+        # (#128) — also a miss, so the write proceeds.
+        fake_lithos.cache_lookup_responses.append(
+            _json.dumps({"hit": False, "stale_exists": False})
+        )
+        # Third cache_lookup is the builds_on resolver (hit).
         fake_lithos.cache_lookup_responses.append(
             _json.dumps(
                 {
@@ -479,9 +484,10 @@ class TestBuildsOnResolver:
 
         # Verify cache_lookup was called with correct args (FR-MCP-3, R-7).
         cache_calls = _calls_by_tool(fake_lithos.calls, "lithos_cache_lookup")
-        # One for dedup + one for builds_on.
-        assert len(cache_calls) == 2
-        builds_on_lookup = cache_calls[1]
+        # One for dedup primary + one for dedup source_url fallback (#128)
+        # + one for builds_on resolver.
+        assert len(cache_calls) == 3
+        builds_on_lookup = cache_calls[2]
         assert builds_on_lookup["query"] == "FooNet"
         assert builds_on_lookup["source_url"] == "https://arxiv.org/abs/2412.12345"
 
@@ -540,7 +546,8 @@ class TestBuildsOnResolver:
 
         # builds_on cache_lookup was called.
         cache_calls = _calls_by_tool(fake_lithos.calls, "lithos_cache_lookup")
-        assert len(cache_calls) == 2
+        # dedup primary + dedup source_url fallback (#128) + builds_on resolver.
+        assert len(cache_calls) == 3
 
         # No builds_on edges upserted.
         edge_calls = _calls_by_tool(fake_lithos.calls, "lithos_edge_upsert")

--- a/tests/integration/test_otel_metrics.py
+++ b/tests/integration/test_otel_metrics.py
@@ -102,6 +102,7 @@ def _mock_lithos_client() -> AsyncMock:
     client = AsyncMock()
     client.task_create_body.return_value = {"task_id": "task-1"}
     client.cache_lookup_for_item_body.return_value = {"hit": False}
+    client.cache_lookup_by_url_body.return_value = {"hit": False}
     client.list_notes_body.return_value = {"items": []}
     client.read_note.return_value = {}
     write_result = MagicMock()

--- a/tests/integration/test_otel_spans.py
+++ b/tests/integration/test_otel_spans.py
@@ -159,6 +159,7 @@ def _mock_lithos_client() -> AsyncMock:
     client = AsyncMock()
     client.task_create_body.return_value = {"task_id": "task-1"}
     client.cache_lookup_for_item_body.return_value = {"hit": False}
+    client.cache_lookup_by_url_body.return_value = {"hit": False}
     client.list_notes_body.return_value = {"items": []}
     client.read_note.return_value = {}
     write_result = MagicMock()

--- a/tests/integration/test_pre_write_dedup_fallback.py
+++ b/tests/integration/test_pre_write_dedup_fallback.py
@@ -1,0 +1,283 @@
+"""Integration tests for pre-write dedup source-URL fallback (issue #128).
+
+The pre-write dedup contract has two stages:
+
+1. **Primary lookup** — title + first sentence of abstract, sent through
+   :func:`influx.dedup.compose_dedup_query`.
+2. **Fallback lookup** — exact ``source_url`` only, used as a defensive
+   second chance when the primary misses.
+
+Either hit treats the item as a cache hit for the rest of
+:func:`influx.run._run_ingest_stage` (skip on backfill, multi-profile
+merge otherwise).  These tests exercise that wiring end-to-end against
+:class:`tests.contract.test_lithos_client.FakeLithosServer`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from influx.coordinator import RunKind
+from influx.lcma_wiring import LcmaWiringDeps
+from influx.lithos_client import LithosClient
+from influx.run import RunPlan, _run_ingest_stage
+from tests.contract.test_lithos_client import FakeLithosServer
+
+PROFILE = "alpha"
+ARXIV_URL = "https://arxiv.org/abs/2601.00001"
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def fake_lithos() -> Generator[FakeLithosServer, None, None]:
+    server = FakeLithosServer()
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.fixture(scope="module")
+def fake_lithos_url(fake_lithos: FakeLithosServer) -> str:
+    return f"http://127.0.0.1:{fake_lithos.port}/sse"
+
+
+@pytest.fixture(autouse=True)
+def clear_fakes(fake_lithos: FakeLithosServer) -> None:
+    fake_lithos.calls.clear()
+    fake_lithos.write_responses.clear()
+    fake_lithos.read_responses.clear()
+    fake_lithos.cache_lookup_responses.clear()
+    fake_lithos.list_responses.clear()
+    fake_lithos.retrieve_responses.clear()
+    fake_lithos.edge_upsert_responses.clear()
+    fake_lithos.task_create_responses.clear()
+    fake_lithos.task_complete_responses.clear()
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _make_item(*, source_url: str = ARXIV_URL) -> dict[str, Any]:
+    """Build a minimal ProfileItem suitable for the ingest stage."""
+    return {
+        "id": "note-1",
+        "title": "Attention Is All You Need",
+        "source_url": source_url,
+        "source": "arxiv",
+        "abstract_or_summary": (
+            "We propose a new architecture based solely on attention."
+        ),
+        "content": "# Attention Is All You Need\n\nbody",
+        "path": f"papers/{source_url.rsplit('/', 1)[-1]}.md",
+        "tags": ["arxiv-id:2601.00001"],
+        "score": 7,
+        "confidence": 0.9,
+        "filter_tags": [],
+    }
+
+
+def _run_ingest(
+    *,
+    fake_lithos_url: str,
+    items: tuple[dict[str, Any], ...],
+    skip_cache_hits: bool = False,
+) -> Any:
+    """Drive ``_run_ingest_stage`` against a fresh client for one profile.
+
+    Builds and closes the :class:`LithosClient` inside a single
+    ``asyncio.run`` call so the SSE task group's cancel scope stays
+    inside one event loop (mcp's anyio plumbing breaks otherwise).
+    """
+    plan = RunPlan(
+        profile=PROFILE,
+        kind=RunKind.BACKFILL if skip_cache_hits else RunKind.SCHEDULED,
+        skip_cache_hits=skip_cache_hits,
+    )
+
+    async def _run() -> Any:
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            lcma_deps = LcmaWiringDeps(
+                client=client,
+                profile=PROFILE,
+                run_task_id="task-1",
+                lcma_edge_score=0.75,
+            )
+            return await _run_ingest_stage(
+                plan,
+                items=items,
+                client=client,
+                lcma_deps=lcma_deps,
+                ledger=None,
+            )
+        finally:
+            await client.close()
+
+    return asyncio.run(_run())
+
+
+def _cache_lookup_calls(fake_lithos: FakeLithosServer) -> list[dict[str, str]]:
+    return [c[1] for c in fake_lithos.calls if c[0] == "lithos_cache_lookup"]
+
+
+def _write_calls(fake_lithos: FakeLithosServer) -> list[dict[str, Any]]:
+    return [c[1] for c in fake_lithos.calls if c[0] == "lithos_write"]
+
+
+# ── Tests ────────────────────────────────────────────────────────────
+
+
+class TestPreWriteDedupFallback:
+    """Pre-write dedup falls back to source_url-only lookup on primary miss."""
+
+    def test_url_fallback_hit_detected_by_pre_write_path(
+        self,
+        fake_lithos: FakeLithosServer,
+        fake_lithos_url: str,
+    ) -> None:
+        """Primary miss + URL-fallback hit → RPC sequence + metric increment.
+
+        Reproduces the issue #128 false-negative shape: title-based
+        dedup misses but the source_url is already in Lithos.  The
+        fallback path catches it pre-write — the duplicate is no longer
+        silently discovered only when ``write_note`` is attempted.
+
+        The downstream effect (skip on backfill, merge on scheduled)
+        is covered by the dedicated tests below.
+        """
+        # Primary text-query lookup misses; URL-only fallback hits.
+        fake_lithos.cache_lookup_responses.append(
+            json.dumps({"hit": False, "stale_exists": False})
+        )
+        fake_lithos.cache_lookup_responses.append(
+            json.dumps({"hit": True, "stale_exists": False})
+        )
+
+        with patch("influx.run.metrics.cache_hits_via_url_fallback") as fallback_metric:
+            _run_ingest(
+                fake_lithos_url=fake_lithos_url,
+                items=(_make_item(),),
+            )
+            fallback_metric.assert_called()
+            fallback_metric.return_value.add.assert_called_once_with(
+                1, {"profile": PROFILE, "source": "arxiv"}
+            )
+
+        lookup_calls = _cache_lookup_calls(fake_lithos)
+        # Both lookups happen — primary text-based, then URL-only fallback.
+        assert len(lookup_calls) == 2
+        # Primary uses the composed dedup query (not equal to source_url).
+        assert lookup_calls[0]["source_url"] == ARXIV_URL
+        assert lookup_calls[0]["query"] != ARXIV_URL
+        # Fallback uses source_url as both query and source_url.
+        assert lookup_calls[1] == {"query": ARXIV_URL, "source_url": ARXIV_URL}
+
+    def test_double_miss_proceeds_to_write(
+        self,
+        fake_lithos: FakeLithosServer,
+        fake_lithos_url: str,
+    ) -> None:
+        """Genuine cache miss (both lookups) → exactly one write attempt."""
+        fake_lithos.cache_lookup_responses.append(
+            json.dumps({"hit": False, "stale_exists": False})
+        )
+        fake_lithos.cache_lookup_responses.append(
+            json.dumps({"hit": False, "stale_exists": False})
+        )
+
+        _run_ingest(
+            fake_lithos_url=fake_lithos_url,
+            items=(_make_item(),),
+        )
+
+        assert len(_cache_lookup_calls(fake_lithos)) == 2
+        # Genuine miss — we proceed to write.
+        writes = _write_calls(fake_lithos)
+        assert len(writes) == 1
+        assert writes[0]["source_url"] == ARXIV_URL
+
+    def test_primary_hit_does_not_invoke_fallback(
+        self,
+        fake_lithos: FakeLithosServer,
+        fake_lithos_url: str,
+    ) -> None:
+        """Primary lookup hits → fallback RPC is skipped (no extra cost)."""
+        fake_lithos.cache_lookup_responses.append(
+            json.dumps({"hit": True, "stale_exists": False})
+        )
+
+        with patch("influx.run.metrics.cache_hits_via_url_fallback") as fallback_metric:
+            _run_ingest(
+                fake_lithos_url=fake_lithos_url,
+                items=(_make_item(),),
+            )
+            # Primary hit means the fallback metric is never bumped.
+            fallback_metric.return_value.add.assert_not_called()
+
+        # Exactly one cache_lookup — the primary one — and no fallback.
+        assert len(_cache_lookup_calls(fake_lithos)) == 1
+        # Primary hit on a SCHEDULED run still falls through to write
+        # (multi-profile merge); we just want to confirm no fallback RPC.
+        assert len(_write_calls(fake_lithos)) == 1
+
+    def test_url_fallback_hit_skipped_on_backfill(
+        self,
+        fake_lithos: FakeLithosServer,
+        fake_lithos_url: str,
+    ) -> None:
+        """On a backfill, a URL-fallback hit causes the item to be skipped."""
+        fake_lithos.cache_lookup_responses.append(
+            json.dumps({"hit": False, "stale_exists": False})
+        )
+        fake_lithos.cache_lookup_responses.append(
+            json.dumps({"hit": True, "stale_exists": False})
+        )
+
+        _run_ingest(
+            fake_lithos_url=fake_lithos_url,
+            items=(_make_item(),),
+            skip_cache_hits=True,
+        )
+
+        assert len(_cache_lookup_calls(fake_lithos)) == 2
+        # Backfill + cache hit (any reason) → skip write entirely (FR-BF-2).
+        assert _write_calls(fake_lithos) == []
+
+    def test_url_fallback_hit_merges_on_normal_run(
+        self,
+        fake_lithos: FakeLithosServer,
+        fake_lithos_url: str,
+    ) -> None:
+        """Normal run with URL-fallback hit still falls through to write.
+
+        Pins the AC: the fix does not regress legitimate multi-profile
+        merge behavior.  A cache hit (whether primary or URL-fallback)
+        on a non-backfill run means the item is merged into the
+        existing note via ``write_note`` — not skipped.
+        """
+        fake_lithos.cache_lookup_responses.append(
+            json.dumps({"hit": False, "stale_exists": False})
+        )
+        fake_lithos.cache_lookup_responses.append(
+            json.dumps({"hit": True, "stale_exists": False})
+        )
+
+        _run_ingest(
+            fake_lithos_url=fake_lithos_url,
+            items=(_make_item(),),
+            skip_cache_hits=False,
+        )
+
+        assert len(_cache_lookup_calls(fake_lithos)) == 2
+        # Non-backfill cache hit → merge-profile write proceeds.
+        writes = _write_calls(fake_lithos)
+        assert len(writes) == 1
+        assert writes[0]["source_url"] == ARXIV_URL

--- a/tests/unit/test_run_module.py
+++ b/tests/unit/test_run_module.py
@@ -439,6 +439,7 @@ async def test_run_execute_walks_provider_and_writes_per_item() -> None:
         )
     )
     mock_client.cache_lookup_for_item_body = AsyncMock(return_value={"hit": False})
+    mock_client.cache_lookup_by_url_body = AsyncMock(return_value={"hit": False})
     write_result = MagicMock()
     write_result.status = "created"
     write_result.note_id = "note-new"
@@ -510,6 +511,7 @@ async def test_run_execute_continues_after_lcma_wiring_failure() -> None:
         )
     )
     mock_client.cache_lookup_for_item_body = AsyncMock(return_value={"hit": False})
+    mock_client.cache_lookup_by_url_body = AsyncMock(return_value={"hit": False})
     write_result_1 = MagicMock()
     write_result_1.status = "created"
     write_result_1.note_id = "note-1"
@@ -585,6 +587,7 @@ async def test_run_execute_persists_unresolved_slug_collision_without_injected_l
         )
     )
     mock_client.cache_lookup_for_item_body = AsyncMock(return_value={"hit": False})
+    mock_client.cache_lookup_by_url_body = AsyncMock(return_value={"hit": False})
     write_result = MagicMock()
     write_result.status = "slug_collision"
     write_result.note_id = ""

--- a/tests/unit/test_telemetry_wiring.py
+++ b/tests/unit/test_telemetry_wiring.py
@@ -1182,6 +1182,9 @@ class TestInfluxLithosWriteSpan:
                 mock_client.cache_lookup_for_item_body = AsyncMock(
                     return_value={"hit": False}
                 )
+                mock_client.cache_lookup_by_url_body = AsyncMock(
+                    return_value={"hit": False}
+                )
                 mock_client.list_archive_terminal_arxiv_ids = AsyncMock(
                     return_value=set()
                 )
@@ -1270,6 +1273,9 @@ class TestInfluxLithosWriteSpan:
             mock_client_cls_run.return_value = mock_client
             mock_client.task_create_body = AsyncMock(return_value={"task_id": "task-1"})
             mock_client.cache_lookup_for_item_body = AsyncMock(
+                return_value={"hit": False}
+            )
+            mock_client.cache_lookup_by_url_body = AsyncMock(
                 return_value={"hit": False}
             )
             mock_client.list_archive_terminal_arxiv_ids = AsyncMock(return_value=set())


### PR DESCRIPTION
## Summary

- Pre-write dedup composed its lookup query as `title + first_sentence(abstract)`, so notes whose title or summary drifted between runs (translation, punctuation, profile-specific summary edits) missed `lithos_cache_lookup` even when their `source_url` was already present — and were only caught at write time as `duplicate` (or via slug-collision squatter recovery).
- Wire a defensive secondary `cache_lookup_by_url_body` (exact `source_url` only) that runs only when the primary text-query lookup misses. Either hit is treated as a cache hit for the rest of `_run_ingest_stage` — skipped on backfill, multi-profile-merge on scheduled runs (no regression to legitimate fuzzy multi-profile merge).
- New `influx_cache_hits_via_url_fallback_total` OTEL counter, distinct `reason=primary|source_url_fallback` field on the cache-hit log, and an explicit `article cache miss` log line so staging operators can distinguish the three outcomes at a glance.

## Test plan

- [x] `uv run pytest` — full suite green (1853 passed)
- [x] `uv run pyright` — 0 errors
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] New contract tests for `cache_lookup_by_url_body` (missing-arg chokepoint, URL forwarded as both `query` and `source_url`, miss body decoded verbatim)
- [x] New integration tests in `tests/integration/test_pre_write_dedup_fallback.py`:
  - `test_url_fallback_hit_detected_by_pre_write_path` — primary miss + URL-fallback hit detected pre-write, metric incremented
  - `test_double_miss_proceeds_to_write` — genuine miss proceeds to one write
  - `test_primary_hit_does_not_invoke_fallback` — primary hit skips the fallback RPC
  - `test_url_fallback_hit_skipped_on_backfill` — URL-fallback hit causes backfill skip
  - `test_url_fallback_hit_merges_on_normal_run` — multi-profile merge behavior preserved
- [x] Adjusted 5 collateral tests (backfill, LCMA edges, OTEL spans/metrics, telemetry wiring, run module) whose `LithosClient` mocks or `cache_lookup_responses` queues assumed exactly one cache_lookup RPC per item

Closes #128