### PR TITLE
fix: request-keyed observability for HTTP background runs and backfills

### DIFF
--- a/src/influx/http_api.py
+++ b/src/influx/http_api.py
@@ -374,6 +374,12 @@ async def post_runs(body: RunRequest, request: Request) -> JSONResponse:
             )
         acquired_profiles.append(profile_cfg.name)
 
+    run_log_context: dict[str, Any] = {
+        "request_id": request_id,
+        "kind": "manual",
+        "scope": "all",
+        "profiles": list(acquired_profiles),
+    }
     _spawn_tracked_task(
         request.app,
         _run_many_and_release(
@@ -386,13 +392,9 @@ async def post_runs(body: RunRequest, request: Request) -> JSONResponse:
             fetch_cache=getattr(request.app.state, "fetch_cache", None),
             request_id=request_id,
             run_ledger=run_ledger,
+            log_context=run_log_context,
         ),
-        log_context={
-            "request_id": request_id,
-            "kind": "manual",
-            "scope": "all",
-            "profiles": list(acquired_profiles),
-        },
+        log_context=run_log_context,
     )
     logger.info(
         "manual run accepted request_id=%s scope=all profiles=%s submitted_at=%s",
@@ -544,12 +546,16 @@ async def _run_many_and_release(
     fetch_cache: Any = None,
     request_id: str | None = None,
     run_ledger: RunLedger | None = None,
+    log_context: dict[str, Any] | None = None,
 ) -> None:
     """Run several already-acquired profiles and release all locks.
 
     Per-profile failures from the underlying ``asyncio.gather`` are
-    inspected and logged with request context (#105) so that multi-
-    profile partial failures are visible in operator logs.
+    logged with request context (#105) so that multi-profile partial
+    failures are visible. When ``log_context`` is supplied, the helper
+    records ``failed_count`` / ``total_count`` / ``failed_profiles``
+    onto it so the request-level done-callback can distinguish
+    ``completed`` from ``partial_failure`` for the same ``request_id``.
     """
     if fetch_cache is not None:
         fetch_cache.begin_fire()
@@ -603,23 +609,10 @@ async def _run_many_and_release(
                         "status": "completed",
                     },
                 )
-        log_fn = logger.warning if failed else logger.info
-        log_fn(
-            "%s run %s aggregate: %d/%d profiles failed",
-            kind.value,
-            request_id,
-            len(failed),
-            len(profiles),
-            extra={
-                "request_id": request_id,
-                "kind": kind.value,
-                "scope": "all",
-                "failed_count": len(failed),
-                "total_count": len(profiles),
-                "failed_profiles": [p for p, _ in failed],
-                "status": "partial_failure" if failed else "completed",
-            },
-        )
+        if log_context is not None:
+            log_context["failed_count"] = len(failed)
+            log_context["total_count"] = len(profiles)
+            log_context["failed_profiles"] = [p for p, _ in failed]
     finally:
         for profile in profiles:
             coordinator.release(profile)
