### PR TITLE
feat: dedup scored candidates before Source.acquire (#125)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -102,8 +102,8 @@ _Avoid_: probes (one input to Health), readiness (one output of Health).
 
 - A **Profile** has many **Runs** over time; at most one Run per Profile is active at once (enforced by the **Coordinator**).
 - A **Run** consumes a **RunPlan** and produces a **RunOutcome**; its history lives in the **RunLedger**.
-- A **Run**'s Acquire stage walks: **Source**.fetch_candidates → **Filter** → **Source**.acquire → **Acquired**.
-- A **Run**'s Ingest stage walks: cache_lookup → **Cascade**.enrich → **Renderer** → **LithosClient**.write_note → **LcmaWiring**.wire. The cache_lookup step is two-stage: a primary `compose_dedup_query` lookup (title + first sentence of summary) followed, on miss, by a defensive exact-`source_url` fallback (#128). Either hit is treated as a cache hit for the rest of the per-item flow — so notes already present under the same URL never silently fall through to a write-time `duplicate` rejection.
+- A **Run**'s Acquire stage walks: **Source**.fetch_candidates → **Filter** → pre-acquire `lithos_cache_lookup` → **Source**.acquire → **Acquired**. The pre-acquire `cache_lookup` is the primary `compose_dedup_query` lookup (title + first sentence of summary, #125). Backfill cache hits short-circuit before `Source.acquire`, so duplicate items skip the download / archive / extract cost; normal-run hits still acquire so the multi-profile merge path inside `LithosClient.write_note` runs.
+- A **Run**'s Ingest stage walks: **Cascade**.enrich → **Renderer** → **LithosClient**.write_note → **LcmaWiring**.wire. On items the Acquire stage flagged as cache misses, Ingest also runs a defensive exact-`source_url` fallback (#128) before write — catching notes whose `source_url` is already in Lithos but whose title/first-sentence abstract drifted between runs, so they never silently fall through to a write-time `duplicate` rejection.
 - A **Cascade** consults **RepairCounters** before each tier and after counted failures.
 - A **LithosClient** owns **WriteResult** parsing and **Squatter-shape dispatch** internally.
 - **Health** latches are flipped by Run stages and read by the scheduler before starting a new Run.

--- a/src/influx/run.py
+++ b/src/influx/run.py
@@ -46,6 +46,8 @@ from influx.lcma_wiring import CascadeOutput, LcmaWiringDeps
 from influx.lcma_wiring import wire as lcma_wire
 from influx.lithos_client import LithosClient
 from influx.notifications import HighlightItem, ProfileRunResult, RunStats
+from influx.run_dedup import dedup_scored_candidates
+from influx.source import BoundScoredCandidate
 from influx.rejection_rate import on_run_complete as rejection_rate_on_run_complete
 from influx.rejection_rate import record_filter_result
 from influx.repair import SweepWriteError
@@ -83,7 +85,7 @@ logger = logging.getLogger(__name__)
 ProfileItem = dict[str, Any]
 ItemProvider = Callable[
     [str, RunKind, dict[str, str | int] | None, str],
-    Awaitable[Iterable[ProfileItem]],
+    Awaitable[Iterable[BoundScoredCandidate]],
 ]
 
 
@@ -397,21 +399,64 @@ async def _run_acquire_stage(
     client: LithosClient,
     filter_prompt: str,
 ) -> tuple[AcquireResult, StageDiagnostics]:
-    """Stage 3 — Source.fetch_candidates → Filter.score → Source.acquire."""
+    """Stage 3 — fetch_candidates → score → pre-acquire dedup → acquire (#125).
+
+    The provider returns :class:`BoundScoredCandidate`s rather than fully
+    acquired ProfileItems.  The Run stage runs ``lithos_cache_lookup``
+    on each candidate's identity and partitions:
+
+    - cache miss → invoke the bound's ``acquire`` closure;
+    - cache hit + ``skip_cache_hits=True`` (backfill) → drop, no acquire;
+    - cache hit + normal run → invoke ``acquire`` so the multi-profile
+      merge path inside :meth:`LithosClient.write_note` still runs.
+
+    Each acquired ProfileItem is stamped with ``cache_hit`` (and
+    ``cache_hit_reason`` on hits) so the Ingest stage can skip its own
+    primary lookup and reach the URL-fallback (#128) only when needed.
+    """
     terminal_ids = await client.list_archive_terminal_arxiv_ids(
         profile=plan.profile,
     )
     terminal_token = current_archive_terminal_arxiv_ids.set(terminal_ids)
     try:
-        items = list(
+        bounds = list(
             await item_provider(
                 plan.profile, plan.kind, plan.date_window, filter_prompt
             )
         )
+        logger.info(
+            "source fetch+score completed profile=%s kind=%s scored=%d",
+            plan.profile,
+            plan.kind.value,
+            len(bounds),
+        )
+
+        outcome = await dedup_scored_candidates(
+            bounds,
+            client=client,
+            profile=plan.profile,
+            skip_cache_hits=plan.skip_cache_hits,
+        )
+        logger.info(
+            "pre-acquire dedup completed profile=%s to_acquire=%d hits_skipped=%d",
+            plan.profile,
+            len(outcome.to_acquire),
+            len(outcome.hits_to_skip),
+        )
+
+        items: list[ProfileItem] = []
+        for decision in outcome.to_acquire:
+            acquired = await decision.bound.acquire()
+            if acquired is None:
+                continue
+            acquired["cache_hit"] = decision.cache_hit
+            if decision.cache_hit_reason is not None:
+                acquired["cache_hit_reason"] = decision.cache_hit_reason
+            items.append(acquired)
     finally:
         current_archive_terminal_arxiv_ids.reset(terminal_token)
     logger.info(
-        "source acquisition completed profile=%s kind=%s candidates=%d",
+        "source acquisition completed profile=%s kind=%s items=%d",
         plan.profile,
         plan.kind.value,
         len(items),
@@ -468,13 +513,29 @@ async def _run_ingest_stage(
             item.get("path", ""),
             item.get("tags", []),
         )
-        cache_body = await client.cache_lookup_for_item_body(
-            title=title,
-            source_url=source_url,
-            abstract_or_summary=item.get("abstract_or_summary"),
-        )
-        cache_hit = bool(cache_body.get("hit"))
-        cache_hit_reason: str | None = "primary" if cache_hit else None
+        # #125: the Acquire stage now performs the primary
+        # ``lithos_cache_lookup`` *before* ``Source.acquire`` and stamps
+        # the verdict on the ProfileItem.  The legacy primary-lookup
+        # branch below is reached only when ``cache_hit`` is absent —
+        # i.e. tests that hand-build ProfileItems and call
+        # ``_run_ingest_stage`` directly without going through the
+        # Acquire stage.  Production runs always carry the metadata.
+        cache_hit_meta = item.get("cache_hit")
+        if cache_hit_meta is None:
+            cache_body = await client.cache_lookup_for_item_body(
+                title=title,
+                source_url=source_url,
+                abstract_or_summary=item.get("abstract_or_summary"),
+            )
+            cache_hit = bool(cache_body.get("hit"))
+            cache_hit_reason: str | None = "primary" if cache_hit else None
+            if cache_hit:
+                metrics.cache_hits().add(
+                    1, {"profile": profile, "source": item_source}
+                )
+        else:
+            cache_hit = bool(cache_hit_meta)
+            cache_hit_reason = item.get("cache_hit_reason") if cache_hit else None
 
         # #128: defensive source_url-only fallback when the primary
         # title+abstract dedup misses.  Catches notes whose source_url
@@ -492,7 +553,6 @@ async def _run_ingest_stage(
                 )
 
         if cache_hit:
-            metrics.cache_hits().add(1, {"profile": profile, "source": item_source})
             logger.info(
                 "article cache hit profile=%s source_url=%s title=%r "
                 "kind=%s action=%s reason=%s",

--- a/src/influx/run.py
+++ b/src/influx/run.py
@@ -46,13 +46,13 @@ from influx.lcma_wiring import CascadeOutput, LcmaWiringDeps
 from influx.lcma_wiring import wire as lcma_wire
 from influx.lithos_client import LithosClient
 from influx.notifications import HighlightItem, ProfileRunResult, RunStats
-from influx.run_dedup import dedup_scored_candidates
-from influx.source import BoundScoredCandidate
 from influx.rejection_rate import on_run_complete as rejection_rate_on_run_complete
 from influx.rejection_rate import record_filter_result
 from influx.repair import SweepWriteError
 from influx.repair import sweep as repair_sweep
+from influx.run_dedup import dedup_scored_candidates
 from influx.run_ledger import RunLedger
+from influx.source import BoundScoredCandidate
 from influx.telemetry import (
     current_archive_terminal_arxiv_ids,
     current_fetched_total,
@@ -530,9 +530,7 @@ async def _run_ingest_stage(
             cache_hit = bool(cache_body.get("hit"))
             cache_hit_reason: str | None = "primary" if cache_hit else None
             if cache_hit:
-                metrics.cache_hits().add(
-                    1, {"profile": profile, "source": item_source}
-                )
+                metrics.cache_hits().add(1, {"profile": profile, "source": item_source})
         else:
             cache_hit = bool(cache_hit_meta)
             cache_hit_reason = item.get("cache_hit_reason") if cache_hit else None

--- a/src/influx/run.py
+++ b/src/influx/run.py
@@ -905,7 +905,7 @@ async def default_item_provider(
     kind: RunKind,
     run_range: dict[str, str | int] | None,
     filter_prompt: str,
-) -> Iterable[ProfileItem]:
+) -> Iterable[BoundScoredCandidate]:
     """No-op fallback (mirrors ``influx.scheduler.default_item_provider``)."""
     del profile, kind, run_range, filter_prompt
     return ()

--- a/src/influx/run_dedup.py
+++ b/src/influx/run_dedup.py
@@ -42,6 +42,24 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
+def _metric_source(source_label: str) -> str:
+    """Normalise ``source_label`` to the bounded ``source`` metric label.
+
+    ``BoundScoredCandidate.source_label`` is rich — ``"arxiv"`` or
+    ``"rss:<feed_name>"`` — so logs can carry per-feed provenance.  The
+    ``source`` label on :func:`metrics.cache_hits` (and every other
+    Influx metric) is contractually bounded to ``"arxiv"`` / ``"rss"``
+    (see ``influx/metrics.py`` "Cardinality discipline").  Collapse the
+    per-feed suffix here so dashboards/alerts keyed on the bounded set
+    keep working and per-feed cardinality never leaks into metrics.
+    """
+    if source_label == "arxiv":
+        return "arxiv"
+    if source_label == "rss" or source_label.startswith("rss:"):
+        return "rss"
+    return "unknown"
+
+
 @dataclass(frozen=True, slots=True)
 class DedupDecision:
     """One scored candidate's pre-acquire dedup outcome.
@@ -97,7 +115,7 @@ async def dedup_scored_candidates(
 
         if hit:
             metrics.cache_hits().add(
-                1, {"profile": profile, "source": bound.source_label}
+                1, {"profile": profile, "source": _metric_source(bound.source_label)}
             )
             action = "skip" if skip_cache_hits else "merge-profile"
             logger.info(

--- a/src/influx/run_dedup.py
+++ b/src/influx/run_dedup.py
@@ -1,0 +1,135 @@
+"""Run-stage pre-acquire dedup helper (#125).
+
+Issue #125 moves :meth:`influx.lithos_client.LithosClient.cache_lookup_for_item_body`
+ahead of :meth:`Source.acquire` so duplicate items skip download / archive /
+extraction cost in backfill profiles and merge-bound items still flow through
+the write path with the cache-hit fact recorded.
+
+Partition rules (one ``cache_lookup`` per scored candidate):
+
+============================  =====================  ===========================
+``hit``                       ``skip_cache_hits``    Goes to
+============================  =====================  ===========================
+``False`` (miss)              ``True``  / ``False``  ``to_acquire`` (cache_hit=False)
+``True`` (hit)                ``True``               ``hits_to_skip`` (drop)
+``True`` (hit)                ``False``              ``to_acquire`` (cache_hit=True)
+============================  =====================  ===========================
+
+The helper emits :func:`metrics.cache_hits` and the ``"article cache hit"``
+log line for each hit it decides — those signals move out of the Ingest
+stage with the lookup itself.  The defensive source-URL fallback (#128)
+stays in Ingest and only fires when ``cache_hit=False`` reaches the write
+path.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from influx import metrics
+from influx.lithos_client import LithosClient
+from influx.source import BoundScoredCandidate
+
+__all__ = [
+    "DedupDecision",
+    "DedupOutcome",
+    "dedup_scored_candidates",
+]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class DedupDecision:
+    """One scored candidate's pre-acquire dedup outcome.
+
+    ``cache_hit_reason`` is ``"primary"`` when the primary
+    title+first-sentence query hit, otherwise ``None``.  ``cache_body``
+    is the raw lookup body so downstream code can inspect server-side
+    metadata without re-querying.
+    """
+
+    bound: BoundScoredCandidate
+    cache_hit: bool
+    cache_hit_reason: str | None
+    cache_body: dict[str, Any] | None
+
+
+@dataclass(frozen=True, slots=True)
+class DedupOutcome:
+    """Partitioned dedup result for a batch of scored candidates."""
+
+    to_acquire: tuple[DedupDecision, ...]
+    hits_to_skip: tuple[DedupDecision, ...]
+
+
+async def dedup_scored_candidates(
+    bounds: Sequence[BoundScoredCandidate],
+    *,
+    client: LithosClient,
+    profile: str,
+    skip_cache_hits: bool,
+) -> DedupOutcome:
+    """Run pre-acquire ``lithos_cache_lookup`` per *bound* and partition.
+
+    Calls :meth:`LithosClient.cache_lookup_for_item_body` once per
+    candidate, classifies each result per the matrix in this module's
+    docstring, and returns a :class:`DedupOutcome`.
+
+    Errors from ``cache_lookup_for_item_body`` propagate — matching the
+    pre-#125 Ingest behaviour, which had no surrounding try/except.
+    """
+    to_acquire: list[DedupDecision] = []
+    hits_to_skip: list[DedupDecision] = []
+
+    for bound in bounds:
+        candidate = bound.scored.candidate
+        abstract = candidate.abstract or None
+        body = await client.cache_lookup_for_item_body(
+            title=candidate.title,
+            source_url=candidate.source_url,
+            abstract_or_summary=abstract,
+        )
+        hit = bool(body.get("hit"))
+
+        if hit:
+            metrics.cache_hits().add(
+                1, {"profile": profile, "source": bound.source_label}
+            )
+            action = "skip" if skip_cache_hits else "merge-profile"
+            logger.info(
+                "article cache hit profile=%s source_url=%s title=%r "
+                "action=%s reason=primary source=%s",
+                profile,
+                candidate.source_url,
+                candidate.title,
+                action,
+                bound.source_label,
+            )
+            decision = DedupDecision(
+                bound=bound,
+                cache_hit=True,
+                cache_hit_reason="primary",
+                cache_body=body,
+            )
+            if skip_cache_hits:
+                hits_to_skip.append(decision)
+            else:
+                to_acquire.append(decision)
+        else:
+            to_acquire.append(
+                DedupDecision(
+                    bound=bound,
+                    cache_hit=False,
+                    cache_hit_reason=None,
+                    cache_body=body,
+                )
+            )
+
+    return DedupOutcome(
+        to_acquire=tuple(to_acquire),
+        hits_to_skip=tuple(hits_to_skip),
+    )

--- a/src/influx/scheduler.py
+++ b/src/influx/scheduler.py
@@ -35,6 +35,7 @@ from influx.config import AppConfig
 from influx.coordinator import Coordinator, ProfileBusyError, RunKind
 from influx.notifications import ProfileRunResult
 from influx.run_ledger import RunLedger
+from influx.source import BoundScoredCandidate
 
 __all__ = [
     "InfluxScheduler",
@@ -46,15 +47,17 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-# An item provider yields the iterable of dicts that ``run_profile``
-# turns into ``lithos_write`` calls.  Each dict must include ``title``,
-# ``source_url``, ``content``, ``tags``, and ``confidence``; ``score``,
-# ``path``, and ``abstract_or_summary`` are optional.  PRD 04 replaces
-# the default no-op provider with the real arXiv + RSS pipeline.
+# An item provider yields the iterable of :class:`BoundScoredCandidate`
+# that the Run's Acquire stage runs through pre-acquire dedup (#125)
+# before invoking the per-item ``acquire`` closure.  Each closure
+# eventually returns a ``ProfileItem`` dict that ``run_profile`` turns
+# into ``lithos_write`` calls — must include ``title``, ``source_url``,
+# ``content``, ``tags``, ``confidence``; ``score``, ``path``, and
+# ``abstract_or_summary`` are optional.
 ProfileItem = dict[str, Any]
 ItemProvider = Callable[
     [str, RunKind, dict[str, str | int] | None, str],
-    Awaitable[Iterable[ProfileItem]],
+    Awaitable[Iterable[BoundScoredCandidate]],
 ]
 # Per-tick factory: returns a fresh ``(item_provider, fetch_cache)`` pair so
 # each cron fire has its own dedup scope and cron tick N+1 cannot see cron
@@ -94,7 +97,7 @@ async def default_item_provider(
     kind: RunKind,
     run_range: dict[str, str | int] | None,
     filter_prompt: str,
-) -> Iterable[ProfileItem]:
+) -> Iterable[BoundScoredCandidate]:
     """No-op item provider — PRD 04 replaces this with arXiv + RSS fetch.
 
     Returns an empty iterable so that PRD 03 / PRD 05 production runs

--- a/src/influx/source.py
+++ b/src/influx/source.py
@@ -15,7 +15,7 @@ This module owns the seam.  Source adapters live under
 
 from __future__ import annotations
 
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
@@ -23,6 +23,7 @@ from influx.config import AppConfig, ProfileConfig
 from influx.coordinator import RunKind
 
 __all__ = [
+    "BoundScoredCandidate",
     "Candidate",
     "ScoredCandidate",
     "Source",
@@ -65,6 +66,30 @@ class ScoredCandidate:
     confidence: float
     reason: str
     filter_tags: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class BoundScoredCandidate:
+    """A :class:`ScoredCandidate` plus a thunk that performs source-specific
+    acquire (#125).
+
+    Returned by the unified ``ItemProvider`` so the orchestration layer
+    can run ``lithos_cache_lookup`` on candidate identity *before* the
+    source adapter pays the full download/archive/extract cost.
+
+    ``acquire`` is a no-arg async callable that captures the source
+    adapter, ``profile_cfg``, and ``config`` from the provider scope;
+    invoking it runs the per-item acquire (typically wrapping
+    :func:`asyncio.to_thread` around blocking work, #124) and returns
+    the ready-to-yield ``ProfileItem`` dict.
+
+    ``source_label`` carries the source family used for metric labels and
+    log lines — ``"arxiv"`` or ``"rss:<feed_name>"``.
+    """
+
+    scored: ScoredCandidate
+    acquire: Callable[[], Awaitable[dict[str, Any] | None]]
+    source_label: str
 
 
 @runtime_checkable

--- a/src/influx/sources/__init__.py
+++ b/src/influx/sources/__init__.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from influx.config import AppConfig
 from influx.coordinator import RunKind
+from influx.source import BoundScoredCandidate
 
 __all__ = [
     "FetchCache",
@@ -152,7 +153,7 @@ def make_item_provider(
     arxiv_filter_scorer: Any | None = None,
 ) -> Callable[
     [str, RunKind, dict[str, str | int] | None, str],
-    Awaitable[Iterable[dict[str, Any]]],
+    Awaitable[Iterable[BoundScoredCandidate]],
 ]:
     """Build a unified item provider for arXiv + RSS with fetch dedup.
 
@@ -192,11 +193,11 @@ def make_item_provider(
         kind: RunKind,
         run_range: dict[str, str | int] | None,
         filter_prompt: str,
-    ) -> Iterable[dict[str, Any]]:
-        arxiv_items = list(
+    ) -> Iterable[BoundScoredCandidate]:
+        arxiv_bounds = list(
             await arxiv_provider(profile, kind, run_range, filter_prompt)
         )
-        rss_items = list(await rss_provider(profile, kind, run_range, filter_prompt))
-        return arxiv_items + rss_items
+        rss_bounds = list(await rss_provider(profile, kind, run_range, filter_prompt))
+        return arxiv_bounds + rss_bounds
 
     return provider

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -46,7 +46,7 @@ from influx.extraction.pipeline import extract_arxiv_text
 from influx.filter import FilterScorerError
 from influx.http_client import guarded_fetch
 from influx.renderer import render
-from influx.source import Candidate, ScoredCandidate
+from influx.source import BoundScoredCandidate, Candidate, ScoredCandidate
 from influx.storage import download_archive
 from influx.telemetry import (
     current_archive_terminal_arxiv_ids,
@@ -1208,7 +1208,7 @@ def make_arxiv_item_provider(
         kind: RunKind,
         run_range: dict[str, str | int] | None,
         filter_prompt: str,
-    ) -> Iterable[dict[str, Any]]:
+    ) -> Iterable[BoundScoredCandidate]:
         profile_cfg = next((p for p in config.profiles if p.name == profile), None)
         if profile_cfg is None:
             _log.info("arxiv source skipped profile=%s reason=unknown_profile", profile)
@@ -1234,28 +1234,38 @@ def make_arxiv_item_provider(
             filter_scorer=filter_scorer,
         )
 
-        # ── 3. Source.acquire per scored candidate ────────────────
-        # Issue #124: ``acquire`` performs blocking archive download
-        # (sync ``guarded_fetch``) plus the cascade enrichment chain
-        # (sync HTTP for tier 1/2/3). Offload each per-item acquisition
-        # to a worker thread so admin endpoints stay responsive.
-        results: list[dict[str, Any]] = [
-            await asyncio.to_thread(
-                source.acquire,
-                sc,
-                profile_cfg=profile_cfg,
-                config=config,
+        # ── 3. Bind per-item acquire as closures (#125) ────────────
+        # ``Source.acquire`` is invoked by the Run's Acquire stage after
+        # pre-acquire cache_lookup partitions cache misses + merge-bound
+        # hits from outright skips.  Issue #124 still applies — the
+        # closure wraps the blocking acquire in ``asyncio.to_thread`` so
+        # admin endpoints stay responsive once the closure is invoked.
+        bounds: list[BoundScoredCandidate] = []
+        for sc in scored_list:
+
+            async def _acquire(sc: ScoredCandidate = sc) -> dict[str, Any] | None:
+                return await asyncio.to_thread(
+                    source.acquire,
+                    sc,
+                    profile_cfg=profile_cfg,
+                    config=config,
+                )
+
+            bounds.append(
+                BoundScoredCandidate(
+                    scored=sc,
+                    acquire=_acquire,
+                    source_label="arxiv",
+                )
             )
-            for sc in scored_list
-        ]
 
         _log.info(
-            "arxiv source completed profile=%s fetched=%d accepted=%d",
+            "arxiv source completed profile=%s fetched=%d scored=%d",
             profile,
             len(candidates),
-            len(results),
+            len(bounds),
         )
-        return results
+        return bounds
 
     return provider
 

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -40,7 +40,7 @@ from influx.filter import FilterScorerError, _acall_filter_model_with_retry
 from influx.http_client import aguarded_fetch as _aguarded_fetch
 from influx.renderer import render
 from influx.slugs import slugify_feed_name
-from influx.source import Candidate, ScoredCandidate
+from influx.source import BoundScoredCandidate, Candidate, ScoredCandidate
 from influx.storage import download_archive
 from influx.telemetry import (
     current_run_id,
@@ -626,7 +626,7 @@ def make_rss_item_provider(
         kind: RunKind,
         run_range: dict[str, str | int] | None,
         filter_prompt: str,
-    ) -> Iterable[dict[str, Any]]:
+    ) -> Iterable[BoundScoredCandidate]:
         del kind, run_range
 
         profile_cfg = next((p for p in config.profiles if p.name == profile), None)
@@ -644,7 +644,7 @@ def make_rss_item_provider(
                 "influx.source": "rss",
             },
         ) as fetch_span:
-            results: list[dict[str, Any]] = []
+            bounds: list[BoundScoredCandidate] = []
             for feed_entry in profile_cfg.sources.rss:
                 _log.info(
                     "rss feed fetch started profile=%s feed=%r url=%s source_tag=%s",
@@ -744,13 +744,32 @@ def make_rss_item_provider(
                         item.title,
                         item.url,
                     )
-                    # Issue #124: build_rss_note_item performs sync HTTP
-                    # (article fetch + archive download) and PDF/HTML
-                    # extraction. Offload to a worker thread so the
-                    # admin event loop stays responsive during long
-                    # acquisition + cascade work.
-                    results.append(
-                        await asyncio.to_thread(
+                    # Issue #125: emit a BoundScoredCandidate so the Run
+                    # stage can run pre-acquire ``lithos_cache_lookup``
+                    # before paying the article fetch / archive / extract
+                    # cost.  ``build_rss_note_item`` is the per-item
+                    # acquire entrypoint; issue #124's ``asyncio.to_thread``
+                    # offload moves into the closure, fired only when the
+                    # orchestrator decides this candidate must be acquired.
+                    sc = ScoredCandidate(
+                        candidate=Candidate(
+                            item_id=_rss_filter_id(item),
+                            title=item.title,
+                            abstract=item.summary or "",
+                            source_url=item.url,
+                            payload=item,
+                        ),
+                        score=scored.score,
+                        confidence=1.0,
+                        reason=scored.reason,
+                        filter_tags=scored.tags,
+                    )
+
+                    async def _acquire(
+                        item: RssFeedItem = item,
+                        scored: Any = scored,
+                    ) -> dict[str, Any] | None:
+                        return await asyncio.to_thread(
                             build_rss_note_item,
                             item=item,
                             profile_name=profile,
@@ -760,22 +779,29 @@ def make_rss_item_provider(
                             reason=scored.reason,
                             filter_tags=scored.tags,
                         )
+
+                    bounds.append(
+                        BoundScoredCandidate(
+                            scored=sc,
+                            acquire=_acquire,
+                            source_label=f"rss:{feed_entry.name}",
+                        )
                     )
                 _log.info(
                     "rss feed completed profile=%s feed=%r accepted_so_far=%d",
                     profile,
                     feed_entry.name,
-                    len(results),
+                    len(bounds),
                 )
-            fetch_span.set_attribute("influx.item_count", len(results))
+            fetch_span.set_attribute("influx.item_count", len(bounds))
             _log.info(
                 "rss source completed profile=%s feeds=%d accepted=%d",
                 profile,
                 len(profile_cfg.sources.rss),
-                len(results),
+                len(bounds),
             )
 
-        return results
+        return bounds
 
     return provider
 

--- a/tests/_bound_helpers.py
+++ b/tests/_bound_helpers.py
@@ -1,0 +1,58 @@
+"""Test helpers for the #125 BoundScoredCandidate seam.
+
+The Run pipeline now expects ``ItemProvider`` to return
+:class:`BoundScoredCandidate` instances rather than fully-acquired
+ProfileItem dicts.  Tests that hand-build their own item providers wrap
+each ProfileItem dict via :func:`bound_for` so the closure simply
+returns the dict — keeping pre-#125 fixture data intact while
+satisfying the new seam.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from influx.source import BoundScoredCandidate, Candidate, ScoredCandidate
+
+
+def bound_for(
+    item: dict[str, Any],
+    *,
+    source_label: str | None = None,
+) -> BoundScoredCandidate:
+    """Wrap a ProfileItem dict as a BoundScoredCandidate.
+
+    The ``acquire`` closure returns the dict verbatim.  ``source_label``
+    defaults to the item's ``source`` key (typically ``"arxiv"`` or
+    ``"rss"``) so metric labels emitted by the Run stage match what the
+    real providers would have produced.
+    """
+    if source_label is None:
+        direct = item.get("source")
+        source_label = direct if isinstance(direct, str) and direct else "arxiv"
+
+    async def _acquire() -> dict[str, Any]:
+        return item
+
+    return BoundScoredCandidate(
+        scored=ScoredCandidate(
+            candidate=Candidate(
+                item_id=str(item.get("source_url") or item.get("id") or "test-id"),
+                title=str(item.get("title", "")),
+                abstract=str(item.get("abstract_or_summary") or ""),
+                source_url=str(item.get("source_url", "")),
+            ),
+            score=int(item.get("score", 0)),
+            confidence=float(item.get("confidence", 0.0)),
+            reason=str(item.get("reason", "")),
+            filter_tags=tuple(item.get("filter_tags", [])),
+        ),
+        acquire=_acquire,
+        source_label=source_label,
+    )
+
+
+def bounds_for(items: Iterable[dict[str, Any]]) -> list[BoundScoredCandidate]:
+    """Map :func:`bound_for` across a list of ProfileItem dicts."""
+    return [bound_for(it) for it in items]

--- a/tests/integration/test_arxiv_to_lithos.py
+++ b/tests/integration/test_arxiv_to_lithos.py
@@ -44,6 +44,7 @@ from influx.notifications import (
 )
 from influx.probes import ProbeLoop
 from influx.scheduler import InfluxScheduler
+from tests._bound_helpers import bounds_for
 from influx.service import post_run_webhook_hook
 from tests.contract.test_lithos_client import FakeLithosServer
 
@@ -228,11 +229,11 @@ def _make_item_provider(
         kind: RunKind,
         run_range: dict[str, str | int] | None,
         filter_prompt: str,
-    ) -> Iterable[dict[str, Any]]:
+    ) -> Iterable[Any]:
         del profile, kind, run_range
         if captured is not None:
             captured["filter_prompt"] = filter_prompt
-        return list(items)
+        return bounds_for(items)
 
     return provider
 

--- a/tests/integration/test_arxiv_to_lithos.py
+++ b/tests/integration/test_arxiv_to_lithos.py
@@ -44,8 +44,8 @@ from influx.notifications import (
 )
 from influx.probes import ProbeLoop
 from influx.scheduler import InfluxScheduler
-from tests._bound_helpers import bounds_for
 from influx.service import post_run_webhook_hook
+from tests._bound_helpers import bounds_for
 from tests.contract.test_lithos_client import FakeLithosServer
 
 # ── Fake webhook receiver ──────────────────────────────────────────

--- a/tests/integration/test_backfill_arxiv.py
+++ b/tests/integration/test_backfill_arxiv.py
@@ -270,17 +270,20 @@ class TestBackfillCacheLookupSkip:
         # Queue Lithos: feedback
         fake_lithos.list_responses.append(json.dumps({"items": []}))
 
-        # First item: primary miss + source_url fallback miss (#128) →
-        # genuine cache miss → will be written.
-        # Second item: primary hit → no fallback runs → skipped on backfill.
-        fake_lithos.cache_lookup_responses.append(
-            json.dumps({"hit": False, "stale_exists": False})
-        )
+        # #125 ordering — pre-acquire dedup runs primary lookup on every
+        # scored candidate FIRST (fetch+score order), then for cache-miss
+        # items the Ingest URL fallback (#128) runs.
+        #   1. item1 (Alpha) primary  → miss (goes to acquire)
+        #   2. item2 (Beta)  primary  → hit  (backfill drops pre-acquire)
+        #   3. item1 (Alpha) URL fbk  → miss (write proceeds)
         fake_lithos.cache_lookup_responses.append(
             json.dumps({"hit": False, "stale_exists": False})
         )
         fake_lithos.cache_lookup_responses.append(
             json.dumps({"hit": True, "stale_exists": False})
+        )
+        fake_lithos.cache_lookup_responses.append(
+            json.dumps({"hit": False, "stale_exists": False})
         )
 
         with patch(
@@ -303,8 +306,10 @@ class TestBackfillCacheLookupSkip:
         assert len(write_calls) == 1
         assert write_calls[0][1]["title"] == "Backfill Paper Alpha"
 
-        # Verify: THREE cache_lookup calls — item 1 does primary + source_url
-        # fallback (#128) on a miss, item 2 does only primary on a hit.
+        # Verify: THREE cache_lookup calls — both items get primary
+        # pre-acquire (#125), then item 1 also does the source_url
+        # fallback (#128) on its primary miss before write.  Item 2's
+        # primary hit short-circuits in Acquire so no fallback runs.
         cache_calls = [c for c in fake_lithos.calls if c[0] == "lithos_cache_lookup"]
         assert len(cache_calls) == 3
 

--- a/tests/integration/test_backfill_exclusion.py
+++ b/tests/integration/test_backfill_exclusion.py
@@ -32,6 +32,7 @@ from influx.coordinator import Coordinator, RunKind
 from influx.http_api import router
 from influx.probes import ProbeLoop
 from influx.scheduler import InfluxScheduler
+from tests._bound_helpers import bounds_for
 from tests.contract.test_lithos_client import FakeLithosServer
 
 # ── Fixtures ───────────────────────────────────────────────────────
@@ -99,9 +100,9 @@ def _make_item_provider(
         kind: RunKind,
         run_range: dict[str, str | int] | None,
         filter_prompt: str,
-    ) -> Iterable[dict[str, Any]]:
+    ) -> Iterable[Any]:
         del profile, kind, run_range, filter_prompt
-        return list(items or [])
+        return bounds_for(items or [])
 
     return provider
 

--- a/tests/integration/test_coordinator_slot.py
+++ b/tests/integration/test_coordinator_slot.py
@@ -37,6 +37,7 @@ from influx.coordinator import Coordinator, RunKind
 from influx.http_api import router
 from influx.probes import ProbeLoop
 from influx.scheduler import InfluxScheduler
+from tests._bound_helpers import bounds_for
 from tests.contract.test_lithos_client import FakeLithosServer
 
 # ── Fixtures ───────────────────────────────────────────────────────
@@ -109,9 +110,9 @@ def _make_item_provider(
         kind: RunKind,
         run_range: dict[str, str | int] | None,
         filter_prompt: str,
-    ) -> Iterable[dict[str, Any]]:
+    ) -> Iterable[Any]:
         del profile, kind, run_range, filter_prompt
-        return list(items or [])
+        return bounds_for(items or [])
 
     return provider
 

--- a/tests/integration/test_lcma_edges_end_to_end.py
+++ b/tests/integration/test_lcma_edges_end_to_end.py
@@ -32,6 +32,7 @@ from influx.config import (
 from influx.coordinator import RunKind
 from influx.probes import ProbeLoop
 from influx.scheduler import run_profile
+from tests._bound_helpers import bounds_for
 from tests.contract.test_lithos_client import FakeLithosServer
 
 # ── Helpers ────────────────────────────────────────────────────────
@@ -254,9 +255,9 @@ def _single_item_provider(
         kind: RunKind,
         run_range: Any,
         filter_prompt: str,
-    ) -> list[dict[str, Any]]:
+    ) -> list[Any]:
         del profile, kind, run_range, filter_prompt
-        return items
+        return bounds_for(items)
 
     return _provider
 

--- a/tests/integration/test_lcma_edges_end_to_end.py
+++ b/tests/integration/test_lcma_edges_end_to_end.py
@@ -220,7 +220,7 @@ class TestTaskBracketing:
             kind: RunKind,
             run_range: Any,
             filter_prompt: str,
-        ) -> list[dict[str, Any]]:
+        ) -> list[Any]:
             raise RuntimeError("simulated provider failure")
 
         with pytest.raises(RuntimeError, match="simulated provider failure"):

--- a/tests/integration/test_multi_profile_shared_source.py
+++ b/tests/integration/test_multi_profile_shared_source.py
@@ -38,6 +38,7 @@ from influx.http_api import router
 from influx.probes import ProbeLoop
 from influx.renderer import ProfileRelevanceEntry, render_note
 from influx.scheduler import InfluxScheduler
+from tests._bound_helpers import bounds_for
 from tests.contract.test_lithos_client import FakeLithosServer
 
 # ── Constants ─────────────────────────────────────────────────────────
@@ -152,9 +153,9 @@ def _make_item_provider(
         kind: RunKind,
         run_range: dict[str, str | int] | None,
         filter_prompt: str,
-    ) -> Iterable[dict[str, Any]]:
+    ) -> Iterable[Any]:
         del kind, run_range, filter_prompt
-        return list(profile_items.get(profile, []))
+        return bounds_for(profile_items.get(profile, []))
 
     return provider
 

--- a/tests/integration/test_otel_absent_service.py
+++ b/tests/integration/test_otel_absent_service.py
@@ -31,7 +31,7 @@ from influx.coordinator import Coordinator, RunKind
 from influx.http_api import router
 from influx.notifications import ProfileRunResult
 from influx.probes import ProbeLoop
-from influx.scheduler import InfluxScheduler, ProfileItem, run_profile
+from influx.scheduler import InfluxScheduler, run_profile
 from tests.contract.test_lithos_client import FakeLithosServer
 
 
@@ -169,7 +169,7 @@ class TestServiceWithOtelAbsent:
             kind: RunKind,
             run_range: dict[str, str | int] | None,
             filter_prompt: str,
-        ) -> Iterable[ProfileItem]:
+        ) -> Iterable[Any]:
             del profile, kind, run_range, filter_prompt
             return ()
 

--- a/tests/integration/test_pre_acquire_dedup.py
+++ b/tests/integration/test_pre_acquire_dedup.py
@@ -1,0 +1,421 @@
+"""Integration tests for #125 — pre-acquire Lithos dedup.
+
+These tests prove the optimisation: before Source.acquire downloads,
+archives, and extracts an article, the Run stage runs
+``lithos_cache_lookup`` on the scored candidate's identity.  In a
+backfill, a primary cache hit drops the candidate before any per-item
+acquisition work is paid for.
+
+Three behaviours covered:
+
+1. ``test_backfill_arxiv_cache_hit_skips_source_acquire`` — backfill
+   profile with a primed cache hit: the arXiv per-item acquire entry
+   point (``build_arxiv_note_item``) is NEVER invoked, no
+   ``lithos_write`` happens, and the run still completes.
+
+2. ``test_backfill_rss_cache_hit_skips_source_acquire`` — backfill
+   profile with a primed RSS cache hit: the RSS per-item acquire entry
+   point (``build_rss_note_item``) is NEVER invoked, no
+   ``lithos_write`` happens.
+
+3. ``test_normal_run_cache_hit_still_acquires_for_merge`` — normal
+   (non-backfill) run with a primed cache hit: acquire IS invoked, the
+   write path runs to support multi-profile merge, and the ProfileItem
+   carries ``cache_hit=True`` / ``cache_hit_reason="primary"``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Generator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from influx.backfill import run_backfill
+from influx.config import (
+    AppConfig,
+    ArxivSourceConfig,
+    FeedbackConfig,
+    LithosConfig,
+    NotificationsConfig,
+    ProfileConfig,
+    ProfileSources,
+    ProfileThresholds,
+    PromptEntryConfig,
+    PromptsConfig,
+    ResilienceConfig,
+    RssSourceEntry,
+    ScheduleConfig,
+    SecurityConfig,
+)
+from influx.coordinator import RunKind
+from influx.scheduler import run_profile
+from influx.sources import FetchCache, make_item_provider
+from influx.sources.arxiv import (
+    ArxivItem,
+    ArxivScorer,
+    ArxivScoreResult,
+)
+from influx.sources.rss import RssFeedItem
+from tests.contract.test_lithos_client import FakeLithosServer
+
+
+PROFILE = "ai-robotics"
+
+
+_ARXIV_FIXTURE = [
+    ArxivItem(
+        arxiv_id="2701.00001",
+        title="Already-Ingested Paper",
+        abstract="A paper that Lithos already has cached for this profile.",
+        published=datetime(2026, 4, 20, tzinfo=UTC),
+        categories=["cs.AI"],
+    ),
+]
+
+
+_RSS_FIXTURE = [
+    RssFeedItem(
+        url="https://example.org/already-ingested",
+        title="Already-Ingested Blog Post",
+        summary="A post that Lithos already has cached.",
+        published=datetime(2026, 4, 20, tzinfo=UTC),
+        source_tag="rss",
+        feed_name="Test Blog",
+    ),
+]
+
+
+def _arxiv_only_config(lithos_url: str) -> AppConfig:
+    return AppConfig(
+        lithos=LithosConfig(url=lithos_url),
+        schedule=ScheduleConfig(cron="0 6 * * *", timezone="UTC"),
+        profiles=[
+            ProfileConfig(
+                name=PROFILE,
+                description="AI and robotics",
+                thresholds=ProfileThresholds(
+                    relevance=7,
+                    full_text=100,
+                    deep_extract=100,
+                    notify_immediate=8,
+                ),
+                sources=ProfileSources(
+                    arxiv=ArxivSourceConfig(
+                        enabled=True,
+                        categories=["cs.AI"],
+                        max_results_per_category=10,
+                        lookback_days=30,
+                    ),
+                ),
+            ),
+        ],
+        providers={},
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(
+                text=(
+                    "Filter: {profile_description} "
+                    "{negative_examples} "
+                    "{min_score_in_results}"
+                ),
+            ),
+            tier1_enrich=PromptEntryConfig(text="t"),
+            tier3_extract=PromptEntryConfig(text="t"),
+        ),
+        notifications=NotificationsConfig(webhook_url="", timeout_seconds=5),
+        security=SecurityConfig(allow_private_ips=True),
+        feedback=FeedbackConfig(negative_examples_per_profile=20),
+        resilience=ResilienceConfig(arxiv_request_min_interval_seconds=0),
+    )
+
+
+def _rss_only_config(lithos_url: str) -> AppConfig:
+    return AppConfig(
+        lithos=LithosConfig(url=lithos_url),
+        schedule=ScheduleConfig(cron="0 6 * * *", timezone="UTC"),
+        profiles=[
+            ProfileConfig(
+                name=PROFILE,
+                description="AI and robotics",
+                thresholds=ProfileThresholds(
+                    relevance=7,
+                    full_text=100,
+                    deep_extract=100,
+                    notify_immediate=8,
+                ),
+                sources=ProfileSources(
+                    arxiv=ArxivSourceConfig(enabled=False),
+                    rss=[
+                        RssSourceEntry(
+                            name="Test Blog",
+                            url="https://example.org/feed.xml",
+                            source_tag="rss",
+                        ),
+                    ],
+                ),
+            ),
+        ],
+        providers={},
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(
+                text=(
+                    "Filter: {profile_description} "
+                    "{negative_examples} "
+                    "{min_score_in_results}"
+                ),
+            ),
+            tier1_enrich=PromptEntryConfig(text="t"),
+            tier3_extract=PromptEntryConfig(text="t"),
+        ),
+        notifications=NotificationsConfig(webhook_url="", timeout_seconds=5),
+        security=SecurityConfig(allow_private_ips=True),
+        feedback=FeedbackConfig(negative_examples_per_profile=20),
+        resilience=ResilienceConfig(arxiv_request_min_interval_seconds=0),
+    )
+
+
+def _deterministic_arxiv_scorer(score: int = 8) -> ArxivScorer:
+    def _score(item: ArxivItem, profile: str) -> ArxivScoreResult:
+        del item, profile
+        return ArxivScoreResult(score=score, confidence=1.0, reason="test-scorer")
+
+    return _score
+
+
+@pytest.fixture(scope="module")
+def fake_lithos() -> Generator[FakeLithosServer, None, None]:
+    server = FakeLithosServer()
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.fixture(scope="module")
+def fake_lithos_url(fake_lithos: FakeLithosServer) -> str:
+    return f"http://127.0.0.1:{fake_lithos.port}/sse"
+
+
+@pytest.fixture(autouse=True)
+def clear_fakes(fake_lithos: FakeLithosServer) -> None:
+    fake_lithos.calls.clear()
+    fake_lithos.write_responses.clear()
+    fake_lithos.read_responses.clear()
+    fake_lithos.cache_lookup_responses.clear()
+    fake_lithos.list_responses.clear()
+    fake_lithos.task_create_responses.clear()
+    fake_lithos.task_complete_responses.clear()
+
+
+# ── arXiv backfill: cache hit short-circuits before acquire ────────────
+
+
+class TestPreAcquireDedupArxivBackfill:
+    """Backfill cache hit drops the candidate before per-item acquire."""
+
+    def test_backfill_arxiv_cache_hit_skips_source_acquire(
+        self,
+        fake_lithos: FakeLithosServer,
+        fake_lithos_url: str,
+    ) -> None:
+        config = _arxiv_only_config(fake_lithos_url)
+        provider = make_item_provider(
+            config,
+            fetch_cache=FetchCache(),
+            arxiv_scorer=_deterministic_arxiv_scorer(8),
+        )
+
+        # Feedback list (loaded by the Feedback stage).
+        fake_lithos.list_responses.append(json.dumps({"items": []}))
+        # Pre-acquire primary lookup → hit.
+        fake_lithos.cache_lookup_responses.append(
+            json.dumps({"hit": True, "stale_exists": False})
+        )
+
+        with (
+            patch(
+                "influx.sources.arxiv.fetch_arxiv",
+                return_value=list(_ARXIV_FIXTURE),
+            ),
+            patch(
+                "influx.sources.arxiv.build_arxiv_note_item"
+            ) as mock_build,
+        ):
+            result = asyncio.run(
+                run_backfill(
+                    PROFILE,
+                    run_range={"days": 7},
+                    config=config,
+                    item_provider=provider,
+                )
+            )
+
+        assert result is not None
+
+        # The whole point of #125: per-item acquire is NEVER called for
+        # a backfill cache hit.
+        mock_build.assert_not_called()
+
+        # Zero writes — the item was dropped pre-acquire.
+        write_calls = [c for c in fake_lithos.calls if c[0] == "lithos_write"]
+        assert len(write_calls) == 0
+
+        # Exactly one cache_lookup — primary, fired in the pre-acquire
+        # dedup helper.  The Ingest URL fallback never runs because the
+        # item never reaches Ingest.
+        cache_calls = [c for c in fake_lithos.calls if c[0] == "lithos_cache_lookup"]
+        assert len(cache_calls) == 1
+
+
+# ── RSS backfill: cache hit short-circuits before acquire ──────────────
+
+
+class TestPreAcquireDedupRssBackfill:
+    """RSS backfill cache hit drops the candidate before per-item acquire."""
+
+    def test_backfill_rss_cache_hit_skips_source_acquire(
+        self,
+        fake_lithos: FakeLithosServer,
+        fake_lithos_url: str,
+    ) -> None:
+        config = _rss_only_config(fake_lithos_url)
+        provider = make_item_provider(config, fetch_cache=FetchCache())
+
+        # Feedback list.
+        fake_lithos.list_responses.append(json.dumps({"items": []}))
+        # Pre-acquire primary lookup → hit.
+        fake_lithos.cache_lookup_responses.append(
+            json.dumps({"hit": True, "stale_exists": False})
+        )
+
+        async def _fake_score_rss_items(
+            *, items: list[RssFeedItem], profile: str, filter_prompt: str, config: AppConfig
+        ) -> dict[str, Any]:
+            from influx.schemas import FilterResult
+            from influx.urls import url_hash
+
+            return {
+                url_hash(item.url): FilterResult(
+                    id=url_hash(item.url),
+                    score=8,
+                    reason="test",
+                    tags=["test"],
+                )
+                for item in items
+            }
+
+        with (
+            patch(
+                "influx.sources.rss._fetch_rss_feed",
+                return_value=list(_RSS_FIXTURE),
+            ),
+            patch(
+                "influx.sources.rss._score_rss_items",
+                side_effect=_fake_score_rss_items,
+            ),
+            patch(
+                "influx.sources.rss.build_rss_note_item"
+            ) as mock_build,
+        ):
+            result = asyncio.run(
+                run_backfill(
+                    PROFILE,
+                    run_range={"days": 7},
+                    config=config,
+                    item_provider=provider,
+                )
+            )
+
+        assert result is not None
+
+        # The whole point of #125: per-item acquire is NEVER called for
+        # a backfill cache hit.
+        mock_build.assert_not_called()
+
+        write_calls = [c for c in fake_lithos.calls if c[0] == "lithos_write"]
+        assert len(write_calls) == 0
+
+        cache_calls = [c for c in fake_lithos.calls if c[0] == "lithos_cache_lookup"]
+        assert len(cache_calls) == 1
+
+
+# ── Normal run: cache hit still goes through acquire (merge path) ──────
+
+
+class TestPreAcquireDedupNormalRun:
+    """Non-backfill cache hits still acquire so multi-profile merge runs."""
+
+    def test_normal_run_cache_hit_still_acquires_for_merge(
+        self,
+        fake_lithos: FakeLithosServer,
+        fake_lithos_url: str,
+    ) -> None:
+        config = _arxiv_only_config(fake_lithos_url)
+        provider = make_item_provider(
+            config,
+            fetch_cache=FetchCache(),
+            arxiv_scorer=_deterministic_arxiv_scorer(8),
+        )
+
+        # Feedback list + repair sweep list (normal run runs repair too).
+        fake_lithos.list_responses.append(json.dumps({"items": []}))  # feedback
+        fake_lithos.list_responses.append(json.dumps({"items": []}))  # repair sweep
+        # Pre-acquire primary lookup → hit (normal run, so merge path).
+        fake_lithos.cache_lookup_responses.append(
+            json.dumps({"hit": True, "stale_exists": False})
+        )
+        # Lithos write succeeds (multi-profile merge).
+        fake_lithos.write_responses.append(
+            json.dumps(
+                {
+                    "status": "updated",
+                    "id": "note-merged",
+                    "detail": "",
+                }
+            )
+        )
+
+        with (
+            patch(
+                "influx.sources.arxiv.fetch_arxiv",
+                return_value=list(_ARXIV_FIXTURE),
+            ),
+            patch(
+                "influx.sources.arxiv.build_arxiv_note_item",
+                return_value={
+                    "title": "Already-Ingested Paper",
+                    "source": "arxiv",
+                    "source_url": "https://arxiv.org/abs/2701.00001",
+                    "content": "merged content",
+                    "tags": ["source:arxiv", "profile:ai-robotics"],
+                    "filter_tags": [],
+                    "score": 8,
+                    "confidence": 1.0,
+                    "reason": "test-scorer",
+                    "path": "papers/arxiv/2026/04",
+                    "abstract_or_summary": "abs",
+                    "contributions": None,
+                    "builds_on": None,
+                },
+            ) as mock_build,
+        ):
+            result = asyncio.run(
+                run_profile(
+                    PROFILE,
+                    RunKind.SCHEDULED,
+                    config=config,
+                    item_provider=provider,
+                )
+            )
+
+        assert result is not None
+
+        # Merge path: acquire IS called for the cache-hit item.
+        assert mock_build.call_count == 1
+
+        # Write IS called (multi-profile merge handled inside write_note).
+        write_calls = [c for c in fake_lithos.calls if c[0] == "lithos_write"]
+        assert len(write_calls) == 1

--- a/tests/integration/test_pre_acquire_dedup.py
+++ b/tests/integration/test_pre_acquire_dedup.py
@@ -63,7 +63,6 @@ from influx.sources.arxiv import (
 from influx.sources.rss import RssFeedItem
 from tests.contract.test_lithos_client import FakeLithosServer
 
-
 PROFILE = "ai-robotics"
 
 
@@ -240,9 +239,7 @@ class TestPreAcquireDedupArxivBackfill:
                 "influx.sources.arxiv.fetch_arxiv",
                 return_value=list(_ARXIV_FIXTURE),
             ),
-            patch(
-                "influx.sources.arxiv.build_arxiv_note_item"
-            ) as mock_build,
+            patch("influx.sources.arxiv.build_arxiv_note_item") as mock_build,
         ):
             result = asyncio.run(
                 run_backfill(
@@ -292,7 +289,11 @@ class TestPreAcquireDedupRssBackfill:
         )
 
         async def _fake_score_rss_items(
-            *, items: list[RssFeedItem], profile: str, filter_prompt: str, config: AppConfig
+            *,
+            items: list[RssFeedItem],
+            profile: str,
+            filter_prompt: str,
+            config: AppConfig,
         ) -> dict[str, Any]:
             from influx.schemas import FilterResult
             from influx.urls import url_hash
@@ -316,9 +317,7 @@ class TestPreAcquireDedupRssBackfill:
                 "influx.sources.rss._score_rss_items",
                 side_effect=_fake_score_rss_items,
             ),
-            patch(
-                "influx.sources.rss.build_rss_note_item"
-            ) as mock_build,
+            patch("influx.sources.rss.build_rss_note_item") as mock_build,
         ):
             result = asyncio.run(
                 run_backfill(

--- a/tests/integration/test_profile_rejection_authority.py
+++ b/tests/integration/test_profile_rejection_authority.py
@@ -39,6 +39,7 @@ from influx.http_api import router
 from influx.probes import ProbeLoop
 from influx.renderer import ProfileRelevanceEntry, render_note
 from influx.scheduler import InfluxScheduler
+from tests._bound_helpers import bounds_for
 from tests.contract.test_lithos_client import FakeLithosServer
 
 # ── Constants ─────────────────────────────────────────────────────────
@@ -153,10 +154,10 @@ def _make_capturing_item_provider(
         kind: RunKind,
         run_range: dict[str, str | int] | None,
         filter_prompt: str,
-    ) -> Iterable[dict[str, Any]]:
+    ) -> Iterable[Any]:
         del kind, run_range
         captured_prompts[profile] = filter_prompt
-        return list(profile_items.get(profile, []))
+        return bounds_for(profile_items.get(profile, []))
 
     return provider
 
@@ -190,9 +191,9 @@ def _make_app(
             kind: RunKind,
             run_range: dict[str, str | int] | None,
             filter_prompt: str,
-        ) -> Iterable[dict[str, Any]]:
+        ) -> Iterable[Any]:
             del kind, run_range, filter_prompt
-            return list(profile_items.get(profile, []))
+            return bounds_for(profile_items.get(profile, []))
 
         app.state.item_provider = _provider
 

--- a/tests/unit/test_rss_fetcher.py
+++ b/tests/unit/test_rss_fetcher.py
@@ -504,9 +504,13 @@ class TestProductionPathIgnoresAllowPrivateIps:
             ),
         ):
             provider = make_rss_item_provider(config)
-            results = list(
+            bounds = list(
                 await provider("ai-robotics", RunKind.SCHEDULED, None, "prompt")
             )
+            # #125: provider returns BoundScoredCandidates; invoke each
+            # closure to drive ``build_rss_note_item`` and obtain the
+            # legacy ProfileItem dict the assertions below operate on.
+            results = [item for item in [await b.acquire() for b in bounds] if item]
 
         # Only the single public-URL item should reach the build step;
         # localhost + 192.168.x.x must be dropped pre-acquire even

--- a/tests/unit/test_run_dedup.py
+++ b/tests/unit/test_run_dedup.py
@@ -276,3 +276,34 @@ async def test_metric_incremented_per_hit(monkeypatch: pytest.MonkeyPatch) -> No
     )
 
     assert counter.add.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_metric_source_label_bounded_for_rss_feed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-feed RSS bounds carry ``source_label="rss:<feed_name>"`` for
+    log richness, but the ``source`` *metric* label must collapse to the
+    bounded ``"rss"`` per ``influx/metrics.py`` cardinality discipline.
+    Otherwise per-feed names would leak into metric series and skew any
+    dashboard / alert keyed on the bounded set."""
+    counter = MagicMock()
+    monkeypatch.setattr("influx.metrics.cache_hits", lambda: counter)
+
+    rss_bound = _make_bound(item_id="rss-hit", source_label="rss:Mozilla Hacks")
+    arxiv_bound = _make_bound(item_id="arxiv-hit", source_label="arxiv")
+    client = _client_with_responses({"hit": True}, {"hit": True})
+
+    await dedup_scored_candidates(
+        [rss_bound, arxiv_bound],
+        client=client,
+        profile="p1",
+        skip_cache_hits=True,
+    )
+
+    label_sets = [call.args[1] for call in counter.add.call_args_list]
+    assert {"profile": "p1", "source": "rss"} in label_sets
+    assert {"profile": "p1", "source": "arxiv"} in label_sets
+    # No per-feed cardinality leak.
+    for labels in label_sets:
+        assert ":" not in labels["source"]

--- a/tests/unit/test_run_dedup.py
+++ b/tests/unit/test_run_dedup.py
@@ -1,0 +1,278 @@
+"""Unit tests for the Run-stage pre-acquire dedup helper (#125).
+
+Validates the partitioning logic of :func:`influx.run_dedup.dedup_scored_candidates`:
+
+- Cache miss → ``to_acquire`` with ``cache_hit=False``.
+- Cache hit + ``skip_cache_hits=True`` → ``hits_to_skip`` (backfill drops
+  duplicates *before* full ``Source.acquire``).
+- Cache hit + ``skip_cache_hits=False`` → ``to_acquire`` with
+  ``cache_hit=True`` (multi-profile merge path preserved).
+
+The helper composes the dedup query via
+:meth:`LithosClient.cache_lookup_for_item_body`, so we mock that call
+directly rather than re-implementing query composition in the tests.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from influx.run_dedup import (
+    DedupOutcome,
+    dedup_scored_candidates,
+)
+from influx.source import BoundScoredCandidate, Candidate, ScoredCandidate
+
+
+def _make_bound(
+    *,
+    item_id: str = "id-1",
+    title: str = "A relevant paper",
+    abstract: str = "We propose a new method for X.",
+    source_url: str = "https://example.org/paper-1",
+    score: int = 8,
+    source_label: str = "arxiv",
+) -> BoundScoredCandidate:
+    """Build a BoundScoredCandidate with a stub acquire closure."""
+
+    async def _acquire() -> dict[str, Any] | None:
+        return {"title": title, "source_url": source_url}
+
+    return BoundScoredCandidate(
+        scored=ScoredCandidate(
+            candidate=Candidate(
+                item_id=item_id,
+                title=title,
+                abstract=abstract,
+                source_url=source_url,
+            ),
+            score=score,
+            confidence=1.0,
+            reason="test",
+            filter_tags=("test",),
+        ),
+        acquire=_acquire,
+        source_label=source_label,
+    )
+
+
+def _client_with_responses(*responses: dict[str, Any]) -> Any:
+    """Build a MagicMock LithosClient whose cache_lookup_for_item_body
+    returns *responses* in order.
+    """
+    client = MagicMock()
+    client.cache_lookup_for_item_body = AsyncMock(side_effect=list(responses))
+    return client
+
+
+@pytest.mark.asyncio
+async def test_empty_input_no_client_calls() -> None:
+    """Zero scored candidates → zero lookups, empty outcome."""
+    client = _client_with_responses()
+    outcome = await dedup_scored_candidates(
+        [],
+        client=client,
+        profile="p1",
+        skip_cache_hits=False,
+    )
+    assert outcome == DedupOutcome(to_acquire=(), hits_to_skip=())
+    client.cache_lookup_for_item_body.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_lookup_called_with_candidate_metadata() -> None:
+    """Helper passes title + source_url + abstract straight through to the client."""
+    bound = _make_bound(
+        title="Scaling Laws",
+        abstract="We study scaling.",
+        source_url="https://example.org/scaling",
+    )
+    client = _client_with_responses({"hit": False})
+
+    await dedup_scored_candidates(
+        [bound],
+        client=client,
+        profile="p1",
+        skip_cache_hits=False,
+    )
+
+    client.cache_lookup_for_item_body.assert_awaited_once_with(
+        title="Scaling Laws",
+        source_url="https://example.org/scaling",
+        abstract_or_summary="We study scaling.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_abstract_passed_as_none() -> None:
+    """Empty-string abstract is normalised to None for the lookup."""
+    bound = _make_bound(abstract="")
+    client = _client_with_responses({"hit": False})
+    await dedup_scored_candidates(
+        [bound],
+        client=client,
+        profile="p1",
+        skip_cache_hits=False,
+    )
+    _, kwargs = client.cache_lookup_for_item_body.call_args
+    assert kwargs["abstract_or_summary"] is None
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_lands_in_to_acquire() -> None:
+    """Miss → to_acquire with cache_hit=False, cache_body recorded."""
+    bound = _make_bound()
+    body = {"hit": False, "stale_exists": False}
+    client = _client_with_responses(body)
+
+    outcome = await dedup_scored_candidates(
+        [bound],
+        client=client,
+        profile="p1",
+        skip_cache_hits=False,
+    )
+
+    assert len(outcome.to_acquire) == 1
+    assert len(outcome.hits_to_skip) == 0
+    decision = outcome.to_acquire[0]
+    assert decision.bound is bound
+    assert decision.cache_hit is False
+    assert decision.cache_hit_reason is None
+    assert decision.cache_body == body
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_with_skip_drops_to_hits_to_skip() -> None:
+    """Backfill (skip_cache_hits=True) drops cache hits pre-acquire."""
+    bound = _make_bound()
+    body = {"hit": True}
+    client = _client_with_responses(body)
+
+    outcome = await dedup_scored_candidates(
+        [bound],
+        client=client,
+        profile="p1",
+        skip_cache_hits=True,
+    )
+
+    assert len(outcome.to_acquire) == 0
+    assert len(outcome.hits_to_skip) == 1
+    decision = outcome.hits_to_skip[0]
+    assert decision.bound is bound
+    assert decision.cache_hit is True
+    assert decision.cache_hit_reason == "primary"
+    assert decision.cache_body == body
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_without_skip_lands_in_to_acquire_for_merge() -> None:
+    """Normal run preserves multi-profile merge: hit still goes to acquire."""
+    bound = _make_bound()
+    body = {"hit": True, "id": "note-123"}
+    client = _client_with_responses(body)
+
+    outcome = await dedup_scored_candidates(
+        [bound],
+        client=client,
+        profile="p1",
+        skip_cache_hits=False,
+    )
+
+    assert len(outcome.to_acquire) == 1
+    assert len(outcome.hits_to_skip) == 0
+    decision = outcome.to_acquire[0]
+    assert decision.cache_hit is True
+    assert decision.cache_hit_reason == "primary"
+
+
+@pytest.mark.asyncio
+async def test_mixed_batch_partitions_correctly() -> None:
+    """Three-way mix: miss → acquire, hit+skip → drop, hit+merge → acquire.
+
+    Order within each partition is preserved.
+    """
+    miss_bound = _make_bound(item_id="miss", title="Miss")
+    skip_bound = _make_bound(item_id="skip", title="Skip")
+    merge_bound = _make_bound(item_id="merge", title="Merge")
+
+    # In skip_cache_hits=True the merge_bound also gets dropped — to test
+    # the three-way partition we run two passes.
+    client = _client_with_responses(
+        {"hit": False},  # miss
+        {"hit": True},  # skip (with skip_cache_hits=True)
+    )
+    outcome_backfill = await dedup_scored_candidates(
+        [miss_bound, skip_bound],
+        client=client,
+        profile="p1",
+        skip_cache_hits=True,
+    )
+    assert [d.bound.scored.candidate.item_id for d in outcome_backfill.to_acquire] == [
+        "miss"
+    ]
+    assert [
+        d.bound.scored.candidate.item_id for d in outcome_backfill.hits_to_skip
+    ] == ["skip"]
+
+    # Normal run: same hit goes to to_acquire (merge path).
+    client2 = _client_with_responses({"hit": True}, {"hit": False})
+    outcome_normal = await dedup_scored_candidates(
+        [merge_bound, miss_bound],
+        client=client2,
+        profile="p1",
+        skip_cache_hits=False,
+    )
+    assert [d.bound.scored.candidate.item_id for d in outcome_normal.to_acquire] == [
+        "merge",
+        "miss",
+    ]
+    assert outcome_normal.hits_to_skip == ()
+    assert outcome_normal.to_acquire[0].cache_hit is True
+    assert outcome_normal.to_acquire[1].cache_hit is False
+
+
+@pytest.mark.asyncio
+async def test_client_error_propagates() -> None:
+    """Lookup errors propagate — helper does not swallow exceptions."""
+    bound = _make_bound()
+    client = MagicMock()
+    client.cache_lookup_for_item_body = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await dedup_scored_candidates(
+            [bound],
+            client=client,
+            profile="p1",
+            skip_cache_hits=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_metric_incremented_per_hit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``metrics.cache_hits()`` is incremented exactly once per cache hit
+    (skip path and merge path both count)."""
+    counter = MagicMock()
+    monkeypatch.setattr("influx.metrics.cache_hits", lambda: counter)
+
+    bounds = [
+        _make_bound(item_id="hit-1"),
+        _make_bound(item_id="miss-1"),
+        _make_bound(item_id="hit-2"),
+    ]
+    client = _client_with_responses(
+        {"hit": True},
+        {"hit": False},
+        {"hit": True},
+    )
+
+    await dedup_scored_candidates(
+        bounds,
+        client=client,
+        profile="p1",
+        skip_cache_hits=False,
+    )
+
+    assert counter.add.call_count == 2

--- a/tests/unit/test_run_module.py
+++ b/tests/unit/test_run_module.py
@@ -45,6 +45,35 @@ from influx.run import (
     _run_repair_stage,
 )
 from influx.run_ledger import RunLedger
+from influx.source import BoundScoredCandidate, Candidate, ScoredCandidate
+
+
+def _bound_for(item: dict[str, Any], *, source_label: str = "arxiv") -> BoundScoredCandidate:
+    """Wrap a ProfileItem dict as a BoundScoredCandidate whose acquire
+    closure returns the dict (#125 — the Run stage now drives acquire
+    after pre-acquire dedup, so test providers yield bounds rather than
+    pre-baked items).
+    """
+
+    async def _acquire() -> dict[str, Any]:
+        return item
+
+    return BoundScoredCandidate(
+        scored=ScoredCandidate(
+            candidate=Candidate(
+                item_id=item.get("source_url", "test-id"),
+                title=item.get("title", ""),
+                abstract=item.get("abstract_or_summary", "") or "",
+                source_url=item.get("source_url", ""),
+            ),
+            score=int(item.get("score", 0)),
+            confidence=float(item.get("confidence", 0.0)),
+            reason=item.get("reason", ""),
+            filter_tags=tuple(item.get("filter_tags", [])),
+        ),
+        acquire=_acquire,
+        source_label=source_label,
+    )
 
 # ── Helpers ─────────────────────────────────────────────────────────
 
@@ -199,7 +228,7 @@ async def test_repair_stage_raises_run_aborted_on_sweep_write_error() -> None:
 
 async def _empty_provider(
     profile: str, kind: RunKind, run_range: Any, filter_prompt: str
-) -> list[dict[str, Any]]:
+) -> list[BoundScoredCandidate]:
     return []
 
 
@@ -418,8 +447,8 @@ async def test_run_execute_walks_provider_and_writes_per_item() -> None:
 
     async def provider(
         profile: str, kind: RunKind, run_range: Any, filter_prompt: str
-    ) -> list[dict[str, Any]]:
-        return items
+    ) -> list[BoundScoredCandidate]:
+        return [_bound_for(it) for it in items]
 
     from mcp import types as mcp_types
 
@@ -490,8 +519,8 @@ async def test_run_execute_continues_after_lcma_wiring_failure() -> None:
 
     async def provider(
         profile: str, kind: RunKind, run_range: Any, filter_prompt: str
-    ) -> list[dict[str, Any]]:
-        return items
+    ) -> list[BoundScoredCandidate]:
+        return [_bound_for(it) for it in items]
 
     from mcp import types as mcp_types
 
@@ -568,8 +597,8 @@ async def test_run_execute_persists_unresolved_slug_collision_without_injected_l
 
     async def provider(
         profile: str, kind: RunKind, run_range: Any, filter_prompt: str
-    ) -> list[dict[str, Any]]:
-        return items
+    ) -> list[BoundScoredCandidate]:
+        return [_bound_for(it) for it in items]
 
     deps = RunDeps(config=config, item_provider=provider, probe_loop=None, ledger=None)
 

--- a/tests/unit/test_run_module.py
+++ b/tests/unit/test_run_module.py
@@ -48,7 +48,9 @@ from influx.run_ledger import RunLedger
 from influx.source import BoundScoredCandidate, Candidate, ScoredCandidate
 
 
-def _bound_for(item: dict[str, Any], *, source_label: str = "arxiv") -> BoundScoredCandidate:
+def _bound_for(
+    item: dict[str, Any], *, source_label: str = "arxiv"
+) -> BoundScoredCandidate:
     """Wrap a ProfileItem dict as a BoundScoredCandidate whose acquire
     closure returns the dict (#125 — the Run stage now drives acquire
     after pre-acquire dedup, so test providers yield bounds rather than
@@ -74,6 +76,7 @@ def _bound_for(item: dict[str, Any], *, source_label: str = "arxiv") -> BoundSco
         acquire=_acquire,
         source_label=source_label,
     )
+
 
 # ── Helpers ─────────────────────────────────────────────────────────
 

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -1125,7 +1125,7 @@ class TestLithosCircuitBreakerShortCircuit:
             kind: RunKind,
             run_range: dict[str, str | int] | None,
             filter_prompt: str,
-        ) -> list[dict[str, Any]]:
+        ) -> list[Any]:
             nonlocal provider_called
             provider_called = True
             return []
@@ -1179,7 +1179,7 @@ class TestLithosCircuitBreakerShortCircuit:
             kind: RunKind,
             run_range: dict[str, str | int] | None,
             filter_prompt: str,
-        ) -> list[dict[str, Any]]:
+        ) -> list[Any]:
             nonlocal provider_called
             provider_called = True
             return []
@@ -1249,7 +1249,7 @@ class TestLcmaToolsUnavailableShortCircuit:
             kind: RunKind,
             run_range: dict[str, str | int] | None,
             filter_prompt: str,
-        ) -> list[dict[str, Any]]:
+        ) -> list[Any]:
             nonlocal provider_called
             provider_called = True
             return []

--- a/tests/unit/test_telemetry_wiring.py
+++ b/tests/unit/test_telemetry_wiring.py
@@ -22,7 +22,32 @@ pytest.importorskip(
 )
 
 from influx.coordinator import RunKind
+from influx.source import BoundScoredCandidate, Candidate, ScoredCandidate
 from influx.telemetry import InfluxTracer, current_run_id, get_tracer
+
+
+def _bound_for(item: dict[str, Any], *, source_label: str = "arxiv") -> BoundScoredCandidate:
+    """Wrap a ProfileItem dict as a BoundScoredCandidate (#125 — test seam)."""
+
+    async def _acquire() -> dict[str, Any]:
+        return item
+
+    return BoundScoredCandidate(
+        scored=ScoredCandidate(
+            candidate=Candidate(
+                item_id=item.get("source_url", "test-id"),
+                title=item.get("title", ""),
+                abstract=item.get("abstract_or_summary", "") or "",
+                source_url=item.get("source_url", ""),
+            ),
+            score=int(item.get("score", 0)),
+            confidence=float(item.get("confidence", 0.0)),
+            reason=item.get("reason", ""),
+            filter_tags=tuple(item.get("filter_tags", [])),
+        ),
+        acquire=_acquire,
+        source_label=source_label,
+    )
 
 # ── Helpers ────────────────────────────────────────────────────────────
 
@@ -1120,17 +1145,19 @@ class TestInfluxLithosWriteSpan:
         # Fake item provider returning one item
         async def fake_provider(
             profile: str, kind: Any, run_range: Any, prompt: str
-        ) -> list[dict[str, Any]]:
+        ) -> list[BoundScoredCandidate]:
             return [
-                {
-                    "title": "Test Note",
-                    "source_url": "https://example.com/paper",
-                    "content": "Content",
-                    "tags": ["cs.AI"],
-                    "confidence": 0.9,
-                    "path": "test/path",
-                    "score": 8,
-                }
+                _bound_for(
+                    {
+                        "title": "Test Note",
+                        "source_url": "https://example.com/paper",
+                        "content": "Content",
+                        "tags": ["cs.AI"],
+                        "confidence": 0.9,
+                        "path": "test/path",
+                        "score": 8,
+                    }
+                )
             ]
 
         # Exercise the actual write span by calling run_profile with
@@ -1226,17 +1253,19 @@ class TestInfluxLithosWriteSpan:
 
         async def fake_provider(
             profile: str, kind: Any, run_range: Any, prompt: str
-        ) -> list[dict[str, Any]]:
+        ) -> list[BoundScoredCandidate]:
             return [
-                {
-                    "title": "Test Note",
-                    "source_url": "https://example.com/paper",
-                    "content": "Content",
-                    "tags": ["cs.AI"],
-                    "confidence": 0.9,
-                    "path": "test/path",
-                    "score": 8,
-                }
+                _bound_for(
+                    {
+                        "title": "Test Note",
+                        "source_url": "https://example.com/paper",
+                        "content": "Content",
+                        "tags": ["cs.AI"],
+                        "confidence": 0.9,
+                        "path": "test/path",
+                        "score": 8,
+                    }
+                )
             ]
 
         with (

--- a/tests/unit/test_telemetry_wiring.py
+++ b/tests/unit/test_telemetry_wiring.py
@@ -26,7 +26,9 @@ from influx.source import BoundScoredCandidate, Candidate, ScoredCandidate
 from influx.telemetry import InfluxTracer, current_run_id, get_tracer
 
 
-def _bound_for(item: dict[str, Any], *, source_label: str = "arxiv") -> BoundScoredCandidate:
+def _bound_for(
+    item: dict[str, Any], *, source_label: str = "arxiv"
+) -> BoundScoredCandidate:
     """Wrap a ProfileItem dict as a BoundScoredCandidate (#125 — test seam)."""
 
     async def _acquire() -> dict[str, Any]:
@@ -48,6 +50,7 @@ def _bound_for(item: dict[str, Any], *, source_label: str = "arxiv") -> BoundSco
         acquire=_acquire,
         source_label=source_label,
     )
+
 
 # ── Helpers ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Move the primary `lithos_cache_lookup` ahead of `Source.acquire` so duplicate items skip the download / archive / extract cost in backfills. Cache hits in normal runs still flow through acquire + `write_note` so the multi-profile merge path is preserved (per the issue's "preserve behaviour first, optimise second" guidance).

The `ItemProvider` seam is reshaped — providers now return `Iterable[BoundScoredCandidate]` (a scored candidate plus a thunk that performs source-specific acquire) and the Run stage orchestrates `fetch+score → dedup → acquire → ingest` centrally. This pushes dedup policy out of the source adapters and into the orchestration layer where it belongs.

## Behaviour

- **Backfill (`skip_cache_hits=True`) + cache hit:** dropped pre-acquire — no archive download, no extraction, no `lithos_write`.
- **Normal run + cache hit:** acquire + write still run — multi-profile merge path inside `LithosClient.write_note` is preserved.
- **Cache miss:** unchanged — acquire then write; defensive `source_url` fallback (#128) still runs in Ingest only when the pre-acquire primary lookup missed.

## Files

- New: `src/influx/run_dedup.py`, `BoundScoredCandidate` in `src/influx/source.py`
- Refactored: `_run_acquire_stage` (drives dedup + acquire), `_run_ingest_stage` (reads pre-recorded `cache_hit` metadata; legacy primary-lookup branch retained as fallback for tests that bypass Acquire)
- Sub-providers (`sources/arxiv.py`, `sources/rss.py`, `sources/__init__.py`) return bounds with closures
- `CONTEXT.md` Acquire/Ingest paragraph updated to match new ordering

## Test plan

- [x] `tests/unit/test_run_dedup.py` — 9 unit cases for the helper (miss, hit-skip, hit-merge, mixed batch, error propagation, metric increments)
- [x] `tests/integration/test_pre_acquire_dedup.py` — backfill arXiv cache hit asserts `build_arxiv_note_item` is NOT called; backfill RSS cache hit asserts `build_rss_note_item` is NOT called; normal-run cache hit asserts acquire + write DO run
- [x] All ~10 existing integration test files rewired to the new seam (`tests/_bound_helpers.py` shared helper)
- [x] Existing backfill / multi-profile merge / URL fallback tests still green
- [x] Full suite: 1888 passed, 0 failed

Closes #125