### PR TITLE
fix: harden arXiv source acquisition for production cadence (#129)

### DIFF
--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -393,9 +393,6 @@ What this does **not** give you:
 - Independent cadence per profile (e.g. profile-A every 6h, profile-B
   every 12h). All profiles share one cron expression. True per-profile
   cron is tracked separately under issue #90.
-- Any change to the arXiv retry/backoff policy. Backoff after a 429
-  remains `resilience.arxiv_429_backoff_seconds` × `resilience.max_retries`;
-  staggering reduces *whether* we hit 429 in the first place.
 
 Verification after a config change:
 
@@ -404,10 +401,46 @@ Verification after a config change:
 ./scripts/influx-diagnose.py warnings --since 24h --contains "429"
 ```
 
-If both staggered profiles still hit 429 clusters, file a follow-up to
-revisit `resilience.arxiv_429_backoff_seconds` (e.g. exponential
-backoff). Don't tune backoff until you can show staggering didn't fix
-the recurrence.
+### arXiv retry / backoff hardening (#129)
+
+The arXiv fetch path absorbs transient 429 and timeout conditions before
+the run degrades, in addition to the staggering above:
+
+- **Progressive 429 backoff.** Each successive 429 in a single fetch
+  waits twice the previous delay (default `30, 60, 120, ...`), capped
+  at `resilience.arxiv_429_backoff_max_seconds`. `Retry-After` headers
+  override the computed delay but are clamped to the same cap.
+- **Separate 429 retry budget.** 429 retries use
+  `resilience.arxiv_429_max_retries` (default `5`), distinct from the
+  `resilience.max_retries` budget that covers network / 5xx failures.
+- **Cross-fetch pacing.** All arXiv fetches in the same process wait
+  `resilience.arxiv_request_min_interval_seconds` since the previous
+  fetch — so two profiles hitting arXiv in the same scheduled tick are
+  paced even when `inter_profile_gap_seconds = 0`.
+- **Recovered-retry diagnostics.** Every retry decision is recorded on
+  the run-ledger entry as `source_retry_counts`. Operators can confirm
+  hardening worked by looking for runs that show `source_retries`
+  *without* the `degraded` flag — those are runs where the hardening
+  absorbed a transient failure.
+
+Acceptable residual degradation: a run can still finish `degraded` with
+`source_acquisition` if arXiv is unreachable for longer than the
+configured budget allows. With the defaults that is roughly
+`(arxiv_429_max_retries + 1) * arxiv_429_backoff_max_seconds` ≈
+`12 minutes` of sustained 429 pressure on a single fetch. Such runs are
+expected production behaviour, not bugs.
+
+Verification:
+
+```
+./scripts/influx-diagnose.py recent --limit 20
+# Look for `source_retries: source=arxiv rate_limit=N` lines on
+# non-degraded runs — those are recovered transient 429s.
+```
+
+If degradation still recurs after staggering and the new defaults, the
+next levers are operator-side: raise `arxiv_429_max_retries`, raise
+`arxiv_429_backoff_max_seconds`, or widen `inter_profile_gap_seconds`.
 
 ## 10. Reference
 

--- a/influx.example.toml
+++ b/influx.example.toml
@@ -293,13 +293,25 @@ strip_tags = ["script", "iframe", "object", "embed"]
 # ---------------------------------------------------------------------------
 
 [resilience]
-# Recommended for staging/prod arXiv traffic: max_retries = 5 and
-# arxiv_429_backoff_seconds = 30. Retry-After headers override the flat
-# 429 backoff when arXiv provides them.
-max_retries = 3
+# Issue #129: defaults are now production-tuned out of the box.
+# - max_retries (5) covers transient network / 5xx failures.
+# - arxiv_429_backoff_seconds (30) is the *base* delay on HTTP 429;
+#   each subsequent 429 in the same fetch doubles the wait
+#   (30, 60, 120, ...) up to arxiv_429_backoff_max_seconds.
+# - arxiv_429_max_retries (5) is a separate, more generous budget for
+#   429 specifically — 429 is a soft rate-limit signal, not a hard
+#   network failure, and warrants more patience.
+# - arxiv_request_min_interval_seconds (3) is enforced *per process*
+#   across all arXiv fetches (scheduled and backfill), so two profiles
+#   in the same tick cannot hit arXiv back-to-back.
+# Retry-After headers, when present, override the computed 429 backoff
+# but are themselves clamped to arxiv_429_backoff_max_seconds.
+max_retries = 5
 backoff_base_seconds = 1
 arxiv_request_min_interval_seconds = 3
-arxiv_429_backoff_seconds = 10
+arxiv_429_backoff_seconds = 30
+arxiv_429_backoff_max_seconds = 120
+arxiv_429_max_retries = 5
 lithos_write_conflict_max_retries = 1
 
 # ---------------------------------------------------------------------------

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -159,6 +159,18 @@ def _print_run_row(run: dict[str, Any]) -> None:
                 f"      source_error: source={src_err.get('source')} "
                 f"kind={src_err.get('kind')} detail={src_err.get('detail')}"
             )
+    # #129: surface recovered-retry counts so an operator can see "we
+    # hit arXiv 429 twice but recovered" alongside any swallowed final
+    # errors.  Empty / missing dicts are skipped silently.
+    retry_counts = run.get("source_retry_counts") or {}
+    if isinstance(retry_counts, dict) and retry_counts:
+        for source, by_kind in sorted(retry_counts.items()):
+            if not isinstance(by_kind, dict) or not by_kind:
+                continue
+            kinds = " ".join(
+                f"{kind}={count}" for kind, count in sorted(by_kind.items())
+            )
+            print(f"      source_retries: source={source} {kinds}")
 
 
 # ── docker logs ─────────────────────────────────────────────────────

--- a/src/influx/config.py
+++ b/src/influx/config.py
@@ -480,11 +480,43 @@ class ExtractionConfig(BaseModel):
 class ResilienceConfig(BaseModel):
     """``[resilience]`` retry and backoff settings."""
 
-    max_retries: int = 3
+    # Issue #129: defaults bumped from the historical 3/10 to the
+    # staging-recommended 5/30 so a fresh deployment is production-ready
+    # without operator-side tuning.  Operator overrides in
+    # ``influx.toml`` continue to win.
+    max_retries: int = 5
     backoff_base_seconds: int = 1
     arxiv_request_min_interval_seconds: int = 3
-    arxiv_429_backoff_seconds: int = 10
+    arxiv_429_backoff_seconds: int = 30
+    # Issue #129: cap the per-attempt 429 backoff so progressive doubling
+    # (``arxiv_429_backoff_seconds * 2**attempt``) and any honoured
+    # ``Retry-After`` header cannot push the run beyond a known wall-clock
+    # ceiling.  120s gives roughly four progressive doublings starting
+    # from the default 30s before the cap binds.
+    arxiv_429_backoff_max_seconds: int = 120
+    # Issue #129: separate retry budget for HTTP 429.  Distinct from
+    # ``max_retries`` (network / 5xx) because 429 is a soft, recoverable
+    # rate-limit signal that warrants more patience than a hard network
+    # failure — the API is healthy, it's just asking us to slow down.
+    arxiv_429_max_retries: int = 5
     lithos_write_conflict_max_retries: int = 1
+
+    @field_validator(
+        "max_retries",
+        "backoff_base_seconds",
+        "arxiv_request_min_interval_seconds",
+        "arxiv_429_backoff_seconds",
+        "arxiv_429_backoff_max_seconds",
+        "arxiv_429_max_retries",
+        "lithos_write_conflict_max_retries",
+    )
+    @classmethod
+    def _non_negative(cls, v: int) -> int:
+        if v < 0:
+            raise ConfigError(
+                "resilience.* retry and backoff fields must be non-negative"
+            )
+        return v
 
 
 class FeedbackConfig(BaseModel):

--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -87,6 +87,12 @@ class RunLedger:
             "degraded": False,
             "degraded_reasons": [],
             "source_acquisition_errors": [],
+            # #129: per-source counter of *recovered* retries (i.e.
+            # retries that did not produce a swallowed error).  Shape:
+            # ``{"arxiv": {"rate_limit": 2, "timeout": 1}}``.  Empty
+            # dict at start; populated from the per-run contextvar at
+            # ``complete`` time.
+            "source_retry_counts": {},
         }
         try:
             active = self._read_active()
@@ -106,6 +112,7 @@ class RunLedger:
         invalid_url_rejections_total: int | None = None,
         archive_failures_total: int | None = None,
         source_acquisition_errors: list[dict[str, str]] | None = None,
+        source_retry_counts: dict[str, dict[str, int]] | None = None,
     ) -> list[str]:
         """Mark an active run as completed and append it to history.
 
@@ -305,6 +312,7 @@ class RunLedger:
             degraded=bool(reasons),
             source_acquisition_errors=errors,
             degraded_reasons=reasons,
+            source_retry_counts=source_retry_counts,
         )
         return reasons
 
@@ -561,6 +569,12 @@ class RunLedger:
                         "source_acquisition_errors": list(
                             entry.get("source_acquisition_errors") or []
                         ),
+                        "source_retry_counts": {
+                            source: dict(by_kind)
+                            for source, by_kind in (
+                                entry.get("source_retry_counts") or {}
+                            ).items()
+                        },
                     }
                 )
                 self._append(entry)
@@ -622,6 +636,7 @@ class RunLedger:
         degraded: bool = False,
         source_acquisition_errors: list[dict[str, str]] | None = None,
         degraded_reasons: list[str] | None = None,
+        source_retry_counts: dict[str, dict[str, int]] | None = None,
     ) -> None:
         try:
             active = self._read_active()
@@ -656,6 +671,13 @@ class RunLedger:
                     "degraded": degraded,
                     "degraded_reasons": list(degraded_reasons or []),
                     "source_acquisition_errors": list(source_acquisition_errors or []),
+                    # #129: deep-copy the per-source retry-count dict so
+                    # later mutations of the contextvar bucket do not
+                    # leak into the persisted ledger entry.
+                    "source_retry_counts": {
+                        source: dict(by_kind)
+                        for source, by_kind in (source_retry_counts or {}).items()
+                    },
                 }
             )
             self._append(entry)

--- a/src/influx/run_service.py
+++ b/src/influx/run_service.py
@@ -50,6 +50,7 @@ from influx.telemetry import (
     current_invalid_url_rejections,
     current_run_id,
     current_source_acquisition_errors,
+    current_source_retry_counts,
     get_tracer,
 )
 
@@ -120,6 +121,14 @@ async def ledger_lifecycle(
     invalid_url_rejections_token = current_invalid_url_rejections.set(
         invalid_url_rejections_counter
     )
+    # #129: per-run counter of recovered source-fetch retries (i.e.
+    # retries followed by another attempt, distinct from the swallowed
+    # final errors recorded via :func:`record_source_acquisition_error`).
+    # A shared mutable dict so source adapters can ``setdefault`` /
+    # increment without ContextVar.set semantics — same pattern as
+    # ``current_source_acquisition_errors``.
+    source_retry_counts: dict[str, dict[str, int]] = {}
+    source_retry_counts_token = current_source_retry_counts.set(source_retry_counts)
     metric_attrs = {"profile": profile, "run_type": plan.kind.value}
 
     ledger.start(
@@ -202,6 +211,11 @@ async def ledger_lifecycle(
             invalid_url_rejections_total=invalid_url_rejections_total,
             archive_failures_total=archive_failures_total,
             source_acquisition_errors=source_errors,
+            # #129: surface recovered retry counts so the ledger entry
+            # carries "we hit arXiv 429 twice but recovered" alongside
+            # the swallowed-error list, letting an operator distinguish
+            # transient retry success from a burned retry budget.
+            source_retry_counts=source_retry_counts,
         )
         run_outcome = "degraded" if source_errors else "success"
         if "ingestion_stall" in degraded_reasons:
@@ -368,6 +382,7 @@ async def ledger_lifecycle(
         current_fetched_total.reset(fetched_total_token)
         current_filter_errors.reset(filter_errors_token)
         current_invalid_url_rejections.reset(invalid_url_rejections_token)
+        current_source_retry_counts.reset(source_retry_counts_token)
 
 
 # ── RunService ──────────────────────────────────────────────────────

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -399,16 +399,23 @@ def _arxiv_429_delay(
     return min(base * (2**attempt), cap)
 
 
-# Issue #129: process-wide last-fetch timestamp used to enforce
+# Issue #129: process-wide next-slot allocator used to enforce
 # ``arxiv_request_min_interval_seconds`` across *all* arXiv fetches in
-# the same process — not just the per-day backfill loop.  The lock
-# serialises concurrent calls (the fetch runs on ``asyncio.to_thread``,
-# so a thread lock is appropriate) and the monotonic timestamp lets
-# back-to-back scheduled-tick fetches (e.g. profile A then profile B in
-# the same tick when ``schedule.inter_profile_gap_seconds`` is 0) pace
-# themselves rather than hitting arXiv simultaneously.
+# the same process — not just the per-day backfill loop.
+#
+# The pattern is a token-bucket-style "claim a slot under the lock,
+# then sleep until that slot outside the lock" scheme.  Storing
+# *next-allowed* (rather than *last-fetched*) lets concurrent callers
+# claim distinct, non-overlapping slots in a single critical section —
+# review of the original implementation flagged that holding the lock
+# only across the read/write but not across the sleep let two
+# concurrent callers observe the same ``last`` timestamp, compute the
+# same wait, and then start their HTTP fetches together, defeating the
+# pacing guarantee.  Slot allocation runs under the lock; the wait
+# itself happens with the lock released so a long ``Retry-After``-style
+# sleep does not block fetches that already hold a later slot.
 _FETCH_PACING_LOCK = threading.Lock()
-_LAST_FETCH_MONOTONIC: float | None = None
+_NEXT_FETCH_SLOT_MONOTONIC: float | None = None
 
 
 def _reset_fetch_pacing_for_tests() -> None:
@@ -417,36 +424,37 @@ def _reset_fetch_pacing_for_tests() -> None:
     Unit tests covering :func:`_apply_min_interval` need a clean baseline
     between cases; production code never calls this.
     """
-    global _LAST_FETCH_MONOTONIC  # noqa: PLW0603
+    global _NEXT_FETCH_SLOT_MONOTONIC  # noqa: PLW0603
     with _FETCH_PACING_LOCK:
-        _LAST_FETCH_MONOTONIC = None
+        _NEXT_FETCH_SLOT_MONOTONIC = None
 
 
 def _apply_min_interval(min_interval: float) -> None:
-    """Sleep until at least *min_interval* has elapsed since the last fetch.
+    """Block until this caller's paced slot starts.
 
-    Records ``time.monotonic()`` *after* sleeping so the timestamp marks
-    the start of the new fetch.  When *min_interval* is ``0`` (or
-    negative) the helper still records the timestamp but never sleeps —
-    callers can disable pacing without removing the call.
+    Atomically claims the next ``min_interval``-spaced slot under
+    :data:`_FETCH_PACING_LOCK`, then sleeps the difference between the
+    claimed slot and ``now`` with the lock released.  Two concurrent
+    callers therefore receive *different* slots — caller A sleeps zero
+    and starts immediately, caller B sleeps ``min_interval`` and starts
+    after A — instead of both observing the same "last fetch" timestamp
+    and racing each other to the wire.
+
+    When *min_interval* is ``0`` (or negative) the helper short-circuits
+    without touching the slot state: pacing is disabled wholesale and a
+    later paced call starts from a clean baseline.
     """
-    global _LAST_FETCH_MONOTONIC  # noqa: PLW0603
+    global _NEXT_FETCH_SLOT_MONOTONIC  # noqa: PLW0603
     if min_interval <= 0:
-        with _FETCH_PACING_LOCK:
-            _LAST_FETCH_MONOTONIC = time.monotonic()
         return
+    now = time.monotonic()
     with _FETCH_PACING_LOCK:
-        last = _LAST_FETCH_MONOTONIC
-        now = time.monotonic()
-        wait = 0.0
-        if last is not None:
-            elapsed = now - last
-            if elapsed < min_interval:
-                wait = min_interval - elapsed
+        next_slot = _NEXT_FETCH_SLOT_MONOTONIC
+        my_slot = now if next_slot is None or next_slot <= now else next_slot
+        _NEXT_FETCH_SLOT_MONOTONIC = my_slot + min_interval
+    wait = my_slot - now
     if wait > 0:
         _sleep(wait)
-    with _FETCH_PACING_LOCK:
-        _LAST_FETCH_MONOTONIC = time.monotonic()
 
 
 def fetch_arxiv(

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 import time
 import xml.etree.ElementTree as ET
 from collections.abc import Awaitable, Callable, Iterable
@@ -54,6 +55,7 @@ from influx.telemetry import (
     record_fetched_items,
     record_filter_error,
     record_source_acquisition_error,
+    record_source_retry,
 )
 
 if TYPE_CHECKING:
@@ -373,13 +375,78 @@ def _parse_retry_after_seconds(value: str) -> float | None:
 def _arxiv_429_delay(
     result_headers: dict[str, str],
     resilience: ResilienceConfig,
+    *,
+    attempt: int,
 ) -> float:
+    """Compute the per-attempt 429 backoff delay.
+
+    Issue #129: progressive doubling of ``arxiv_429_backoff_seconds``
+    by ``2 ** attempt`` so a run that hits 429 repeatedly waits longer
+    each time, capped at ``arxiv_429_backoff_max_seconds``.  An
+    ``Retry-After`` header (when present and parseable) overrides the
+    computed delay but is itself clamped to the same cap so a misbehaving
+    upstream cannot extend a run indefinitely.  ``attempt`` is the
+    zero-based index of the current attempt (0 on the first try).
+    """
+    cap = float(resilience.arxiv_429_backoff_max_seconds)
+    min_interval = float(resilience.arxiv_request_min_interval_seconds)
+    base = float(resilience.arxiv_429_backoff_seconds)
     retry_after = _header_value(result_headers, "Retry-After")
     if retry_after is not None:
         parsed = _parse_retry_after_seconds(retry_after)
         if parsed is not None:
-            return max(float(resilience.arxiv_request_min_interval_seconds), parsed)
-    return float(resilience.arxiv_429_backoff_seconds)
+            return min(max(min_interval, parsed), cap)
+    return min(base * (2**attempt), cap)
+
+
+# Issue #129: process-wide last-fetch timestamp used to enforce
+# ``arxiv_request_min_interval_seconds`` across *all* arXiv fetches in
+# the same process — not just the per-day backfill loop.  The lock
+# serialises concurrent calls (the fetch runs on ``asyncio.to_thread``,
+# so a thread lock is appropriate) and the monotonic timestamp lets
+# back-to-back scheduled-tick fetches (e.g. profile A then profile B in
+# the same tick when ``schedule.inter_profile_gap_seconds`` is 0) pace
+# themselves rather than hitting arXiv simultaneously.
+_FETCH_PACING_LOCK = threading.Lock()
+_LAST_FETCH_MONOTONIC: float | None = None
+
+
+def _reset_fetch_pacing_for_tests() -> None:
+    """Reset the module-level pacing state — test seam only.
+
+    Unit tests covering :func:`_apply_min_interval` need a clean baseline
+    between cases; production code never calls this.
+    """
+    global _LAST_FETCH_MONOTONIC  # noqa: PLW0603
+    with _FETCH_PACING_LOCK:
+        _LAST_FETCH_MONOTONIC = None
+
+
+def _apply_min_interval(min_interval: float) -> None:
+    """Sleep until at least *min_interval* has elapsed since the last fetch.
+
+    Records ``time.monotonic()`` *after* sleeping so the timestamp marks
+    the start of the new fetch.  When *min_interval* is ``0`` (or
+    negative) the helper still records the timestamp but never sleeps —
+    callers can disable pacing without removing the call.
+    """
+    global _LAST_FETCH_MONOTONIC  # noqa: PLW0603
+    if min_interval <= 0:
+        with _FETCH_PACING_LOCK:
+            _LAST_FETCH_MONOTONIC = time.monotonic()
+        return
+    with _FETCH_PACING_LOCK:
+        last = _LAST_FETCH_MONOTONIC
+        now = time.monotonic()
+        wait = 0.0
+        if last is not None:
+            elapsed = now - last
+            if elapsed < min_interval:
+                wait = min_interval - elapsed
+    if wait > 0:
+        _sleep(wait)
+    with _FETCH_PACING_LOCK:
+        _LAST_FETCH_MONOTONIC = time.monotonic()
 
 
 def fetch_arxiv(
@@ -474,6 +541,23 @@ def _fetch_with_retry(
     when omitted they are resolved from the pydantic
     :class:`~influx.config.StorageConfig` field defaults so the only
     place these tunable defaults live is config-parsing code (AC-X-1).
+
+    Issue #129 hardening:
+
+    - 429 retries use a separate, more generous budget
+      (``arxiv_429_max_retries``) than network/5xx retries
+      (``max_retries``) because 429 is a soft, recoverable signal.
+    - 429 backoff is progressive (doubling per attempt) and capped at
+      ``arxiv_429_backoff_max_seconds`` so a flapping upstream cannot
+      degrade the run while still preventing unbounded waits.
+    - The first attempt waits for ``arxiv_request_min_interval_seconds``
+      to elapse since the last in-process arXiv fetch, pacing fetches
+      across profiles within a single scheduled tick (the per-day
+      backfill loop already paces itself with the same interval, so the
+      helper fast-paths through there).
+    - Each retry decision is recorded via :func:`record_source_retry`
+      so the run ledger surfaces "we hit 429 N times but recovered"
+      distinct from the swallowed-error list.
     """
     if max_download_bytes is None or timeout_seconds is None:
         _storage_defaults = StorageConfig()
@@ -484,10 +568,20 @@ def _fetch_with_retry(
 
     max_retries = resilience.max_retries
     backoff_base = resilience.backoff_base_seconds
+    rate_limit_max_retries = resilience.arxiv_429_max_retries
+
+    # Pace this fetch against the previous in-process arXiv fetch.  A
+    # zero / negative interval is treated as "no pacing" by the helper.
+    _apply_min_interval(float(resilience.arxiv_request_min_interval_seconds))
 
     last_error: Exception | None = None
 
-    for attempt in range(max_retries + 1):
+    # The retry loop runs up to ``1 + max(network, rate-limit)`` times so
+    # the more generous 429 budget can still drive forward progress when
+    # 429s dominate.  Each branch checks its own budget before deciding
+    # to retry.
+    total_attempts = 1 + max(max_retries, rate_limit_max_retries)
+    for attempt in range(total_attempts):
         try:
             # Fetch without expected_content_type so status-code handling
             # (429 backoff, 5xx retry) runs first. Non-XML 429/5xx
@@ -509,6 +603,10 @@ def _fetch_with_retry(
                     exc.kind,
                     delay,
                 )
+                record_source_retry(
+                    source="arxiv",
+                    kind=exc.kind or "network",
+                )
                 _sleep(delay)
                 continue
             raise
@@ -519,14 +617,15 @@ def _fetch_with_retry(
                 url=url,
                 kind="rate_limit",
             )
-            if attempt < max_retries:
-                delay = _arxiv_429_delay(result.headers, resilience)
+            if attempt < rate_limit_max_retries:
+                delay = _arxiv_429_delay(result.headers, resilience, attempt=attempt)
                 _log.warning(
                     "arXiv 429 on attempt %d/%d, backing off %.1fs (FR-RES-2)",
                     attempt + 1,
-                    max_retries + 1,
+                    rate_limit_max_retries + 1,
                     delay,
                 )
+                record_source_retry(source="arxiv", kind="rate_limit")
                 _sleep(delay)
                 continue
             raise last_error
@@ -547,6 +646,7 @@ def _fetch_with_retry(
                     max_retries + 1,
                     delay,
                 )
+                record_source_retry(source="arxiv", kind="network")
                 _sleep(delay)
                 continue
             raise last_error

--- a/src/influx/telemetry.py
+++ b/src/influx/telemetry.py
@@ -29,6 +29,7 @@ __all__ = [
     "InfluxMeter",
     "InfluxTracer",
     "SourceAcquisitionError",
+    "SourceRetryCounts",
     "SpanWrapper",
     "current_archive_terminal_arxiv_ids",
     "current_fetched_total",
@@ -36,12 +37,14 @@ __all__ = [
     "current_invalid_url_rejections",
     "current_run_id",
     "current_source_acquisition_errors",
+    "current_source_retry_counts",
     "get_meter",
     "get_tracer",
     "record_fetched_items",
     "record_filter_error",
     "record_invalid_url_rejection",
     "record_source_acquisition_error",
+    "record_source_retry",
 ]
 
 # Context variable for the current run ID — set by ``run_profile()`` so
@@ -108,6 +111,41 @@ def record_source_acquisition_error(
             }
         )
     )
+
+
+# Per-run counter of source-fetch retries that the run **recovered from**
+# (i.e. retries that did not produce a final swallowed error).  Shape:
+# ``{"arxiv": {"rate_limit": 2, "timeout": 1}}``.  Source adapters call
+# :func:`record_source_retry` once per retry decision (each non-final
+# attempt that the retry loop is about to sleep + retry).  Surfaced on
+# the run-ledger entry as ``source_retry_counts`` so operators can
+# distinguish "one transient 429 we recovered from" from "we burned the
+# entire retry budget" — issue #129.
+SourceRetryCounts = dict[str, dict[str, int]]
+
+
+current_source_retry_counts: ContextVar[SourceRetryCounts | None] = ContextVar(
+    "current_source_retry_counts",
+    default=None,
+)
+
+
+def record_source_retry(*, source: str, kind: str) -> None:
+    """Increment the current run's recovered-retry counter for *source*/*kind*.
+
+    Safe to call outside a run context — silently no-ops when
+    :data:`current_source_retry_counts` is unset.  Source adapters call
+    this on every retry decision (every attempt that failed but is
+    followed by another attempt).  When the retry budget is exhausted
+    and the failure is finally swallowed, the source instead calls
+    :func:`record_source_acquisition_error`; the two records together
+    let an operator see "we retried N times before giving up".
+    """
+    counts = current_source_retry_counts.get()
+    if counts is None:
+        return
+    by_kind = counts.setdefault(source, {})
+    by_kind[kind] = by_kind.get(kind, 0) + 1
 
 
 # Per-run counter of pre-filter fetched candidates.  Set to ``[0]`` at

--- a/tests/unit/test_arxiv_fetcher.py
+++ b/tests/unit/test_arxiv_fetcher.py
@@ -17,10 +17,25 @@ from influx.sources.arxiv import (
     _extract_arxiv_id,
     _filter_by_lookback,
     _parse_atom,
+    _reset_fetch_pacing_for_tests,
     build_query_url,
     fetch_arxiv,
     resolve_backfill_range,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_arxiv_pacing() -> None:
+    """Clear the module-level cross-fetch pacing state between tests.
+
+    ``_fetch_with_retry`` now applies ``arxiv_request_min_interval_seconds``
+    against a process-wide last-fetch timestamp (issue #129).  Without
+    this fixture, the second test in a pytest run would pick up the
+    timestamp the first test left behind and trigger an unexpected
+    ``_sleep`` call that breaks ``mock_sleep.assert_called_once_with``.
+    """
+    _reset_fetch_pacing_for_tests()
+
 
 _FIXTURES = Path(__file__).resolve().parent.parent / "fixtures" / "arxiv"
 
@@ -379,7 +394,8 @@ class TestFetchRetry:
         mock_fetch: MagicMock,
         mock_sleep: MagicMock,
     ) -> None:
-        """429 on all attempts raises NetworkError."""
+        """429 on every attempt of the 429 retry budget raises NetworkError."""
+        del mock_sleep
         mock_fetch.side_effect = [
             _make_fetch_result(b"", status_code=429),
             _make_fetch_result(b"", status_code=429),
@@ -387,7 +403,10 @@ class TestFetchRetry:
             _make_fetch_result(b"", status_code=429),
         ]
 
-        resilience = ResilienceConfig(max_retries=3)
+        # Issue #129: the 429 retry budget defaults to 5; pin both
+        # budgets to 3 so the existing 4-element side_effect still
+        # exercises "exhaust all 429 retries" exactly.
+        resilience = ResilienceConfig(max_retries=3, arxiv_429_max_retries=3)
         cfg = ArxivSourceConfig(categories=["cs.AI"])
         with pytest.raises(NetworkError, match="429"):
             fetch_arxiv(
@@ -676,6 +695,12 @@ class TestFetchRetry:
         mock_fetch: MagicMock,
         mock_sleep: MagicMock,
     ) -> None:
+        """Issue #129: ``Retry-After`` cannot exceed
+        ``arxiv_429_backoff_max_seconds``.  ``Retry-After`` is first
+        clamped to the parser's RFC ceiling (300s) and then to the
+        config's progressive-backoff cap so a misbehaving upstream
+        cannot extend a single retry beyond a known wall-clock bound.
+        """
         body = _load_fixture("recent_two.atom")
         mock_fetch.side_effect = [
             _make_fetch_result(
@@ -688,6 +713,7 @@ class TestFetchRetry:
 
         resilience = ResilienceConfig(
             arxiv_429_backoff_seconds=10,
+            arxiv_429_backoff_max_seconds=120,
             max_retries=3,
         )
         cfg = ArxivSourceConfig(categories=["cs.AI"], lookback_days=30)
@@ -695,7 +721,7 @@ class TestFetchRetry:
         items = fetch_arxiv(arxiv_config=cfg, resilience=resilience, now=now)
 
         assert len(items) == 2
-        mock_sleep.assert_called_once_with(300)
+        mock_sleep.assert_called_once_with(120)
 
     @patch("influx.sources.arxiv.guarded_fetch")
     def test_successful_non_xml_content_type_raises(
@@ -735,3 +761,173 @@ class TestFetchRetry:
         kwargs = mock_fetch.call_args.kwargs
         assert kwargs.get("max_download_bytes") == 4321
         assert kwargs.get("timeout_seconds") == 42
+
+
+class TestArxivHardening:
+    """Issue #129 — production-cadence hardening tests.
+
+    Cover progressive 429 backoff, the separate 429 retry budget,
+    cross-fetch pacing, and the run-ledger retry-count linkage.
+    """
+
+    @patch("influx.sources.arxiv._sleep")
+    @patch("influx.sources.arxiv.guarded_fetch")
+    def test_429_backoff_doubles_per_attempt_until_cap(
+        self,
+        mock_fetch: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        """Progressive 429 backoff: each successive 429 in one fetch
+        waits twice the previous delay, capped at
+        ``arxiv_429_backoff_max_seconds``.
+        """
+        body = _load_fixture("recent_two.atom")
+        mock_fetch.side_effect = [
+            _make_fetch_result(b"", status_code=429),
+            _make_fetch_result(b"", status_code=429),
+            _make_fetch_result(b"", status_code=429),
+            _make_fetch_result(b"", status_code=429),
+            _make_fetch_result(body),
+        ]
+        resilience = ResilienceConfig(
+            arxiv_429_backoff_seconds=10,
+            arxiv_429_backoff_max_seconds=60,
+            arxiv_429_max_retries=5,
+            max_retries=5,
+            arxiv_request_min_interval_seconds=0,
+        )
+        cfg = ArxivSourceConfig(categories=["cs.AI"], lookback_days=30)
+        now = datetime(2026, 4, 24, 0, 0, 0, tzinfo=UTC)
+        fetch_arxiv(arxiv_config=cfg, resilience=resilience, now=now)
+        # Attempts 0..3 each pre-retry sleep: 10, 20, 40, 60 (capped).
+        assert mock_sleep.call_args_list == [
+            call(10.0),
+            call(20.0),
+            call(40.0),
+            call(60.0),
+        ]
+
+    @patch("influx.sources.arxiv._sleep")
+    @patch("influx.sources.arxiv.guarded_fetch")
+    def test_429_uses_separate_retry_budget(
+        self,
+        mock_fetch: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        """``arxiv_429_max_retries`` exceeds ``max_retries`` and 429s
+        keep retrying past the network/5xx budget — the more generous
+        soft-failure budget is what gets the run home.
+        """
+        del mock_sleep
+        body = _load_fixture("recent_two.atom")
+        mock_fetch.side_effect = [
+            _make_fetch_result(b"", status_code=429),
+            _make_fetch_result(b"", status_code=429),
+            _make_fetch_result(b"", status_code=429),
+            _make_fetch_result(b"", status_code=429),
+            _make_fetch_result(body),
+        ]
+        resilience = ResilienceConfig(
+            arxiv_429_backoff_seconds=1,
+            arxiv_429_backoff_max_seconds=10,
+            max_retries=2,  # would only allow 3 attempts total for 5xx
+            arxiv_429_max_retries=5,  # but 429s keep going
+            arxiv_request_min_interval_seconds=0,
+        )
+        cfg = ArxivSourceConfig(categories=["cs.AI"], lookback_days=30)
+        now = datetime(2026, 4, 24, 0, 0, 0, tzinfo=UTC)
+        items = fetch_arxiv(arxiv_config=cfg, resilience=resilience, now=now)
+        assert len(items) == 2
+        assert mock_fetch.call_count == 5
+
+    @patch("influx.sources.arxiv._sleep")
+    @patch("influx.sources.arxiv.guarded_fetch")
+    def test_network_path_still_uses_max_retries(
+        self,
+        mock_fetch: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        """Issue #129 hardening must not loosen the network/5xx budget.
+        ``max_retries=2`` means 3 attempts total before raising even
+        when ``arxiv_429_max_retries`` is far higher.
+        """
+        del mock_sleep
+        mock_fetch.side_effect = NetworkError("boom", url="http://x", kind="network")
+        resilience = ResilienceConfig(
+            max_retries=2,
+            arxiv_429_max_retries=10,
+            arxiv_request_min_interval_seconds=0,
+        )
+        cfg = ArxivSourceConfig(categories=["cs.AI"])
+        with pytest.raises(NetworkError, match="boom"):
+            fetch_arxiv(arxiv_config=cfg, resilience=resilience)
+        assert mock_fetch.call_count == 3
+
+    @patch("influx.sources.arxiv._sleep")
+    @patch("influx.sources.arxiv.guarded_fetch")
+    def test_cross_fetch_pacing_applies_min_interval(
+        self,
+        mock_fetch: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        """Two consecutive fetches in the same process pace themselves.
+
+        The first fetch records the timestamp without sleeping; the
+        second sees the recent timestamp and sleeps the remaining
+        interval.  The per-day backfill loop already paced itself with
+        the same interval, but the scheduled-tick path did not — this
+        is the new behaviour that absorbs back-to-back profile fetches
+        in the same tick (issue #129).
+        """
+        body = _load_fixture("empty_feed.atom")
+        mock_fetch.return_value = _make_fetch_result(body)
+        resilience = ResilienceConfig(
+            arxiv_request_min_interval_seconds=3,
+            max_retries=0,
+            arxiv_429_max_retries=0,
+        )
+        cfg = ArxivSourceConfig(categories=["cs.AI"])
+        fetch_arxiv(arxiv_config=cfg, resilience=resilience)
+        # First call records the timestamp; no pacing sleep yet.
+        assert mock_sleep.call_count == 0
+        fetch_arxiv(arxiv_config=cfg, resilience=resilience)
+        # Second call, still within 3s wall-clock of the first, must
+        # have slept to bring the gap up to ~3 seconds.  Allow a
+        # generous lower bound to avoid flakiness on slow CI.
+        assert mock_sleep.call_count == 1
+        slept = mock_sleep.call_args_list[0].args[0]
+        assert 0 < slept <= 3
+
+    @patch("influx.sources.arxiv._sleep")
+    @patch("influx.sources.arxiv.guarded_fetch")
+    def test_record_source_retry_called_per_retry_decision(
+        self,
+        mock_fetch: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        """Each retry — 429 or network — calls ``record_source_retry``
+        with the correct kind so the run-ledger entry can surface
+        recovered-retry counts (#129).
+        """
+        del mock_sleep
+        body = _load_fixture("empty_feed.atom")
+        mock_fetch.side_effect = [
+            NetworkError("t/o", url="http://x", kind="timeout"),
+            _make_fetch_result(b"", status_code=429),
+            _make_fetch_result(body),
+        ]
+        resilience = ResilienceConfig(
+            arxiv_429_backoff_seconds=1,
+            arxiv_429_backoff_max_seconds=2,
+            backoff_base_seconds=1,
+            max_retries=3,
+            arxiv_429_max_retries=3,
+            arxiv_request_min_interval_seconds=0,
+        )
+        cfg = ArxivSourceConfig(categories=["cs.AI"])
+        with patch("influx.sources.arxiv.record_source_retry") as mock_record:
+            fetch_arxiv(arxiv_config=cfg, resilience=resilience)
+        kinds = [c.kwargs["kind"] for c in mock_record.call_args_list]
+        sources = [c.kwargs["source"] for c in mock_record.call_args_list]
+        assert kinds == ["timeout", "rate_limit"]
+        assert sources == ["arxiv", "arxiv"]

--- a/tests/unit/test_arxiv_fetcher.py
+++ b/tests/unit/test_arxiv_fetcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
@@ -14,6 +15,7 @@ from influx.http_client import FetchResult
 from influx.sources.arxiv import (
     ArxivItem,
     BackfillRange,
+    _apply_min_interval,
     _extract_arxiv_id,
     _filter_by_lookback,
     _parse_atom,
@@ -931,3 +933,76 @@ class TestArxivHardening:
         sources = [c.kwargs["source"] for c in mock_record.call_args_list]
         assert kinds == ["timeout", "rate_limit"]
         assert sources == ["arxiv", "arxiv"]
+
+
+class TestApplyMinInterval:
+    """Direct tests for the cross-fetch pacing slot allocator (#129).
+
+    Review feedback: the original implementation released the lock
+    before sleeping, so two concurrent callers could observe the same
+    ``last`` timestamp, compute the same wait, and then both start
+    their HTTP fetch together.  The slot-allocator version below
+    serialises *slot allocation* under the lock — concurrent callers
+    therefore receive *different* slots and pace themselves correctly.
+    """
+
+    @patch("influx.sources.arxiv._sleep")
+    def test_first_call_does_not_sleep(self, mock_sleep: MagicMock) -> None:
+        _apply_min_interval(3.0)
+        mock_sleep.assert_not_called()
+
+    @patch("influx.sources.arxiv._sleep")
+    def test_zero_interval_is_no_op(self, mock_sleep: MagicMock) -> None:
+        """``min_interval=0`` short-circuits and never touches the slot
+        state, so a subsequent paced call sees a clean baseline."""
+        _apply_min_interval(0.0)
+        _apply_min_interval(3.0)
+        # First call: short-circuit. Second call: clean baseline → no
+        # waiting slot, sleeps zero.
+        mock_sleep.assert_not_called()
+
+    @patch("influx.sources.arxiv._sleep")
+    def test_three_back_to_back_callers_get_distinct_slots(
+        self, mock_sleep: MagicMock
+    ) -> None:
+        """Three calls in rapid succession (``_sleep`` mocked, so wall-
+        clock barely advances) each claim a slot
+        ``min_interval`` apart: the first sleeps zero, the second
+        sleeps ~``min_interval``, the third sleeps ~``2 * min_interval``.
+
+        This is the property that cross-profile pacing depends on:
+        even if profiles A, B, and C all reach
+        ``_fetch_with_retry`` at the same wall-clock instant (the
+        scheduled-tick concurrency case the original review flagged),
+        each gets a unique slot under the lock and they hit arXiv
+        ``min_interval`` apart on the wire — not all together.
+        """
+        _apply_min_interval(3.0)
+        _apply_min_interval(3.0)
+        _apply_min_interval(3.0)
+        # The first call short-circuits the sleep guard with wait=0.
+        # The remaining two each call ``_sleep`` with their full slot
+        # offset because ``_sleep`` is mocked and so wall-clock time
+        # barely advances between calls.
+        assert mock_sleep.call_count == 2
+        slept_first = mock_sleep.call_args_list[0].args[0]
+        slept_second = mock_sleep.call_args_list[1].args[0]
+        # Generous lower bounds to absorb the few microseconds that
+        # *do* advance during the test; tight upper bounds to verify
+        # the slot allocator is not over-spacing.
+        assert 2.9 < slept_first <= 3.0
+        assert 5.9 < slept_second <= 6.0
+
+    @patch("influx.sources.arxiv._sleep")
+    def test_call_after_slot_already_passed_does_not_sleep(
+        self, mock_sleep: MagicMock
+    ) -> None:
+        """When the previously claimed slot is already in the past, a
+        fresh call starts immediately at ``now`` — pacing only kicks in
+        when calls cluster within a single interval window."""
+        _apply_min_interval(0.001)  # claims a slot ~1 ms in the future
+        # Sleep so the previously-claimed slot is firmly in the past.
+        time.sleep(0.01)
+        mock_sleep.reset_mock()
+        _apply_min_interval(3.0)
+        mock_sleep.assert_not_called()

--- a/tests/unit/test_run_ledger.py
+++ b/tests/unit/test_run_ledger.py
@@ -140,6 +140,66 @@ def test_complete_with_source_errors_marks_run_degraded(tmp_path: Path) -> None:
     assert entry["source_acquisition_errors"] == errors
 
 
+# ── Issue #129: surface recovered source-fetch retries ──────────────
+
+
+def test_complete_without_retry_counts_persists_empty_dict(
+    tmp_path: Path,
+) -> None:
+    """A clean run with no retry-count input lands ``source_retry_counts={}``
+    so downstream consumers always see the field, never KeyError.
+    """
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(
+        run_id="run-1",
+        profile="ai-robotics",
+        kind="scheduled",
+        run_range=None,
+    )
+    ledger.complete(run_id="run-1", sources_checked=3, ingested=2)
+    entry = ledger.recent()[0]
+    assert entry["source_retry_counts"] == {}
+
+
+def test_complete_records_source_retry_counts(tmp_path: Path) -> None:
+    """``source_retry_counts`` survives the ledger round-trip and is
+    deep-copied so post-complete mutations of the caller's dict do not
+    leak into persisted entries (issue #129).
+    """
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(
+        run_id="run-1",
+        profile="ai-robotics",
+        kind="scheduled",
+        run_range=None,
+    )
+    counts = {"arxiv": {"rate_limit": 2, "timeout": 1}}
+    ledger.complete(
+        run_id="run-1",
+        sources_checked=8,
+        ingested=3,
+        source_retry_counts=counts,
+    )
+    entry = ledger.recent()[0]
+    assert entry["source_retry_counts"] == {
+        "arxiv": {"rate_limit": 2, "timeout": 1},
+    }
+    # Run that recovered transient retries is **not** degraded — only
+    # *swallowed* errors land in the degraded set, retries that
+    # succeeded are pure diagnostics.
+    assert entry["degraded"] is False
+    assert entry["degraded_reasons"] == []
+
+    # Mutating the original dict after ``complete`` must not change
+    # what the ledger persisted (deep-copy invariant).
+    counts["arxiv"]["rate_limit"] = 99
+    counts["rss"] = {"timeout": 7}
+    re_read = ledger.recent()[0]
+    assert re_read["source_retry_counts"] == {
+        "arxiv": {"rate_limit": 2, "timeout": 1},
+    }
+
+
 def test_failed_run_has_degraded_false(tmp_path: Path) -> None:
     """``fail`` always lands ``degraded=false`` so the field's semantics
     stay narrow: it means *partial source-fetch failure on an otherwise

--- a/tests/unit/test_source_acquisition_errors.py
+++ b/tests/unit/test_source_acquisition_errors.py
@@ -167,6 +167,50 @@ async def test_scheduler_drains_context_into_ledger_complete(
     ]
 
 
+async def test_scheduler_drains_retry_counts_into_ledger_complete(
+    tmp_path: Any,
+) -> None:
+    """Issue #129: ``record_source_retry`` calls during a run land on
+    the ledger entry as ``source_retry_counts`` so an operator can see
+    "we hit arXiv 429 twice but recovered" alongside the swallowed
+    final-error list.
+    """
+    from unittest.mock import AsyncMock
+
+    from influx.run_ledger import RunLedger
+    from influx.scheduler import run_profile
+    from influx.telemetry import record_source_retry
+
+    config = _make_minimal_config()
+    ledger = RunLedger(tmp_path / "state")
+
+    from influx.run import RunOutcome
+
+    async def fake_body(*_args: Any, **_kwargs: Any) -> RunOutcome:
+        # Mimic two recovered 429 retries plus one recovered timeout.
+        record_source_retry(source="arxiv", kind="rate_limit")
+        record_source_retry(source="arxiv", kind="rate_limit")
+        record_source_retry(source="arxiv", kind="timeout")
+        return RunOutcome()
+
+    fake = AsyncMock(side_effect=fake_body)
+    with patch("influx.run.Run.execute", new=fake):
+        await run_profile(
+            "ai-robotics",
+            RunKind.SCHEDULED,
+            config=config,
+            run_ledger=ledger,
+        )
+
+    entry = ledger.recent()[0]
+    # Recovered retries do **not** degrade the run on their own —
+    # they are pure diagnostics for triaging upstream pressure.
+    assert entry["degraded"] is False
+    assert entry["source_retry_counts"] == {
+        "arxiv": {"rate_limit": 2, "timeout": 1},
+    }
+
+
 async def test_scheduler_writes_clean_ledger_on_no_errors(tmp_path: Any) -> None:
     """A run with no swallowed errors writes ``degraded=false`` and an
     empty list — preserves the dashboard semantics that "degraded" means


### PR DESCRIPTION
## Summary

Targeted hardening of `src/influx/sources/arxiv.py` so transient arXiv 429s and timeouts during scheduled runs are absorbed by the retry path instead of degrading the run, and so operators can see at a glance how many retries a run recovered from.

### Levers

- **Capped exponential 429 backoff** — each successive 429 in one fetch doubles the wait (`arxiv_429_backoff_seconds * 2**attempt`), clamped to the new `arxiv_429_backoff_max_seconds` knob. `Retry-After` still wins when present and is clamped to the same cap.
- **Separate 429 retry budget** — `arxiv_429_max_retries` (default `5`), distinct from `max_retries` so the soft 429 signal gets more patience than a hard network failure.
- **Cross-fetch pacing for scheduled runs** — `arxiv_request_min_interval_seconds` is now applied to every in-process arXiv fetch via a module-level monotonic timestamp + thread lock, so two profiles in the same scheduled tick pace themselves even when `inter_profile_gap_seconds = 0`. The per-day backfill loop fast-paths through the helper, preserving backfill semantics.
- **Run-ledger retry diagnostics** — new `current_source_retry_counts` contextvar (mirroring `current_source_acquisition_errors`); ledger entries gain `source_retry_counts` and `influx-diagnose` prints them. Distinguishes "we recovered from 2 transient 429s" from "we burned the entire retry budget".
- **Production-tuned defaults** — `max_retries` 3 → 5, `arxiv_429_backoff_seconds` 10 → 30. `influx.example.toml` is updated to drop the old "for staging/prod, use these other values" comment; the staging runbook documents the new acceptable residual degradation envelope.

### Acceptance criteria

- [x] Intended production behavior for recurring 429 / timeout is explicit in code and operator-visible diagnostics.
- [x] Hardening reduces recurring `source_acquisition` degradation under staging-like cadence (progressive backoff + cross-tick pacing + larger 429 budget).
- [x] New tests cover the chosen retry / pacing / backoff behaviour.
- [x] Backfill semantics preserved (`tests/integration/test_backfill_arxiv.py` still green; pacing helper fast-paths through inside the per-day loop).
- [x] Residual acceptable degradation documented in `docs/operations/staging-runbook.md`.

## Test plan

- [x] `uv run pytest tests/unit/test_arxiv_fetcher.py tests/unit/test_run_ledger.py tests/unit/test_source_acquisition_errors.py` — new + existing pass.
- [x] `uv run pytest tests/unit/` — 1532 passed.
- [x] `uv run pytest tests/integration/` — 205 passed (including `test_backfill_arxiv.py`, `test_arxiv_pipeline_end_to_end.py`).
- [x] `uv run ruff check src/ tests/ scripts/` — clean.
- [x] `uv run ruff format --check src/ tests/ scripts/` — clean.
- [x] `uv run pyright` — 0 errors, 0 warnings.

Closes #129