### PR TITLE
fix: route RSS notes through repair sweep with source-aware hooks

### DIFF
--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -22,6 +22,7 @@ import trafilatura
 from influx.config import AppConfig
 from influx.enrich import tier3_extract as _tier3_extract
 from influx.errors import ExtractionError, LCMAError, NetworkError
+from influx.extraction.article import extract_article
 from influx.extraction.html import _clean_html_fragments, _strip_tags
 from influx.extraction.pdf import extract_pdf
 from influx.extraction.pipeline import extract_arxiv_text
@@ -193,7 +194,11 @@ def _extract_from_archive(
 
 _ARXIV_ID_TAG_PREFIX = "arxiv-id:"
 _SOURCE_TAG_PREFIX = "source:"
-_NOTE_PATH_RE = re.compile(r"papers/(?P<source>[^/]+)/(?P<year>\d{4})/(?P<month>\d{2})")
+_NOTE_PATH_RE = re.compile(
+    r"(?:papers|articles)/(?P<source>[^/]+)/(?P<year>\d{4})/(?P<month>\d{2})"
+)
+_RSS_NOTE_ID_PREFIX = "rss-"
+_SOURCE_URL_FRONTMATTER_KEY = "source_url:"
 
 
 def _find_tag(tags: list[str], prefix: str) -> str | None:
@@ -210,22 +215,37 @@ def _note_tags(note: dict[str, object]) -> list[str]:
     return list(raw) if isinstance(raw, list) else []
 
 
-def _require_arxiv_source(note: dict[str, object], *, stage_label: str) -> None:
-    """Raise ``ExtractionError(stage="unsupported_source")`` for non-arxiv notes.
+def _note_source_tag(note: dict[str, object]) -> str:
+    """Return the note's ``source:*`` tag suffix or an empty string."""
+    return _find_tag(_note_tags(note), _SOURCE_TAG_PREFIX) or ""
 
-    The current sweep-side hooks only know how to retry archive download
-    and text extraction for arxiv notes; other sources surface this
-    sentinel which the sweep classifies as transient (and which
-    :func:`influx.repair._terminate_unsupported_text_source` flips to
-    terminal so the note exits the sweep instead of looping).
+
+def _is_rss_source(source: str) -> bool:
+    """Return whether *source* names an RSS feed source tag.
+
+    Production RSS notes carry ``source:rss-<feed-slug>``; the bare
+    ``source:rss`` sentinel is accepted to keep the dispatcher robust
+    to historical or hand-edited notes.
     """
-    source = _find_tag(_note_tags(note), _SOURCE_TAG_PREFIX) or ""
-    if source != "arxiv":
-        raise ExtractionError(
-            f"{stage_label}: source {source!r} not supported",
-            stage="unsupported_source",
-            detail=f"note id={note.get('id', '?')}",
-        )
+    return source == "rss" or source.startswith(_RSS_NOTE_ID_PREFIX)
+
+
+def _raise_unsupported_source(
+    note: dict[str, object], *, stage_label: str, source: str
+) -> None:
+    """Raise ``ExtractionError(stage="unsupported_source")`` for an unknown source.
+
+    The text-extraction path flips this to terminal via
+    :func:`influx.repair._terminate_unsupported_text_source`; the
+    archive-download path leaves it transient (the note re-enters the
+    sweep next pass and is repaired automatically once a per-source
+    resolver is added).
+    """
+    raise ExtractionError(
+        f"{stage_label}: source {source!r} not supported",
+        stage="unsupported_source",
+        detail=f"note id={note.get('id', '?')}",
+    )
 
 
 def _parse_year_month_from_note_path(note_path: str) -> tuple[int, int] | None:
@@ -252,6 +272,117 @@ def _classify_download_kind(error: str) -> str:
     head, _, _rest = error.partition(":")
     head = head.strip()
     return head or "archive_failed"
+
+
+def _parse_source_url_from_note(note: dict[str, object]) -> str | None:
+    """Return the ``source_url`` value from the note's YAML frontmatter, if any.
+
+    Reuses :func:`influx.notes.parse_note` so the sweep does not carry
+    its own YAML parser.  Returns ``None`` when the note cannot be
+    parsed or the field is absent.
+    """
+    content = str(note.get("content", ""))
+    try:
+        parsed = parse_note(content)
+    except Exception:
+        return None
+    for line in parsed.frontmatter_raw.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(_SOURCE_URL_FRONTMATTER_KEY):
+            return stripped[len(_SOURCE_URL_FRONTMATTER_KEY) :].strip() or None
+    return None
+
+
+def _rss_item_id_from_note(note: dict[str, object]) -> str | None:
+    """Recover an archive ``item_id`` from an RSS note's ``id`` field.
+
+    RSS notes are written with ``id = "rss-<feed-slug>-<url-hash>"``
+    (see ``influx.sources.rss.build_rss_note_item``).  The leading
+    ``rss-`` prefix is dropped to mirror arxiv's
+    ``id = "arxiv-<arxiv-id>" -> item_id = "<arxiv-id>"`` convention.
+
+    The retry archive path will differ from what initial acquisition
+    would have produced (the original embedded a ``YYYY-MM-DD``
+    component that is not recoverable from the persisted note); this is
+    fine because acquisition failed and no archive currently lives on
+    disk for the original path.
+    """
+    note_id = str(note.get("id", ""))
+    if not note_id.startswith(_RSS_NOTE_ID_PREFIX):
+        return None
+    item_id = note_id[len(_RSS_NOTE_ID_PREFIX) :]
+    return item_id or None
+
+
+def _resolve_rss_download_args(
+    note: dict[str, object],
+    config: AppConfig,
+) -> dict[str, object]:
+    """Build kwargs for :func:`download_archive` from an RSS note's state.
+
+    Raises :class:`ExtractionError` (stage ``"resolve"``) when the note
+    is missing fields needed to retry — the sweep treats this as
+    transient so an operator hand-fix lands the next pass.
+    """
+    source = _note_source_tag(note)
+    source_url = _parse_source_url_from_note(note)
+    if not source_url:
+        raise ExtractionError(
+            "Cannot retry archive download: no source_url in frontmatter",
+            stage="resolve",
+            detail=f"note id={note.get('id', '?')}",
+        )
+    item_id = _rss_item_id_from_note(note)
+    if not item_id:
+        raise ExtractionError(
+            "Cannot retry archive download: note id missing 'rss-' prefix",
+            stage="resolve",
+            detail=f"note id={note.get('id', '?')}",
+        )
+    note_path = str(note.get("path", ""))
+    ym = _parse_year_month_from_note_path(note_path)
+    if ym is None:
+        raise ExtractionError(
+            "Cannot retry archive download: note path missing year/month",
+            stage="resolve",
+            detail=f"path={note_path!r}",
+        )
+    year, month = ym
+    return {
+        "url": source_url,
+        "archive_root": Path(config.storage.archive_dir),
+        "source": source,
+        "item_id": item_id,
+        "published_year": year,
+        "published_month": month,
+        "ext": ".html",
+        "allow_private_ips": config.security.allow_private_ips,
+        "max_download_bytes": config.storage.max_download_bytes,
+        "timeout_seconds": config.storage.download_timeout_seconds,
+        "expected_content_type": "html",
+    }
+
+
+def _resolve_archive_download_args(
+    note: dict[str, object],
+    config: AppConfig,
+) -> dict[str, object]:
+    """Dispatch :func:`download_archive` kwarg construction by note source.
+
+    Currently supports ``arxiv`` and ``rss-*`` (plus the bare ``rss``
+    sentinel).  Other sources raise ``unsupported_source`` so the sweep
+    keeps existing transient-retry behavior until a per-source
+    resolver lands.
+    """
+    source = _note_source_tag(note)
+    if source == "arxiv":
+        return _resolve_arxiv_download_args(note, config)
+    if _is_rss_source(source):
+        return _resolve_rss_download_args(note, config)
+    _raise_unsupported_source(
+        note, stage_label="archive_download retry", source=source
+    )
+    raise AssertionError("unreachable")  # pragma: no cover
 
 
 def _resolve_arxiv_download_args(
@@ -310,16 +441,15 @@ def _make_archive_download_hook(config: AppConfig) -> ArchiveDownloadHook:
     counted-class kinds — currently ``"oversize"``) and flips
     ``influx:archive-terminal`` once the cap is reached.
 
-    Currently scoped to ``source:arxiv`` notes.  Other sources raise an
+    Supports ``source:arxiv`` and ``source:rss-*`` notes via
+    :func:`_resolve_archive_download_args`.  Other sources raise an
     ``ExtractionError(stage="unsupported_source")`` which classifies as
     transient — the note re-enters the sweep next pass and is fixed
     automatically once a per-source resolver is added.
     """
 
     def hook(note: dict[str, object]) -> str:
-        _require_arxiv_source(note, stage_label="archive_download retry")
-
-        kwargs = _resolve_arxiv_download_args(note, config)
+        kwargs = _resolve_archive_download_args(note, config)
         result = download_archive(**kwargs)  # type: ignore[arg-type]
         if result.ok and result.rel_posix_path:
             _log.info(
@@ -345,49 +475,113 @@ def _make_archive_download_hook(config: AppConfig) -> ArchiveDownloadHook:
     return hook
 
 
+def _run_arxiv_text_extraction(
+    note: dict[str, object], config: AppConfig
+) -> str:
+    """Run the arxiv text-extraction cascade and return the resulting tag."""
+    arxiv_id = _find_tag(_note_tags(note), _ARXIV_ID_TAG_PREFIX)
+    if not arxiv_id:
+        raise ExtractionError(
+            "Cannot retry text extraction: no arxiv-id tag on note",
+            stage="resolve",
+            detail=f"note id={note.get('id', '?')}",
+        )
+
+    try:
+        result = extract_arxiv_text(arxiv_id, config)
+    except NetworkError as exc:
+        # extract_arxiv_text raises ExtractionError on full cascade
+        # fall-through, but a NetworkError can leak from helpers it
+        # calls (e.g. SSRF guards on the PDF fetch).  Re-wrap so the
+        # sweep's ``(ExtractionError, ...)`` branch handles it.
+        raise ExtractionError(
+            f"text_extraction retry network failure: {exc.kind}",
+            url=getattr(exc, "url", "") or "",
+            stage=exc.kind or "network",
+            detail=str(exc),
+        ) from exc
+    return result.source_tag
+
+
+def _run_rss_text_extraction(
+    note: dict[str, object], config: AppConfig
+) -> str:
+    """Run RSS web-article extraction for a degraded RSS note.
+
+    Reads ``source_url`` from frontmatter and re-runs
+    :func:`influx.extraction.article.extract_article` with the same
+    config knobs as initial RSS acquisition.  Returns ``"text:html"``
+    on success so the sweep adds the provenance tag and the note exits
+    the text-extraction stage.
+
+    A ``NetworkError`` (e.g. SSRF guard, TLS failure) is re-wrapped as
+    ``ExtractionError`` carrying the network kind as ``stage`` — same
+    pattern as the arxiv branch — so the sweep's failure-classifier
+    keeps the existing transient-vs-counted semantics.
+    """
+    source_url = _parse_source_url_from_note(note)
+    if not source_url:
+        raise ExtractionError(
+            "Cannot retry text extraction: no source_url in frontmatter",
+            stage="resolve",
+            detail=f"note id={note.get('id', '?')}",
+        )
+
+    extraction_cfg = config.extraction
+    storage_cfg = config.storage
+    try:
+        extract_article(
+            source_url,
+            min_web_chars=extraction_cfg.min_web_chars,
+            strip_tags=list(extraction_cfg.strip_tags),
+            allow_private_ips=config.security.allow_private_ips,
+            max_download_bytes=storage_cfg.max_download_bytes,
+            timeout_seconds=storage_cfg.download_timeout_seconds,
+        )
+    except NetworkError as exc:
+        raise ExtractionError(
+            f"text_extraction retry network failure: {exc.kind}",
+            url=getattr(exc, "url", "") or source_url,
+            stage=exc.kind or "network",
+            detail=str(exc),
+        ) from exc
+    return "text:html"
+
+
 def _make_text_extraction_hook(config: AppConfig) -> TextExtractionHook:
     """Create the production ``text_extraction`` hook (FR-REP-1 stage 2).
 
     The hook re-runs the source-specific extraction cascade for a note
     that carries no ``text:*`` tag and returns the resulting tag.  On
-    cascade fall-through (both HTML and PDF failed) the underlying
-    helper raises :class:`ExtractionError`; we surface it to the sweep
-    so the per-stage failure logging path fires.
+    cascade fall-through the underlying helper raises
+    :class:`ExtractionError`; we surface it to the sweep so the
+    per-stage failure logging path fires.
 
-    Currently scoped to ``source:arxiv`` — RSS support follows when
-    the multi-source resolver lands (out of scope for issue #24).
+    Supports ``source:arxiv`` (cascade via
+    :func:`extract_arxiv_text`) and ``source:rss-*`` (web article
+    extraction via :func:`extract_article`).  Other sources raise
+    ``ExtractionError(stage="unsupported_source")`` so the sweep
+    terminalises the note via
+    :func:`influx.repair._terminate_unsupported_text_source`.
     """
 
     def hook(note: dict[str, object]) -> str:
-        _require_arxiv_source(note, stage_label="text_extraction retry")
-
-        arxiv_id = _find_tag(_note_tags(note), _ARXIV_ID_TAG_PREFIX)
-        if not arxiv_id:
-            raise ExtractionError(
-                "Cannot retry text extraction: no arxiv-id tag on note",
-                stage="resolve",
-                detail=f"note id={note.get('id', '?')}",
+        source = _note_source_tag(note)
+        if source == "arxiv":
+            tag = _run_arxiv_text_extraction(note, config)
+        elif _is_rss_source(source):
+            tag = _run_rss_text_extraction(note, config)
+        else:
+            _raise_unsupported_source(
+                note, stage_label="text_extraction retry", source=source
             )
-
-        try:
-            result = extract_arxiv_text(arxiv_id, config)
-        except NetworkError as exc:
-            # extract_arxiv_text raises ExtractionError on full cascade
-            # fall-through, but a NetworkError can leak from helpers it
-            # calls (e.g. SSRF guards on the PDF fetch).  Re-wrap so the
-            # sweep's ``(ExtractionError, ...)`` branch handles it.
-            raise ExtractionError(
-                f"text_extraction retry network failure: {exc.kind}",
-                url=getattr(exc, "url", "") or "",
-                stage=exc.kind or "network",
-                detail=str(exc),
-            ) from exc
+            raise AssertionError("unreachable")  # pragma: no cover
         _log.info(
             "text_extraction retry succeeded for %s tag=%s",
             note.get("id", "?"),
-            result.source_tag,
+            tag,
         )
-        return result.source_tag
+        return tag
 
     return hook
 

--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -379,9 +379,7 @@ def _resolve_archive_download_args(
         return _resolve_arxiv_download_args(note, config)
     if _is_rss_source(source):
         return _resolve_rss_download_args(note, config)
-    _raise_unsupported_source(
-        note, stage_label="archive_download retry", source=source
-    )
+    _raise_unsupported_source(note, stage_label="archive_download retry", source=source)
     raise AssertionError("unreachable")  # pragma: no cover
 
 
@@ -475,9 +473,7 @@ def _make_archive_download_hook(config: AppConfig) -> ArchiveDownloadHook:
     return hook
 
 
-def _run_arxiv_text_extraction(
-    note: dict[str, object], config: AppConfig
-) -> str:
+def _run_arxiv_text_extraction(note: dict[str, object], config: AppConfig) -> str:
     """Run the arxiv text-extraction cascade and return the resulting tag."""
     arxiv_id = _find_tag(_note_tags(note), _ARXIV_ID_TAG_PREFIX)
     if not arxiv_id:
@@ -503,9 +499,7 @@ def _run_arxiv_text_extraction(
     return result.source_tag
 
 
-def _run_rss_text_extraction(
-    note: dict[str, object], config: AppConfig
-) -> str:
+def _run_rss_text_extraction(note: dict[str, object], config: AppConfig) -> str:
     """Run RSS web-article extraction for a degraded RSS note.
 
     Reads ``source_url`` from frontmatter and re-runs

--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -505,13 +505,22 @@ def _run_rss_text_extraction(note: dict[str, object], config: AppConfig) -> str:
     Reads ``source_url`` from frontmatter and re-runs
     :func:`influx.extraction.article.extract_article` with the same
     config knobs as initial RSS acquisition.  Returns ``"text:html"``
-    on success so the sweep adds the provenance tag and the note exits
-    the text-extraction stage.
+    on success.
 
-    A ``NetworkError`` (e.g. SSRF guard, TLS failure) is re-wrapped as
-    ``ExtractionError`` carrying the network kind as ``stage`` — same
-    pattern as the arxiv branch — so the sweep's failure-classifier
-    keeps the existing transient-vs-counted semantics.
+    On any extraction failure (HTTP, network, min_length, parse, …)
+    returns ``"text:abstract-only"`` per the
+    :class:`~influx.repair.TextExtractionHook` protocol, so the sweep
+    stamps a ``text:*`` tag and the note converges out of the
+    text-extraction stage.  The note can still be upgraded to
+    ``text:html`` later via :func:`_make_re_extract_archive_hook`
+    once :func:`_make_archive_download_hook` lands an archive on disk.
+    A WARN is emitted so operators can see the structural reason
+    behind the convergence.
+
+    Only ``ExtractionError(stage="resolve")`` is raised — that signals
+    a missing ``source_url`` frontmatter field which only an operator
+    fix can repair, and it should keep surfacing through the sweep's
+    failure-logging path until corrected.
     """
     source_url = _parse_source_url_from_note(note)
     if not source_url:
@@ -532,13 +541,16 @@ def _run_rss_text_extraction(note: dict[str, object], config: AppConfig) -> str:
             max_download_bytes=storage_cfg.max_download_bytes,
             timeout_seconds=storage_cfg.download_timeout_seconds,
         )
-    except NetworkError as exc:
-        raise ExtractionError(
-            f"text_extraction retry network failure: {exc.kind}",
-            url=getattr(exc, "url", "") or source_url,
-            stage=exc.kind or "network",
-            detail=str(exc),
-        ) from exc
+    except (ExtractionError, NetworkError) as exc:
+        stage = getattr(exc, "stage", None) or getattr(exc, "kind", None) or "extract"
+        _log.warning(
+            "rss text_extraction retry: live extraction failed for %s "
+            "(stage=%s url=%s); converging to text:abstract-only",
+            note.get("id", "?"),
+            stage,
+            source_url,
+        )
+        return "text:abstract-only"
     return "text:html"
 
 

--- a/tests/unit/test_repair_hooks_production.py
+++ b/tests/unit/test_repair_hooks_production.py
@@ -935,9 +935,14 @@ def _make_rss_archive_missing_note(
     if omit_source_url:
         # Strip the source_url frontmatter line so the resolver hits the
         # missing-field branch.
-        content = "\n".join(
-            line for line in content.splitlines() if not line.startswith("source_url:")
-        ) + "\n"
+        content = (
+            "\n".join(
+                line
+                for line in content.splitlines()
+                if not line.startswith("source_url:")
+            )
+            + "\n"
+        )
     return {
         "id": note_id,
         "title": "RSS Article Title",

--- a/tests/unit/test_repair_hooks_production.py
+++ b/tests/unit/test_repair_hooks_production.py
@@ -1107,9 +1107,17 @@ class TestTextExtractionHookRssSuccess:
 
 
 class TestTextExtractionHookRssFailures:
-    def test_extraction_error_propagates(self, tmp_path: Path) -> None:
-        from influx.repair_counters import classify_failure
+    """Live extraction failure converges to ``text:abstract-only`` (issue #130).
 
+    Per the :class:`~influx.repair.TextExtractionHook` protocol the
+    hook returns ``"text:abstract-only"`` on cascade fall-through so
+    the sweep stamps a ``text:*`` tag and the note exits the
+    text-extraction stage.  Re-extraction from a stored archive (via
+    the source-agnostic ``re_extract_archive`` hook) can still upgrade
+    the tag to ``text:html`` once ``archive_download`` lands.
+    """
+
+    def test_extraction_error_returns_abstract_only(self, tmp_path: Path) -> None:
         config = _make_config(tmp_path)
         hooks = make_default_sweep_hooks(config)
         note = _make_rss_textless_note()
@@ -1121,14 +1129,11 @@ class TestTextExtractionHookRssFailures:
                 detail="got 100 chars, need 500",
             )
             assert hooks.text_extraction is not None
-            with pytest.raises(ExtractionError) as exc_info:
-                hooks.text_extraction(note)
+            tag = hooks.text_extraction(note)
 
-        assert exc_info.value.stage == "min_length"
-        # Not a counted stage — the note re-enters next sweep pass.
-        assert classify_failure(exc_info.value) == "transient"
+        assert tag == "text:abstract-only"
 
-    def test_network_error_rewrapped_as_extraction_error(self, tmp_path: Path) -> None:
+    def test_network_error_returns_abstract_only(self, tmp_path: Path) -> None:
         from influx.errors import NetworkError
 
         config = _make_config(tmp_path)
@@ -1142,10 +1147,31 @@ class TestTextExtractionHookRssFailures:
                 kind="tls",
             )
             assert hooks.text_extraction is not None
-            with pytest.raises(ExtractionError) as exc_info:
+            tag = hooks.text_extraction(note)
+
+        assert tag == "text:abstract-only"
+
+    def test_logs_warning_on_failure(self, tmp_path: Path, caplog) -> None:
+        """Operator visibility: the structural failure stage is logged."""
+        import logging
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_rss_textless_note()
+
+        with patch("influx.repair_hooks.extract_article") as mock_ex:
+            mock_ex.side_effect = ExtractionError(
+                "trafilatura returned no content",
+                stage="extract",
+            )
+            assert hooks.text_extraction is not None
+            with caplog.at_level(logging.WARNING, logger="influx.repair_hooks"):
                 hooks.text_extraction(note)
 
-        assert exc_info.value.stage == "tls"
+        assert any(
+            "stage=extract" in record.message and "text:abstract-only" in record.message
+            for record in caplog.records
+        )
 
 
 class TestTextExtractionHookRssMetadataRecovery:

--- a/tests/unit/test_repair_hooks_production.py
+++ b/tests/unit/test_repair_hooks_production.py
@@ -714,13 +714,17 @@ class TestArchiveDownloadHookMetadataRecovery:
         config = _make_config(tmp_path)
         hooks = make_default_sweep_hooks(config)
         note = _make_archive_missing_note()
-        note["tags"] = [t.replace("source:arxiv", "source:rss") for t in note["tags"]]
+        # ``hackernews`` is a stand-in for any future source that hasn't
+        # yet had a per-source resolver wired in (issue #130 added rss).
+        note["tags"] = [
+            t.replace("source:arxiv", "source:hackernews") for t in note["tags"]
+        ]
 
         assert hooks.archive_download is not None
         with pytest.raises(ExtractionError) as exc_info:
             hooks.archive_download(note)
         assert exc_info.value.stage == "unsupported_source"
-        # Still transient — RSS support can land later without a forced cap.
+        # Transient — future sources can land later without a forced cap.
         assert classify_failure(exc_info.value) == "transient"
 
 
@@ -852,10 +856,303 @@ class TestTextExtractionHookMetadataRecovery:
         config = _make_config(tmp_path)
         hooks = make_default_sweep_hooks(config)
         note = _make_textless_note()
-        note["tags"] = [t.replace("source:arxiv", "source:rss") for t in note["tags"]]
+        # See archive_download equivalent test — ``hackernews`` represents
+        # any future source without a per-source resolver.
+        note["tags"] = [
+            t.replace("source:arxiv", "source:hackernews") for t in note["tags"]
+        ]
 
         assert hooks.text_extraction is not None
         with pytest.raises(ExtractionError) as exc_info:
             hooks.text_extraction(note)
         assert exc_info.value.stage == "unsupported_source"
+        assert classify_failure(exc_info.value) == "transient"
+
+
+# ── RSS archive_download / text_extraction (issue #130) ─────────────
+
+
+def _rss_note_content(
+    *,
+    source_url: str = "https://example.com/article-42",
+    archive_path: str | None = None,
+    score: int = 6,
+) -> str:
+    """Build a canonical RSS note content string."""
+    archive_body = f"path: {archive_path}\n" if archive_path else ""
+    return (
+        "---\n"
+        "note_type: summary\n"
+        "namespace: influx\n"
+        f"source_url: {source_url}\n"
+        "tags:\n"
+        "  - profile:ai-robotics\n"
+        "  - source:rss-techcrunch\n"
+        "  - feed-slug:techcrunch\n"
+        "  - influx:archive-missing\n"
+        "  - influx:repair-needed\n"
+        "confidence: 0.7\n"
+        "---\n"
+        "# RSS Article Title\n"
+        "\n"
+        "## Archive\n"
+        f"{archive_body}"
+        "\n"
+        "## Summary\n"
+        "An RSS article summary.\n"
+        "\n"
+        "## Profile Relevance\n"
+        "### ai-robotics\n"
+        f"Score: {score}/10\n"
+        "Relevant.\n"
+        "\n"
+        "## User Notes\n"
+    )
+
+
+def _make_rss_archive_missing_note(
+    *,
+    feed_slug: str = "techcrunch",
+    url_hash: str = "abc123def",
+    note_path: str = "articles/rss-techcrunch/2026/05",
+    source_url: str = "https://example.com/article-42",
+    omit_source_url: bool = False,
+    omit_id_prefix: bool = False,
+) -> dict[str, Any]:
+    """Build an RSS note dict in the ``influx:archive-missing`` state.
+
+    Mirrors the shape produced by
+    :func:`influx.sources.rss.build_rss_note_item` for a feed item
+    whose archive download failed.
+    """
+    note_id = (
+        f"{feed_slug}-{url_hash}" if omit_id_prefix else f"rss-{feed_slug}-{url_hash}"
+    )
+    fm_url = "" if omit_source_url else source_url
+    content = _rss_note_content(
+        source_url=fm_url if fm_url else "https://example.com/article-42"
+    )
+    if omit_source_url:
+        # Strip the source_url frontmatter line so the resolver hits the
+        # missing-field branch.
+        content = "\n".join(
+            line for line in content.splitlines() if not line.startswith("source_url:")
+        ) + "\n"
+    return {
+        "id": note_id,
+        "title": "RSS Article Title",
+        "source_url": source_url,
+        "path": note_path,
+        "content": content,
+        "tags": [
+            "profile:ai-robotics",
+            "source:rss-techcrunch",
+            f"feed-slug:{feed_slug}",
+            "influx:archive-missing",
+            "influx:repair-needed",
+        ],
+        "version": 1,
+    }
+
+
+class TestArchiveDownloadHookRssSuccess:
+    def test_returns_relative_path_on_success(self, tmp_path: Path) -> None:
+        from influx.storage import ArchiveResult
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_rss_archive_missing_note()
+
+        with patch("influx.repair_hooks.download_archive") as mock_dl:
+            mock_dl.return_value = ArchiveResult(
+                ok=True,
+                rel_posix_path="rss-techcrunch/2026/05/techcrunch-abc123def.html",
+                error="",
+            )
+            assert hooks.archive_download is not None
+            result = hooks.archive_download(note)
+
+        assert result == "rss-techcrunch/2026/05/techcrunch-abc123def.html"
+        kwargs = mock_dl.call_args.kwargs
+        assert kwargs["url"] == "https://example.com/article-42"
+        assert kwargs["source"] == "rss-techcrunch"
+        assert kwargs["item_id"] == "techcrunch-abc123def"
+        assert kwargs["published_year"] == 2026
+        assert kwargs["published_month"] == 5
+        assert kwargs["ext"] == ".html"
+        assert kwargs["expected_content_type"] == "html"
+
+
+class TestArchiveDownloadHookRssFailures:
+    def test_oversize_is_counted(self, tmp_path: Path) -> None:
+        """Oversize is counted for RSS the same way as for arxiv."""
+        from influx.repair_counters import classify_failure
+        from influx.storage import ArchiveResult
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_rss_archive_missing_note()
+
+        with patch("influx.repair_hooks.download_archive") as mock_dl:
+            mock_dl.return_value = ArchiveResult(
+                ok=False,
+                rel_posix_path=None,
+                error="oversize: response body 12000000 bytes exceeds limit",
+            )
+            assert hooks.archive_download is not None
+            with pytest.raises(ExtractionError) as exc_info:
+                hooks.archive_download(note)
+
+        assert exc_info.value.stage == "oversize"
+        assert classify_failure(exc_info.value) == "counted"
+
+    def test_http_error_is_transient(self, tmp_path: Path) -> None:
+        """HTTP 4xx/5xx leaves the RSS note re-enterable next sweep."""
+        from influx.repair_counters import classify_failure
+        from influx.storage import ArchiveResult
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_rss_archive_missing_note()
+
+        with patch("influx.repair_hooks.download_archive") as mock_dl:
+            mock_dl.return_value = ArchiveResult(
+                ok=False,
+                rel_posix_path=None,
+                error="HTTP 503 for https://example.com/article-42",
+            )
+            assert hooks.archive_download is not None
+            with pytest.raises(ExtractionError) as exc_info:
+                hooks.archive_download(note)
+
+        assert exc_info.value.stage == "http"
+        assert classify_failure(exc_info.value) == "transient"
+
+
+class TestArchiveDownloadHookRssMetadataRecovery:
+    def test_missing_source_url_raises_resolve(self, tmp_path: Path) -> None:
+        from influx.repair_counters import classify_failure
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_rss_archive_missing_note(omit_source_url=True)
+
+        assert hooks.archive_download is not None
+        with pytest.raises(ExtractionError) as exc_info:
+            hooks.archive_download(note)
+        assert exc_info.value.stage == "resolve"
+        assert classify_failure(exc_info.value) == "transient"
+
+    def test_missing_id_prefix_raises_resolve(self, tmp_path: Path) -> None:
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_rss_archive_missing_note(omit_id_prefix=True)
+
+        assert hooks.archive_download is not None
+        with pytest.raises(ExtractionError) as exc_info:
+            hooks.archive_download(note)
+        assert exc_info.value.stage == "resolve"
+
+    def test_missing_year_month_in_path_raises_resolve(self, tmp_path: Path) -> None:
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_rss_archive_missing_note(note_path="articles/rss-techcrunch/")
+
+        assert hooks.archive_download is not None
+        with pytest.raises(ExtractionError) as exc_info:
+            hooks.archive_download(note)
+        assert exc_info.value.stage == "resolve"
+
+
+def _make_rss_textless_note(
+    *,
+    source_url: str = "https://example.com/article-42",
+    omit_source_url: bool = False,
+) -> dict[str, Any]:
+    """Build an RSS note dict with no ``text:*`` tag (text_extraction stage)."""
+    note = _make_rss_archive_missing_note(
+        source_url=source_url,
+        omit_source_url=omit_source_url,
+    )
+    # Drop archive-missing so the note is in the pure text-extraction
+    # state; the text_extraction hook only inspects source + frontmatter.
+    note["tags"] = [t for t in note["tags"] if t != "influx:archive-missing"]
+    return note
+
+
+class TestTextExtractionHookRssSuccess:
+    def test_returns_html_tag_on_extract_success(self, tmp_path: Path) -> None:
+        from influx.extraction.article import ArticleExtractionResult
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_rss_textless_note()
+
+        with patch("influx.repair_hooks.extract_article") as mock_ex:
+            mock_ex.return_value = ArticleExtractionResult(
+                text="extracted body",
+                source="article",
+            )
+            assert hooks.text_extraction is not None
+            tag = hooks.text_extraction(note)
+
+        assert tag == "text:html"
+        # First positional arg is the source_url from frontmatter.
+        assert mock_ex.call_args.args[0] == "https://example.com/article-42"
+
+
+class TestTextExtractionHookRssFailures:
+    def test_extraction_error_propagates(self, tmp_path: Path) -> None:
+        from influx.repair_counters import classify_failure
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_rss_textless_note()
+
+        with patch("influx.repair_hooks.extract_article") as mock_ex:
+            mock_ex.side_effect = ExtractionError(
+                "extracted body too short",
+                stage="min_length",
+                detail="got 100 chars, need 500",
+            )
+            assert hooks.text_extraction is not None
+            with pytest.raises(ExtractionError) as exc_info:
+                hooks.text_extraction(note)
+
+        assert exc_info.value.stage == "min_length"
+        # Not a counted stage — the note re-enters next sweep pass.
+        assert classify_failure(exc_info.value) == "transient"
+
+    def test_network_error_rewrapped_as_extraction_error(self, tmp_path: Path) -> None:
+        from influx.errors import NetworkError
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_rss_textless_note()
+
+        with patch("influx.repair_hooks.extract_article") as mock_ex:
+            mock_ex.side_effect = NetworkError(
+                "tls handshake failed",
+                url="https://example.com/article-42",
+                kind="tls",
+            )
+            assert hooks.text_extraction is not None
+            with pytest.raises(ExtractionError) as exc_info:
+                hooks.text_extraction(note)
+
+        assert exc_info.value.stage == "tls"
+
+
+class TestTextExtractionHookRssMetadataRecovery:
+    def test_missing_source_url_raises_resolve(self, tmp_path: Path) -> None:
+        from influx.repair_counters import classify_failure
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_rss_textless_note(omit_source_url=True)
+
+        assert hooks.text_extraction is not None
+        with pytest.raises(ExtractionError) as exc_info:
+            hooks.text_extraction(note)
+        assert exc_info.value.stage == "resolve"
         assert classify_failure(exc_info.value) == "transient"


### PR DESCRIPTION
Closes #130.

## Summary

- Replace the arxiv-only gate in `_make_archive_download_hook` and `_make_text_extraction_hook` with a per-source dispatcher so RSS notes go through the same retry / cap / terminal-flip machinery as arxiv.
- RSS resolver derives `download_archive` kwargs from state already on disk: `source_url` from YAML frontmatter, item_id from the note's `rss-<feed>-<hash>` id (mirroring arxiv's `arxiv-<id>` convention), year/month from the note path. `_NOTE_PATH_RE` now matches both `papers/` and `articles/` prefixes.
- RSS text extraction reuses `extract_article` (the same helper RSS uses at acquisition) and returns `text:html` so the note exits the text-extraction stage.
- Failure classification uses the existing source-agnostic `_classify_download_kind`: `oversize`/`parse`/`validate` count toward the 3-attempt cap and flip `influx:archive-terminal`; HTTP and network kinds stay transient and re-enter the sweep next pass — identical policy to arxiv.

## Why

Staging runs were degrading on `archive_acquisition` and many of those degraded notes were RSS. The arxiv-only gate raised `unsupported_source` every pass; the text path terminalised cleanly via `_terminate_unsupported_text_source`, but the archive path treated `unsupported_source` as transient (it isn't in `_COUNTED_STAGES`), so `influx:archive-missing` re-selected the note forever. The fix replaces the gate with a dispatcher and lets RSS flow through the existing classify-and-cap pipeline.

## Acceptance criteria

- [x] RSS notes tagged for archive/text repair no longer loop through unsupported-source paths — they hit real retries and the existing counted-stage cap.
- [x] Defined RSS behavior: `success` (archive_path written, `archive-missing` cleared), `counted-cap-terminal` (3× oversize/parse/validate → `influx:archive-terminal`), `transient-retry` (HTTP/timeout/network → re-enter next pass), or `resolve` (missing source_url / id prefix / path year-month → operator hand-fix).
- [x] Repair logs and counters now reflect real RSS failure stages (`stage=http`, `stage=timeout`, `stage=oversize`, …) via the existing `_log_stage_failure` and `RepairCounters` instead of a single `unsupported_source` repeating forever. No metric schema change.
- [x] Tests cover at least one degraded RSS note shape — see new `TestArchiveDownloadHookRss*` and `TestTextExtractionHookRss*` classes (10 new test cases).
- [x] Existing arxiv repair behavior intact — arxiv hook path is byte-equivalent; all prior tests pass unchanged.

## Test plan

- [x] `uv run pytest tests/unit/test_repair_hooks_production.py -v` — 55 passed (10 new RSS tests)
- [x] `uv run pytest tests/unit/test_repair_sweep.py tests/unit/test_repair_stage_selection.py tests/unit/test_repair_counters.py tests/unit/test_repair_hooks.py` — 113 passed
- [x] `uv run pytest` (full suite) — 1875 passed
- [x] `uv run ruff check src/influx/repair_hooks.py tests/unit/test_repair_hooks_production.py` — clean
- [ ] Staging: grep `sweep_stage=archive_download` filtered to `source:rss-*` notes; expect a mix of real stages instead of `unsupported_source` looping