@@ -642,15 +635,7 @@ def _log_task_completion(
         if task.cancelled():
             return
         exc = task.exception()
-        if exc is None:
-            logger.info(
-                "background task completed request_id=%s kind=%s scope=%s",
-                log_context.get("request_id"),
-                log_context.get("kind"),
-                log_context.get("scope"),
-                extra={**log_context, "status": "completed"},
-            )
-        else:
+        if exc is not None:
             logger.error(
                 "background task failed request_id=%s kind=%s scope=%s: %s",
                 log_context.get("request_id"),
@@ -660,6 +645,31 @@ def _log_task_completion(
                 exc_info=exc,
                 extra={**log_context, "status": "failed"},
             )
+            return
+        # Task itself succeeded — but for all-profiles fan-out a
+        # partial failure surfaces via ``failed_count`` written back
+        # onto the shared ``log_context`` by ``_run_many_and_release``.
+        # We must NOT report ``completed`` for those requests (#105).
+        failed_count = int(log_context.get("failed_count") or 0)
+        if failed_count > 0:
+            logger.warning(
+                "background task partial failure request_id=%s kind=%s "
+                "scope=%s failed=%d/%d",
+                log_context.get("request_id"),
+                log_context.get("kind"),
+                log_context.get("scope"),
+                failed_count,
+                int(log_context.get("total_count") or 0),
+                extra={**log_context, "status": "partial_failure"},
+            )
+            return
+        logger.info(
+            "background task completed request_id=%s kind=%s scope=%s",
+            log_context.get("request_id"),
+            log_context.get("kind"),
+            log_context.get("scope"),
+            extra={**log_context, "status": "completed"},
+        )
 
     return _callback
 
@@ -941,6 +951,12 @@ async def post_backfills(body: BackfillRequest, request: Request) -> JSONRespons
             )
         acquired_profiles.append(profile_cfg.name)
 
+    backfill_log_context: dict[str, Any] = {
+        "request_id": request_id,
+        "kind": "backfill",
+        "scope": "all",
+        "profiles": list(acquired_profiles),
+    }
     _spawn_tracked_task(
         request.app,
         _run_many_and_release(
@@ -954,13 +970,9 @@ async def post_backfills(body: BackfillRequest, request: Request) -> JSONRespons
             fetch_cache=getattr(request.app.state, "fetch_cache", None),
             request_id=request_id,
             run_ledger=run_ledger,
+            log_context=backfill_log_context,
         ),
-        log_context={
-            "request_id": request_id,
-            "kind": "backfill",
-            "scope": "all",
-            "profiles": list(acquired_profiles),
-        },
+        log_context=backfill_log_context,
     )
     logger.info(
         "backfill accepted request_id=%s scope=all profiles=%s submitted_at=%s",

--- a/src/influx/http_api.py
+++ b/src/influx/http_api.py
@@ -17,7 +17,7 @@ import asyncio
 import logging
 import os
 import uuid
-from collections.abc import Coroutine
+from collections.abc import Callable, Coroutine
 from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any, cast
@@ -328,12 +328,26 @@ async def post_runs(body: RunRequest, request: Request) -> JSONResponse:
                 run_id=request_id,
                 run_ledger=run_ledger,
             ),
+            log_context={
+                "request_id": request_id,
+                "kind": "manual",
+                "scope": body.profile,
+                "profile": body.profile,
+            },
         )
         logger.info(
             "manual run accepted request_id=%s profile=%s submitted_at=%s",
             request_id,
             body.profile,
             submitted_at,
+            extra={
+                "request_id": request_id,
+                "kind": "manual",
+                "scope": body.profile,
+                "profile": body.profile,
+                "submitted_at": submitted_at,
+                "status": "accepted",
+            },
         )
 
         return JSONResponse(
@@ -373,12 +387,26 @@ async def post_runs(body: RunRequest, request: Request) -> JSONResponse:
             request_id=request_id,
             run_ledger=run_ledger,
         ),
