### PR TITLE
test: sweep-level integration coverage for RSS repair flows

### DIFF
--- a/tests/integration/test_repair_sweep_rss_archive_recovery.py
+++ b/tests/integration/test_repair_sweep_rss_archive_recovery.py
@@ -1,0 +1,349 @@
+"""Integration tests for the RSS archive-recovery repair flow (issue #138).
+
+Mirrors :mod:`tests.integration.test_repair_sweep_archive_only` and the
+archive→re-extract→tier2→tier3 walk in
+:mod:`tests.integration.test_repair_sweep_abstract_only`, but with an
+RSS-shaped note (``source:rss-<feed>`` + ``feed-slug:<slug>`` +
+``articles/rss-<feed>/`` path) and a non-arxiv ``source_url``.
+
+The flow exercised here:
+
+- Pass 1: ``influx:archive-missing`` + ``text:abstract-only`` →
+  ``archive_download`` succeeds → ``archive-missing`` cleared,
+  ``## Archive`` populated with ``path:``.
+- Pass 2: feed run-1 written note back → ``re_extract_archive`` returns
+  ``UPGRADE`` → ``text:abstract-only`` replaced by ``text:html`` →
+  ``tier2_enrich`` adds ``full-text`` → ``tier3_extract`` adds
+  ``influx:deep-extracted`` → ``influx:repair-needed`` cleared.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+
+from influx.config import (
+    AppConfig,
+    FeedbackConfig,
+    LithosConfig,
+    ProfileConfig,
+    ProfileThresholds,
+    PromptEntryConfig,
+    PromptsConfig,
+    RepairConfig,
+    ScheduleConfig,
+    SecurityConfig,
+)
+from influx.lithos_client import LithosClient
+from influx.repair import (
+    ExtractionOutcome,
+    ReExtractionResult,
+    SweepHooks,
+    sweep,
+)
+from tests.contract.test_lithos_client import FakeLithosServer
+
+# ── Fixtures ───────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def fake_lithos() -> Generator[FakeLithosServer, None, None]:
+    server = FakeLithosServer()
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.fixture(scope="module")
+def fake_lithos_url(fake_lithos: FakeLithosServer) -> str:
+    return f"http://127.0.0.1:{fake_lithos.port}/sse"
+
+
+@pytest.fixture(autouse=True)
+def clear_fakes(fake_lithos: FakeLithosServer) -> None:
+    fake_lithos.calls.clear()
+    fake_lithos.write_responses.clear()
+    fake_lithos.read_responses.clear()
+    fake_lithos.cache_lookup_responses.clear()
+    fake_lithos.list_responses.clear()
+
+
+# ── RSS-shaped helpers ────────────────────────────────────────────
+
+_FEED_SLUG = "techcrunch"
+_URL_HASH = "abc123def"
+_NOTE_ID = f"rss-{_FEED_SLUG}-{_URL_HASH}"
+_NOTE_PATH = f"articles/rss-{_FEED_SLUG}/2026/05"
+_SOURCE_URL = "https://example.com/article-42"
+_ARCHIVE_PATH = f"rss-{_FEED_SLUG}/2026/05/{_FEED_SLUG}-{_URL_HASH}.html"
+
+
+def _make_config(
+    *,
+    lithos_url: str,
+    max_items: int = 100,
+) -> AppConfig:
+    return AppConfig(
+        lithos=LithosConfig(url=lithos_url),
+        schedule=ScheduleConfig(cron="0 6 * * *", timezone="UTC"),
+        profiles=[
+            ProfileConfig(
+                name="ai-robotics",
+                description="AI & Robotics",
+                thresholds=ProfileThresholds(notify_immediate=8),
+            ),
+        ],
+        providers={},
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(
+                text="Filter: {profile_description} "
+                "{negative_examples} "
+                "{min_score_in_results}",
+            ),
+            tier1_enrich=PromptEntryConfig(text="test"),
+            tier3_extract=PromptEntryConfig(text="test"),
+        ),
+        security=SecurityConfig(allow_private_ips=True),
+        feedback=FeedbackConfig(negative_examples_per_profile=20),
+        repair=RepairConfig(max_items_per_run=max_items),
+    )
+
+
+def _make_rss_note_content(
+    *,
+    archive_path: str | None = None,
+    score: int = 9,
+) -> str:
+    """Build canonical RSS note content with optional archive path."""
+    archive_body = f"path: {archive_path}\n" if archive_path is not None else ""
+    return (
+        "---\n"
+        "note_type: summary\n"
+        "namespace: influx\n"
+        f"source_url: {_SOURCE_URL}\n"
+        "tags:\n"
+        "  - profile:ai-robotics\n"
+        f"  - source:rss-{_FEED_SLUG}\n"
+        f"  - feed-slug:{_FEED_SLUG}\n"
+        "confidence: 0.7\n"
+        "---\n"
+        "# RSS Article Title\n"
+        "\n"
+        "## Archive\n"
+        f"{archive_body}"
+        "\n"
+        "## Summary\n"
+        "An RSS article summary.\n"
+        "\n"
+        "## Profile Relevance\n"
+        "### ai-robotics\n"
+        f"Score: {score}/10\n"
+        "Relevant.\n"
+        "\n"
+        "## User Notes\n"
+    )
+
+
+def _make_rss_note_dict(
+    *,
+    tags: list[str],
+    archive_path: str | None = None,
+    score: int = 9,
+) -> dict[str, Any]:
+    """Build an RSS note dict as returned by ``lithos_read``."""
+    return {
+        "id": _NOTE_ID,
+        "title": "RSS Article Title",
+        "content": _make_rss_note_content(
+            archive_path=archive_path,
+            score=score,
+        ),
+        "tags": tags,
+        "version": 1,
+        "source_url": _SOURCE_URL,
+        "path": _NOTE_PATH,
+        "confidence": 0.7,
+        "note_type": "summary",
+        "namespace": "influx",
+    }
+
+
+def _queue_single_note(
+    fake_lithos: FakeLithosServer,
+    note: dict[str, Any],
+) -> None:
+    """Queue list + read + write responses for a single-note sweep."""
+    fake_lithos.list_responses.append(
+        json.dumps({"items": [{"id": note["id"], "title": note["title"]}]})
+    )
+    fake_lithos.read_responses.append(json.dumps(note))
+    fake_lithos.write_responses.append('{"status": "updated"}')
+
+
+def _next_pass_note(
+    base_note: dict[str, Any],
+    write_payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the next sweep pass's read response from a prior write payload."""
+    return {
+        **base_note,
+        "content": write_payload["content"],
+        "tags": list(write_payload["tags"]),
+    }
+
+
+# ── Stub hooks ────────────────────────────────────────────────────
+
+
+def _archive_download_ok(note: dict[str, object]) -> str:
+    return _ARCHIVE_PATH
+
+
+def _re_extract_upgrade_html(
+    note: dict[str, object],
+    archive_path: str,
+) -> ReExtractionResult:
+    return ReExtractionResult(
+        outcome=ExtractionOutcome.UPGRADE,
+        upgraded_text_tag="text:html",
+    )
+
+
+def _add_tag_in_place(note: dict[str, object], tag: str) -> None:
+    raw = note.get("tags") or []
+    tags = list(raw) if isinstance(raw, list) else []
+    if tag not in tags:
+        tags.append(tag)
+    note["tags"] = tags
+
+
+def _tier2_enrich_adds_full_text(note: dict[str, object]) -> None:
+    _add_tag_in_place(note, "full-text")
+
+
+def _tier3_extract_adds_deep_extracted(note: dict[str, object]) -> None:
+    _add_tag_in_place(note, "influx:deep-extracted")
+
+
+# ── Tests ──────────────────────────────────────────────────────────
+
+
+class TestRssArchiveRecoveryFlow:
+    """End-to-end RSS repair recovery across two sweep passes."""
+
+    async def test_pass1_archive_lands_clears_archive_missing(
+        self,
+        fake_lithos: FakeLithosServer,
+        fake_lithos_url: str,
+    ) -> None:
+        """Pass 1: archive_download succeeds → archive-missing cleared,
+        ``path:`` written, text:abstract-only preserved (text stage waits
+        for archive to land first)."""
+        tags = [
+            "profile:ai-robotics",
+            "influx:repair-needed",
+            "influx:archive-missing",
+            f"source:rss-{_FEED_SLUG}",
+            f"feed-slug:{_FEED_SLUG}",
+            "text:abstract-only",
+        ]
+        note = _make_rss_note_dict(tags=tags)
+        _queue_single_note(fake_lithos, note)
+
+        config = _make_config(lithos_url=fake_lithos_url)
+        hooks = SweepHooks(archive_download=_archive_download_ok)
+
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            visited = await sweep(
+                "ai-robotics",
+                client=client,
+                config=config,
+                hooks=hooks,
+            )
+            assert len(visited) == 1
+
+            write_calls = [c for c in fake_lithos.calls if c[0] == "lithos_write"]
+            assert len(write_calls) == 1
+            payload = write_calls[0][1]
+
+            assert "influx:archive-missing" not in payload["tags"]
+            assert f"path: {_ARCHIVE_PATH}" in payload["content"]
+
+            assert "text:abstract-only" in payload["tags"]
+            assert f"source:rss-{_FEED_SLUG}" in payload["tags"]
+            assert f"feed-slug:{_FEED_SLUG}" in payload["tags"]
+        finally:
+            await client.close()
+
+    async def test_full_recovery_two_passes_converges_to_stable_state(
+        self,
+        fake_lithos: FakeLithosServer,
+        fake_lithos_url: str,
+    ) -> None:
+        """Pass 1 lands archive; pass 2 upgrades text + adds full-text +
+        deep-extracted → influx:repair-needed cleared."""
+        tags = [
+            "profile:ai-robotics",
+            "influx:repair-needed",
+            "influx:archive-missing",
+            f"source:rss-{_FEED_SLUG}",
+            f"feed-slug:{_FEED_SLUG}",
+            "text:abstract-only",
+        ]
+        note = _make_rss_note_dict(tags=tags, score=9)
+
+        # ── Pass 1: archive lands. ──
+        _queue_single_note(fake_lithos, note)
+        config = _make_config(lithos_url=fake_lithos_url)
+        hooks_p1 = SweepHooks(archive_download=_archive_download_ok)
+
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            await sweep(
+                "ai-robotics",
+                client=client,
+                config=config,
+                hooks=hooks_p1,
+            )
+            write_calls_p1 = [c for c in fake_lithos.calls if c[0] == "lithos_write"]
+            assert len(write_calls_p1) == 1
+            p1_payload = write_calls_p1[0][1]
+            assert "influx:archive-missing" not in p1_payload["tags"]
+            assert "influx:repair-needed" in p1_payload["tags"]
+
+            # ── Pass 2: re-extract upgrades text, tier2/tier3 fill in. ──
+            fake_lithos.calls.clear()
+            note_p2 = _next_pass_note(note, p1_payload)
+            _queue_single_note(fake_lithos, note_p2)
+
+            hooks_p2 = SweepHooks(
+                re_extract_archive=_re_extract_upgrade_html,
+                tier2_enrich=_tier2_enrich_adds_full_text,
+                tier3_extract=_tier3_extract_adds_deep_extracted,
+            )
+            await sweep(
+                "ai-robotics",
+                client=client,
+                config=config,
+                hooks=hooks_p2,
+            )
+
+            write_calls_p2 = [c for c in fake_lithos.calls if c[0] == "lithos_write"]
+            assert len(write_calls_p2) == 1
+            p2_payload = write_calls_p2[0][1]
+
+            assert "text:abstract-only" not in p2_payload["tags"]
+            assert "text:html" in p2_payload["tags"]
+            assert "full-text" in p2_payload["tags"]
+            assert "influx:deep-extracted" in p2_payload["tags"]
+
+            assert "influx:repair-needed" not in p2_payload["tags"]
+
+            assert f"source:rss-{_FEED_SLUG}" in p2_payload["tags"]
+            assert f"feed-slug:{_FEED_SLUG}" in p2_payload["tags"]
+        finally:
+            await client.close()

