### PR TITLE
fix: converge arxiv text_extraction failures to text:abstract-only

### DIFF
--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -474,7 +474,27 @@ def _make_archive_download_hook(config: AppConfig) -> ArchiveDownloadHook:
 
 
 def _run_arxiv_text_extraction(note: dict[str, object], config: AppConfig) -> str:
-    """Run the arxiv text-extraction cascade and return the resulting tag."""
+    """Run the arxiv text-extraction cascade and return the resulting tag.
+
+    Returns ``"text:html"`` / ``"text:pdf"`` from the cascade's success
+    paths.  On cascade fall-through (``ExtractionError`` from
+    :func:`extract_arxiv_text`) or a ``NetworkError`` leaking from
+    helpers it calls (e.g. SSRF / TLS / timeout on the PDF fetch),
+    returns ``"text:abstract-only"`` per the
+    :class:`~influx.repair.TextExtractionHook` protocol so the sweep
+    stamps a ``text:*`` tag and the note converges out of the
+    text-extraction stage.  The note can still be upgraded to
+    ``text:html`` / ``text:pdf`` later via
+    :func:`_make_re_extract_archive_hook` once
+    :func:`_make_archive_download_hook` lands an archive on disk.  A
+    WARN is emitted so operators can see the structural reason behind
+    the convergence.
+
+    Only ``ExtractionError(stage="resolve")`` is raised — that signals
+    a missing ``arxiv-id:`` tag which only an operator fix can repair,
+    and it should keep surfacing through the sweep's failure-logging
+    path until corrected.
+    """
     arxiv_id = _find_tag(_note_tags(note), _ARXIV_ID_TAG_PREFIX)
     if not arxiv_id:
         raise ExtractionError(
@@ -485,17 +505,16 @@ def _run_arxiv_text_extraction(note: dict[str, object], config: AppConfig) -> st
 
     try:
         result = extract_arxiv_text(arxiv_id, config)
-    except NetworkError as exc:
-        # extract_arxiv_text raises ExtractionError on full cascade
-        # fall-through, but a NetworkError can leak from helpers it
-        # calls (e.g. SSRF guards on the PDF fetch).  Re-wrap so the
-        # sweep's ``(ExtractionError, ...)`` branch handles it.
-        raise ExtractionError(
-            f"text_extraction retry network failure: {exc.kind}",
-            url=getattr(exc, "url", "") or "",
-            stage=exc.kind or "network",
-            detail=str(exc),
-        ) from exc
+    except (ExtractionError, NetworkError) as exc:
+        stage = getattr(exc, "stage", None) or getattr(exc, "kind", None) or "extract"
+        _log.warning(
+            "arxiv text_extraction retry: live extraction failed for %s "
+            "(stage=%s arxiv_id=%s); converging to text:abstract-only",
+            note.get("id", "?"),
+            stage,
+            arxiv_id,
+        )
+        return "text:abstract-only"
     return result.source_tag
 
 

--- a/tests/unit/test_repair_hooks_production.py
+++ b/tests/unit/test_repair_hooks_production.py
@@ -793,9 +793,18 @@ class TestTextExtractionHookSuccess:
 
 
 class TestTextExtractionHookFailures:
-    def test_cascade_failure_propagates_extraction_error(self, tmp_path: Path) -> None:
-        from influx.repair_counters import classify_failure
+    """Live extraction failure converges to ``text:abstract-only`` (issue #137).
 
+    Per the :class:`~influx.repair.TextExtractionHook` protocol the
+    hook returns ``"text:abstract-only"`` on cascade fall-through so
+    the sweep stamps a ``text:*`` tag and the note exits the
+    text-extraction stage.  Re-extraction from a stored archive (via
+    the source-agnostic ``re_extract_archive`` hook) can still upgrade
+    the tag to ``text:html`` / ``text:pdf`` once ``archive_download``
+    lands.
+    """
+
+    def test_cascade_failure_returns_abstract_only(self, tmp_path: Path) -> None:
         config = _make_config(tmp_path)
         hooks = make_default_sweep_hooks(config)
         note = _make_textless_note()
@@ -807,15 +816,11 @@ class TestTextExtractionHookFailures:
                 detail="both html and pdf failed",
             )
             assert hooks.text_extraction is not None
