### PR TITLE
fix: converge Lithos slug-collision recovery on URL identity dedupe (#148)

### DIFF
--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -42,6 +42,7 @@ from influx.renderer import (
 from influx.renderer import (
     _render_profile_relevance_body as _render_pr_body,
 )
+from influx.urls import normalise_url
 
 __all__ = ["LithosClient", "WriteResult"]
 
@@ -226,6 +227,20 @@ class SquatterClassification:
     reason: str  # human-readable explanation, surfaced in detail / logs
 
 
+def _safe_normalise_url(url: str) -> str:
+    """Return :func:`normalise_url` output, falling back to *url* on error.
+
+    The classifier is on the conflict-recovery hot path; a malformed URL
+    must not crash the write loop.  Empty input returns ``""``.
+    """
+    if not url:
+        return ""
+    try:
+        return normalise_url(url)
+    except Exception:  # noqa: BLE001 — defensive: never crash recovery on bad URLs
+        return url
+
+
 def _classify_squatter(
     doc: dict[str, Any],
     *,
@@ -237,9 +252,10 @@ def _classify_squatter(
     Returns one of three outcomes:
 
     * ``"duplicate"`` — the squatter already represents the same paper
-      as the incoming write (matching ``arxiv-id:<id>`` tag, or
-      matching ``source_url``).  Lithos's URL/cache dedup should have
-      caught this; surfacing it here recovers from that miss.
+      as the incoming write (matching ``arxiv-id:<id>`` tag, matching
+      ``source_url``, or canonical-URL equivalence).  Lithos's URL/cache
+      dedup should have caught this; surfacing it here recovers from
+      that miss.
     * ``"reclaimable"`` — the squatter is an empty residue from an
       aborted prior write (no tags AND no source_url AND no body).
       Safe to delete and retry the original write.
@@ -247,6 +263,19 @@ def _classify_squatter(
       happens to slugify the same.  The caller should fall back to
       the suffix-retry path; if THAT also collides, the entry goes
       to the unresolved-collisions backlog.
+
+    Stable-identity matches (#148) now include:
+
+    * arxiv-id tag equality (existing);
+    * exact ``source_url`` equality (existing);
+    * canonical-URL equality via :func:`influx.urls.normalise_url`
+      (handles scheme case, default ports, tracking params, trailing
+      slashes) — catches the staging cases where two writes for the
+      same paper differ only in URL normalisation;
+    * arxiv id extracted from the squatter's ``source_url`` when no
+      explicit ``arxiv-id:`` tag is present — catches squatters whose
+      tagset was truncated by an earlier merge but whose ``source_url``
+      still names the same paper.
 
     This function is pure: I/O lives in :meth:`LithosClient._retry_slug_collision`.
     """
@@ -269,16 +298,48 @@ def _classify_squatter(
                     ),
                 )
 
-    # Match #2: source_url equality.
-    if sq_source_url and sq_source_url == incoming_source_url:
-        return SquatterClassification(
-            kind="duplicate",
-            squatter_id=squatter_id,
-            reason=(
-                f"squatter source_url matches incoming ({sq_source_url}) — "
-                "treat as duplicate of the same paper"
-            ),
-        )
+    # Match #1b: arxiv-id extracted from the squatter's source_url matches the
+    # incoming arxiv-id.  Squatters whose tagset was truncated by an earlier
+    # merge can still be identified by URL alone.
+    if incoming_arxiv_id and sq_source_url:
+        sq_arxiv_id = _arxiv_id_from_url(sq_source_url)
+        if sq_arxiv_id == incoming_arxiv_id:
+            return SquatterClassification(
+                kind="duplicate",
+                squatter_id=squatter_id,
+                reason=(
+                    f"squatter source_url names arxiv-id:{incoming_arxiv_id} — "
+                    "treat as duplicate of the same paper"
+                ),
+            )
+
+    # Match #2: source_url equality (exact or canonical).
+    if sq_source_url:
+        if sq_source_url == incoming_source_url:
+            return SquatterClassification(
+                kind="duplicate",
+                squatter_id=squatter_id,
+                reason=(
+                    f"squatter source_url matches incoming ({sq_source_url}) — "
+                    "treat as duplicate of the same paper"
+                ),
+            )
+        # Canonical-URL equality: handles scheme case, default ports,
+        # tracking params, trailing slashes.  Same paper, different URL
+        # shape — Lithos's URL dedup missed it because the stored URL
+        # was a slightly different rendering of the same logical link.
+        sq_canonical = _safe_normalise_url(sq_source_url)
+        incoming_canonical = _safe_normalise_url(incoming_source_url)
+        if sq_canonical and incoming_canonical and sq_canonical == incoming_canonical:
+            return SquatterClassification(
+                kind="duplicate",
+                squatter_id=squatter_id,
+                reason=(
+                    f"squatter source_url is canonical match for incoming "
+                    f"({sq_source_url} ≡ {incoming_source_url}) — "
+                    "treat as duplicate of the same paper"
+                ),
+            )
 
     # Reclaim path: empty residue.  Conservative: ALL of the following
     # must hold so we never delete a real note that just shares a slug.
@@ -774,16 +835,24 @@ class LithosClient:
         source_url: str,
         initial_collision: WriteResult,
     ) -> WriteResult:
-        """Recover from slug_collision by inspecting the squatter (#31).
+        """Recover from slug_collision by stable-identity then squatter shape.
 
-        Strategy (replaces the original AC-05-D ""one suffix retry"" form):
+        Strategy (issue #148 builds on the #31 squatter-shape dispatch):
 
+        0. **Stable-identity pre-check** (#148): before any squatter
+           inspection, run a source-URL-keyed ``lithos_cache_lookup``.
+           A hit means Lithos already has a note for this exact source
+           URL — slug collision was incidental and the right answer is
+           ``duplicate``.  This converts the "Lithos found the conflict
+           only at write time" noise into a clean dedupe outcome and
+           keeps the ingestion path idempotent for repeated runs.
         1. Read the squatter via the ``existing_id`` lithos returned in
            the initial collision envelope.
         2. Classify (:func:`_classify_squatter`):
 
            * ``duplicate`` — squatter shares the incoming write's
-             ``arxiv-id`` or ``source_url``.  Return as ``duplicate``.
+             ``arxiv-id``, ``source_url``, or canonical URL.  Return as
+             ``duplicate``.
            * ``reclaimable`` — squatter is empty residue (no tags, no
              source_url, no body).  Delete it then re-issue the original
              write.
@@ -799,6 +868,16 @@ class LithosClient:
         from influx import metrics
 
         first_title = args["title"]
+
+        # Round 0 (#148): stable-identity pre-check.  If Lithos already
+        # has a note for this source URL, the slug collision is just
+        # noise around an existing duplicate — fold it into the dedup
+        # outcome rather than fighting through suffix retries.
+        url_recovery = await self._url_identity_recovery(
+            source_url=source_url, metrics_module=metrics
+        )
+        if url_recovery is not None:
+            return url_recovery
 
         # Round 1: inspect the squatter named in the initial collision.
         recovered = await self._try_recover_collision(
@@ -849,6 +928,76 @@ class LithosClient:
                 recovered.detail,
             )
         return recovered
+
+    async def _url_identity_recovery(
+        self,
+        *,
+        source_url: str,
+        metrics_module: Any,
+    ) -> WriteResult | None:
+        """Stable-identity pre-check for slug_collision recovery (#148).
+
+        Issues a ``source_url``-keyed ``lithos_cache_lookup``.  When the
+        lookup hits, Lithos already has a note for this exact URL — the
+        slug collision is incidental, the correct outcome is
+        ``duplicate``.  Returns ``None`` when the lookup misses (caller
+        falls through to the existing squatter-shape dispatch) or when
+        *source_url* is empty.
+
+        Lookup failures (network, malformed response) return ``None`` so
+        the recovery chain still runs — this pre-check is purely a
+        latency/noise optimisation, never a correctness gate.
+        """
+        if not source_url:
+            return None
+        try:
+            body = await self.cache_lookup_by_url_body(source_url=source_url)
+        except (LithosError, McpError):
+            # Defensive: never crash the write loop because the
+            # pre-check failed.  Fall through to squatter inspection.
+            logger.warning(
+                "slug_collision url-identity pre-check failed for %s; "
+                "falling back to squatter inspection",
+                source_url,
+                exc_info=True,
+            )
+            return None
+        except Exception:  # noqa: BLE001 — see comment above
+            logger.warning(
+                "slug_collision url-identity pre-check raised unexpectedly "
+                "for %s; falling back to squatter inspection",
+                source_url,
+                exc_info=True,
+            )
+            return None
+
+        if not body.get("hit"):
+            return None
+
+        existing_id = ""
+        if isinstance(body, dict):
+            for key in ("id", "note_id", "existing_id"):
+                value = body.get(key)
+                if isinstance(value, str) and value:
+                    existing_id = value
+                    break
+
+        metrics_module.slug_collision_url_recovery().add(1)
+        logger.info(
+            "slug_collision recovered via source_url identity for %s "
+            "(existing_id=%s) — Lithos already had this URL",
+            source_url,
+            existing_id or "<unknown>",
+        )
+        return WriteResult(
+            status="duplicate",
+            source_url=source_url,
+            detail=(
+                f"recovered: source_url already in lithos "
+                f"(existing_id={existing_id or '<unknown>'})"
+            ),
+            note_id=existing_id,
+        )
 
     async def _try_recover_collision(
         self,

--- a/src/influx/metrics.py
+++ b/src/influx/metrics.py
@@ -52,6 +52,7 @@ __all__ = [
     "slug_collision_dedup_recovery",
     "slug_collision_reclaimed",
     "slug_collision_unresolved",
+    "slug_collision_url_recovery",
     "source_acquisition_errors",
 ]
 
@@ -364,6 +365,32 @@ def slug_collision_reclaimed() -> Any:
         description=(
             "slug_collision events resolved by deleting an empty stale "
             "squatter and re-issuing the write"
+        ),
+    )
+
+
+def slug_collision_url_recovery() -> Any:
+    """Counter of slug collisions short-circuited via source-URL identity (#148).
+
+    Increments when the pre-suffix-retry source-URL ``cache_lookup`` hits,
+    proving Lithos already owns a note for the incoming write's URL.
+    Influx treats the write as a duplicate without descending into the
+    squatter-shape dispatch (squatter inspection, suffix retry,
+    unresolved-collision backlog).
+
+    A steadily non-zero value indicates Lithos's URL/cache dedup is
+    missing items that source-URL equality would catch — file a Lithos
+    issue if the rate is significant.
+
+    No labels: low-volume signal that mostly tracks the quality of
+    upstream URL dedup.
+    """
+    return get_meter().counter(
+        "influx_slug_collision_url_recovery_total",
+        description=(
+            "slug_collision events short-circuited via source-URL identity "
+            "lookup (Lithos already had the URL; no squatter inspection "
+            "needed)"
         ),
     )
 

--- a/tests/contract/test_lithos_client.py
+++ b/tests/contract/test_lithos_client.py
@@ -1616,6 +1616,208 @@ class TestWriteSlugCollisionRecovery:
         assert "retry_slug='OmniRobotHome [arXiv 2604.28197]'" in result.detail
 
 
+class TestSlugCollisionUrlIdentityRecovery:
+    """Issue #148: source-URL identity pre-check short-circuits slug_collision.
+
+    When ``lithos_cache_lookup`` (keyed on the incoming ``source_url``)
+    reports a hit before suffix-retry, the recovery path treats the
+    write as a duplicate without descending into squatter inspection
+    or suffix retry.  Converts repeated-run noise into a clean dedupe.
+    """
+
+    async def test_url_hit_short_circuits_to_duplicate(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+    ) -> None:
+        """A source-URL cache hit during slug_collision recovery means
+        Lithos already owns the URL; surface as duplicate, no suffix
+        retry, no squatter read.
+        """
+        fake_lithos_server.write_responses.append(
+            '{"status": "slug_collision", "existing_id": "doc-other",'
+            ' "message": "Slug already in use", "warnings": []}'
+        )
+        fake_lithos_server.cache_lookup_responses.append(
+            '{"hit": true, "id": "note-existing-99", "stale_exists": false}'
+        )
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            result = await client.write_note(
+                title="Some Paper",
+                content="# Summary\nContent.",
+                path="papers/arxiv/2026/04",
+                source_url="https://arxiv.org/abs/2604.28197",
+                tags=["profile:staging-robotics"],
+                confidence=0.8,
+            )
+        finally:
+            await client.close()
+
+        assert result.status == "duplicate"
+        assert "source_url already in lithos" in result.detail
+        assert "note-existing-99" in result.detail
+        assert result.note_id == "note-existing-99"
+        # Only the initial write should have run — no suffix retry.
+        write_calls = [c for c in fake_lithos_server.calls if c[0] == "lithos_write"]
+        assert len(write_calls) == 1
+        # The squatter must NOT have been read; the pre-check obviates it.
+        read_calls = [c for c in fake_lithos_server.calls if c[0] == "lithos_read"]
+        assert len(read_calls) == 0
+        # And the cache_lookup was keyed on the source URL only (issue #128 shape).
+        cache_calls = [
+            c for c in fake_lithos_server.calls if c[0] == "lithos_cache_lookup"
+        ]
+        assert len(cache_calls) == 1
+        assert cache_calls[0][1]["source_url"] == "https://arxiv.org/abs/2604.28197"
+        assert cache_calls[0][1]["query"] == "https://arxiv.org/abs/2604.28197"
+
+    async def test_url_miss_falls_through_to_squatter_inspection(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+    ) -> None:
+        """When the URL pre-check misses, the chain continues into the
+        existing squatter-shape dispatch (#31).
+        """
+        fake_lithos_server.write_responses.extend(
+            [
+                # First attempt collides.
+                '{"status": "slug_collision", "existing_id": "doc-dup-1",'
+                ' "message": "Slug already in use", "warnings": []}',
+            ]
+        )
+        # cache_lookup returns no hit — the pre-check is a noop.
+        fake_lithos_server.cache_lookup_responses.append(
+            '{"hit": false, "stale_exists": false}'
+        )
+        # Squatter carries the same arxiv-id, so classification still
+        # returns duplicate via the #31 path.
+        fake_lithos_server.read_responses.append(
+            '{"id": "doc-dup-1", "title": "Different Title",'
+            ' "content": "real content",'
+            ' "tags": ["arxiv-id:2604.28197", "source:arxiv"]}'
+        )
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            result = await client.write_note(
+                title="OmniRobotHome",
+                content="# Summary\nContent.",
+                path="papers/arxiv/2026/04",
+                source_url="https://arxiv.org/abs/2604.28197",
+                tags=["profile:staging-robotics"],
+                confidence=0.8,
+            )
+        finally:
+            await client.close()
+
+        # Still recovered as duplicate, just via the squatter-shape path.
+        assert result.status == "duplicate"
+        assert "arxiv-id:2604.28197" in result.detail
+        # And the squatter WAS read this time.
+        read_calls = [c for c in fake_lithos_server.calls if c[0] == "lithos_read"]
+        assert len(read_calls) == 1
+
+    async def test_url_precheck_failure_falls_through(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A malformed ``cache_lookup`` response must not crash recovery;
+        the chain still runs and the squatter is inspected normally.
+        """
+        import logging
+
+        fake_lithos_server.write_responses.append(
+            '{"status": "slug_collision", "existing_id": "doc-dup-1",'
+            ' "message": "Slug already in use", "warnings": []}'
+        )
+        # Malformed JSON → LithosError("malformed_tool_response")
+        fake_lithos_server.cache_lookup_responses.append("{not-json")
+        # Squatter is the same paper by arxiv-id.
+        fake_lithos_server.read_responses.append(
+            '{"id": "doc-dup-1", "title": "x",'
+            ' "content": "real", "tags": ["arxiv-id:2604.28197"]}'
+        )
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            with caplog.at_level(logging.WARNING):
+                result = await client.write_note(
+                    title="Paper",
+                    content="# Summary\nContent.",
+                    path="papers/arxiv/2026/04",
+                    source_url="https://arxiv.org/abs/2604.28197",
+                    tags=["profile:staging-robotics"],
+                    confidence=0.8,
+                )
+        finally:
+            await client.close()
+
+        # Pre-check failure is logged but the squatter-shape recovery
+        # still classifies the write as duplicate.
+        assert result.status == "duplicate"
+        assert any(
+            "url-identity pre-check failed" in r.getMessage() for r in caplog.records
+        )
+
+    async def test_idempotent_repeated_runs_no_unresolved_noise(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A second scheduled run that re-encounters an existing note
+        must NOT log ``slug_collision unresolved after recovery``.
+
+        Regression coverage for the AC: "Ingestion path remains
+        idempotent for repeated scheduled runs."
+        """
+        import logging
+
+        # Both runs hit slug_collision (squatter exists under a
+        # different slug), but URL identity recovers both.
+        fake_lithos_server.write_responses.extend(
+            [
+                '{"status": "slug_collision", "existing_id": "doc-x",'
+                ' "message": "Slug in use", "warnings": []}',
+                '{"status": "slug_collision", "existing_id": "doc-x",'
+                ' "message": "Slug in use", "warnings": []}',
+            ]
+        )
+        fake_lithos_server.cache_lookup_responses.extend(
+            [
+                '{"hit": true, "id": "note-already", "stale_exists": false}',
+                '{"hit": true, "id": "note-already", "stale_exists": false}',
+            ]
+        )
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            with caplog.at_level(logging.WARNING):
+                for _ in range(2):
+                    result = await client.write_note(
+                        title="Idempotent Paper",
+                        content="# Summary\n",
+                        path="papers/arxiv/2026/04",
+                        source_url="https://arxiv.org/abs/2604.99999",
+                        tags=["profile:staging-robotics"],
+                        confidence=0.8,
+                    )
+                    assert result.status == "duplicate"
+        finally:
+            await client.close()
+
+        # No unresolved-collision warning emitted on either pass.
+        assert not any(
+            "slug_collision unresolved after recovery" in r.getMessage()
+            for r in caplog.records
+        )
+
+
 # ── Write envelopes — version_conflict (FR-MCP-7, AC-05-E) ────────
 
 

--- a/tests/unit/test_lithos_client.py
+++ b/tests/unit/test_lithos_client.py
@@ -236,6 +236,64 @@ class TestClassifySquatter:
         )
         assert result.kind == "duplicate"
 
+    def test_canonical_url_match_classifies_as_duplicate(self) -> None:
+        """Issue #148: squatter and incoming URLs differ only in shape
+        (scheme case, trailing slash, tracking params) — canonical
+        equality must still classify as duplicate.
+        """
+        from influx.lithos_client import _classify_squatter
+
+        doc = self._make_doc(
+            tags=["source:rss"],
+            source_url="HTTPS://Example.com/Article-X/?utm_source=feedreader",
+            content="real body",
+        )
+        result = _classify_squatter(
+            doc,
+            squatter_id="doc-x",
+            incoming_source_url="https://example.com/Article-X",
+        )
+        assert result.kind == "duplicate"
+        assert "canonical match" in result.reason
+
+    def test_arxiv_id_extracted_from_squatter_source_url(self) -> None:
+        """Issue #148: squatter has no ``arxiv-id:`` tag but its
+        ``source_url`` names the same arxiv id — treat as duplicate.
+        """
+        from influx.lithos_client import _classify_squatter
+
+        doc = self._make_doc(
+            tags=["source:arxiv"],
+            source_url="https://arxiv.org/abs/2604.28197",
+            content="body without arxiv-id tag",
+        )
+        result = _classify_squatter(
+            doc,
+            squatter_id="doc-x",
+            incoming_source_url="https://arxiv.org/abs/2604.28197",
+        )
+        assert result.kind == "duplicate"
+        assert "arxiv-id:2604.28197" in result.reason
+
+    def test_malformed_url_falls_back_safely(self) -> None:
+        """Malformed URLs must not crash the classifier; fall back to
+        the exact-equality check.
+        """
+        from influx.lithos_client import _classify_squatter
+
+        doc = self._make_doc(
+            tags=["source:rss"],
+            source_url="not a url at all",
+            content="real",
+        )
+        result = _classify_squatter(
+            doc,
+            squatter_id="doc-x",
+            incoming_source_url="https://example.com/article-x",
+        )
+        # Not exact, not canonical (different shapes) → distinct.
+        assert result.kind == "distinct"
+
 
 class TestExistingIdParsing:
     """``_existing_id_from_detail`` extracts the squatter id from PR-#30 detail."""

--- a/tests/unit/test_metrics_module.py
+++ b/tests/unit/test_metrics_module.py
@@ -60,6 +60,7 @@ HELPERS: dict[str, str] = {
     "llm_validation_failures": "influx_llm_validation_failures_total",
     "archive_missing": "influx_archive_missing_total",
     "source_acquisition_errors": "influx_source_acquisition_errors_total",
+    "slug_collision_url_recovery": "influx_slug_collision_url_recovery_total",
 }
 
 


### PR DESCRIPTION
## Summary
- Add URL-keyed `cache_lookup` pre-check at the top of `_retry_slug_collision` so repeat scheduled runs short-circuit to `duplicate` instead of attempting a fresh write and exhausting into `slug_collision unresolved after recovery`.
- Extend `_classify_squatter` with canonical-URL equality (via `urls.normalise_url`) and arxiv-id-from-squatter-source-URL detection so existing Lithos notes with trimmed/renormalised tags still classify as the same identity.
- New `slug_collision_url_recovery` counter keeps the short-circuit observable; `slug_collision_unresolved` is reserved for genuine exhaustion.

## Test plan
- [x] `uv run pytest` — 1908 passed
- [x] `uv run pyright src/influx/lithos_client.py src/influx/metrics.py` — 0 errors
- [x] `uv run ruff check` — clean
- [x] New unit + contract tests for canonical-URL match, arxiv-id-from-URL match, malformed-URL fallback, URL-hit short-circuit, URL-miss falls through, malformed pre-check fallback, and idempotence (two runs → 0 unresolved warnings)

Closes #148