--- a/tests/integration/test_repair_sweep_rss_archive_terminal.py
+++ b/tests/integration/test_repair_sweep_rss_archive_terminal.py
@@ -1,0 +1,300 @@
+"""Integration tests for the RSS archive-terminal counted-cap flip (issue #138).
+
+Walks an RSS note through three sequential sweep passes, each one
+hitting an ``ExtractionError(stage="oversize")`` from the
+``archive_download`` hook (a counted-class stage per
+:data:`influx.repair_counters._COUNTED_STAGES`).  After
+``REPAIR_COUNTED_CAP`` (=3) counted failures the sweep flips
+``influx:archive-terminal``.  A fourth pass confirms the terminal
+gate from :func:`influx.repair.select_stages` skips
+``archive_retry`` even though ``influx:archive-missing`` is still
+present.
+
+There is no equivalent for this flow in the existing arxiv integration
+suite — the chronic-oversize file handles ``content_too_large`` from
+``lithos_write``, a different code path.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+
+from influx.config import (
+    AppConfig,
+    FeedbackConfig,
+    LithosConfig,
+    ProfileConfig,
+    ProfileThresholds,
+    PromptEntryConfig,
+    PromptsConfig,
+    RepairConfig,
+    ScheduleConfig,
+    SecurityConfig,
+)
+from influx.errors import ExtractionError
+from influx.lithos_client import LithosClient
+from influx.repair import SweepHooks, sweep
+from tests.contract.test_lithos_client import FakeLithosServer
+
+# ── Fixtures ───────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def fake_lithos() -> Generator[FakeLithosServer, None, None]:
+    server = FakeLithosServer()
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.fixture(scope="module")
+def fake_lithos_url(fake_lithos: FakeLithosServer) -> str:
+    return f"http://127.0.0.1:{fake_lithos.port}/sse"
+
+
+@pytest.fixture(autouse=True)
+def clear_fakes(fake_lithos: FakeLithosServer) -> None:
+    fake_lithos.calls.clear()
+    fake_lithos.write_responses.clear()
+    fake_lithos.read_responses.clear()
+    fake_lithos.cache_lookup_responses.clear()
+    fake_lithos.list_responses.clear()
+
+
+# ── RSS-shaped helpers ────────────────────────────────────────────
+
+_FEED_SLUG = "techcrunch"
+_URL_HASH = "abc123def"
+_NOTE_ID = f"rss-{_FEED_SLUG}-{_URL_HASH}"
+_NOTE_PATH = f"articles/rss-{_FEED_SLUG}/2026/05"
+_SOURCE_URL = "https://example.com/article-42"
+
+
+def _make_config(
+    *,
+    lithos_url: str,
+    max_items: int = 100,
+) -> AppConfig:
+    return AppConfig(
+        lithos=LithosConfig(url=lithos_url),
+        schedule=ScheduleConfig(cron="0 6 * * *", timezone="UTC"),
+        profiles=[
+            ProfileConfig(
+                name="ai-robotics",
+                description="AI & Robotics",
+                thresholds=ProfileThresholds(notify_immediate=8),
+            ),
+        ],
+        providers={},
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(
+                text="Filter: {profile_description} "
+                "{negative_examples} "
+                "{min_score_in_results}",
+            ),
+            tier1_enrich=PromptEntryConfig(text="test"),
+            tier3_extract=PromptEntryConfig(text="test"),
+        ),
+        security=SecurityConfig(allow_private_ips=True),
+        feedback=FeedbackConfig(negative_examples_per_profile=20),
+        repair=RepairConfig(max_items_per_run=max_items),
+    )
+
+
+def _make_rss_note_content(
+    *,
+    archive_path: str | None = None,
+    score: int = 5,
+) -> str:
+    archive_body = f"path: {archive_path}\n" if archive_path is not None else ""
+    return (
+        "---\n"
+        "note_type: summary\n"
+        "namespace: influx\n"
+        f"source_url: {_SOURCE_URL}\n"
+        "tags:\n"
+        "  - profile:ai-robotics\n"
+        f"  - source:rss-{_FEED_SLUG}\n"
+        f"  - feed-slug:{_FEED_SLUG}\n"
+        "confidence: 0.7\n"
+        "---\n"
+        "# RSS Article Title\n"
+        "\n"
+        "## Archive\n"
+        f"{archive_body}"
+        "\n"
+        "## Summary\n"
+        "An RSS article summary.\n"
+        "\n"
+        "## Profile Relevance\n"
+        "### ai-robotics\n"
+        f"Score: {score}/10\n"
+        "Relevant.\n"
+        "\n"
+        "## User Notes\n"
+    )
+
+
+def _make_rss_note_dict(
+    *,
+    tags: list[str],
+    archive_path: str | None = None,
+    score: int = 5,
+) -> dict[str, Any]:
+    return {
+        "id": _NOTE_ID,
+        "title": "RSS Article Title",
+        "content": _make_rss_note_content(
+            archive_path=archive_path,
+            score=score,
+        ),
+        "tags": tags,
+        "version": 1,
+        "source_url": _SOURCE_URL,
+        "path": _NOTE_PATH,
+        "confidence": 0.7,
+        "note_type": "summary",
+        "namespace": "influx",
+    }
+
+
+def _queue_single_note(
+    fake_lithos: FakeLithosServer,
+    note: dict[str, Any],
+) -> None:
+    fake_lithos.list_responses.append(
+        json.dumps({"items": [{"id": note["id"], "title": note["title"]}]})
+    )
+    fake_lithos.read_responses.append(json.dumps(note))
+    fake_lithos.write_responses.append('{"status": "updated"}')
+
+
+def _next_pass_note(
+    base_note: dict[str, Any],
+    write_payload: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        **base_note,
+        "content": write_payload["content"],
+        "tags": list(write_payload["tags"]),
+    }
+
+
+def _archive_download_oversize(note: dict[str, object]) -> str:
+    raise ExtractionError(
+        "archive too large",
+        url=str(note.get("source_url", "")),
+        stage="oversize",
+    )
+
+
+def _archive_attempt_count(content: str) -> int:
+    """Pull the ``- archive_attempts: N`` value from ``## Repair`` body."""
+    marker = "- archive_attempts:"
+    idx = content.find(marker)
+    if idx == -1:
+        return 0
+    line_end = content.find("\n", idx)
+    line = content[idx:line_end] if line_end != -1 else content[idx:]
+    return int(line.split(":", 1)[1].strip())
+
+
+# ── Tests ──────────────────────────────────────────────────────────
+
+
+class TestRssArchiveTerminalCountedCap:
+    """Three counted ``oversize`` failures flip ``influx:archive-terminal``."""
+
+    async def test_three_passes_flip_terminal_then_skip_archive_retry(
+        self,
+        fake_lithos: FakeLithosServer,
+        fake_lithos_url: str,
+    ) -> None:
+        tags = [
+            "profile:ai-robotics",
+            "influx:repair-needed",
+            "influx:archive-missing",
+            f"source:rss-{_FEED_SLUG}",
+            f"feed-slug:{_FEED_SLUG}",
+            "text:html",
+        ]
+        note = _make_rss_note_dict(tags=tags)
+
+        config = _make_config(lithos_url=fake_lithos_url)
+        client = LithosClient(url=fake_lithos_url)
+
+        try:
+            # ── Pass 1: counted failure #1 → attempts=1, no terminal. ──
+            _queue_single_note(fake_lithos, note)
+            hooks = SweepHooks(archive_download=_archive_download_oversize)
+            await sweep(
+                "ai-robotics",
+                client=client,
+                config=config,
+                hooks=hooks,
+            )
+            p1_payload = next(c[1] for c in fake_lithos.calls if c[0] == "lithos_write")
+            assert _archive_attempt_count(p1_payload["content"]) == 1
+            assert "influx:archive-terminal" not in p1_payload["tags"]
+            assert "influx:archive-missing" in p1_payload["tags"]
+
+            # ── Pass 2: counted failure #2 → attempts=2, no terminal. ──
+            fake_lithos.calls.clear()
+            note_p2 = _next_pass_note(note, p1_payload)
+            _queue_single_note(fake_lithos, note_p2)
+            await sweep(
+                "ai-robotics",
+                client=client,
+                config=config,
+                hooks=hooks,
+            )
+            p2_payload = next(c[1] for c in fake_lithos.calls if c[0] == "lithos_write")
+            assert _archive_attempt_count(p2_payload["content"]) == 2
+            assert "influx:archive-terminal" not in p2_payload["tags"]
+
+            # ── Pass 3: counted failure #3 → attempts=3, terminal flipped. ──
+            fake_lithos.calls.clear()
+            note_p3 = _next_pass_note(note, p2_payload)
+            _queue_single_note(fake_lithos, note_p3)
+            await sweep(
+                "ai-robotics",
+                client=client,
+                config=config,
+                hooks=hooks,
+            )
+            p3_payload = next(c[1] for c in fake_lithos.calls if c[0] == "lithos_write")
+            assert _archive_attempt_count(p3_payload["content"]) == 3
+            assert "influx:archive-terminal" in p3_payload["tags"]
+            # archive-missing stays — terminal records "we gave up", not "fixed".
+            assert "influx:archive-missing" in p3_payload["tags"]
+
+            # ── Pass 4: terminal-tagged note → archive_retry skipped. ──
+            fake_lithos.calls.clear()
+            archive_calls: list[bool] = []
+
+            def _track_archive(note: dict[str, object]) -> str:
+                archive_calls.append(True)
+                raise ExtractionError(
+                    "should not be called",
+                    url=str(note.get("source_url", "")),
+                    stage="oversize",
+                )
+
+            note_p4 = _next_pass_note(note, p3_payload)
+            _queue_single_note(fake_lithos, note_p4)
+            await sweep(
+                "ai-robotics",
+                client=client,
+                config=config,
+                hooks=SweepHooks(archive_download=_track_archive),
+            )
+
+            # archive_retry is gated by ``not is_archive_terminal`` in
+            # repair.py:381-385, so the hook must NOT run on pass 4.
+            assert archive_calls == []
+        finally:
+            await client.close()

