### PR TITLE
feat: domain-aware archive acquisition policy (#149)

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -245,6 +245,8 @@ The arXiv provider:
 
 Archive failures do not abort note creation. The note is tagged `influx:archive-missing` and `influx:repair-needed`, and the Archive section is left empty.
 
+Issue #149: archive acquisition consults a per-domain policy registry built from `[storage.archive_policy]`. Domains classified as `blocked` (HTTP 403 / WAF challenge), `rate_limited` (HTTP 429 under normal cadence), or `skip` (no attempt made at all) produce distinct note tags — `influx:archive-blocked`, `influx:archive-rate-limited`, or `influx:archive-skipped-by-policy` — alongside the generic `influx:archive-missing`. `blocked` and `skip` notes additionally carry `influx:archive-terminal` so the repair sweep stops re-attempting the doomed path. The defaults set covers staging hot offenders (`science.org`, `alignmentforum.org`, `therobotreport.com`, …).
+
 ### 6.2 RSS and Atom Feeds
 
 The RSS provider:
@@ -468,6 +470,10 @@ Common tags include:
 - `full-text`
 - `influx:deep-extracted`
 - `influx:archive-missing`
+- `influx:archive-blocked` (issue #149 — domain policy `blocked`)
+- `influx:archive-rate-limited` (issue #149 — domain policy `rate_limited`)
+- `influx:archive-skipped-by-policy` (issue #149 — domain policy `skip`)
+- `influx:archive-terminal`
 - `influx:repair-needed`
 - `influx:text-terminal`
 - `influx:tier2-terminal`

--- a/influx.example.toml
+++ b/influx.example.toml
@@ -29,6 +29,34 @@ retain_days = 3650              # ~10 years
 max_download_bytes = 52_428_800 # 50 MB per file
 download_timeout_seconds = 30
 
+# Issue #149: domain-aware archive acquisition policy.  Maps a host
+# suffix to one of three modes:
+#   blocked       — try the download but expect HTTP 403 / WAF; the
+#                    note is tagged ``influx:archive-blocked`` and
+#                    ``influx:archive-terminal`` so the repair sweep
+#                    stops re-attempting the doomed path.
+#   rate_limited  — try the download but expect HTTP 429; the note is
+#                    tagged ``influx:archive-rate-limited`` and stays
+#                    in the normal repair-needed loop.
+#   skip          — do not attempt the download at all; the note is
+#                    tagged ``influx:archive-skipped-by-policy``.
+# A built-in defaults set already covers the staging hot offenders
+# (``science.org``, ``alignmentforum.org``, ``therobotreport.com``,
+# ``tnmoc.org``, ``lesswrong.com``); set ``include_defaults = false``
+# to opt out, or override per-domain in the maps below.
+#
+# [storage.archive_policy]
+# include_defaults = true
+#
+# [storage.archive_policy.blocked]
+# "example.com" = "WAF challenge observed 2026-04-15 onward"
+#
+# [storage.archive_policy.rate_limited]
+# "slow.example" = "429 under 1-min cadence; cool-down before retry"
+#
+# [storage.archive_policy.skip]
+# "never.example" = "auth-walled; archive disabled permanently"
+
 [notifications]
 timeout_seconds = 5
 

--- a/src/influx/archive_policy.py
+++ b/src/influx/archive_policy.py
@@ -44,6 +44,8 @@ from typing import TYPE_CHECKING, Literal
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from influx.config import ArchivePolicyConfig
 
 __all__ = [
@@ -306,11 +308,12 @@ def build_registry(
     # Operator overrides win.  ``skip`` then ``blocked`` then
     # ``rate_limited`` so that a later-declared mode beats an earlier
     # mode for the same suffix (last-write-wins discipline).
-    for table, mode in (
+    overrides: tuple[tuple[Mapping[str, str] | None, ArchivePolicyMode], ...] = (
         (rate_limited, "rate_limited"),
         (blocked, "blocked"),
         (skip, "skip"),
-    ):
+    )
+    for table, mode in overrides:
         if not table:
             continue
         for suffix, note in table.items():
@@ -321,9 +324,7 @@ def build_registry(
 
     # Sort longest-first so :meth:`policy_for`'s iteration order makes
     # the most specific suffix win.
-    entries = tuple(
-        sorted(merged.items(), key=lambda kv: (-len(kv[0]), kv[0]))
-    )
+    entries = tuple(sorted(merged.items(), key=lambda kv: (-len(kv[0]), kv[0])))
     return ArchivePolicyRegistry(_entries=entries)
 
 

--- a/src/influx/archive_policy.py
+++ b/src/influx/archive_policy.py
@@ -1,0 +1,485 @@
+"""Domain-aware archive acquisition policy (issue #149).
+
+Influx archives every fetched candidate by default — download the source
+document via the guarded HTTP client and persist it under
+``storage.archive_dir``.  Some domains repeatedly fail this download
+loop for structural reasons that no retry can fix:
+
+* **Blocked** domains return HTTP 403 / 401 / WAF challenges to every
+  unauthenticated client.  Examples observed in staging:
+  ``science.org`` (Cloudflare bot challenge), ``alignmentforum.org``
+  (LessWrong-family auth wall), ``therobotreport.com`` (anti-bot CDN).
+
+* **Rate-limited** domains return HTTP 429 episodically when the run
+  cadence overlaps with their per-IP throttle.  These deserve a bounded
+  retry / cool-down distinct from the hard-blocked case so a polite
+  back-off can recover the archive on a subsequent sweep.
+
+Treating every archive failure as a uniform generic HTTP error means
+the operator sees hundreds of ``influx:archive-missing`` repair tags
+per sweep with no signal about *why* — they all look the same in
+``classify_failure``.  This module introduces a tiny policy model that:
+
+* maps domain → :class:`ArchivePolicy` (``attempt`` / ``rate_limited``
+  / ``blocked`` / ``skip``),
+* classifies an :class:`~influx.storage.ArchiveResult` error string into
+  a stable :class:`ArchiveFailureKind` discriminator, and
+* exports the tag literals (``influx:archive-blocked``,
+  ``influx:archive-rate-limited``, ``influx:archive-skipped-by-policy``)
+  source adapters apply when a policy short-circuits the attempt or
+  reclassifies its failure.
+
+The registry is intentionally **extensible**: built-in defaults cover
+the staging-log hot offenders, and operators can extend it via
+``[storage.archive_policy]`` in ``influx.toml`` (a Python override
+helper :func:`build_registry` lets tests / callers compose registries
+without round-tripping through TOML).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from influx.config import ArchivePolicyConfig
+
+__all__ = [
+    "ARCHIVE_BLOCKED_TAG",
+    "ARCHIVE_RATE_LIMITED_TAG",
+    "ARCHIVE_SKIPPED_BY_POLICY_TAG",
+    "ArchiveFailureKind",
+    "ArchivePolicy",
+    "ArchivePolicyMode",
+    "ArchivePolicyRegistry",
+    "build_registry",
+    "classify_failure_kind",
+    "default_registry",
+    "extract_domain",
+    "registry_from_config",
+    "tag_for_failure_kind",
+]
+
+
+# ── Public tag literals ────────────────────────────────────────────────
+# These are the tags downstream source adapters / repair hooks add to a
+# note when a policy short-circuits an archive attempt or reclassifies
+# the failure.  Kept here so callers do not have to remember the literal
+# string shape.
+
+ARCHIVE_BLOCKED_TAG = "influx:archive-blocked"
+ARCHIVE_RATE_LIMITED_TAG = "influx:archive-rate-limited"
+ARCHIVE_SKIPPED_BY_POLICY_TAG = "influx:archive-skipped-by-policy"
+
+
+# ── Failure-kind taxonomy ──────────────────────────────────────────────
+
+
+# Stable discriminator for archive failures.  ``ArchiveResult.error``
+# (a free-form string) is mapped into one of these values by
+# :func:`classify_failure_kind` so callers can decide on tags, retries,
+# and run diagnostics without re-parsing the error.
+#
+# ``blocked`` and ``rate_limited`` are the policy-aware HTTP failure
+# kinds (HTTP 403 / 429 specifically).  ``missing_by_policy`` is set
+# when the policy short-circuited the attempt entirely — no network
+# call was made.
+ArchiveFailureKind = Literal[
+    "blocked",
+    "rate_limited",
+    "missing_by_policy",
+    "http_403",
+    "http_404",
+    "http_429",
+    "http_4xx",
+    "http_5xx",
+    "oversize",
+    "timeout",
+    "ssrf",
+    "dns",
+    "network",
+    "content_type_mismatch",
+    "write",
+    "unknown",
+]
+
+
+# Patterns used by :func:`classify_failure_kind` to map free-form
+# ``ArchiveResult.error`` strings onto :data:`ArchiveFailureKind`
+# values.  Anchored at the start where possible so partial-match noise
+# stays bounded.
+_HTTP_PREFIX_RE = re.compile(r"^HTTP (\d{3})\b")
+_KIND_PREFIX_RE = re.compile(r"^([a-z_]+):")
+
+
+# ── Policy taxonomy ────────────────────────────────────────────────────
+
+
+# Three modes for an archive policy:
+#
+# * ``attempt``: the default — try the download, classify failure
+#   generically.  Equivalent to "no policy registered".
+# * ``rate_limited``: try the download but expect occasional 429s.
+#   When the failure kind is ``rate_limited`` the source applies the
+#   ``influx:archive-rate-limited`` tag instead of (or alongside) the
+#   generic ``influx:archive-missing`` tag, so the repair sweep can
+#   apply a bounded cool-down rather than tight-looping.
+# * ``blocked``: known to refuse archive downloads.  The source still
+#   attempts the download (so a domain that lifts its block recovers
+#   automatically), but a ``blocked`` / ``http_403`` failure is tagged
+#   ``influx:archive-blocked`` and the note carries
+#   ``influx:archive-missing`` exactly once rather than re-attempting
+#   the same doomed path every sweep.
+# * ``skip``: do not attempt the download at all.  The note is
+#   tagged ``influx:archive-skipped-by-policy`` and never produces a
+#   network call.  Reserved for domains where every observed attempt
+#   over weeks of operation has produced 403 / 401 / WAF challenge.
+ArchivePolicyMode = Literal["attempt", "rate_limited", "blocked", "skip"]
+
+
+@dataclass(frozen=True, slots=True)
+class ArchivePolicy:
+    """A small policy decision for one archive acquisition.
+
+    Attributes
+    ----------
+    mode:
+        One of :data:`ArchivePolicyMode`.
+    note:
+        Operator-facing diagnostic string ("WAF challenge, observed
+        2026-05-01 onward").  Surfaced verbatim in WARN-level logs so
+        an operator inspecting why a domain was skipped does not have
+        to grep the source for the policy entry.
+    """
+
+    mode: ArchivePolicyMode = "attempt"
+    note: str = ""
+
+    @property
+    def should_attempt(self) -> bool:
+        """Return ``True`` when the policy permits an archive download attempt.
+
+        ``skip`` mode is the only one that short-circuits before a
+        network call.  ``blocked`` and ``rate_limited`` still attempt
+        the download so a domain that lifts its restriction recovers
+        without an operator hand-edit.
+        """
+        return self.mode != "skip"
+
+
+# Single sentinel for the default "no specific policy, attempt the
+# download" decision.  Returned by :meth:`ArchivePolicyRegistry.policy_for`
+# when no registered domain matches.
+DEFAULT_POLICY = ArchivePolicy(mode="attempt", note="")
+
+
+# ── Built-in registry defaults ─────────────────────────────────────────
+#
+# Domains observed in staging logs (issue #149) where archive
+# acquisition fails for structural reasons.  These are *defaults* — an
+# operator may override them via :func:`build_registry` or by editing
+# the runtime registry directly.
+#
+# ``blocked`` domains: every recent attempt returned HTTP 403 / WAF
+# challenge.  ``rate_limited`` domains: episodic 429 under normal
+# cadence — try with a bounded cool-down.
+#
+# Suffix-matched: ``science.org`` matches ``www.science.org`` and any
+# other subdomain.  See :meth:`ArchivePolicyRegistry.policy_for`.
+_DEFAULT_BLOCKED_DOMAINS: tuple[tuple[str, str], ...] = (
+    ("science.org", "Cloudflare bot challenge; archive download returns 403."),
+    (
+        "therobotreport.com",
+        "Anti-bot CDN; archive download returns 403 to unauthenticated clients.",
+    ),
+    (
+        "alignmentforum.org",
+        "LessWrong-family auth wall; archive download returns 403.",
+    ),
+    (
+        "tnmoc.org",
+        "Site returns 403 to unauthenticated archive download requests.",
+    ),
+    (
+        "lesswrong.com",
+        "Auth-walled article body; archive download returns 403.",
+    ),
+)
+
+
+_DEFAULT_RATE_LIMITED_DOMAINS: tuple[tuple[str, str], ...] = (
+    # Reserved for sites observed to throttle archive downloads under
+    # production cadence.  Empty for now; populated as staging logs
+    # identify candidates.
+)
+
+
+# ── Registry ───────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class ArchivePolicyRegistry:
+    """Maps a request URL to an :class:`ArchivePolicy`.
+
+    The registry stores a mapping of *registrable domain suffix* →
+    :class:`ArchivePolicy`.  :meth:`policy_for` matches a URL's host
+    against each registered suffix (longest first) so a more specific
+    entry (``preview.science.org``) wins over a broader one
+    (``science.org``).
+
+    The registry is intentionally immutable — :func:`build_registry`
+    constructs a new instance per config load.  Tests construct
+    registries directly via the constructor.
+    """
+
+    # Map of lowercased suffix → policy.  Frozenset-of-tuples lets the
+    # dataclass stay frozen while keeping efficient lookup; we copy to
+    # a dict at construction so :meth:`policy_for` is O(suffix count)
+    # rather than O(N**2).
+    _entries: tuple[tuple[str, ArchivePolicy], ...] = field(default_factory=tuple)
+
+    def policy_for(self, url: str) -> ArchivePolicy:
+        """Return the :class:`ArchivePolicy` for *url* (default ``attempt``).
+
+        Matches the request URL's host against each registered suffix.
+        Longer (more specific) suffixes win.  Returns
+        :data:`DEFAULT_POLICY` when no suffix matches — this is the
+        ``mode="attempt"`` no-op case.
+        """
+        host = extract_domain(url)
+        if not host:
+            return DEFAULT_POLICY
+        # Iterate longest-first so a more specific suffix wins over a
+        # broader one (longest is the operator's most specific signal).
+        for suffix, policy in self._entries:
+            if host == suffix or host.endswith("." + suffix):
+                return policy
+        return DEFAULT_POLICY
+
+    def domains(self) -> tuple[str, ...]:
+        """Return the registered domain suffixes (sorted longest-first).
+
+        Exposed for diagnostics and tests; production callers go
+        through :meth:`policy_for`.
+        """
+        return tuple(suffix for suffix, _ in self._entries)
+
+
+def build_registry(
+    *,
+    blocked: dict[str, str] | None = None,
+    rate_limited: dict[str, str] | None = None,
+    skip: dict[str, str] | None = None,
+    include_defaults: bool = True,
+) -> ArchivePolicyRegistry:
+    """Construct an :class:`ArchivePolicyRegistry` from policy overrides.
+
+    Operator overrides win over the built-in defaults.  Use
+    ``include_defaults=False`` to start from an empty registry (e.g.
+    in unit tests that need to exercise the registry's matching logic
+    in isolation from the staging-defaults set).
+
+    Parameters
+    ----------
+    blocked:
+        Mapping of ``domain_suffix → operator-facing note`` for
+        :data:`ArchivePolicyMode` ``"blocked"`` entries.
+    rate_limited:
+        Same shape, for ``"rate_limited"`` entries.
+    skip:
+        Same shape, for ``"skip"`` entries (no archive attempt at all).
+    include_defaults:
+        Include the built-in :data:`_DEFAULT_BLOCKED_DOMAINS` and
+        :data:`_DEFAULT_RATE_LIMITED_DOMAINS` (overridable per-suffix
+        by the explicit mappings).  Defaults to ``True`` so production
+        behaviour is "ship with sensible defaults" out of the box.
+    """
+    merged: dict[str, ArchivePolicy] = {}
+    if include_defaults:
+        for suffix, note in _DEFAULT_BLOCKED_DOMAINS:
+            merged[suffix.lower()] = ArchivePolicy(mode="blocked", note=note)
+        for suffix, note in _DEFAULT_RATE_LIMITED_DOMAINS:
+            merged[suffix.lower()] = ArchivePolicy(mode="rate_limited", note=note)
+
+    # Operator overrides win.  ``skip`` then ``blocked`` then
+    # ``rate_limited`` so that a later-declared mode beats an earlier
+    # mode for the same suffix (last-write-wins discipline).
+    for table, mode in (
+        (rate_limited, "rate_limited"),
+        (blocked, "blocked"),
+        (skip, "skip"),
+    ):
+        if not table:
+            continue
+        for suffix, note in table.items():
+            cleaned = suffix.strip().lower().lstrip(".")
+            if not cleaned:
+                continue
+            merged[cleaned] = ArchivePolicy(mode=mode, note=note)
+
+    # Sort longest-first so :meth:`policy_for`'s iteration order makes
+    # the most specific suffix win.
+    entries = tuple(
+        sorted(merged.items(), key=lambda kv: (-len(kv[0]), kv[0]))
+    )
+    return ArchivePolicyRegistry(_entries=entries)
+
+
+# Module-level shared default registry — used by sources that have no
+# explicit injection point (e.g. legacy direct ``download_archive``
+# callers in scripts).  Production paths pass a config-derived registry
+# so an operator's TOML overrides win.
+_DEFAULT_REGISTRY = build_registry()
+
+
+def default_registry() -> ArchivePolicyRegistry:
+    """Return the module-level default :class:`ArchivePolicyRegistry`.
+
+    Exposed for callers that have no obvious place to thread a
+    config-derived registry through (e.g. CLI smoke commands).  The
+    Run path passes a registry built from
+    :class:`~influx.config.ArchivePolicyConfig` instead, so operator
+    overrides win on production calls.
+    """
+    return _DEFAULT_REGISTRY
+
+
+def registry_from_config(
+    archive_policy: ArchivePolicyConfig,
+) -> ArchivePolicyRegistry:
+    """Build an :class:`ArchivePolicyRegistry` from
+    :class:`~influx.config.ArchivePolicyConfig`.
+
+    Imported separately to keep the policy module free of pydantic /
+    config-load dependencies — production callers (the Run path)
+    invoke this once at config-load time and pass the registry into
+    :func:`download_archive` per-acquisition.
+    """
+    return build_registry(
+        blocked=dict(archive_policy.blocked),
+        rate_limited=dict(archive_policy.rate_limited),
+        skip=dict(archive_policy.skip),
+        include_defaults=archive_policy.include_defaults,
+    )
+
+
+# ── Host extraction ────────────────────────────────────────────────────
+
+
+def extract_domain(url: str) -> str:
+    """Return the lowercased host of *url*, or ``""`` when unparseable.
+
+    Used by :meth:`ArchivePolicyRegistry.policy_for`.  Stripped to a
+    plain ``urlparse`` because policy suffix matching wants the full
+    host (including any subdomain) — a subdomain-specific policy entry
+    should win over a parent-domain entry.
+    """
+    if not url:
+        return ""
+    try:
+        parsed = urlparse(url)
+    except (TypeError, ValueError):
+        return ""
+    host = parsed.hostname or ""
+    return host.lower()
+
+
+# ── Failure classification ────────────────────────────────────────────
+
+
+# Map low-level NetworkError ``kind`` values onto the public
+# :data:`ArchiveFailureKind` taxonomy.  Anything not listed falls
+# through to ``"network"`` so :func:`classify_failure_kind` always
+# returns a recognised label.
+_NETWORK_KIND_TO_FAILURE: dict[str, ArchiveFailureKind] = {
+    "ssrf": "ssrf",
+    "scheme": "network",
+    "oversize": "oversize",
+    "timeout": "timeout",
+    "dns": "dns",
+    "content_type_mismatch": "content_type_mismatch",
+    "network": "network",
+}
+
+
+def classify_failure_kind(
+    *,
+    error: str,
+    policy_mode: ArchivePolicyMode = "attempt",
+) -> ArchiveFailureKind:
+    """Map an :class:`~influx.storage.ArchiveResult` error string onto a kind.
+
+    ``ArchiveResult.error`` is one of:
+
+    * ``""`` — success (callers should not invoke this helper).
+    * ``"HTTP {code} for {url}"`` — non-2xx response from the guarded
+      fetch.
+    * ``"{kind}: {message}"`` — :class:`~influx.errors.NetworkError`
+      packed by :func:`~influx.storage.download_archive`.
+    * ``"write: {message}"`` — local filesystem write failure.
+
+    The policy mode subtly influences classification: for a
+    ``rate_limited`` policy, an HTTP 429 collapses to the
+    ``rate_limited`` kind (its tag is ``influx:archive-rate-limited``);
+    for ``blocked``, an HTTP 403 collapses to the ``blocked`` kind.
+    The raw ``http_403`` / ``http_429`` kinds are still returned for
+    the ``attempt`` policy so the diagnostic shape is preserved when
+    no policy is active.
+    """
+    if not error:
+        return "unknown"
+
+    http_match = _HTTP_PREFIX_RE.match(error)
+    if http_match:
+        code = int(http_match.group(1))
+        if code == 403:
+            if policy_mode == "blocked":
+                return "blocked"
+            return "http_403"
+        if code == 429:
+            if policy_mode == "rate_limited":
+                return "rate_limited"
+            return "http_429"
+        if code == 404:
+            return "http_404"
+        if 400 <= code < 500:
+            return "http_4xx"
+        if 500 <= code < 600:
+            return "http_5xx"
+        return "network"
+
+    if error.startswith("write:"):
+        return "write"
+
+    kind_match = _KIND_PREFIX_RE.match(error)
+    if kind_match:
+        kind = kind_match.group(1)
+        return _NETWORK_KIND_TO_FAILURE.get(kind, "network")
+
+    return "unknown"
+
+
+def tag_for_failure_kind(kind: ArchiveFailureKind) -> str | None:
+    """Return the policy-driven tag for *kind*, or ``None`` for generic kinds.
+
+    Three failure kinds carry a dedicated policy tag callers add to
+    the note alongside (or in place of) the generic
+    ``influx:archive-missing``:
+
+    * ``blocked`` → :data:`ARCHIVE_BLOCKED_TAG`
+    * ``rate_limited`` → :data:`ARCHIVE_RATE_LIMITED_TAG`
+    * ``missing_by_policy`` → :data:`ARCHIVE_SKIPPED_BY_POLICY_TAG`
+
+    All other kinds (``http_404``, ``timeout``, ``oversize``, …) keep
+    the generic missing-tag shape — they describe transient or
+    item-specific failures rather than a structural domain policy.
+    """
+    if kind == "blocked":
+        return ARCHIVE_BLOCKED_TAG
+    if kind == "rate_limited":
+        return ARCHIVE_RATE_LIMITED_TAG
+    if kind == "missing_by_policy":
+        return ARCHIVE_SKIPPED_BY_POLICY_TAG
+    return None

--- a/src/influx/config.py
+++ b/src/influx/config.py
@@ -25,6 +25,7 @@ from influx.slugs import slugify_feed_name
 __all__ = [
     # v0.7 pydantic schema models
     "AppConfig",
+    "ArchivePolicyConfig",
     "ArxivSourceConfig",
     "ExtractionConfig",
     "FeedbackConfig",
@@ -98,6 +99,38 @@ class ScheduleConfig(BaseModel):
         return v
 
 
+class ArchivePolicyConfig(BaseModel):
+    """``[storage.archive_policy]`` domain-aware archive policy overrides (#149).
+
+    Maps domain (host suffix) → operator-facing diagnostic note for
+    each policy mode.  Built-in defaults already cover staging hot
+    offenders (``science.org``, ``alignmentforum.org``, …); these
+    operator-supplied entries are *merged on top* so a domain can be
+    promoted from ``blocked`` to ``skip``, or a new domain added
+    without code changes.
+
+    Modes:
+
+    * ``blocked``: attempt the download but expect HTTP 403 / WAF
+      challenge.  Failures are tagged ``influx:archive-blocked`` so
+      the repair sweep can stop re-attempting the same doomed path.
+    * ``rate_limited``: attempt but expect HTTP 429.  Failures are
+      tagged ``influx:archive-rate-limited``; the repair sweep applies
+      a bounded cool-down on this kind.
+    * ``skip``: do not attempt the download.  The note is tagged
+      ``influx:archive-skipped-by-policy`` and never produces a
+      network call.
+
+    ``include_defaults = false`` opts out of the built-in
+    staging-defaults set — primarily a test-injection lever.
+    """
+
+    blocked: dict[str, str] = Field(default_factory=dict)
+    rate_limited: dict[str, str] = Field(default_factory=dict)
+    skip: dict[str, str] = Field(default_factory=dict)
+    include_defaults: bool = True
+
+
 class StorageConfig(BaseModel):
     """``[storage]`` archive storage settings."""
 
@@ -106,6 +139,10 @@ class StorageConfig(BaseModel):
     retain_days: int = 3650
     max_download_bytes: int = 52_428_800
     download_timeout_seconds: int = 30
+    # Issue #149: per-domain archive acquisition policy overrides.
+    # Defaults to an empty override set plus the built-in staging
+    # offender list; see :class:`ArchivePolicyConfig` for the shape.
+    archive_policy: ArchivePolicyConfig = Field(default_factory=ArchivePolicyConfig)
 
 
 class NotificationsConfig(BaseModel):

--- a/src/influx/metrics.py
+++ b/src/influx/metrics.py
@@ -35,6 +35,7 @@ from influx.telemetry import get_meter
 __all__ = [
     "active_runs",
     "archive_missing",
+    "archive_policy_failures",
     "articles_filtered",
     "articles_inspected",
     "cache_hits",
@@ -234,6 +235,35 @@ def archive_missing() -> Any:
     return get_meter().counter(
         "influx_archive_missing_total",
         description="Items tagged influx:archive-missing during a run.",
+    )
+
+
+def archive_policy_failures() -> Any:
+    """Counter of archive failures classified by domain-aware policy (#149).
+
+    Increments alongside :func:`archive_missing` whenever
+    :class:`~influx.archive_policy.ArchivePolicy` reclassifies an
+    archive failure into a structural shape (``blocked`` /
+    ``rate_limited`` / ``missing_by_policy``).  ``kind="generic"`` is
+    reserved for the (large, expected) baseline of unclassified
+    failures so dashboards can compute the ratio without subtracting
+    series.
+
+    Labels: ``profile``, ``source``, ``kind``
+    (``"blocked"`` | ``"rate_limited"`` | ``"missing_by_policy"`` |
+    ``"http_403"`` | ``"http_429"`` | ``"http_404"`` | ``"http_4xx"`` |
+    ``"http_5xx"`` | ``"oversize"`` | ``"timeout"`` | ``"ssrf"`` |
+    ``"dns"`` | ``"network"`` | ``"content_type_mismatch"`` |
+    ``"write"`` | ``"unknown"``).
+    """
+    return get_meter().counter(
+        "influx_archive_policy_failures_total",
+        description=(
+            "Archive download failures classified by domain-aware policy; "
+            "the ``kind`` label distinguishes blocked / rate-limited / "
+            "missing-by-policy from generic HTTP / network shapes (issue "
+            "#149)."
+        ),
     )
 
 

--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -19,6 +19,9 @@ from pathlib import Path
 
 import trafilatura
 
+from influx.archive_policy import (
+    registry_from_config as _archive_policy_registry_from_config,
+)
 from influx.config import AppConfig
 from influx.enrich import tier3_extract as _tier3_extract
 from influx.errors import ExtractionError, LCMAError, NetworkError
@@ -444,11 +447,26 @@ def _make_archive_download_hook(config: AppConfig) -> ArchiveDownloadHook:
     ``ExtractionError(stage="unsupported_source")`` which classifies as
     transient — the note re-enters the sweep next pass and is fixed
     automatically once a per-source resolver is added.
+
+    Issue #149 follow-up: the per-domain archive policy registry is
+    built once from ``config.storage.archive_policy`` and threaded into
+    :func:`download_archive` so operator overrides (``blocked`` /
+    ``rate_limited`` / ``skip`` and ``include_defaults = false``) apply
+    identically during repair sweeps and initial acquisition.  Without
+    this the repair path silently fell back to
+    :func:`~influx.archive_policy.default_registry`, ignoring per-run
+    config and re-attempting doomed domains.
     """
+    policy_registry = _archive_policy_registry_from_config(
+        config.storage.archive_policy
+    )
 
     def hook(note: dict[str, object]) -> str:
         kwargs = _resolve_archive_download_args(note, config)
-        result = download_archive(**kwargs)  # type: ignore[arg-type]
+        result = download_archive(
+            policy_registry=policy_registry,
+            **kwargs,  # type: ignore[arg-type]
+        )
         if result.ok and result.rel_posix_path:
             _log.info(
                 "archive_download retry succeeded for %s path=%s",

--- a/src/influx/run_service.py
+++ b/src/influx/run_service.py
@@ -186,12 +186,24 @@ async def ledger_lifecycle(
         sources_checked = outcome.sources_checked if outcome is not None else None
         ingested = outcome.ingested if outcome is not None else None
         archive_failures_total = 0
+        # Issue #149: per-policy-kind breakdown of archive failures so
+        # run summaries distinguish blocked / rate-limited / skip
+        # diagnostic shapes from generic failures.  Computed alongside
+        # the existing ``archive_failures_total`` so the ledger /
+        # degraded-reasons logic is unchanged for downstream callers.
+        archive_blocked_total = 0
+        archive_rate_limited_total = 0
+        archive_skipped_by_policy_total = 0
         if outcome is not None and outcome.profile_run_result is not None:
-            archive_failures_total = sum(
-                1
-                for item in outcome.profile_run_result.items
-                if "influx:archive-missing" in item.tags
-            )
+            for item in outcome.profile_run_result.items:
+                if "influx:archive-missing" in item.tags:
+                    archive_failures_total += 1
+                if "influx:archive-blocked" in item.tags:
+                    archive_blocked_total += 1
+                if "influx:archive-rate-limited" in item.tags:
+                    archive_rate_limited_total += 1
+                if "influx:archive-skipped-by-policy" in item.tags:
+                    archive_skipped_by_policy_total += 1
         # #85: pull the pre-filter fetched-count from the contextvar
         # bucket the source layer accumulated into.  ``outcome`` may be
         # ``None`` on the early-skip / abort paths; in that case we
@@ -298,13 +310,19 @@ async def ledger_lifecycle(
                 run_outcome = "degraded"
             logger.warning(
                 "run flagged archive_acquisition profile=%s kind=%s run_id=%s "
-                "archive_failures=%d "
+                "archive_failures=%d blocked=%d rate_limited=%d "
+                "skipped_by_policy=%d "
                 "(accepted items were ingested with influx:archive-missing "
-                "after archive download failed)",
+                "after archive download failed; issue #149: blocked / "
+                "rate_limited / skipped_by_policy break down the structural "
+                "domain-policy failure shapes)",
                 profile,
                 plan.kind.value,
                 run_id,
                 archive_failures_total,
+                archive_blocked_total,
+                archive_rate_limited_total,
+                archive_skipped_by_policy_total,
             )
         if "invalid_url_stall" in degraded_reasons:
             # #131 review concern 2: feed returned items but every URL

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -40,6 +40,12 @@ from influx.config import (
     ResilienceConfig,
     StorageConfig,
 )
+from influx.archive_policy import (
+    tag_for_failure_kind as _tag_for_archive_failure_kind,
+)
+from influx.archive_policy import (
+    registry_from_config as _archive_policy_registry_from_config,
+)
 from influx.coordinator import RunKind
 from influx.errors import NetworkError
 from influx.extraction.pipeline import extract_arxiv_text
@@ -744,6 +750,10 @@ def build_arxiv_note_item(
     is_archive_terminal = item.arxiv_id in archive_terminal_ids
     archive_path: str | None = None
     archive_missing = False
+    # Issue #149: per-domain policy tag (blocked / rate-limited /
+    # skipped-by-policy) the acquire stage adds when the policy
+    # short-circuits or reclassifies the failure.
+    archive_policy_tag: str | None = None
     pdf_url = f"https://arxiv.org/pdf/{item.arxiv_id}.pdf"
     tracer = get_tracer()
 
@@ -760,6 +770,13 @@ def build_arxiv_note_item(
             item.arxiv_id,
         )
     else:
+        # Issue #149: build the policy registry from config so the
+        # operator's blocked / rate-limited / skip overrides win.  The
+        # registry is built once per acquire (cheap — pure dataclass
+        # composition); a per-run cache would help only at high QPS.
+        policy_registry = _archive_policy_registry_from_config(
+            config.storage.archive_policy
+        )
         with tracer.span(
             "influx.archive.download",
             attributes={
@@ -780,6 +797,7 @@ def build_arxiv_note_item(
                 max_download_bytes=config.storage.max_download_bytes,
                 timeout_seconds=config.storage.download_timeout_seconds,
                 expected_content_type="pdf",
+                policy_registry=policy_registry,
             )
         if archive_result.ok:
             archive_path = archive_result.rel_posix_path
@@ -787,6 +805,23 @@ def build_arxiv_note_item(
             archive_missing = True
             metrics.archive_missing().add(
                 1, {"profile": profile_name, "source": "arxiv"}
+            )
+            # Issue #149: reclassify the failure into a policy tag
+            # when the failure_kind is one of blocked / rate_limited /
+            # missing_by_policy.  Generic failures (http_404, oversize,
+            # timeout, …) keep the default ``influx:archive-missing``
+            # shape so repair-sweep behaviour is unchanged for them.
+            archive_policy_tag = _tag_for_archive_failure_kind(
+                # ArchiveFailureKind is a Literal; mypy needs a cast.
+                archive_result.failure_kind  # type: ignore[arg-type]
+            )
+            metrics.archive_policy_failures().add(
+                1,
+                {
+                    "profile": profile_name,
+                    "source": "arxiv",
+                    "kind": archive_result.failure_kind or "unknown",
+                },
             )
 
     acquired = Acquired(
@@ -822,6 +857,23 @@ def build_arxiv_note_item(
     if archive_missing:
         tags.append("influx:archive-missing")
     if is_archive_terminal:
+        tags.append("influx:archive-terminal")
+    # Issue #149: domain-policy tag (blocked / rate-limited /
+    # skipped-by-policy) — applied alongside ``influx:archive-missing``
+    # so existing repair-sweep selectors keep working, but the
+    # diagnostic shape is now visible in the tag list.  For ``blocked``
+    # and ``missing_by_policy`` (skip) the note is also flipped to
+    # ``influx:archive-terminal`` so the repair sweep does NOT
+    # tight-loop on a doomed path (this is the staging-log behaviour
+    # we are fixing).  ``rate_limited`` retries on cool-down, so it
+    # stays in the normal repair-needed loop.
+    if archive_policy_tag is not None and archive_policy_tag not in tags:
+        tags.append(archive_policy_tag)
+    if (
+        archive_policy_tag
+        in ("influx:archive-blocked", "influx:archive-skipped-by-policy")
+        and "influx:archive-terminal" not in tags
+    ):
         tags.append("influx:archive-terminal")
     tags.append(sections.text_tag)
     if sections.full_text is not None:

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -31,6 +31,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from influx import metrics
+from influx.archive_policy import (
+    registry_from_config as _archive_policy_registry_from_config,
+)
+from influx.archive_policy import (
+    tag_for_failure_kind as _tag_for_archive_failure_kind,
+)
 from influx.cascade import Acquired, Cascade, Tier2Result
 from influx.config import (
     AppConfig,
@@ -39,12 +45,6 @@ from influx.config import (
     ProfileThresholds,
     ResilienceConfig,
     StorageConfig,
-)
-from influx.archive_policy import (
-    tag_for_failure_kind as _tag_for_archive_failure_kind,
-)
-from influx.archive_policy import (
-    registry_from_config as _archive_policy_registry_from_config,
 )
 from influx.coordinator import RunKind
 from influx.errors import NetworkError

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -32,6 +32,12 @@ from typing import TYPE_CHECKING, Any
 import feedparser
 
 from influx import metrics
+from influx.archive_policy import (
+    registry_from_config as _archive_policy_registry_from_config,
+)
+from influx.archive_policy import (
+    tag_for_failure_kind as _tag_for_archive_failure_kind,
+)
 from influx.cascade import Acquired, Cascade
 from influx.coordinator import RunKind
 from influx.errors import ExtractionError, NetworkError
@@ -256,6 +262,13 @@ def build_rss_note_item(
 
     # ── Acquire stage (RSS-specific) ──────────────────────────────
     # Download and archive the article HTML (FR-SRC-5 / FR-RES-4).
+    # Issue #149: build the per-domain archive policy registry from
+    # config; ``download_archive`` short-circuits skip-mode policies
+    # and tags blocked / rate-limited failures distinctly so the
+    # repair sweep does not tight-loop on doomed paths.
+    archive_policy_registry = _archive_policy_registry_from_config(
+        config.storage.archive_policy
+    )
     tracer = get_tracer()
     with tracer.span(
         "influx.archive.download",
@@ -277,10 +290,34 @@ def build_rss_note_item(
             max_download_bytes=config.storage.max_download_bytes,
             timeout_seconds=config.storage.download_timeout_seconds,
             expected_content_type="html",
+            policy_registry=archive_policy_registry,
         )
 
     archive_path = archive_result.rel_posix_path
     archive_missing = not archive_result.ok
+    # Issue #149: extract the policy-driven tag (if any) so the tag
+    # composition below can apply ``influx:archive-blocked`` /
+    # ``influx:archive-rate-limited`` /
+    # ``influx:archive-skipped-by-policy`` alongside
+    # ``influx:archive-missing``.  Returns ``None`` for generic
+    # failures (http_404, oversize, timeout, …) so the existing
+    # ``influx:archive-missing`` shape is preserved.
+    archive_policy_tag = (
+        _tag_for_archive_failure_kind(
+            archive_result.failure_kind  # type: ignore[arg-type]
+        )
+        if archive_missing
+        else None
+    )
+    if archive_missing:
+        metrics.archive_policy_failures().add(
+            1,
+            {
+                "profile": profile_name,
+                "source": item.source_tag,
+                "kind": archive_result.failure_kind or "unknown",
+            },
+        )
 
     # Article text extraction with summary fallback (FR-ENR-3): try web
     # article extraction; fall back to the feed item's ``<summary>``
@@ -358,6 +395,23 @@ def build_rss_note_item(
     ]
     if archive_missing:
         tags.append("influx:archive-missing")
+    # Issue #149: domain-policy tag (blocked / rate-limited /
+    # skipped-by-policy) — applied alongside ``influx:archive-missing``
+    # so existing repair-sweep selectors keep working, but the
+    # diagnostic shape is now visible in the tag list.  For ``blocked``
+    # and ``missing_by_policy`` (skip) the note is also flipped to
+    # ``influx:archive-terminal`` so the repair sweep does NOT
+    # tight-loop on a doomed path (this is the staging-log behaviour
+    # we are fixing).  ``rate_limited`` retries on cool-down, so it
+    # stays in the normal repair-needed loop.
+    if archive_policy_tag is not None and archive_policy_tag not in tags:
+        tags.append(archive_policy_tag)
+    if (
+        archive_policy_tag
+        in ("influx:archive-blocked", "influx:archive-skipped-by-policy")
+        and "influx:archive-terminal" not in tags
+    ):
+        tags.append("influx:archive-terminal")
     if sections.full_text is not None:
         tags.append("full-text")
     if archive_missing and "influx:repair-needed" not in tags:

--- a/src/influx/storage.py
+++ b/src/influx/storage.py
@@ -4,14 +4,31 @@ Builds archive filesystem paths and note-facing relative paths for
 archived PDFs and other source documents.  Path-safety checks prevent
 directory traversal attacks (AC-04-C).  The download helper uses the
 guarded HTTP client from PRD 02 (FR-ST-4).
+
+Issue #149: :func:`download_archive` consults an
+:class:`~influx.archive_policy.ArchivePolicyRegistry` so that known
+blocked / rate-limited / skip-by-policy domains are classified
+distinctly instead of producing identical generic
+``influx:archive-missing`` failures.  The classification surfaces on
+:attr:`ArchiveResult.failure_kind` so callers can apply the matching
+``influx:archive-blocked`` / ``influx:archive-rate-limited`` /
+``influx:archive-skipped-by-policy`` tag and the run-ledger
+discriminator picks up the structural signal.
 """
 
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 
+from influx.archive_policy import (
+    ArchiveFailureKind,
+    ArchivePolicy,
+    ArchivePolicyRegistry,
+    classify_failure_kind,
+    default_registry,
+)
 from influx.config import StorageConfig
 from influx.errors import InfluxError, NetworkError
 from influx.http_client import ContentTypeFamily, guarded_fetch
@@ -122,11 +139,34 @@ class ArchiveResult:
     *error* describes what went wrong.  The caller should render the
     note with an empty ``## Archive`` body and tag it with
     ``influx:repair-needed`` + ``influx:archive-missing`` (FR-ST-4).
+
+    Issue #149: :attr:`failure_kind` is a stable
+    :data:`~influx.archive_policy.ArchiveFailureKind` discriminator
+    (``blocked`` / ``rate_limited`` / ``missing_by_policy`` / ``http_*``
+    / ``oversize`` / ``timeout`` / …).  :attr:`policy_mode` records the
+    :class:`~influx.archive_policy.ArchivePolicy` that was applied for
+    the request URL — ``attempt`` for the no-op default case.  Both
+    are empty strings on success so the field remains the failure
+    side's concern.
     """
 
     ok: bool
     rel_posix_path: str | None
     error: str
+    # Issue #149: stable discriminator for the failure shape.  Empty
+    # string on success; one of :data:`ArchiveFailureKind` on failure.
+    failure_kind: str = ""
+    # Issue #149: the policy mode applied for this URL — ``""`` when
+    # no policy was applied (no registry threaded through), otherwise
+    # one of :data:`ArchivePolicyMode`.  Surfaced on
+    # ``ArchiveResult`` rather than inferred from ``failure_kind``
+    # because the ``skip`` mode never produces a failure_kind beyond
+    # ``missing_by_policy`` yet the run summary still wants to log
+    # which domain policy fired.
+    policy_mode: str = ""
+    # Domain (host) of the URL the policy was applied against.
+    # Convenience field so callers don't have to re-parse the URL.
+    domain: str = ""
 
 
 # ── Archive download ────────────────────────────────────────────────
@@ -145,6 +185,7 @@ def download_archive(
     max_download_bytes: int | None = None,
     timeout_seconds: int | None = None,
     expected_content_type: ContentTypeFamily = "pdf",
+    policy_registry: ArchivePolicyRegistry | None = None,
 ) -> ArchiveResult:
     """Download a file via the guarded HTTP client and archive it.
 
@@ -160,6 +201,20 @@ def download_archive(
     when omitted they are resolved from the pydantic
     :class:`~influx.config.StorageConfig` field defaults so the only
     place these tunable defaults live is config-parsing code (AC-X-1).
+
+    Issue #149: when *policy_registry* is provided, the URL's host is
+    looked up to obtain an :class:`ArchivePolicy`.  For ``skip``-mode
+    policies the function returns immediately with
+    ``failure_kind="missing_by_policy"`` and no network call is made.
+    For ``blocked`` / ``rate_limited`` policies the download is still
+    attempted; the failure (if any) is classified into the
+    domain-aware :data:`ArchiveFailureKind` shape so callers can apply
+    the matching ``influx:archive-blocked`` /
+    ``influx:archive-rate-limited`` tag.  When *policy_registry* is
+    ``None``, the module-level
+    :func:`~influx.archive_policy.default_registry` is used so even
+    untargeted callers (CLI smoke commands, repair sweep) honour the
+    staging-defaults set.
     """
     if max_download_bytes is None or timeout_seconds is None:
         _storage_defaults = StorageConfig()
@@ -167,6 +222,33 @@ def download_archive(
             max_download_bytes = _storage_defaults.max_download_bytes
         if timeout_seconds is None:
             timeout_seconds = _storage_defaults.download_timeout_seconds
+
+    # Issue #149: resolve the policy for this URL.  Defaults to the
+    # module-level registry so legacy callers (CLI, scripts) still
+    # honour the staging-defaults block-list without rewiring.
+    registry = policy_registry if policy_registry is not None else default_registry()
+    policy = registry.policy_for(url)
+    domain = _domain_from_url(url)
+
+    # Skip-mode policies short-circuit before path construction so an
+    # entire blocked domain pays zero IO cost (the staging issue: the
+    # same blocked domain was retried on every sweep, generating
+    # hundreds of repair-noise failures per 12h window).
+    if policy.mode == "skip":
+        _log.info(
+            "archive download skipped (policy=skip) url=%s domain=%s note=%s",
+            url,
+            domain,
+            policy.note,
+        )
+        return ArchiveResult(
+            ok=False,
+            rel_posix_path=None,
+            error=f"missing_by_policy: {policy.note or 'archive disabled by policy'}",
+            failure_kind="missing_by_policy",
+            policy_mode=policy.mode,
+            domain=domain,
+        )
 
     # Path construction first — reject unsafe IDs before any download
     fs_path, rel_posix = build_archive_path(
@@ -187,40 +269,79 @@ def download_archive(
             expected_content_type=expected_content_type,
         )
     except NetworkError as exc:
+        error = f"{exc.kind}: {exc}"
+        failure_kind = classify_failure_kind(error=error, policy_mode=policy.mode)
         _log.warning(
-            "Archive download failed for %s: [%s] %s",
+            "Archive download failed for %s: [%s] %s (failure_kind=%s "
+            "policy=%s domain=%s)",
             url,
             exc.kind,
             exc,
+            failure_kind,
+            policy.mode,
+            domain,
         )
         return ArchiveResult(
             ok=False,
             rel_posix_path=None,
-            error=f"{exc.kind}: {exc}",
+            error=error,
+            failure_kind=failure_kind,
+            policy_mode=policy.mode,
+            domain=domain,
         )
 
     if result.status_code >= 400:
         msg = f"HTTP {result.status_code} for {url}"
-        _log.warning("Archive download failed: %s", msg)
+        failure_kind = classify_failure_kind(error=msg, policy_mode=policy.mode)
+        _log.warning(
+            "Archive download failed: %s (failure_kind=%s policy=%s domain=%s)",
+            msg,
+            failure_kind,
+            policy.mode,
+            domain,
+        )
         return ArchiveResult(
             ok=False,
             rel_posix_path=None,
             error=msg,
+            failure_kind=failure_kind,
+            policy_mode=policy.mode,
+            domain=domain,
         )
 
     try:
         fs_path.parent.mkdir(parents=True, exist_ok=True)
         fs_path.write_bytes(result.body)
     except OSError as exc:
+        error = f"write: {exc}"
         _log.warning("Archive write failed for %s: %s", fs_path, exc)
         return ArchiveResult(
             ok=False,
             rel_posix_path=None,
-            error=f"write: {exc}",
+            error=error,
+            failure_kind="write",
+            policy_mode=policy.mode,
+            domain=domain,
         )
 
     return ArchiveResult(
         ok=True,
         rel_posix_path=rel_posix,
         error="",
+        failure_kind="",
+        policy_mode=policy.mode,
+        domain=domain,
     )
+
+
+def _domain_from_url(url: str) -> str:
+    """Best-effort host extraction without raising — for ArchiveResult.domain.
+
+    Wraps :func:`~influx.archive_policy.extract_domain` but kept local
+    so the storage module does not pull the policy module into a tight
+    import cycle if the policy registry is ever bootstrapped from
+    storage code (defence-in-depth).
+    """
+    from influx.archive_policy import extract_domain
+
+    return extract_domain(url)

--- a/src/influx/storage.py
+++ b/src/influx/storage.py
@@ -19,12 +19,10 @@ discriminator picks up the structural signal.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
 from influx.archive_policy import (
-    ArchiveFailureKind,
-    ArchivePolicy,
     ArchivePolicyRegistry,
     classify_failure_kind,
     default_registry,

--- a/tests/unit/test_archive_download_policy.py
+++ b/tests/unit/test_archive_download_policy.py
@@ -1,0 +1,328 @@
+"""Tests for ``download_archive`` × domain policy interactions (issue #149).
+
+Covers the cross-product of:
+
+* policy mode (``attempt`` / ``rate_limited`` / ``blocked`` / ``skip``), and
+* HTTP outcome (success, 403, 429, 404, 5xx, oversize, timeout).
+
+Each combination asserts:
+
+* whether a network call was made (skip-mode short-circuits),
+* the resulting ``ArchiveResult.failure_kind``, and
+* the policy-mode attribution on the result.
+
+These tests complement the existing ``test_archive_download.py`` suite —
+that one verifies the path-safety + happy / generic-failure contract;
+this one focuses on the domain-policy reclassification layer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from influx.archive_policy import (
+    ArchivePolicyRegistry,
+    build_registry,
+    default_registry,
+)
+from influx.errors import NetworkError
+from influx.http_client import FetchResult
+from influx.storage import ArchiveResult, download_archive
+
+
+def _make_fetch_result(
+    status_code: int = 200,
+    body: bytes = b"%PDF-1.4 ok",
+    content_type: str = "application/pdf",
+    final_url: str = "https://example.com/x.pdf",
+) -> FetchResult:
+    return FetchResult(
+        body=body,
+        status_code=status_code,
+        content_type=content_type,
+        final_url=final_url,
+    )
+
+
+def _dl(
+    tmp_path: Path,
+    url: str,
+    *,
+    registry: ArchivePolicyRegistry | None = None,
+    source: str = "rss",
+    item_id: str = "feed-2026-01-01-deadbeef",
+    ext: str = ".html",
+) -> ArchiveResult:
+    return download_archive(
+        url=url,
+        archive_root=tmp_path,
+        source=source,
+        item_id=item_id,
+        published_year=2026,
+        published_month=1,
+        ext=ext,
+        expected_content_type="html" if ext == ".html" else "pdf",
+        policy_registry=registry,
+    )
+
+
+# ── Skip-mode: no network call, distinct failure_kind ──────────────────
+
+
+class TestSkipModePolicy:
+    """``skip`` mode short-circuits before the network call."""
+
+    def test_skip_returns_missing_by_policy_and_no_fetch(
+        self, tmp_path: Path
+    ) -> None:
+        registry = build_registry(
+            skip={"blocked.example": "permanent skip"},
+            include_defaults=False,
+        )
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            result = _dl(
+                tmp_path,
+                "https://blocked.example/article",
+                registry=registry,
+            )
+        # Network was never called.
+        mock_fetch.assert_not_called()
+        assert result.ok is False
+        assert result.rel_posix_path is None
+        assert result.failure_kind == "missing_by_policy"
+        assert result.policy_mode == "skip"
+        assert result.domain == "blocked.example"
+        assert "missing_by_policy" in result.error
+
+    def test_skip_does_not_create_archive_file(self, tmp_path: Path) -> None:
+        registry = build_registry(
+            skip={"blocked.example": ""},
+            include_defaults=False,
+        )
+        with patch("influx.storage.guarded_fetch"):
+            _dl(tmp_path, "https://blocked.example/article", registry=registry)
+        # No archive directory should be created for a skipped policy
+        # — path construction comes after the skip short-circuit.
+        assert not (tmp_path / "rss").exists()
+
+
+# ── Blocked-mode HTTP 403 reclassification ─────────────────────────────
+
+
+class TestBlockedModePolicy:
+    """``blocked`` mode attempts the fetch and maps 403 to ``blocked``."""
+
+    def test_blocked_http_403_returns_blocked_kind(self, tmp_path: Path) -> None:
+        registry = build_registry(
+            blocked={"science.example": "test-blocked"},
+            include_defaults=False,
+        )
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            mock_fetch.return_value = _make_fetch_result(status_code=403)
+            result = _dl(
+                tmp_path,
+                "https://www.science.example/abc",
+                registry=registry,
+            )
+        mock_fetch.assert_called_once()
+        assert result.ok is False
+        assert result.failure_kind == "blocked"
+        assert result.policy_mode == "blocked"
+        assert result.domain == "www.science.example"
+
+    def test_blocked_does_not_swallow_unrelated_codes(self, tmp_path: Path) -> None:
+        registry = build_registry(
+            blocked={"science.example": ""},
+            include_defaults=False,
+        )
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            mock_fetch.return_value = _make_fetch_result(status_code=503)
+            result = _dl(
+                tmp_path,
+                "https://www.science.example/abc",
+                registry=registry,
+            )
+        # 5xx is a transient failure, NOT a policy-blocked one.
+        assert result.failure_kind == "http_5xx"
+        assert result.policy_mode == "blocked"
+
+    def test_blocked_lets_success_through(self, tmp_path: Path) -> None:
+        # If the policy is wrong (or the upstream lifts the block),
+        # a successful fetch must still produce a normal archive.
+        registry = build_registry(
+            blocked={"science.example": ""},
+            include_defaults=False,
+        )
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            mock_fetch.return_value = _make_fetch_result(
+                body=b"<html>ok</html>",
+                content_type="text/html",
+            )
+            result = _dl(
+                tmp_path,
+                "https://www.science.example/abc",
+                registry=registry,
+            )
+        assert result.ok is True
+        assert result.failure_kind == ""
+        assert result.policy_mode == "blocked"
+
+
+# ── Rate-limited mode HTTP 429 reclassification ────────────────────────
+
+
+class TestRateLimitedModePolicy:
+    """``rate_limited`` mode attempts the fetch and maps 429 to ``rate_limited``."""
+
+    def test_rate_limited_http_429_returns_rate_limited_kind(
+        self, tmp_path: Path
+    ) -> None:
+        registry = build_registry(
+            rate_limited={"slow.example": ""},
+            include_defaults=False,
+        )
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            mock_fetch.return_value = _make_fetch_result(status_code=429)
+            result = _dl(
+                tmp_path,
+                "https://slow.example/article",
+                registry=registry,
+            )
+        mock_fetch.assert_called_once()
+        assert result.failure_kind == "rate_limited"
+        assert result.policy_mode == "rate_limited"
+
+    def test_rate_limited_does_not_swallow_403(self, tmp_path: Path) -> None:
+        registry = build_registry(
+            rate_limited={"slow.example": ""},
+            include_defaults=False,
+        )
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            mock_fetch.return_value = _make_fetch_result(status_code=403)
+            result = _dl(
+                tmp_path,
+                "https://slow.example/article",
+                registry=registry,
+            )
+        # 403 under a rate-limited policy stays as generic http_403 —
+        # only 429 collapses into the policy-driven kind.
+        assert result.failure_kind == "http_403"
+
+
+# ── Attempt-mode (default) generic classification ──────────────────────
+
+
+class TestAttemptModeClassification:
+    """The default ``attempt`` policy preserves HTTP-code attribution."""
+
+    @pytest.mark.parametrize(
+        "status_code, expected_kind",
+        [
+            (403, "http_403"),
+            (404, "http_404"),
+            (429, "http_429"),
+            (451, "http_4xx"),
+            (503, "http_5xx"),
+        ],
+    )
+    def test_attempt_classifies_http_codes(
+        self, tmp_path: Path, status_code: int, expected_kind: str
+    ) -> None:
+        # No registry → defaults to ``default_registry`` which has no
+        # entry for ``unmapped.test``.
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            mock_fetch.return_value = _make_fetch_result(status_code=status_code)
+            result = _dl(tmp_path, "https://unmapped.test/x")
+        assert result.failure_kind == expected_kind
+        assert result.policy_mode == "attempt"
+
+    def test_attempt_network_error_classified(self, tmp_path: Path) -> None:
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            mock_fetch.side_effect = NetworkError(
+                "Request timed out",
+                url="https://unmapped.test/x",
+                kind="timeout",
+                reason="ReadTimeout",
+            )
+            result = _dl(tmp_path, "https://unmapped.test/x")
+        assert result.failure_kind == "timeout"
+        assert result.policy_mode == "attempt"
+
+
+# ── Default-registry regression coverage ────────────────────────────────
+
+
+class TestDefaultRegistryRegression:
+    """Known-blocked staging domains route through the policy."""
+
+    def test_science_org_403_routes_through_blocked_policy(
+        self, tmp_path: Path
+    ) -> None:
+        # ``science.org`` is in the default blocked list — without
+        # passing a registry, the default registry should apply.
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            mock_fetch.return_value = _make_fetch_result(status_code=403)
+            result = _dl(tmp_path, "https://www.science.org/article/abc")
+        assert result.failure_kind == "blocked"
+        assert result.policy_mode == "blocked"
+
+    def test_alignmentforum_403_routes_through_blocked_policy(
+        self, tmp_path: Path
+    ) -> None:
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            mock_fetch.return_value = _make_fetch_result(status_code=403)
+            result = _dl(
+                tmp_path, "https://www.alignmentforum.org/posts/xyz"
+            )
+        assert result.failure_kind == "blocked"
+        assert result.policy_mode == "blocked"
+
+    def test_arxiv_pdf_does_not_match_default_blocked(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression: an unrelated domain (arxiv.org) must keep the
+        # ``attempt`` no-op policy even when the staging defaults are
+        # active.
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            mock_fetch.return_value = _make_fetch_result()
+            result = _dl(
+                tmp_path,
+                "https://arxiv.org/pdf/2601.12345.pdf",
+                source="arxiv",
+                item_id="2601.12345",
+                ext=".pdf",
+            )
+        assert result.ok is True
+        assert result.policy_mode == "attempt"
+        assert result.domain == "arxiv.org"
+
+
+class TestSuccessHasEmptyFailureKind:
+    """A successful archive carries no failure_kind."""
+
+    def test_success_failure_kind_empty(self, tmp_path: Path) -> None:
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            mock_fetch.return_value = _make_fetch_result()
+            result = _dl(
+                tmp_path,
+                "https://arxiv.org/pdf/2601.12345.pdf",
+                source="arxiv",
+                item_id="2601.12345",
+                ext=".pdf",
+            )
+        assert isinstance(result, ArchiveResult)
+        assert result.ok is True
+        assert result.failure_kind == ""
+
+
+# ── default_registry is shared across calls ────────────────────────────
+
+
+class TestDefaultRegistryIdentity:
+    """Calls to ``default_registry()`` return the same singleton."""
+
+    def test_singleton_identity(self) -> None:
+        assert default_registry() is default_registry()

--- a/tests/unit/test_archive_download_policy.py
+++ b/tests/unit/test_archive_download_policy.py
@@ -75,9 +75,7 @@ def _dl(
 class TestSkipModePolicy:
     """``skip`` mode short-circuits before the network call."""
 
-    def test_skip_returns_missing_by_policy_and_no_fetch(
-        self, tmp_path: Path
-    ) -> None:
+    def test_skip_returns_missing_by_policy_and_no_fetch(self, tmp_path: Path) -> None:
         registry = build_registry(
             skip={"blocked.example": "permanent skip"},
             include_defaults=False,
@@ -274,15 +272,11 @@ class TestDefaultRegistryRegression:
     ) -> None:
         with patch("influx.storage.guarded_fetch") as mock_fetch:
             mock_fetch.return_value = _make_fetch_result(status_code=403)
-            result = _dl(
-                tmp_path, "https://www.alignmentforum.org/posts/xyz"
-            )
+            result = _dl(tmp_path, "https://www.alignmentforum.org/posts/xyz")
         assert result.failure_kind == "blocked"
         assert result.policy_mode == "blocked"
 
-    def test_arxiv_pdf_does_not_match_default_blocked(
-        self, tmp_path: Path
-    ) -> None:
+    def test_arxiv_pdf_does_not_match_default_blocked(self, tmp_path: Path) -> None:
         # Regression: an unrelated domain (arxiv.org) must keep the
         # ``attempt`` no-op policy even when the staging defaults are
         # active.

--- a/tests/unit/test_archive_policy.py
+++ b/tests/unit/test_archive_policy.py
@@ -67,9 +67,7 @@ class TestRegistryDefaults:
     def test_subdomain_inherits_parent_policy(self) -> None:
         # ``preview.science.org`` is not registered explicitly but
         # should inherit the parent suffix's policy.
-        policy = default_registry().policy_for(
-            "https://preview.science.org/draft/abc"
-        )
+        policy = default_registry().policy_for("https://preview.science.org/draft/abc")
         assert policy.mode == "blocked"
 
     def test_unrelated_domain_uses_default_attempt(self) -> None:
@@ -282,9 +280,7 @@ class TestRegistryFromConfig:
         registry = registry_from_config(cfg)
         # Without operator overrides and without defaults the registry
         # is empty — every URL falls through to ``attempt``.
-        assert (
-            registry.policy_for("https://www.science.org/x").mode == "attempt"
-        )
+        assert registry.policy_for("https://www.science.org/x").mode == "attempt"
         assert registry.domains() == ()
 
 

--- a/tests/unit/test_archive_policy.py
+++ b/tests/unit/test_archive_policy.py
@@ -1,0 +1,330 @@
+"""Tests for the domain-aware archive acquisition policy (issue #149).
+
+Covers:
+
+* :class:`ArchivePolicyRegistry` longest-suffix matching and default
+  fall-through.
+* :func:`classify_failure_kind` mapping of free-form ``ArchiveResult.error``
+  strings onto the stable :data:`ArchiveFailureKind` taxonomy.
+* :func:`tag_for_failure_kind` mapping into the three public note tags.
+* :func:`registry_from_config` round-trips :class:`ArchivePolicyConfig`
+  into a registry that the production source adapters can use.
+
+These tests intentionally live alongside the storage / arxiv / rss
+integration tests so the policy model can evolve without coupling to
+the call-site adapters.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from influx.archive_policy import (
+    ARCHIVE_BLOCKED_TAG,
+    ARCHIVE_RATE_LIMITED_TAG,
+    ARCHIVE_SKIPPED_BY_POLICY_TAG,
+    ArchivePolicy,
+    ArchivePolicyRegistry,
+    build_registry,
+    classify_failure_kind,
+    default_registry,
+    extract_domain,
+    registry_from_config,
+    tag_for_failure_kind,
+)
+from influx.config import ArchivePolicyConfig
+
+
+class TestExtractDomain:
+    """``extract_domain`` returns a lowercased hostname or ``""``."""
+
+    @pytest.mark.parametrize(
+        "url, expected",
+        [
+            ("https://www.science.org/journal/abc", "www.science.org"),
+            ("HTTP://Example.COM/path", "example.com"),
+            ("https://arxiv.org/pdf/2601.12345.pdf", "arxiv.org"),
+            # Path-only / malformed → empty string, not exception.
+            ("not-a-url", ""),
+            ("", ""),
+            # IP-literal hosts pass through verbatim.
+            ("https://192.0.2.1:8443/x", "192.0.2.1"),
+        ],
+    )
+    def test_extracts_host(self, url: str, expected: str) -> None:
+        assert extract_domain(url) == expected
+
+
+class TestRegistryDefaults:
+    """The module-level default registry covers the staging hot offenders."""
+
+    def test_science_org_is_blocked(self) -> None:
+        policy = default_registry().policy_for("https://www.science.org/article/123")
+        assert policy.mode == "blocked"
+        assert policy.should_attempt is True
+        assert policy.note
+
+    def test_subdomain_inherits_parent_policy(self) -> None:
+        # ``preview.science.org`` is not registered explicitly but
+        # should inherit the parent suffix's policy.
+        policy = default_registry().policy_for(
+            "https://preview.science.org/draft/abc"
+        )
+        assert policy.mode == "blocked"
+
+    def test_unrelated_domain_uses_default_attempt(self) -> None:
+        policy = default_registry().policy_for("https://arxiv.org/pdf/2601.12345.pdf")
+        assert policy.mode == "attempt"
+        assert policy.should_attempt is True
+
+    def test_alignmentforum_is_blocked(self) -> None:
+        policy = default_registry().policy_for("https://www.alignmentforum.org/posts/x")
+        assert policy.mode == "blocked"
+
+
+class TestRegistryMatching:
+    """Suffix matching is longest-first and case-insensitive."""
+
+    def test_more_specific_suffix_wins(self) -> None:
+        registry = build_registry(
+            blocked={"example.com": "broad"},
+            skip={"api.example.com": "more specific"},
+            include_defaults=False,
+        )
+        # The skip-mode entry is more specific and wins.
+        assert registry.policy_for("https://api.example.com/x").mode == "skip"
+        # The broader entry still applies to other subdomains.
+        assert registry.policy_for("https://www.example.com/y").mode == "blocked"
+
+    def test_hostname_case_is_normalised(self) -> None:
+        registry = build_registry(
+            blocked={"Example.COM": "case-insensitive"},
+            include_defaults=False,
+        )
+        assert registry.policy_for("https://example.com/x").mode == "blocked"
+        assert registry.policy_for("https://EXAMPLE.com/x").mode == "blocked"
+
+    def test_leading_dot_is_stripped(self) -> None:
+        registry = build_registry(
+            blocked={".example.com": "leading-dot tolerated"},
+            include_defaults=False,
+        )
+        assert registry.policy_for("https://example.com/x").mode == "blocked"
+        assert registry.policy_for("https://www.example.com/x").mode == "blocked"
+
+    def test_unmatched_url_returns_attempt(self) -> None:
+        registry = build_registry(
+            blocked={"example.com": "blocked"},
+            include_defaults=False,
+        )
+        assert registry.policy_for("https://other.test/x").mode == "attempt"
+
+    def test_empty_url_returns_attempt(self) -> None:
+        assert default_registry().policy_for("").mode == "attempt"
+
+
+class TestArchivePolicyShouldAttempt:
+    """``should_attempt`` short-circuits for the skip mode only."""
+
+    @pytest.mark.parametrize(
+        "mode, should_attempt",
+        [
+            ("attempt", True),
+            ("rate_limited", True),
+            ("blocked", True),
+            ("skip", False),
+        ],
+    )
+    def test_should_attempt(self, mode: str, should_attempt: bool) -> None:
+        # ``mode`` is constrained by the Literal type but the test
+        # exercises the runtime contract.
+        policy = ArchivePolicy(mode=mode)  # type: ignore[arg-type]
+        assert policy.should_attempt is should_attempt
+
+
+class TestClassifyFailureKind:
+    """Free-form error strings map onto stable failure-kind labels."""
+
+    @pytest.mark.parametrize(
+        "error, expected",
+        [
+            ("HTTP 403 for https://example.com/x", "http_403"),
+            ("HTTP 429 for https://example.com/x", "http_429"),
+            ("HTTP 404 for https://example.com/x", "http_404"),
+            ("HTTP 451 for https://example.com/x", "http_4xx"),
+            ("HTTP 503 for https://example.com/x", "http_5xx"),
+            ("HTTP 600 for https://example.com/x", "network"),
+            ("oversize: Response body exceeds 1000 bytes", "oversize"),
+            ("timeout: Request timed out", "timeout"),
+            ("ssrf: SSRF guard: localhost", "ssrf"),
+            ("dns: DNS resolution failed", "dns"),
+            (
+                "content_type_mismatch: Content-type 'text/html' does not match",
+                "content_type_mismatch",
+            ),
+            ("write: Permission denied", "write"),
+            ("", "unknown"),
+            ("totally-unrecognised-shape", "unknown"),
+        ],
+    )
+    def test_attempt_mode_classification(self, error: str, expected: str) -> None:
+        assert classify_failure_kind(error=error, policy_mode="attempt") == expected
+
+    def test_blocked_policy_reclassifies_403(self) -> None:
+        # Under a ``blocked`` policy, HTTP 403 collapses into the
+        # public ``blocked`` kind so the tag mapping produces
+        # ``influx:archive-blocked`` rather than the generic shape.
+        assert (
+            classify_failure_kind(
+                error="HTTP 403 for https://example.com/x",
+                policy_mode="blocked",
+            )
+            == "blocked"
+        )
+
+    def test_rate_limited_policy_reclassifies_429(self) -> None:
+        assert (
+            classify_failure_kind(
+                error="HTTP 429 for https://example.com/x",
+                policy_mode="rate_limited",
+            )
+            == "rate_limited"
+        )
+
+    def test_blocked_policy_does_not_swallow_other_codes(self) -> None:
+        # A ``blocked`` policy that hits 503 / timeout should NOT
+        # collapse to ``blocked`` — only 403 is the policy-driven
+        # blocked signal.
+        assert (
+            classify_failure_kind(
+                error="HTTP 503 for https://example.com/x",
+                policy_mode="blocked",
+            )
+            == "http_5xx"
+        )
+        assert (
+            classify_failure_kind(
+                error="timeout: Request timed out",
+                policy_mode="blocked",
+            )
+            == "timeout"
+        )
+
+
+class TestTagForFailureKind:
+    """Mapping from failure kind onto the three public note tags."""
+
+    @pytest.mark.parametrize(
+        "kind, expected_tag",
+        [
+            ("blocked", ARCHIVE_BLOCKED_TAG),
+            ("rate_limited", ARCHIVE_RATE_LIMITED_TAG),
+            ("missing_by_policy", ARCHIVE_SKIPPED_BY_POLICY_TAG),
+        ],
+    )
+    def test_policy_kinds_map_to_dedicated_tags(
+        self, kind: str, expected_tag: str
+    ) -> None:
+        # ``kind`` is constrained by the Literal type but the test
+        # exercises the runtime contract.
+        assert tag_for_failure_kind(kind) == expected_tag  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "kind",
+        [
+            "http_403",
+            "http_429",
+            "http_404",
+            "http_4xx",
+            "http_5xx",
+            "oversize",
+            "timeout",
+            "ssrf",
+            "dns",
+            "network",
+            "content_type_mismatch",
+            "write",
+            "unknown",
+        ],
+    )
+    def test_generic_kinds_have_no_dedicated_tag(self, kind: str) -> None:
+        # Generic failures keep the ``influx:archive-missing`` shape.
+        assert tag_for_failure_kind(kind) is None  # type: ignore[arg-type]
+
+
+class TestRegistryFromConfig:
+    """``ArchivePolicyConfig`` round-trips into a registry."""
+
+    def test_operator_blocked_entry_wins_over_default(self) -> None:
+        # Override ``arxiv.org`` (which is NOT in the staging defaults
+        # but stands in for an operator wanting to add a new domain).
+        cfg = ArchivePolicyConfig(
+            blocked={"arxiv.org": "operator-policy"},
+            include_defaults=True,
+        )
+        registry = registry_from_config(cfg)
+        assert registry.policy_for("https://arxiv.org/pdf/2601.12345").mode == "blocked"
+
+    def test_operator_skip_supersedes_default_blocked(self) -> None:
+        # Promote the default ``science.org`` blocked policy to ``skip``
+        # via an operator-supplied override.
+        cfg = ArchivePolicyConfig(
+            skip={"science.org": "skip outright"},
+            include_defaults=True,
+        )
+        registry = registry_from_config(cfg)
+        policy = registry.policy_for("https://www.science.org/x")
+        assert policy.mode == "skip"
+        assert policy.should_attempt is False
+
+    def test_include_defaults_false_starts_empty(self) -> None:
+        cfg = ArchivePolicyConfig(include_defaults=False)
+        registry = registry_from_config(cfg)
+        # Without operator overrides and without defaults the registry
+        # is empty — every URL falls through to ``attempt``.
+        assert (
+            registry.policy_for("https://www.science.org/x").mode == "attempt"
+        )
+        assert registry.domains() == ()
+
+
+class TestRegistryDomainsListing:
+    """``ArchivePolicyRegistry.domains`` exposes the registered suffix set."""
+
+    def test_defaults_listed(self) -> None:
+        domains = default_registry().domains()
+        assert "science.org" in domains
+        assert "alignmentforum.org" in domains
+
+    def test_no_duplicates_after_merge(self) -> None:
+        # If an operator override re-declares a default suffix the
+        # registry should still contain that suffix exactly once.
+        cfg = ArchivePolicyConfig(
+            blocked={"science.org": "operator note"},
+            include_defaults=True,
+        )
+        registry = registry_from_config(cfg)
+        domains = registry.domains()
+        assert domains.count("science.org") == 1
+
+
+class TestArchivePolicyRegistryFromTuples:
+    """The ``_entries`` constructor honours longest-first ordering."""
+
+    def test_direct_construction_matches_longest_first(self) -> None:
+        # Equivalent of build_registry() but bypassing the helper so
+        # the dataclass's invariant is verified directly.
+        broad = ArchivePolicy(mode="blocked", note="broad")
+        specific = ArchivePolicy(mode="skip", note="specific")
+        entries = (
+            ("api.example.com", specific),
+            ("example.com", broad),
+        )
+        # The constructor itself does not sort — ``build_registry``
+        # is responsible for that.  Ordering matters here because the
+        # registry walks entries in order and short-circuits on first
+        # match.  This is a regression test for the helper's ordering
+        # contract: pass entries longest-first and the specific entry
+        # wins.
+        registry = ArchivePolicyRegistry(_entries=entries)
+        assert registry.policy_for("https://api.example.com/x").mode == "skip"

--- a/tests/unit/test_archive_policy_source_tags.py
+++ b/tests/unit/test_archive_policy_source_tags.py
@@ -1,0 +1,430 @@
+"""Tests for archive-policy tag emission in source adapters (issue #149).
+
+Verifies the cross-product behaviour:
+
+* ``build_rss_note_item`` and ``build_arxiv_note_item`` consult the
+  per-domain :class:`~influx.archive_policy.ArchivePolicy` (built from
+  :class:`~influx.config.ArchivePolicyConfig` on the loaded config).
+* When the policy short-circuits (``skip``) or reclassifies the failure
+  (``blocked`` / ``rate_limited``), the resulting note carries the
+  policy-driven tag (``influx:archive-blocked`` /
+  ``influx:archive-rate-limited`` / ``influx:archive-skipped-by-policy``).
+* ``blocked`` and ``missing_by_policy`` notes also carry
+  ``influx:archive-terminal`` so the repair sweep does not tight-loop on
+  a doomed path (this is the staging-log behaviour the issue fixes).
+* A generic non-policy failure (404, oversize, …) keeps the existing
+  ``influx:archive-missing`` shape with NO policy tag — guaranteeing
+  zero behaviour change for the common case.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+
+from influx.config import (
+    AppConfig,
+    ArchivePolicyConfig,
+    ExtractionConfig,
+    LithosConfig,
+    ProfileConfig,
+    ProfileThresholds,
+    PromptEntryConfig,
+    PromptsConfig,
+    RssSourceEntry,
+    ScheduleConfig,
+    SecurityConfig,
+    StorageConfig,
+)
+from influx.sources.arxiv import ArxivItem, build_arxiv_note_item
+from influx.sources.rss import RssFeedItem, build_rss_note_item
+from influx.storage import ArchiveResult
+
+
+def _profile() -> ProfileConfig:
+    return ProfileConfig(
+        name="ai-robotics",
+        description="AI and robotics research",
+        thresholds=ProfileThresholds(
+            relevance=7, full_text=100, deep_extract=100
+        ),
+    )
+
+
+def _make_config(
+    *,
+    blocked: dict[str, str] | None = None,
+    rate_limited: dict[str, str] | None = None,
+    skip: dict[str, str] | None = None,
+    include_defaults: bool = False,
+    archive_dir: str = "/archive",
+) -> AppConfig:
+    return AppConfig(
+        lithos=LithosConfig(url="http://localhost:0/sse"),
+        schedule=ScheduleConfig(),
+        storage=StorageConfig(
+            archive_dir=archive_dir,
+            archive_policy=ArchivePolicyConfig(
+                blocked=blocked or {},
+                rate_limited=rate_limited or {},
+                skip=skip or {},
+                include_defaults=include_defaults,
+            ),
+        ),
+        profiles=[_profile()],
+        providers={},
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="x"),
+            tier1_enrich=PromptEntryConfig(text="x"),
+            tier3_extract=PromptEntryConfig(text="x"),
+        ),
+        security=SecurityConfig(allow_private_ips=True),
+        extraction=ExtractionConfig(),
+    )
+
+
+# ── RSS adapter × policy ──────────────────────────────────────────────
+
+
+def _make_rss_item(url: str = "https://example.com/article") -> RssFeedItem:
+    return RssFeedItem(
+        title="Test Article",
+        url=url,
+        published=datetime(2026, 4, 25, tzinfo=UTC),
+        summary="A summary of the article.",
+        source_tag="rss",
+        feed_name="example-feed",
+    )
+
+
+class TestRssArchivePolicyTags:
+    """``build_rss_note_item`` applies the policy tag for known domains."""
+
+    @patch("influx.sources.rss.download_archive")
+    def test_skip_policy_emits_skipped_by_policy_tag(
+        self, mock_dl: object
+    ) -> None:
+        # The skip-mode policy short-circuits ``download_archive`` so
+        # the mock must return the same shape the real function would.
+        mock_dl.return_value = ArchiveResult(  # type: ignore[union-attr]
+            ok=False,
+            rel_posix_path=None,
+            error="missing_by_policy: skip outright",
+            failure_kind="missing_by_policy",
+            policy_mode="skip",
+            domain="blocked.example",
+        )
+        config = _make_config(skip={"blocked.example": "skip outright"})
+        item = _make_rss_item(url="https://blocked.example/article")
+
+        result = build_rss_note_item(item=item, profile_name="ai-robotics", config=config)
+
+        tags = cast(list[str], result["tags"])
+        assert "influx:archive-skipped-by-policy" in tags
+        assert "influx:archive-missing" in tags
+        # Blocked / skip flip the note terminal so the repair sweep
+        # does NOT tight-loop on the doomed path.
+        assert "influx:archive-terminal" in tags
+
+    @patch("influx.sources.rss.download_archive")
+    def test_blocked_policy_emits_blocked_tag(self, mock_dl: object) -> None:
+        mock_dl.return_value = ArchiveResult(  # type: ignore[union-attr]
+            ok=False,
+            rel_posix_path=None,
+            error="HTTP 403 for https://science.example/x",
+            failure_kind="blocked",
+            policy_mode="blocked",
+            domain="science.example",
+        )
+        config = _make_config(blocked={"science.example": ""})
+        item = _make_rss_item(url="https://science.example/article")
+
+        result = build_rss_note_item(item=item, profile_name="ai-robotics", config=config)
+
+        tags = cast(list[str], result["tags"])
+        assert "influx:archive-blocked" in tags
+        assert "influx:archive-missing" in tags
+        assert "influx:archive-terminal" in tags
+
+    @patch("influx.sources.rss.download_archive")
+    def test_rate_limited_policy_emits_rate_limited_tag(
+        self, mock_dl: object
+    ) -> None:
+        mock_dl.return_value = ArchiveResult(  # type: ignore[union-attr]
+            ok=False,
+            rel_posix_path=None,
+            error="HTTP 429 for https://slow.example/x",
+            failure_kind="rate_limited",
+            policy_mode="rate_limited",
+            domain="slow.example",
+        )
+        config = _make_config(rate_limited={"slow.example": ""})
+        item = _make_rss_item(url="https://slow.example/article")
+
+        result = build_rss_note_item(item=item, profile_name="ai-robotics", config=config)
+
+        tags = cast(list[str], result["tags"])
+        assert "influx:archive-rate-limited" in tags
+        assert "influx:archive-missing" in tags
+        # Rate-limited retries on cool-down — must NOT be flipped terminal.
+        assert "influx:archive-terminal" not in tags
+
+    @patch("influx.sources.rss.download_archive")
+    def test_generic_failure_keeps_archive_missing_only(
+        self, mock_dl: object
+    ) -> None:
+        mock_dl.return_value = ArchiveResult(  # type: ignore[union-attr]
+            ok=False,
+            rel_posix_path=None,
+            error="HTTP 404 for https://example.com/x",
+            failure_kind="http_404",
+            policy_mode="attempt",
+            domain="example.com",
+        )
+        config = _make_config()
+        item = _make_rss_item(url="https://example.com/article")
+
+        result = build_rss_note_item(item=item, profile_name="ai-robotics", config=config)
+
+        tags = cast(list[str], result["tags"])
+        assert "influx:archive-missing" in tags
+        # No policy-driven tag.
+        assert "influx:archive-blocked" not in tags
+        assert "influx:archive-rate-limited" not in tags
+        assert "influx:archive-skipped-by-policy" not in tags
+        # Not flipped terminal.
+        assert "influx:archive-terminal" not in tags
+
+    @patch("influx.sources.rss.download_archive")
+    def test_successful_archive_emits_no_policy_tag(
+        self, mock_dl: object
+    ) -> None:
+        mock_dl.return_value = ArchiveResult(  # type: ignore[union-attr]
+            ok=True,
+            rel_posix_path="rss/2026/04/example-feed-2026-04-25-abc.html",
+            error="",
+            failure_kind="",
+            policy_mode="attempt",
+            domain="example.com",
+        )
+        config = _make_config()
+        item = _make_rss_item(url="https://example.com/article")
+
+        result = build_rss_note_item(item=item, profile_name="ai-robotics", config=config)
+
+        tags = cast(list[str], result["tags"])
+        assert "influx:archive-missing" not in tags
+        assert "influx:archive-blocked" not in tags
+        assert "influx:archive-rate-limited" not in tags
+        assert "influx:archive-skipped-by-policy" not in tags
+
+
+# ── arXiv adapter × policy ────────────────────────────────────────────
+
+
+def _make_arxiv_item() -> ArxivItem:
+    return ArxivItem(
+        arxiv_id="2601.12345",
+        title="Test Paper",
+        abstract="An abstract.",
+        published=datetime(2026, 4, 25, tzinfo=UTC),
+        categories=["cs.AI"],
+    )
+
+
+class TestArxivArchivePolicyTags:
+    """``build_arxiv_note_item`` applies the policy tag when set.
+
+    arXiv itself is not in the staging-defaults blocked list, so these
+    tests use operator-supplied overrides to exercise the policy
+    integration end-to-end without relying on a particular default.
+    """
+
+    @patch("influx.sources.arxiv.download_archive")
+    def test_blocked_policy_for_arxiv_marks_terminal(
+        self, mock_dl: object
+    ) -> None:
+        # Hypothetical operator override: pretend arxiv.org is blocked
+        # in this profile.  Exercises that the arxiv adapter honours
+        # the policy registry instead of treating every 403 as generic.
+        mock_dl.return_value = ArchiveResult(  # type: ignore[union-attr]
+            ok=False,
+            rel_posix_path=None,
+            error="HTTP 403 for https://arxiv.org/pdf/2601.12345.pdf",
+            failure_kind="blocked",
+            policy_mode="blocked",
+            domain="arxiv.org",
+        )
+        config = _make_config(blocked={"arxiv.org": "operator override"})
+
+        result = build_arxiv_note_item(
+            item=_make_arxiv_item(),
+            score=7,
+            confidence=0.7,
+            reason="R",
+            profile_name="ai-robotics",
+            config=config,
+        )
+
+        tags = cast(list[str], result["tags"])
+        assert "influx:archive-blocked" in tags
+        assert "influx:archive-missing" in tags
+        assert "influx:archive-terminal" in tags
+
+    @patch("influx.sources.arxiv.download_archive")
+    def test_rate_limited_policy_for_arxiv_does_not_terminalise(
+        self, mock_dl: object
+    ) -> None:
+        mock_dl.return_value = ArchiveResult(  # type: ignore[union-attr]
+            ok=False,
+            rel_posix_path=None,
+            error="HTTP 429 for https://arxiv.org/pdf/2601.12345.pdf",
+            failure_kind="rate_limited",
+            policy_mode="rate_limited",
+            domain="arxiv.org",
+        )
+        config = _make_config(rate_limited={"arxiv.org": "operator override"})
+
+        result = build_arxiv_note_item(
+            item=_make_arxiv_item(),
+            score=7,
+            confidence=0.7,
+            reason="R",
+            profile_name="ai-robotics",
+            config=config,
+        )
+
+        tags = cast(list[str], result["tags"])
+        assert "influx:archive-rate-limited" in tags
+        assert "influx:archive-missing" in tags
+        # Must NOT be flipped terminal — rate-limited retries on cool-down.
+        assert "influx:archive-terminal" not in tags
+
+    @patch("influx.sources.arxiv.download_archive")
+    def test_generic_404_unchanged_arxiv_shape(self, mock_dl: object) -> None:
+        # Regression: with policy enabled but for unrelated domains,
+        # an arxiv 404 keeps its existing shape.
+        mock_dl.return_value = ArchiveResult(  # type: ignore[union-attr]
+            ok=False,
+            rel_posix_path=None,
+            error="HTTP 404 for https://arxiv.org/pdf/2601.12345.pdf",
+            failure_kind="http_404",
+            policy_mode="attempt",
+            domain="arxiv.org",
+        )
+        config = _make_config(blocked={"science.example": ""})
+
+        result = build_arxiv_note_item(
+            item=_make_arxiv_item(),
+            score=7,
+            confidence=0.7,
+            reason="R",
+            profile_name="ai-robotics",
+            config=config,
+        )
+
+        tags = cast(list[str], result["tags"])
+        assert "influx:archive-missing" in tags
+        assert "influx:archive-blocked" not in tags
+        assert "influx:archive-rate-limited" not in tags
+        assert "influx:archive-skipped-by-policy" not in tags
+        assert "influx:archive-terminal" not in tags
+
+    @patch("influx.sources.arxiv.download_archive")
+    def test_arxiv_calls_through_with_policy_registry(
+        self, mock_dl: object
+    ) -> None:
+        """Smoke: ``download_archive`` receives a ``policy_registry``
+        argument so the call site honours operator overrides.
+        """
+        mock_dl.return_value = ArchiveResult(  # type: ignore[union-attr]
+            ok=True,
+            rel_posix_path="arxiv/2026/04/2601.12345.pdf",
+            error="",
+            policy_mode="attempt",
+            domain="arxiv.org",
+        )
+        config = _make_config()
+
+        build_arxiv_note_item(
+            item=_make_arxiv_item(),
+            score=7,
+            confidence=0.7,
+            reason="R",
+            profile_name="ai-robotics",
+            config=config,
+        )
+
+        call = mock_dl.call_args  # type: ignore[attr-defined]
+        assert "policy_registry" in call.kwargs
+        # Registry constructed from the empty config — has no
+        # operator overrides and ``include_defaults=False`` per
+        # ``_make_config`` so the registry is empty (and arxiv.org
+        # falls through to attempt).
+        assert call.kwargs["policy_registry"].domains() == ()
+
+
+# ── Suffix entry: parametrised cross-product over policy modes ─────────
+
+
+@pytest.mark.parametrize(
+    "policy_mode, failure_kind, expected_tag, terminalises",
+    [
+        ("blocked", "blocked", "influx:archive-blocked", True),
+        ("rate_limited", "rate_limited", "influx:archive-rate-limited", False),
+        (
+            "skip",
+            "missing_by_policy",
+            "influx:archive-skipped-by-policy",
+            True,
+        ),
+    ],
+)
+class TestPolicyModeTagCrossProduct:
+    """Cross-product matrix: policy mode × tag emission × terminal flag.
+
+    Mirrors the AC list in #149:
+
+    * Known-blocked domains classify as ``archive_blocked`` instead of
+      generic failures.
+    * Known rate-limited domains use bounded retry distinct from
+      hard-blocked.
+    * Run diagnostics distinguish at least: blocked, rate-limited,
+      missing-by-policy, and generic archive failure.
+    """
+
+    @patch("influx.sources.rss.download_archive")
+    def test_rss_emits_expected_tag(
+        self,
+        mock_dl: object,
+        policy_mode: str,
+        failure_kind: str,
+        expected_tag: str,
+        terminalises: bool,
+    ) -> None:
+        mock_dl.return_value = ArchiveResult(  # type: ignore[union-attr]
+            ok=False,
+            rel_posix_path=None,
+            error=f"{failure_kind}: synthetic",
+            failure_kind=failure_kind,
+            policy_mode=policy_mode,
+            domain="example.com",
+        )
+        config = _make_config()
+
+        result = build_rss_note_item(
+            item=_make_rss_item(url="https://example.com/x"),
+            profile_name="ai-robotics",
+            config=config,
+        )
+        tags = cast(list[str], result["tags"])
+
+        assert expected_tag in tags
+        assert "influx:archive-missing" in tags
+        if terminalises:
+            assert "influx:archive-terminal" in tags
+        else:
+            assert "influx:archive-terminal" not in tags

--- a/tests/unit/test_archive_policy_source_tags.py
+++ b/tests/unit/test_archive_policy_source_tags.py
@@ -34,7 +34,6 @@ from influx.config import (
     ProfileThresholds,
     PromptEntryConfig,
     PromptsConfig,
-    RssSourceEntry,
     ScheduleConfig,
     SecurityConfig,
     StorageConfig,
@@ -48,9 +47,7 @@ def _profile() -> ProfileConfig:
     return ProfileConfig(
         name="ai-robotics",
         description="AI and robotics research",
-        thresholds=ProfileThresholds(
-            relevance=7, full_text=100, deep_extract=100
-        ),
+        thresholds=ProfileThresholds(relevance=7, full_text=100, deep_extract=100),
     )
 
 
@@ -104,9 +101,7 @@ class TestRssArchivePolicyTags:
     """``build_rss_note_item`` applies the policy tag for known domains."""
 
     @patch("influx.sources.rss.download_archive")
-    def test_skip_policy_emits_skipped_by_policy_tag(
-        self, mock_dl: object
-    ) -> None:
+    def test_skip_policy_emits_skipped_by_policy_tag(self, mock_dl: object) -> None:
         # The skip-mode policy short-circuits ``download_archive`` so
         # the mock must return the same shape the real function would.
         mock_dl.return_value = ArchiveResult(  # type: ignore[union-attr]
@@ -120,7 +115,9 @@ class TestRssArchivePolicyTags:
         config = _make_config(skip={"blocked.example": "skip outright"})
         item = _make_rss_item(url="https://blocked.example/article")
 
-        result = build_rss_note_item(item=item, profile_name="ai-robotics", config=config)
+        result = build_rss_note_item(
+            item=item, profile_name="ai-robotics", config=config
+        )
 
         tags = cast(list[str], result["tags"])
         assert "influx:archive-skipped-by-policy" in tags
@@ -142,7 +139,9 @@ class TestRssArchivePolicyTags:
         config = _make_config(blocked={"science.example": ""})
         item = _make_rss_item(url="https://science.example/article")
 
-        result = build_rss_note_item(item=item, profile_name="ai-robotics", config=config)
+        result = build_rss_note_item(
+            item=item, profile_name="ai-robotics", config=config
+        )
 
         tags = cast(list[str], result["tags"])
         assert "influx:archive-blocked" in tags
@@ -150,9 +149,7 @@ class TestRssArchivePolicyTags:
         assert "influx:archive-terminal" in tags
 
     @patch("influx.sources.rss.download_archive")
-    def test_rate_limited_policy_emits_rate_limited_tag(
-        self, mock_dl: object
-    ) -> None:
+    def test_rate_limited_policy_emits_rate_limited_tag(self, mock_dl: object) -> None:
         mock_dl.return_value = ArchiveResult(  # type: ignore[union-attr]
             ok=False,
             rel_posix_path=None,
@@ -164,7 +161,9 @@ class TestRssArchivePolicyTags:
         config = _make_config(rate_limited={"slow.example": ""})
         item = _make_rss_item(url="https://slow.example/article")
 
-        result = build_rss_note_item(item=item, profile_name="ai-robotics", config=config)
+        result = build_rss_note_item(
+            item=item, profile_name="ai-robotics", config=config
+        )
 
         tags = cast(list[str], result["tags"])
         assert "influx:archive-rate-limited" in tags
@@ -173,9 +172,7 @@ class TestRssArchivePolicyTags:
         assert "influx:archive-terminal" not in tags
 
     @patch("influx.sources.rss.download_archive")
-    def test_generic_failure_keeps_archive_missing_only(
-        self, mock_dl: object
-    ) -> None:
+    def test_generic_failure_keeps_archive_missing_only(self, mock_dl: object) -> None:
         mock_dl.return_value = ArchiveResult(  # type: ignore[union-attr]
             ok=False,
             rel_posix_path=None,
@@ -187,7 +184,9 @@ class TestRssArchivePolicyTags:
         config = _make_config()
         item = _make_rss_item(url="https://example.com/article")
 
-        result = build_rss_note_item(item=item, profile_name="ai-robotics", config=config)
+        result = build_rss_note_item(
+            item=item, profile_name="ai-robotics", config=config
+        )
 
         tags = cast(list[str], result["tags"])
         assert "influx:archive-missing" in tags
@@ -199,9 +198,7 @@ class TestRssArchivePolicyTags:
         assert "influx:archive-terminal" not in tags
 
     @patch("influx.sources.rss.download_archive")
-    def test_successful_archive_emits_no_policy_tag(
-        self, mock_dl: object
-    ) -> None:
+    def test_successful_archive_emits_no_policy_tag(self, mock_dl: object) -> None:
         mock_dl.return_value = ArchiveResult(  # type: ignore[union-attr]
             ok=True,
             rel_posix_path="rss/2026/04/example-feed-2026-04-25-abc.html",
@@ -213,7 +210,9 @@ class TestRssArchivePolicyTags:
         config = _make_config()
         item = _make_rss_item(url="https://example.com/article")
 
-        result = build_rss_note_item(item=item, profile_name="ai-robotics", config=config)
+        result = build_rss_note_item(
+            item=item, profile_name="ai-robotics", config=config
+        )
 
         tags = cast(list[str], result["tags"])
         assert "influx:archive-missing" not in tags
@@ -244,9 +243,7 @@ class TestArxivArchivePolicyTags:
     """
 
     @patch("influx.sources.arxiv.download_archive")
-    def test_blocked_policy_for_arxiv_marks_terminal(
-        self, mock_dl: object
-    ) -> None:
+    def test_blocked_policy_for_arxiv_marks_terminal(self, mock_dl: object) -> None:
         # Hypothetical operator override: pretend arxiv.org is blocked
         # in this profile.  Exercises that the arxiv adapter honours
         # the policy registry instead of treating every 403 as generic.
@@ -334,9 +331,7 @@ class TestArxivArchivePolicyTags:
         assert "influx:archive-terminal" not in tags
 
     @patch("influx.sources.arxiv.download_archive")
-    def test_arxiv_calls_through_with_policy_registry(
-        self, mock_dl: object
-    ) -> None:
+    def test_arxiv_calls_through_with_policy_registry(self, mock_dl: object) -> None:
         """Smoke: ``download_archive`` receives a ``policy_registry``
         argument so the call site honours operator overrides.
         """

--- a/tests/unit/test_repair_hooks_production.py
+++ b/tests/unit/test_repair_hooks_production.py
@@ -14,7 +14,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from influx.config import AppConfig, ExtractionConfig, StorageConfig
+from influx.config import (
+    AppConfig,
+    ArchivePolicyConfig,
+    ExtractionConfig,
+    StorageConfig,
+)
 from influx.errors import ExtractionError, LCMAError
 from influx.repair import (
     ExtractionOutcome,
@@ -40,6 +45,7 @@ def _make_config(
     *,
     min_html_chars: int = 1000,
     min_web_chars: int = 500,
+    archive_policy: ArchivePolicyConfig | None = None,
 ) -> MagicMock:
     """Build a minimal AppConfig mock with storage and extraction settings."""
     config = MagicMock(spec=AppConfig)
@@ -47,6 +53,9 @@ def _make_config(
     config.storage.archive_dir = str(tmp_path / "archive")
     config.storage.max_download_bytes = 10_000_000
     config.storage.download_timeout_seconds = 30
+    # Issue #149 follow-up: repair archive hook now builds a policy
+    # registry from this attr, so it must be present on the mock.
+    config.storage.archive_policy = archive_policy or ArchivePolicyConfig()
     config.security = MagicMock()
     config.security.allow_private_ips = False
     config.extraction = MagicMock(spec=ExtractionConfig)
@@ -1216,3 +1225,165 @@ class TestTextExtractionHookRssMetadataRecovery:
             hooks.text_extraction(note)
         assert exc_info.value.stage == "resolve"
         assert classify_failure(exc_info.value) == "transient"
+
+
+# ── archive policy registry threading (issue #149 follow-up) ──────────
+#
+# The repair archive download path must honour the same per-domain
+# policy overrides as initial acquisition.  Before this fix the repair
+# hook silently fell back to the module-level ``default_registry`` and
+# ignored operator overrides like ``include_defaults = false`` or
+# custom per-domain entries.  These tests pin the contract: the registry
+# the hook threads into :func:`download_archive` is built from
+# ``config.storage.archive_policy``.
+
+
+class TestArchiveDownloadHookPolicyRegistry:
+    """Operator overrides in config win during repair, not just acquire."""
+
+    def test_threads_registry_built_from_config_archive_policy(
+        self, tmp_path: Path
+    ) -> None:
+        """The hook passes a config-derived registry into ``download_archive``."""
+        from influx.archive_policy import ArchivePolicyRegistry
+        from influx.storage import ArchiveResult
+
+        # Custom override: block a domain that is NOT in the built-in
+        # staging defaults so the assertion can prove the override was
+        # threaded through (and not merely the default registry).
+        policy = ArchivePolicyConfig(
+            blocked={"example-custom.test": "operator override"},
+            include_defaults=True,
+        )
+        config = _make_config(tmp_path, archive_policy=policy)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_archive_missing_note()
+
+        with patch("influx.repair_hooks.download_archive") as mock_dl:
+            mock_dl.return_value = ArchiveResult(
+                ok=True,
+                rel_posix_path="arxiv/2026/04/2604.26946.pdf",
+                error="",
+            )
+            assert hooks.archive_download is not None
+            hooks.archive_download(note)
+
+        registry = mock_dl.call_args.kwargs["policy_registry"]
+        assert isinstance(registry, ArchivePolicyRegistry)
+        # The operator-added domain is present in the threaded registry.
+        assert "example-custom.test" in registry.domains()
+
+    def test_include_defaults_false_drops_builtin_defaults(
+        self, tmp_path: Path
+    ) -> None:
+        """``include_defaults = false`` honoured on the repair path."""
+        from influx.archive_policy import ArchivePolicyRegistry
+        from influx.storage import ArchiveResult
+
+        policy = ArchivePolicyConfig(include_defaults=False)
+        config = _make_config(tmp_path, archive_policy=policy)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_archive_missing_note()
+
+        with patch("influx.repair_hooks.download_archive") as mock_dl:
+            mock_dl.return_value = ArchiveResult(
+                ok=True,
+                rel_posix_path="arxiv/2026/04/2604.26946.pdf",
+                error="",
+            )
+            assert hooks.archive_download is not None
+            hooks.archive_download(note)
+
+        registry = mock_dl.call_args.kwargs["policy_registry"]
+        assert isinstance(registry, ArchivePolicyRegistry)
+        # Built-in staging-defaults are absent; the registry is empty.
+        assert registry.domains() == ()
+
+    def test_custom_blocked_override_shortcircuits_during_repair(
+        self, tmp_path: Path
+    ) -> None:
+        """A custom per-domain blocked entry classifies failures during repair.
+
+        The test uses a real (non-mocked) ``download_archive`` and a
+        custom-blocked arxiv.org override to demonstrate that the
+        operator override flows through to the policy classification
+        path on repair sweeps.  We expect the policy_mode on the
+        :class:`ArchiveResult` to reflect the operator setting.
+        """
+        from influx.storage import ArchiveResult
+
+        policy = ArchivePolicyConfig(
+            blocked={"arxiv.org": "operator-blocked for test"},
+            include_defaults=False,
+        )
+        config = _make_config(tmp_path, archive_policy=policy)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_archive_missing_note()
+
+        captured: dict[str, object] = {}
+
+        def fake_download_archive(
+            *,
+            policy_registry: object = None,
+            **_kwargs: object,
+        ) -> ArchiveResult:
+            # Mimic ``download_archive`` consulting the registry — the
+            # contract under test is purely that the registry it
+            # received reflects the operator override.
+            captured["registry"] = policy_registry
+            return ArchiveResult(
+                ok=False,
+                rel_posix_path=None,
+                error="HTTP 403 for https://arxiv.org/pdf/2604.26946.pdf",
+                failure_kind="blocked",
+                policy_mode="blocked",
+                domain="arxiv.org",
+            )
+
+        with patch(
+            "influx.repair_hooks.download_archive", side_effect=fake_download_archive
+        ):
+            assert hooks.archive_download is not None
+            with pytest.raises(ExtractionError):
+                hooks.archive_download(note)
+
+        registry = captured["registry"]
+        # The registry the hook threaded through resolves arxiv.org to
+        # the operator's blocked policy.
+        from influx.archive_policy import ArchivePolicyRegistry
+
+        assert isinstance(registry, ArchivePolicyRegistry)
+        resolved = registry.policy_for("https://arxiv.org/pdf/2604.26946.pdf")
+        assert resolved.mode == "blocked"
+        assert resolved.note == "operator-blocked for test"
+
+    def test_default_empty_policy_config_falls_back_gracefully(
+        self, tmp_path: Path
+    ) -> None:
+        """A default ``ArchivePolicyConfig`` still produces a real registry.
+
+        With no operator overrides, the registry built carries only the
+        built-in staging defaults — exercising the no-op happy path on
+        the repair sweep.
+        """
+        from influx.archive_policy import ArchivePolicyRegistry
+        from influx.storage import ArchiveResult
+
+        config = _make_config(tmp_path)  # default ArchivePolicyConfig()
+        hooks = make_default_sweep_hooks(config)
+        note = _make_archive_missing_note()
+
+        with patch("influx.repair_hooks.download_archive") as mock_dl:
+            mock_dl.return_value = ArchiveResult(
+                ok=True,
+                rel_posix_path="arxiv/2026/04/2604.26946.pdf",
+                error="",
+            )
+            assert hooks.archive_download is not None
+            hooks.archive_download(note)
+
+        registry = mock_dl.call_args.kwargs["policy_registry"]
+        assert isinstance(registry, ArchivePolicyRegistry)
+        # arxiv.org has no built-in policy entry, so it resolves to the
+        # no-op ``attempt`` policy.
+        assert registry.policy_for("https://arxiv.org/pdf/x.pdf").mode == "attempt"


### PR DESCRIPTION
## Summary
- Introduce `ArchivePolicy` (modes: `attempt` / `rate_limited` / `blocked` / `skip`) and `ArchivePolicyRegistry` with longest host-suffix matching.
- Built-in defaults cover the staging-noise domains (science.org, alignmentforum.org, therobotreport.com, tnmoc.org, lesswrong.com); operators can layer overrides via `[storage.archive_policy.*]` in `influx.toml`.
- `download_archive` short-circuits skip-mode without a network call and emits `ArchiveResult.failure_kind` from a new `ArchiveFailureKind` taxonomy (`blocked`, `rate_limited`, `missing_by_policy`, `http_*`, etc.).
- ArXiv + RSS sources thread the registry through and emit `influx:archive-{blocked,rate-limited,skipped-by-policy}` tags alongside `influx:archive-missing`; blocked/skip notes also flip `influx:archive-terminal`.
- Run summary surfaces per-kind counters; new `archive_policy_failures_total{kind=...}` metric.

## Test plan
- [x] `uv run pytest` — 1989 passed
- [x] 88 new tests across registry suffix matching, failure-kind classification, default-registry regressions (science.org, alignmentforum.org), `download_archive` × policy cross-product (skip / blocked-403 / rate-limited-429 / generic), and arxiv+RSS tag emission
- [x] `docs/SPECIFICATION.md` and `influx.example.toml` updated

Closes #149