-            with pytest.raises(ExtractionError) as exc_info:
-                hooks.text_extraction(note)
+            tag = hooks.text_extraction(note)
 
-        assert exc_info.value.stage == "cascade"
-        # ``cascade`` is not in _COUNTED_STAGES, so it stays transient —
-        # the note re-enters the sweep next pass.
-        assert classify_failure(exc_info.value) == "transient"
+        assert tag == "text:abstract-only"
 
-    def test_network_error_rewrapped_as_extraction_error(self, tmp_path: Path) -> None:
+    def test_network_error_returns_abstract_only(self, tmp_path: Path) -> None:
         from influx.errors import NetworkError
 
         config = _make_config(tmp_path)
@@ -829,10 +834,34 @@ class TestTextExtractionHookFailures:
                 kind="ssrf",
             )
             assert hooks.text_extraction is not None
-            with pytest.raises(ExtractionError) as exc_info:
+            tag = hooks.text_extraction(note)
+
+        assert tag == "text:abstract-only"
+
+    def test_logs_warning_on_failure(self, tmp_path: Path, caplog) -> None:
+        """Operator visibility: the structural failure stage is logged."""
+        import logging
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_textless_note()
+
+        with patch("influx.repair_hooks.extract_arxiv_text") as mock_x:
+            mock_x.side_effect = ExtractionError(
+                "cascade fell through",
+                stage="cascade",
+                detail="both html and pdf failed",
+            )
+            assert hooks.text_extraction is not None
+            with caplog.at_level(logging.WARNING, logger="influx.repair_hooks"):
                 hooks.text_extraction(note)
 
-        assert exc_info.value.stage == "ssrf"
+        assert any(
+            "stage=cascade" in record.message
+            and "text:abstract-only" in record.message
+            and "2604.26946" in record.message
+            for record in caplog.records
+        )
 
 
 class TestTextExtractionHookMetadataRecovery:


### PR DESCRIPTION
## Summary

- Make `_run_arxiv_text_extraction` honour the `TextExtractionHook` protocol contract: on cascade fall-through (`ExtractionError` from `extract_arxiv_text`) **and** on `NetworkError` leaking from cascade helpers, return `"text:abstract-only"` so the sweep stamps a `text:*` tag and the note exits `text_extraction_retry` instead of looping every pass.
- Mirrors the RSS convergence shape from PR #136 / issue #130.
- `ExtractionError(stage="resolve")` (missing `arxiv-id:` tag) still raises — operator-fix-required structural failure.
- WARN log emits the structural `stage` / `kind`, the arxiv id, and a `converging to text:abstract-only` indicator for operator visibility.
- Inverted two failure tests in `TestTextExtractionHookFailures` (`cascade` and `NetworkError` paths now assert convergence) and added a WARN-log test mirroring the RSS shape. The `resolve` test in `TestTextExtractionHookMetadataRecovery` and all RSS tests remain unchanged.

Closes #137

## Test plan

- [x] `uv run pytest tests/unit/test_repair_hooks_production.py -v` — 57 passed (including 3 new/inverted arxiv tests + unchanged `resolve` test + all RSS reference tests)
- [x] `uv run pytest tests/unit/test_repair_hooks.py tests/unit/test_repair_hooks_production.py tests/unit/test_repair_sweep.py tests/unit/test_repair_hook_rollback.py` — 122 passed (no behavioural drift in RSS branch or sweep handler)
- [x] `uv run ruff format` / `uv run ruff check` on touched files — clean
- [x] `uv run mypy src/influx/repair_hooks.py` — only pre-existing missing-stub warnings (`trafilatura`); no new errors