--- a/tests/integration/test_repair_sweep_rss_http_transient.py
+++ b/tests/integration/test_repair_sweep_rss_http_transient.py
@@ -1,0 +1,260 @@
+"""Integration tests for RSS archive HTTP-transient retry recovery (issue #138).
+
+A transient stage (``stage="http"``) classifies as transient per
+:func:`influx.repair_counters.classify_failure` (the counted set is
+``{"parse", "validate", "oversize"}``).  The sweep must therefore:
+
+- not flip ``influx:archive-terminal``,
+- not bump ``archive_attempts``,
+- leave ``influx:archive-missing`` in place so the note re-enters the
+  next sweep,
+- recover cleanly when ``archive_download`` succeeds on the next pass.
+
+This file mirrors the failure-keeps-tags shape of
+``test_repair_sweep_archive_only.test_archive_download_failure_keeps_tags``
+but adds an explicit recovery pass after the transient failure.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+
+from influx.config import (
+    AppConfig,
+    FeedbackConfig,
+    LithosConfig,
+    ProfileConfig,
+    ProfileThresholds,
+    PromptEntryConfig,
+    PromptsConfig,
+    RepairConfig,
+    ScheduleConfig,
+    SecurityConfig,
+)
+from influx.errors import ExtractionError
+from influx.lithos_client import LithosClient
+from influx.repair import SweepHooks, sweep
+from tests.contract.test_lithos_client import FakeLithosServer
+
+# ── Fixtures ───────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def fake_lithos() -> Generator[FakeLithosServer, None, None]:
+    server = FakeLithosServer()
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.fixture(scope="module")
+def fake_lithos_url(fake_lithos: FakeLithosServer) -> str:
+    return f"http://127.0.0.1:{fake_lithos.port}/sse"
+
+
+@pytest.fixture(autouse=True)
+def clear_fakes(fake_lithos: FakeLithosServer) -> None:
+    fake_lithos.calls.clear()
+    fake_lithos.write_responses.clear()
+    fake_lithos.read_responses.clear()
+    fake_lithos.cache_lookup_responses.clear()
+    fake_lithos.list_responses.clear()
+
+
+# ── RSS-shaped helpers ────────────────────────────────────────────
+
+_FEED_SLUG = "techcrunch"
+_URL_HASH = "abc123def"
+_NOTE_ID = f"rss-{_FEED_SLUG}-{_URL_HASH}"
+_NOTE_PATH = f"articles/rss-{_FEED_SLUG}/2026/05"
+_SOURCE_URL = "https://example.com/article-42"
+_ARCHIVE_PATH = f"rss-{_FEED_SLUG}/2026/05/{_FEED_SLUG}-{_URL_HASH}.html"
+
+
+def _make_config(
+    *,
+    lithos_url: str,
+    max_items: int = 100,
+) -> AppConfig:
+    return AppConfig(
+        lithos=LithosConfig(url=lithos_url),
+        schedule=ScheduleConfig(cron="0 6 * * *", timezone="UTC"),
+        profiles=[
+            ProfileConfig(
+                name="ai-robotics",
+                description="AI & Robotics",
+                thresholds=ProfileThresholds(notify_immediate=8),
+            ),
+        ],
+        providers={},
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(
+                text="Filter: {profile_description} "
+                "{negative_examples} "
+                "{min_score_in_results}",
+            ),
+            tier1_enrich=PromptEntryConfig(text="test"),
+            tier3_extract=PromptEntryConfig(text="test"),
+        ),
+        security=SecurityConfig(allow_private_ips=True),
+        feedback=FeedbackConfig(negative_examples_per_profile=20),
+        repair=RepairConfig(max_items_per_run=max_items),
+    )
+
+
+def _make_rss_note_content(
+    *,
+    archive_path: str | None = None,
+    score: int = 5,
+) -> str:
+    archive_body = f"path: {archive_path}\n" if archive_path is not None else ""
+    return (
+        "---\n"
+        "note_type: summary\n"
+        "namespace: influx\n"
+        f"source_url: {_SOURCE_URL}\n"
+        "tags:\n"
+        "  - profile:ai-robotics\n"
+        f"  - source:rss-{_FEED_SLUG}\n"
+        f"  - feed-slug:{_FEED_SLUG}\n"
+        "confidence: 0.7\n"
+        "---\n"
+        "# RSS Article Title\n"
+        "\n"
+        "## Archive\n"
+        f"{archive_body}"
+        "\n"
+        "## Summary\n"
+        "An RSS article summary.\n"
+        "\n"
+        "## Profile Relevance\n"
+        "### ai-robotics\n"
+        f"Score: {score}/10\n"
+        "Relevant.\n"
+        "\n"
+        "## User Notes\n"
+    )
+
+
+def _make_rss_note_dict(
+    *,
+    tags: list[str],
+    archive_path: str | None = None,
+    score: int = 5,
+) -> dict[str, Any]:
+    return {
+        "id": _NOTE_ID,
+        "title": "RSS Article Title",
+        "content": _make_rss_note_content(
+            archive_path=archive_path,
+            score=score,
+        ),
+        "tags": tags,
+        "version": 1,
+        "source_url": _SOURCE_URL,
+        "path": _NOTE_PATH,
+        "confidence": 0.7,
+        "note_type": "summary",
+        "namespace": "influx",
+    }
+
+
+def _queue_single_note(
+    fake_lithos: FakeLithosServer,
+    note: dict[str, Any],
+) -> None:
+    fake_lithos.list_responses.append(
+        json.dumps({"items": [{"id": note["id"], "title": note["title"]}]})
+    )
+    fake_lithos.read_responses.append(json.dumps(note))
+    fake_lithos.write_responses.append('{"status": "updated"}')
+
+
+def _next_pass_note(
+    base_note: dict[str, Any],
+    write_payload: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        **base_note,
+        "content": write_payload["content"],
+        "tags": list(write_payload["tags"]),
+    }
+
+
+# ── Tests ──────────────────────────────────────────────────────────
+
+
+class TestRssArchiveHttpTransientRetry:
+    """``stage="http"`` failures are transient — no terminal flip, recover next pass."""
+
+    async def test_transient_keeps_tags_then_next_pass_recovers(
+        self,
+        fake_lithos: FakeLithosServer,
+        fake_lithos_url: str,
+    ) -> None:
+        tags = [
+            "profile:ai-robotics",
+            "influx:repair-needed",
+            "influx:archive-missing",
+            f"source:rss-{_FEED_SLUG}",
+            f"feed-slug:{_FEED_SLUG}",
+            "text:html",
+        ]
+        note = _make_rss_note_dict(tags=tags)
+
+        config = _make_config(lithos_url=fake_lithos_url)
+        client = LithosClient(url=fake_lithos_url)
+
+        def _archive_http_503(note: dict[str, object]) -> str:
+            raise ExtractionError(
+                "upstream 503",
+                url=str(note.get("source_url", "")),
+                stage="http",
+            )
+
+        def _archive_lands(note: dict[str, object]) -> str:
+            return _ARCHIVE_PATH
+
+        try:
+            # ── Pass 1: transient HTTP 503 → tags unchanged. ──
+            _queue_single_note(fake_lithos, note)
+            await sweep(
+                "ai-robotics",
+                client=client,
+                config=config,
+                hooks=SweepHooks(archive_download=_archive_http_503),
+            )
+            p1_payload = next(c[1] for c in fake_lithos.calls if c[0] == "lithos_write")
+
+            # No terminal flip and no counter bump.
+            assert "influx:archive-terminal" not in p1_payload["tags"]
+            assert "- archive_attempts:" not in p1_payload["content"]
+
+            # archive-missing kept → note re-enters next sweep.
+            assert "influx:archive-missing" in p1_payload["tags"]
+            assert "influx:repair-needed" in p1_payload["tags"]
+
+            # No archive path was written.
+            assert f"path: {_ARCHIVE_PATH}" not in p1_payload["content"]
+
+            # ── Pass 2: archive_download succeeds → recovery. ──
+            fake_lithos.calls.clear()
+            note_p2 = _next_pass_note(note, p1_payload)
+            _queue_single_note(fake_lithos, note_p2)
+            await sweep(
+                "ai-robotics",
+                client=client,
+                config=config,
+                hooks=SweepHooks(archive_download=_archive_lands),
+            )
+            p2_payload = next(c[1] for c in fake_lithos.calls if c[0] == "lithos_write")
+
+            assert "influx:archive-missing" not in p2_payload["tags"]
+            assert f"path: {_ARCHIVE_PATH}" in p2_payload["content"]
+            assert "influx:archive-terminal" not in p2_payload["tags"]
+        finally:
+            await client.close()

--- a/tests/integration/test_repair_sweep_rss_text_extraction_convergence.py
+++ b/tests/integration/test_repair_sweep_rss_text_extraction_convergence.py
@@ -1,0 +1,338 @@
+"""Integration tests for RSS text_extraction convergence (issue #138).
+
+Walks a textless RSS note through three sweep passes:
+
+- Pass 1: no ``text:*`` tag → ``text_extraction`` stub returns
+  ``"text:abstract-only"`` (the cascade fall-through path documented
+  on :class:`influx.repair.TextExtractionHook` and implemented for
+  RSS by :func:`influx.repair_hooks._run_rss_text_extraction`).
+  The note exits the text-extraction stage with
+  ``text:abstract-only`` stamped.
+
+- Pass 2: feed the run-1 note back.  Both ``text_extraction`` and
+  ``re_extract_archive`` stubs are tracked; neither should be called
+  (text stage no longer selected because ``text:abstract-only`` is
+  present, and there is no archive yet to drive
+  abstract-only re-extraction).
+
+- Pass 3: a later landing scenario — re-introduce
+  ``influx:archive-missing`` so an ``archive_download`` stub lands an
+  archive on this pass, and a ``re_extract_archive`` stub upgrades
+  ``text:abstract-only`` to ``text:html``.
+
+This is the integration-level proof of the convergence contract that
+unit tests cannot demonstrate: that the *sweep* state machine
+converges across passes when the production hook returns
+``"text:abstract-only"`` on cascade fall-through, rather than
+re-entering ``text_extraction_retry`` forever.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+
+from influx.config import (
+    AppConfig,
+    FeedbackConfig,
+    LithosConfig,
+    ProfileConfig,
+    ProfileThresholds,
+    PromptEntryConfig,
+    PromptsConfig,
+    RepairConfig,
+    ScheduleConfig,
+    SecurityConfig,
+)
+from influx.lithos_client import LithosClient
+from influx.repair import (
+    ExtractionOutcome,
+    ReExtractionResult,
+    SweepHooks,
+    sweep,
+)
+from tests.contract.test_lithos_client import FakeLithosServer
+
+# ── Fixtures ───────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def fake_lithos() -> Generator[FakeLithosServer, None, None]:
+    server = FakeLithosServer()
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.fixture(scope="module")
+def fake_lithos_url(fake_lithos: FakeLithosServer) -> str:
+    return f"http://127.0.0.1:{fake_lithos.port}/sse"
+
+
+@pytest.fixture(autouse=True)
+def clear_fakes(fake_lithos: FakeLithosServer) -> None:
+    fake_lithos.calls.clear()
+    fake_lithos.write_responses.clear()
+    fake_lithos.read_responses.clear()
+    fake_lithos.cache_lookup_responses.clear()
+    fake_lithos.list_responses.clear()
+
+
+# ── RSS-shaped helpers ────────────────────────────────────────────
+
+_FEED_SLUG = "techcrunch"
+_URL_HASH = "abc123def"
+_NOTE_ID = f"rss-{_FEED_SLUG}-{_URL_HASH}"
+_NOTE_PATH = f"articles/rss-{_FEED_SLUG}/2026/05"
+_SOURCE_URL = "https://example.com/article-42"
+_ARCHIVE_PATH = f"rss-{_FEED_SLUG}/2026/05/{_FEED_SLUG}-{_URL_HASH}.html"
+
+
+def _make_config(
+    *,
+    lithos_url: str,
+    max_items: int = 100,
+) -> AppConfig:
+    return AppConfig(
+        lithos=LithosConfig(url=lithos_url),
+        schedule=ScheduleConfig(cron="0 6 * * *", timezone="UTC"),
+        profiles=[
+            ProfileConfig(
+                name="ai-robotics",
+                description="AI & Robotics",
+                thresholds=ProfileThresholds(notify_immediate=8),
+            ),
+        ],
+        providers={},
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(
+                text="Filter: {profile_description} "
+                "{negative_examples} "
+                "{min_score_in_results}",
+            ),
+            tier1_enrich=PromptEntryConfig(text="test"),
+            tier3_extract=PromptEntryConfig(text="test"),
+        ),
+        security=SecurityConfig(allow_private_ips=True),
+        feedback=FeedbackConfig(negative_examples_per_profile=20),
+        repair=RepairConfig(max_items_per_run=max_items),
+    )
+
+
+def _make_rss_note_content(
+    *,
+    archive_path: str | None = None,
+    score: int = 5,
+) -> str:
+    archive_body = f"path: {archive_path}\n" if archive_path is not None else ""
+    return (
+        "---\n"
+        "note_type: summary\n"
+        "namespace: influx\n"
+        f"source_url: {_SOURCE_URL}\n"
+        "tags:\n"
+        "  - profile:ai-robotics\n"
+        f"  - source:rss-{_FEED_SLUG}\n"
+        f"  - feed-slug:{_FEED_SLUG}\n"
+        "confidence: 0.7\n"
+        "---\n"
+        "# RSS Article Title\n"
+        "\n"
+        "## Archive\n"
+        f"{archive_body}"
+        "\n"
+        "## Summary\n"
+        "An RSS article summary.\n"
+        "\n"
+        "## Profile Relevance\n"
+        "### ai-robotics\n"
+        f"Score: {score}/10\n"
+        "Relevant.\n"
+        "\n"
+        "## User Notes\n"
+    )
+
+
+def _make_rss_note_dict(
+    *,
+    tags: list[str],
+    archive_path: str | None = None,
+    score: int = 5,
+) -> dict[str, Any]:
+    return {
+        "id": _NOTE_ID,
+        "title": "RSS Article Title",
+        "content": _make_rss_note_content(
+            archive_path=archive_path,
+            score=score,
+        ),
+        "tags": tags,
+        "version": 1,
+        "source_url": _SOURCE_URL,
+        "path": _NOTE_PATH,
+        "confidence": 0.7,
+        "note_type": "summary",
+        "namespace": "influx",
+    }
+
+
+def _queue_single_note(
+    fake_lithos: FakeLithosServer,
+    note: dict[str, Any],
+) -> None:
+    fake_lithos.list_responses.append(
+        json.dumps({"items": [{"id": note["id"], "title": note["title"]}]})
+    )
+    fake_lithos.read_responses.append(json.dumps(note))
+    fake_lithos.write_responses.append('{"status": "updated"}')
+
+
+def _next_pass_note(
+    base_note: dict[str, Any],
+    write_payload: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        **base_note,
+        "content": write_payload["content"],
+        "tags": list(write_payload["tags"]),
+    }
+
+
+# ── Tests ──────────────────────────────────────────────────────────
+
+
+class TestRssTextExtractionConvergence:
+    """text_extraction returns ``text:abstract-only`` → sweep converges."""
+
+    async def test_pass1_converges_to_abstract_only_then_pass2_skips_text_stage(
+        self,
+        fake_lithos: FakeLithosServer,
+        fake_lithos_url: str,
+    ) -> None:
+        """The textless note gets ``text:abstract-only`` after pass 1
+        and the text_extraction stage is no longer selected on pass 2.
+        """
+        # Textless RSS note: no text:* tag, no archive-missing.
+        tags = [
+            "profile:ai-robotics",
+            "influx:repair-needed",
+            f"source:rss-{_FEED_SLUG}",
+            f"feed-slug:{_FEED_SLUG}",
+        ]
+        note = _make_rss_note_dict(tags=tags)
+
+        config = _make_config(lithos_url=fake_lithos_url)
+        client = LithosClient(url=fake_lithos_url)
+
+        text_extraction_calls: list[str] = []
+
+        def _text_extraction_converge(note: dict[str, object]) -> str:
+            """Mirrors the production cascade fall-through return."""
+            text_extraction_calls.append(str(note.get("id", "?")))
+            return "text:abstract-only"
+
+        try:
+            # ── Pass 1: convergence stamps text:abstract-only. ──
+            _queue_single_note(fake_lithos, note)
+            await sweep(
+                "ai-robotics",
+                client=client,
+                config=config,
+                hooks=SweepHooks(text_extraction=_text_extraction_converge),
+            )
+            assert text_extraction_calls == [_NOTE_ID]
+
+            p1_payload = next(c[1] for c in fake_lithos.calls if c[0] == "lithos_write")
+            assert "text:abstract-only" in p1_payload["tags"]
+
+            # ── Pass 2: re-feed the run-1 note; text stage must not run. ──
+            fake_lithos.calls.clear()
+            text_extraction_calls.clear()
+            re_extract_calls: list[str] = []
+
+            def _re_extract_should_not_run(
+                note: dict[str, object],
+                archive_path: str,
+            ) -> ReExtractionResult:
+                re_extract_calls.append(str(note.get("id", "?")))
+                return ReExtractionResult(outcome=ExtractionOutcome.TRANSIENT)
+
+            note_p2 = _next_pass_note(note, p1_payload)
+            _queue_single_note(fake_lithos, note_p2)
+            await sweep(
+                "ai-robotics",
+                client=client,
+                config=config,
+                hooks=SweepHooks(
+                    text_extraction=_text_extraction_converge,
+                    re_extract_archive=_re_extract_should_not_run,
+                ),
+            )
+
+            assert text_extraction_calls == []
+            # No archive landed yet → re_extract_archive can't run either.
+            assert re_extract_calls == []
+        finally:
+            await client.close()
+
+    async def test_later_archive_landing_upgrades_abstract_only_to_html(
+        self,
+        fake_lithos: FakeLithosServer,
+        fake_lithos_url: str,
+    ) -> None:
+        """After convergence, a later landing of the archive (via
+        ``archive_download``) followed by ``re_extract_archive`` UPGRADE
+        replaces ``text:abstract-only`` with ``text:html``.
+        """
+        # Start in convergence-result state: text:abstract-only present,
+        # archive-missing present (e.g. inspector noticed archive gap on a
+        # later sweep), repair-needed kept.
+        tags = [
+            "profile:ai-robotics",
+            "influx:repair-needed",
+            "influx:archive-missing",
+            f"source:rss-{_FEED_SLUG}",
+            f"feed-slug:{_FEED_SLUG}",
+            "text:abstract-only",
+        ]
+        note = _make_rss_note_dict(tags=tags)
+
+        config = _make_config(lithos_url=fake_lithos_url)
+        client = LithosClient(url=fake_lithos_url)
+
+        def _archive_lands(note: dict[str, object]) -> str:
+            return _ARCHIVE_PATH
+
+        def _re_extract_upgrade(
+            note: dict[str, object],
+            archive_path: str,
+        ) -> ReExtractionResult:
+            return ReExtractionResult(
+                outcome=ExtractionOutcome.UPGRADE,
+                upgraded_text_tag="text:html",
+            )
+
+        try:
+            # Single sweep pass: archive lands AND abstract-only upgrades.
+            _queue_single_note(fake_lithos, note)
+            await sweep(
+                "ai-robotics",
+                client=client,
+                config=config,
+                hooks=SweepHooks(
+                    archive_download=_archive_lands,
+                    re_extract_archive=_re_extract_upgrade,
+                ),
+            )
+
+            payload = next(c[1] for c in fake_lithos.calls if c[0] == "lithos_write")
+            assert "influx:archive-missing" not in payload["tags"]
+            assert f"path: {_ARCHIVE_PATH}" in payload["content"]
+
+            assert "text:abstract-only" not in payload["tags"]
+            assert "text:html" in payload["tags"]
+        finally:
+            await client.close()