+        log_context={
+            "request_id": request_id,
+            "kind": "manual",
+            "scope": "all",
+            "profiles": list(acquired_profiles),
+        },
     )
     logger.info(
         "manual run accepted request_id=%s scope=all profiles=%s submitted_at=%s",
         request_id,
         acquired_profiles,
         submitted_at,
+        extra={
+            "request_id": request_id,
+            "kind": "manual",
+            "scope": "all",
+            "profiles": list(acquired_profiles),
+            "submitted_at": submitted_at,
+            "status": "accepted",
+        },
     )
     return JSONResponse(
         {
@@ -408,8 +436,11 @@ async def _run_and_release(
     """Run ``run_profile`` and release the coordinator lock afterward.
 
     Failures in ``run_profile`` (e.g. Lithos unreachable per AC-M1-11)
-    are logged and swallowed so that the manual-run lock is released
-    cleanly and the service stays alive (FR-HTTP-4 + AC-M1-11).
+    are logged with request context and re-raised; the surrounding
+    asyncio task captures the exception and the request-level done-
+    callback (#105) records a failure log keyed by ``request_id``. The
+    coordinator lock is always released via ``finally`` so the service
+    stays alive (FR-HTTP-4 + AC-M1-11).
     """
     if fetch_cache is not None:
         fetch_cache.begin_fire()
@@ -426,13 +457,21 @@ async def _run_and_release(
                 run_ledger=run_ledger,
             )
         except Exception:
-            import logging
-
-            logging.getLogger(__name__).warning(
-                "run_profile %r aborted",
+            logger.warning(
+                "run_profile %r aborted request_id=%s kind=%s",
                 profile,
+                run_id,
+                kind.value,
                 exc_info=True,
+                extra={
+                    "request_id": run_id,
+                    "kind": kind.value,
+                    "scope": profile,
+                    "profile": profile,
+                    "status": "failed",
+                },
             )
+            raise
     finally:
         coordinator.release(profile)
         if fetch_cache is not None:
@@ -473,13 +512,20 @@ async def _backfill_and_release(
                 run_ledger=run_ledger,
             )
         except Exception:
-            import logging
-
-            logging.getLogger(__name__).warning(
-                "run_backfill %r aborted",
+            logger.warning(
+                "run_backfill %r aborted request_id=%s",
                 profile,
+                run_id,
                 exc_info=True,
+                extra={
+                    "request_id": run_id,
+                    "kind": "backfill",
+                    "scope": profile,
+                    "profile": profile,
+                    "status": "failed",
+                },
             )
+            raise
     finally:
         coordinator.release(profile)
         if fetch_cache is not None:
@@ -499,11 +545,16 @@ async def _run_many_and_release(
     request_id: str | None = None,
     run_ledger: RunLedger | None = None,
 ) -> None:
-    """Run several already-acquired profiles and release all locks."""
+    """Run several already-acquired profiles and release all locks.
+
+    Per-profile failures from the underlying ``asyncio.gather`` are
+    inspected and logged with request context (#105) so that multi-
+    profile partial failures are visible in operator logs.
+    """
     if fetch_cache is not None:
         fetch_cache.begin_fire()
     try:
-        await asyncio.gather(
+        results = await asyncio.gather(
             *(
                 run_profile(
                     profile,
@@ -519,6 +570,56 @@ async def _run_many_and_release(
             ),
             return_exceptions=True,
         )
+        failed: list[tuple[str, BaseException]] = []
+        for profile, result in zip(profiles, results, strict=True):
+            if isinstance(result, BaseException):
+                failed.append((profile, result))
+                logger.warning(
+                    "profile %r in %s run %s failed: %s",
+                    profile,
+                    kind.value,
+                    request_id,
+                    result,
+                    exc_info=result,
+                    extra={
+                        "request_id": request_id,
+                        "kind": kind.value,
+                        "scope": "all",
+                        "profile": profile,
+                        "status": "failed",
+                    },
+                )
+            else:
+                logger.info(
+                    "profile %r in %s run %s completed",
+                    profile,
+                    kind.value,
+                    request_id,
+                    extra={
+                        "request_id": request_id,
+                        "kind": kind.value,
+                        "scope": "all",
+                        "profile": profile,
+                        "status": "completed",
+                    },
+                )
+        log_fn = logger.warning if failed else logger.info
+        log_fn(
+            "%s run %s aggregate: %d/%d profiles failed",
+            kind.value,
+            request_id,
+            len(failed),
+            len(profiles),
+            extra={
+                "request_id": request_id,
+                "kind": kind.value,
+                "scope": "all",
+                "failed_count": len(failed),
+                "total_count": len(profiles),
+                "failed_profiles": [p for p, _ in failed],
+                "status": "partial_failure" if failed else "completed",
+            },
+        )
     finally:
         for profile in profiles:
             coordinator.release(profile)
@@ -526,14 +627,57 @@ async def _run_many_and_release(
             fetch_cache.end_fire()
 
 
+def _log_task_completion(
+    log_context: dict[str, Any],
+) -> Callable[[asyncio.Task[Any]], None]:
+    """Build a done-callback that logs task outcome with request context (#105).
+
+    Treats cancellation as graceful shutdown rather than failure so that
+    the US-008 shutdown path stays quiet, and routes uncaught exceptions
+    to ``logger.error`` with ``exc_info`` so operators can find them by
+    ``request_id``.
+    """
+
+    def _callback(task: asyncio.Task[Any]) -> None:
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is None:
+            logger.info(
+                "background task completed request_id=%s kind=%s scope=%s",
+                log_context.get("request_id"),
+                log_context.get("kind"),
+                log_context.get("scope"),
+                extra={**log_context, "status": "completed"},
+            )
+        else:
+            logger.error(
+                "background task failed request_id=%s kind=%s scope=%s: %s",
+                log_context.get("request_id"),
+                log_context.get("kind"),
+                log_context.get("scope"),
+                exc,
+                exc_info=exc,
+                extra={**log_context, "status": "failed"},
+            )
+
+    return _callback
+
+
 def _spawn_tracked_task(
-    app: FastAPI, coro: Coroutine[Any, Any, Any]
+    app: FastAPI,
+    coro: Coroutine[Any, Any, Any],
+    *,
+    log_context: dict[str, Any] | None = None,
 ) -> asyncio.Task[Any]:
     """Create an ``asyncio.Task`` and register it on ``app.state.active_tasks``.
 
     The task set is consulted by :meth:`InfluxService.stop` so HTTP-triggered
     work can complete within ``schedule.shutdown_grace_seconds`` before
     the service shuts down (US-008 shutdown-grace contract).
+
+    When ``log_context`` is provided the task gets a second done-callback
+    that logs request-keyed completion or failure (#105).
     """
     # Preserve the existing set even when empty — ``... or set()`` would
     # treat an empty set as falsy and replace it with a throwaway local
@@ -547,6 +691,8 @@ def _spawn_tracked_task(
     task = asyncio.get_event_loop().create_task(coro)
     active_tasks.add(task)
     task.add_done_callback(active_tasks.discard)
+    if log_context is not None:
+        task.add_done_callback(_log_task_completion(log_context))
     return task
 
 
@@ -749,6 +895,26 @@ async def post_backfills(body: BackfillRequest, request: Request) -> JSONRespons
                 run_id=request_id,
                 run_ledger=run_ledger,
             ),
+            log_context={
+                "request_id": request_id,
+                "kind": "backfill",
+                "scope": body.profile,
+                "profile": body.profile,
+            },
+        )
+        logger.info(
+            "backfill accepted request_id=%s profile=%s submitted_at=%s",
+            request_id,
+            body.profile,
+            submitted_at,
+            extra={
+                "request_id": request_id,
+                "kind": "backfill",
+                "scope": body.profile,
+                "profile": body.profile,
+                "submitted_at": submitted_at,
+                "status": "accepted",
+            },
         )
 
         return JSONResponse(
@@ -789,6 +955,26 @@ async def post_backfills(body: BackfillRequest, request: Request) -> JSONRespons
             request_id=request_id,
             run_ledger=run_ledger,
         ),
+        log_context={
+            "request_id": request_id,
+            "kind": "backfill",
+            "scope": "all",
+            "profiles": list(acquired_profiles),
+        },
+    )
+    logger.info(
+        "backfill accepted request_id=%s scope=all profiles=%s submitted_at=%s",
+        request_id,
+        acquired_profiles,
+        submitted_at,
+        extra={
+            "request_id": request_id,
+            "kind": "backfill",
+            "scope": "all",
+            "profiles": list(acquired_profiles),
+            "submitted_at": submitted_at,
+            "status": "accepted",
+        },
     )
     return JSONResponse(
         {

--- a/tests/integration/test_http_api.py
+++ b/tests/integration/test_http_api.py
@@ -699,14 +699,8 @@ async def _drain_active_tasks(app: FastAPI) -> None:
         await asyncio.gather(*pending, return_exceptions=True)
 
 
-def _records_with_status(
-    caplog: pytest.LogCaptureFixture, status: str
-) -> list[Any]:
-    return [
-        r
-        for r in caplog.records
-        if getattr(r, "status", None) == status
-    ]
+def _records_with_status(caplog: pytest.LogCaptureFixture, status: str) -> list[Any]:
+    return [r for r in caplog.records if getattr(r, "status", None) == status]
 
 
 class TestRunObservability:
@@ -732,9 +726,7 @@ class TestRunObservability:
             async with httpx.AsyncClient(
                 transport=transport, base_url="http://test"
             ) as client:
-                resp = await client.post(
-                    "/runs", json={"profile": "ai-robotics"}
-                )
+                resp = await client.post("/runs", json={"profile": "ai-robotics"})
             await _drain_active_tasks(app_with_state)
 
         assert resp.status_code == 202
@@ -772,9 +764,7 @@ class TestRunObservability:
             async with httpx.AsyncClient(
                 transport=transport, base_url="http://test"
             ) as client:
-                resp = await client.post(
-                    "/runs", json={"profile": "ai-robotics"}
-                )
+                resp = await client.post("/runs", json={"profile": "ai-robotics"})
             await _drain_active_tasks(app_with_state)
 
         assert resp.status_code == 202

--- a/tests/integration/test_http_api.py
+++ b/tests/integration/test_http_api.py
@@ -685,3 +685,289 @@ class TestBackfillSchedulerOverlap:
             coordinator.release("ai-robotics")
             if coordinator.is_busy("web-tech"):
                 coordinator.release("web-tech")
+
+
+# ── #105: request-level observability for background runs / backfills ──
+
+
+async def _drain_active_tasks(app: FastAPI) -> None:
+    """Wait for HTTP-spawned background tasks to finish so log assertions
+    have a stable target.
+    """
+    pending = [t for t in getattr(app.state, "active_tasks", set()) if not t.done()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+def _records_with_status(
+    caplog: pytest.LogCaptureFixture, status: str
+) -> list[Any]:
+    return [
+        r
+        for r in caplog.records
+        if getattr(r, "status", None) == status
+    ]
+
+
+class TestRunObservability:
+    """``POST /runs`` emits request-keyed completion / failure logs (#105)."""
+
+    async def test_single_profile_run_logs_completion_with_request_id(
+        self,
+        app_with_state: FastAPI,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import httpx
+
+        from influx import http_api as http_api_mod
+
+        async def fake_run_profile(*args: Any, **kwargs: Any) -> None:
+            return None
+
+        monkeypatch.setattr(http_api_mod, "run_profile", fake_run_profile)
+
+        with caplog.at_level("INFO", logger="influx.http_api"):
+            transport = httpx.ASGITransport(app=app_with_state)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    "/runs", json={"profile": "ai-robotics"}
+                )
+            await _drain_active_tasks(app_with_state)
+
+        assert resp.status_code == 202
+        request_id = resp.json()["request_id"]
+
+        completed = [
+            r
+            for r in _records_with_status(caplog, "completed")
+            if r.message.startswith("background task completed")
+        ]
+        assert len(completed) == 1, [r.message for r in caplog.records]
+        record = completed[0]
+        assert record.request_id == request_id
+        assert record.kind == "manual"
+        assert record.scope == "ai-robotics"
+        assert record.profile == "ai-robotics"
+
+    async def test_single_profile_run_logs_failure_with_exc_info(
+        self,
+        app_with_state: FastAPI,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import httpx
+
+        from influx import http_api as http_api_mod
+
+        async def boom(*args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(http_api_mod, "run_profile", boom)
+
+        with caplog.at_level("INFO", logger="influx.http_api"):
+            transport = httpx.ASGITransport(app=app_with_state)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    "/runs", json={"profile": "ai-robotics"}
+                )
+            await _drain_active_tasks(app_with_state)
+
+        assert resp.status_code == 202
+        request_id = resp.json()["request_id"]
+
+        failed = [
+            r
+            for r in _records_with_status(caplog, "failed")
+            if r.message.startswith("background task failed")
+            and getattr(r, "request_id", None) == request_id
+        ]
+        assert len(failed) == 1
+        record = failed[0]
+        assert record.levelname == "ERROR"
+        assert record.kind == "manual"
+        assert record.profile == "ai-robotics"
+        assert record.exc_info is not None
+
+        helper_warnings = [
+            r
+            for r in caplog.records
+            if r.message.startswith("run_profile")
+            and getattr(r, "request_id", None) == request_id
+        ]
+        assert len(helper_warnings) == 1
+        assert helper_warnings[0].exc_info is not None
+        assert helper_warnings[0].kind == "manual"
+
+    async def test_all_profiles_run_logs_per_profile_failure_and_aggregate(
+        self,
+        app_with_state: FastAPI,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import httpx
+
+        from influx import http_api as http_api_mod
+
+        async def selective_run_profile(
+            profile: str, *args: Any, **kwargs: Any
+        ) -> None:
+            if profile == "web-tech":
+                raise RuntimeError("web-tech blew up")
+            return None
+
+        monkeypatch.setattr(http_api_mod, "run_profile", selective_run_profile)
+
+        with caplog.at_level("INFO", logger="influx.http_api"):
+            transport = httpx.ASGITransport(app=app_with_state)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                resp = await client.post("/runs", json={"all_profiles": True})
+            await _drain_active_tasks(app_with_state)
+
+        assert resp.status_code == 202
+        request_id = resp.json()["request_id"]
+
+        per_profile_failed = [
+            r
+            for r in _records_with_status(caplog, "failed")
+            if getattr(r, "profile", None) == "web-tech"
+            and getattr(r, "request_id", None) == request_id
+        ]
+        assert len(per_profile_failed) == 1
+        assert per_profile_failed[0].levelname == "WARNING"
+
+        per_profile_ok = [
+            r
+            for r in _records_with_status(caplog, "completed")
+            if getattr(r, "profile", None) == "ai-robotics"
+            and getattr(r, "request_id", None) == request_id
+        ]
+        assert len(per_profile_ok) == 1
+
+        aggregate = [
+            r
+            for r in _records_with_status(caplog, "partial_failure")
+            if getattr(r, "request_id", None) == request_id
+        ]
+        assert len(aggregate) == 1
+        agg = aggregate[0]
+        assert agg.failed_count == 1
+        assert agg.total_count == 2
+        assert agg.failed_profiles == ["web-tech"]
+        assert agg.levelname == "WARNING"
+
+
+class TestBackfillObservability:
+    """``POST /backfills`` emits acceptance + request-keyed completion logs (#105)."""
+
+    async def test_single_profile_backfill_logs_acceptance_and_completion(
+        self,
+        app_with_state: FastAPI,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import httpx
+
+        import influx.backfill as backfill_mod
+
+        async def fake_run_backfill(*args: Any, **kwargs: Any) -> None:
+            return None
+
+        monkeypatch.setattr(backfill_mod, "run_backfill", fake_run_backfill)
+
+        with caplog.at_level("INFO", logger="influx.http_api"):
+            transport = httpx.ASGITransport(app=app_with_state)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    "/backfills",
+                    json={
+                        "profile": "ai-robotics",
+                        "days": 7,
+                        "confirm": True,
+                    },
+                )
+            await _drain_active_tasks(app_with_state)
+
+        assert resp.status_code == 202
+        request_id = resp.json()["request_id"]
+
+        accepted = [
+            r
+            for r in _records_with_status(caplog, "accepted")
+            if r.message.startswith("backfill accepted")
+            and getattr(r, "request_id", None) == request_id
+        ]
+        assert len(accepted) == 1
+        assert accepted[0].kind == "backfill"
+        assert accepted[0].profile == "ai-robotics"
+
+        completed = [
+            r
+            for r in _records_with_status(caplog, "completed")
+            if r.message.startswith("background task completed")
+            and getattr(r, "request_id", None) == request_id
+        ]
+        assert len(completed) == 1
+        assert completed[0].kind == "backfill"
+        assert completed[0].scope == "ai-robotics"
+
+    async def test_all_profiles_backfill_logs_per_profile_failure_and_aggregate(
+        self,
+        app_with_state: FastAPI,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import httpx
+
+        from influx import http_api as http_api_mod
+
+        async def selective_run_profile(
+            profile: str, *args: Any, **kwargs: Any
+        ) -> None:
+            if profile == "ai-robotics":
+                raise RuntimeError("ai-robotics blew up")
+            return None
+
+        monkeypatch.setattr(http_api_mod, "run_profile", selective_run_profile)
+
+        with caplog.at_level("INFO", logger="influx.http_api"):
+            transport = httpx.ASGITransport(app=app_with_state)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    "/backfills",
+                    json={"all_profiles": True, "days": 7, "confirm": True},
+                )
+            await _drain_active_tasks(app_with_state)
+
+        assert resp.status_code == 202
+        request_id = resp.json()["request_id"]
+
+        accepted = [
+            r
+            for r in _records_with_status(caplog, "accepted")
+            if r.message.startswith("backfill accepted")
+            and getattr(r, "request_id", None) == request_id
+        ]
+        assert len(accepted) == 1
+        assert accepted[0].scope == "all"
+
+        aggregate = [
+            r
+            for r in _records_with_status(caplog, "partial_failure")
+            if getattr(r, "request_id", None) == request_id
+        ]
+        assert len(aggregate) == 1
+        agg = aggregate[0]
+        assert agg.failed_count == 1
+        assert agg.total_count == 2
+        assert agg.failed_profiles == ["ai-robotics"]

--- a/tests/integration/test_http_api.py
+++ b/tests/integration/test_http_api.py
@@ -847,10 +847,24 @@ class TestRunObservability:
         ]
         assert len(aggregate) == 1
         agg = aggregate[0]
+        assert agg.message.startswith("background task partial failure")
         assert agg.failed_count == 1
         assert agg.total_count == 2
         assert agg.failed_profiles == ["web-tech"]
         assert agg.levelname == "WARNING"
+
+        # The request-level done-callback must NOT also report
+        # ``status="completed"`` for a request that had failures —
+        # that contradiction is exactly what #105 is meant to remove.
+        request_level_completed = [
+            r
+            for r in _records_with_status(caplog, "completed")
+            if r.message.startswith("background task")
+            and getattr(r, "request_id", None) == request_id
+        ]
+        assert request_level_completed == [], [
+            r.message for r in request_level_completed
+        ]
 
 
 class TestBackfillObservability:
@@ -958,6 +972,18 @@ class TestBackfillObservability:
         ]
         assert len(aggregate) == 1
         agg = aggregate[0]
+        assert agg.message.startswith("background task partial failure")
         assert agg.failed_count == 1
         assert agg.total_count == 2
         assert agg.failed_profiles == ["ai-robotics"]
+        assert agg.levelname == "WARNING"
+
+        request_level_completed = [
+            r
+            for r in _records_with_status(caplog, "completed")
+            if r.message.startswith("background task")
+            and getattr(r, "request_id", None) == request_id
+        ]
+        assert request_level_completed == [], [
+            r.message for r in request_level_completed
+        ]

--- a/tests/integration/test_http_api.py
+++ b/tests/integration/test_http_api.py
@@ -783,7 +783,7 @@ class TestRunObservability:
         assert record.profile == "ai-robotics"
         assert record.exc_info is not None
 
-        helper_warnings = [
+        helper_warnings: list[Any] = [
             r
             for r in caplog.records
             if r.message.startswith("run_profile")


### PR DESCRIPTION
## Summary
- HTTP-triggered manual runs and backfills now emit a request-keyed completion or failure log for every accepted task, so operators who see an accepted `request_id` can always find out what happened to it.
- `_run_many_and_release` inspects the `gather(..., return_exceptions=True)` results and emits per-profile success/failure logs plus an aggregate `partial_failure` summary, so multi-profile failures no longer disappear.
- Backfill spawn sites get the same `acceptance` log the run sites have always had, with structured `extra=` fields (`request_id`, `kind`, `scope`, `profile`) that flow into the existing JSON / OTEL log handlers.
- The single-profile `_run_and_release` / `_backfill_and_release` helpers now re-raise after the lock-release safety net so the request-level done-callback fires the `error` path with `exc_info`.

## Test plan
- [x] `uv run pytest tests/integration/test_http_api.py -k Observability -vv` — 5 new tests pass
- [x] `uv run pytest tests/integration/test_http_api.py` — all 45 tests pass
- [x] `uv run pytest tests/unit -q` — 1557 unit tests pass
- [x] `uv run pytest tests/integration -q` (skipping OTEL-only files that need extra deps) — 200 pass
- [x] `uv run ruff check src/influx/http_api.py tests/integration/test_http_api.py` — clean
- [x] `uv run mypy src/influx/http_api.py` — no new errors introduced (only pre-existing missing-stub and one pre-existing `var-annotated` warning on `acquired_profiles`)

Closes #105