### PR DESCRIPTION
## Summary

- Add four RSS-shaped integration tests under `tests/integration/`, mirroring the existing arxiv repair-sweep file split. The arxiv suite previously had **zero RSS coverage** (`grep -l "rss|source:rss|articles/" tests/integration/test_repair_sweep_*.py` returned 0 hits across the five files).
- Each test seeds an RSS-shaped note (`source:rss-techcrunch` + `feed-slug:techcrunch` + `articles/rss-techcrunch/2026/05` path + non-arxiv `source_url`), runs the real `sweep` entrypoint with stub hooks injected via `SweepHooks(...)`, and asserts tag-set transitions and content mutations across passes — not just per-hook return values.
- No production code changes.

## Files added

| File | Flow |
|---|---|
| `test_repair_sweep_rss_archive_recovery.py` | `archive_download` lands path; pass 2 upgrades text + adds `full-text` + `influx:deep-extracted`; `influx:repair-needed` cleared. |
| `test_repair_sweep_rss_archive_terminal.py` | 3× `ExtractionError(stage="oversize")` flips `influx:archive-terminal` at the counted cap; pass 4 confirms `archive_retry` is skipped via the `is_archive_terminal` gate. Fills a gap that has no arxiv equivalent (the existing chronic-oversize file handles `content_too_large` from `lithos_write`, a different code path). |
| `test_repair_sweep_rss_text_extraction_convergence.py` | `text_extraction` returns `"text:abstract-only"` (cascade fall-through); next pass no longer selects `text_extraction_retry`; later archive landing upgrades to `text:html`. |
| `test_repair_sweep_rss_http_transient.py` | `ExtractionError(stage="http")` classifies as transient — no terminal flip, no counter bump, `archive-missing` preserved; recovery on the next pass. |

## Test plan

- [x] `uv run pytest tests/integration/test_repair_sweep_rss_*.py -v` — all 6 new tests green
- [x] `uv run pytest tests/integration/test_repair_sweep_archive_only.py tests/integration/test_repair_sweep_advancement.py tests/integration/test_repair_sweep_abstract_only.py tests/integration/test_repair_sweep_chronic_oversize.py tests/integration/test_repair_sweep_high_score_terminal.py -v` — all 25 existing arxiv tests unchanged
- [x] `uv run pytest tests/integration/ -q` — full integration suite (219 tests) passes
- [x] `uv run ruff check tests/integration/test_repair_sweep_rss_*.py` clean
- [x] `uv run --group dev pyright tests/integration/test_repair_sweep_rss_*.py` clean (0 errors)
- [x] RSS gap closed: `grep -l "rss|source:rss|articles/" tests/integration/test_repair_sweep_*.py` now returns 4 files

Closes #138