### PR TITLE
fix: terminate repair retries on invalid source metadata (#150)

### DIFF
--- a/src/influx/notes.py
+++ b/src/influx/notes.py
@@ -268,6 +268,11 @@ _INFLUX_OWNED_EXACT: frozenset[str] = frozenset(
         # download failures — caps the archive_retry stage in select_stages
         # the same way tier{2,3}-terminal cap their respective stages.
         "influx:archive-terminal",
+        # Set by the repair sweep when a note's source metadata is
+        # unrecoverable (#150) — pins the bad-state notes terminal AND
+        # makes them discoverable via Lithos tag search for operator
+        # cleanup.  Mirrors the influx:text-terminal lifecycle.
+        "influx:source-invalid",
     }
 )
 

--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -1077,6 +1077,38 @@ def _terminate_unsupported_text_source(note: dict[str, Any]) -> list[str]:
     return restored_tags
 
 
+def _terminate_invalid_source_metadata(note: dict[str, Any]) -> list[str]:
+    """Mark a note terminal because its source metadata is unrecoverable (#150).
+
+    Distinct from :func:`_terminate_unsupported_text_source` — that
+    helper covers legitimate future sources without a resolver yet
+    (``source:hackernews``).  This helper covers notes whose source
+    tag is empty/garbled AND whose URL/path/id provide no inference
+    fallback, so the previous behaviour was an infinite loop of
+    ``text_extraction retry: source '' not supported`` warnings every
+    sweep.
+
+    The note is pinned at ``text:abstract-only`` with
+    ``influx:text-terminal`` so the text-extraction stage is skipped,
+    AND tagged with ``influx:source-invalid`` so the bad-state notes
+    are independently discoverable (Lithos tag search) for later
+    operator cleanup.  ``influx:repair-needed`` is dropped when no
+    other repair condition remains pending, mirroring the unsupported-
+    source path so the note exits the sweep entirely.
+    """
+    restored_tags = list(note.get("tags", []))
+    if not any(tag.startswith("text:") for tag in restored_tags):
+        restored_tags.append("text:abstract-only")
+    if "influx:text-terminal" not in restored_tags:
+        restored_tags.append("influx:text-terminal")
+    if "influx:source-invalid" not in restored_tags:
+        restored_tags.append("influx:source-invalid")
+    if "influx:archive-missing" not in restored_tags:
+        restored_tags = [tag for tag in restored_tags if tag != "influx:repair-needed"]
+    note["tags"] = list(restored_tags)
+    return restored_tags
+
+
 def _run_text_extraction_retry(
     note: dict[str, Any],
     *,
@@ -1091,6 +1123,13 @@ def _run_text_extraction_retry(
     new terminal tag is introduced for normal failures (out of scope
     for issue #24); ``unsupported_source`` failures are flipped to
     terminal so the note exits the sweep instead of looping.
+
+    ``invalid_source_metadata`` failures (#150) are also flipped to
+    terminal — distinct from ``unsupported_source`` so logs and tags
+    cleanly separate the metadata-integrity case from the future-
+    source case.  The terminal flip also adds the
+    ``influx:source-invalid`` tag so the bad-state notes are
+    independently discoverable for operator cleanup.
     """
     try:
         with _stage_attempt(
@@ -1102,17 +1141,25 @@ def _run_text_extraction_retry(
         ):
             new_text_tag = hook(note)
         new_tags = list(current_tags)
+        # The hook may have backfilled the ``source:*`` tag on the
+        # note dict during inference (#150); reflect that mutation in
+        # the working tag set so the rewrite persists it even on the
+        # success path.
+        hook_tags = list(note.get("tags", new_tags))
+        if hook_tags != new_tags:
+            new_tags = merge_tags(existing_tags=new_tags, new_tags=hook_tags)
         if new_text_tag and not any(t.startswith("text:") for t in new_tags):
             new_tags.append(new_text_tag)
-            note["tags"] = list(new_tags)
+        note["tags"] = list(new_tags)
         return new_tags
     except (ExtractionError, LCMAError, LithosError) as exc:
         new_tags = current_tags
-        if (
-            isinstance(exc, ExtractionError)
-            and getattr(exc, "stage", "") == "unsupported_source"
-        ):
-            new_tags = _terminate_unsupported_text_source(note)
+        if isinstance(exc, ExtractionError):
+            stage = getattr(exc, "stage", "")
+            if stage == "unsupported_source":
+                new_tags = _terminate_unsupported_text_source(note)
+            elif stage == "invalid_source_metadata":
+                new_tags = _terminate_invalid_source_metadata(note)
         _log_stage_failure(
             "text_extraction",
             note=note,

--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -197,7 +197,10 @@ _SOURCE_TAG_PREFIX = "source:"
 _NOTE_PATH_RE = re.compile(
     r"(?:papers|articles)/(?P<source>[^/]+)/(?P<year>\d{4})/(?P<month>\d{2})"
 )
+_NOTE_PATH_SOURCE_RE = re.compile(r"(?:^|/)(?:papers|articles)/(?P<source>[^/]+)/")
 _RSS_NOTE_ID_PREFIX = "rss-"
+_ARXIV_NOTE_ID_PREFIX = "arxiv-"
+_ARXIV_HOSTNAMES: frozenset[str] = frozenset({"arxiv.org", "www.arxiv.org"})
 _SOURCE_URL_FRONTMATTER_KEY = "source_url:"
 
 
@@ -230,6 +233,137 @@ def _is_rss_source(source: str) -> bool:
     return source == "rss" or source.startswith(_RSS_NOTE_ID_PREFIX)
 
 
+# ── Source metadata invariant (#150) ────────────────────────────────
+
+
+def _infer_source_from_url(source_url: str) -> str | None:
+    """Infer a ``source:*`` suffix from an arxiv URL.
+
+    Returns ``"arxiv"`` for any URL whose host is in
+    :data:`_ARXIV_HOSTNAMES`.  Returns ``None`` for everything else —
+    RSS feeds carry a ``feed-slug:`` derived value that can't be
+    reconstructed from the article URL alone.
+    """
+    if not source_url:
+        return None
+    try:
+        from urllib.parse import urlparse
+
+        host = urlparse(source_url).hostname or ""
+    except ValueError:
+        return None
+    if host.lower() in _ARXIV_HOSTNAMES:
+        return "arxiv"
+    return None
+
+
+def _infer_source_from_note_path(note_path: str) -> str | None:
+    """Infer a ``source:*`` suffix from a Lithos note path.
+
+    ``papers/arxiv/...`` → ``"arxiv"``; ``articles/<feed-slug>/...``
+    → ``"rss-<feed-slug>"`` (RSS notes live under
+    ``articles/<source_tag>/{YYYY}/{MM}`` per
+    :mod:`influx.sources.rss`, so the path's first segment after
+    ``articles/`` is already the full source-tag suffix).  Returns
+    ``None`` when the path doesn't match either canonical layout.
+    """
+    if not note_path:
+        return None
+    m = _NOTE_PATH_SOURCE_RE.search(note_path)
+    if not m:
+        return None
+    candidate = m.group("source")
+    if "/" in candidate:  # defensive — shouldn't trigger with the regex above
+        return None
+    # ``papers/`` carries arxiv exclusively; ``articles/`` carries RSS.
+    if note_path.lstrip("/").startswith("papers/") and candidate == "arxiv":
+        return "arxiv"
+    if note_path.lstrip("/").startswith("articles/"):
+        # The configured RSS source_tag may or may not already include
+        # the ``rss-`` prefix; the path stores it verbatim.  Normalise to
+        # the canonical ``rss-<slug>`` shape if missing.
+        if candidate.startswith(_RSS_NOTE_ID_PREFIX) or candidate == "rss":
+            return candidate
+        return f"{_RSS_NOTE_ID_PREFIX}{candidate}"
+    return None
+
+
+def _infer_source_from_note_id(note_id: str) -> str | None:
+    """Infer a ``source:*`` suffix from a Lithos note ``id``.
+
+    Production note ids carry an explicit source-prefix: ``arxiv-<id>``
+    for arxiv, ``rss-<feed-slug>-<hash>`` for RSS.  The RSS case
+    returns the bare ``"rss"`` sentinel because the feed-slug-hash
+    suffix is not safely separable here (it can contain hyphens of its
+    own); the dispatcher accepts the bare sentinel via
+    :func:`_is_rss_source` so this is still actionable.
+    """
+    if not note_id:
+        return None
+    if note_id.startswith(_ARXIV_NOTE_ID_PREFIX):
+        return "arxiv"
+    if note_id.startswith(_RSS_NOTE_ID_PREFIX):
+        return "rss"
+    return None
+
+
+def infer_note_source(note: dict[str, object]) -> str | None:
+    """Return a dispatchable ``source:*`` suffix for *note*, or ``None``.
+
+    Resolution order, stopping at the first hit:
+
+    1. Any **non-empty** existing ``source:*`` tag is honoured
+       verbatim — even if it names a source we don't support yet
+       (e.g. ``hackernews``).  That case is "unsupported but
+       well-formed metadata" and is handled by the existing
+       :func:`_raise_unsupported_source` path; we don't second-guess
+       an explicit operator/source label here.
+    2. (When the existing tag is empty/absent.)  A ``source_url`` in
+       the note's frontmatter pointing at arxiv.
+    3. The Lithos note ``path`` (``papers/<source>/...`` or
+       ``articles/<feed-slug>/...``).
+    4. The Lithos note ``id`` prefix (``arxiv-`` / ``rss-``).
+
+    Returns ``None`` only when the source tag is empty AND every
+    inference signal is missing/unrecognised — the caller treats
+    that as a terminal metadata failure (#150) rather than a
+    transient extraction failure.
+    """
+    existing = _note_source_tag(note)
+    if existing:
+        return existing
+
+    source_url = _parse_source_url_from_note(note) or ""
+    inferred = _infer_source_from_url(source_url)
+    if inferred is not None:
+        return inferred
+
+    inferred = _infer_source_from_note_path(str(note.get("path", "")))
+    if inferred is not None:
+        return inferred
+
+    inferred = _infer_source_from_note_id(str(note.get("id", "")))
+    if inferred is not None:
+        return inferred
+
+    return None
+
+
+def _backfill_source_tag(note: dict[str, object], inferred: str) -> None:
+    """Replace any (possibly empty/garbled) ``source:*`` tag on *note*.
+
+    Mutates ``note["tags"]`` in place so the rewrite step persists the
+    repaired tag.  Idempotent — calling twice with the same value is a
+    no-op.  Used after :func:`infer_note_source` returns a non-``None``
+    suffix so the next sweep pass never re-enters the inference path
+    for the same note.
+    """
+    tags = _note_tags(note)
+    rebuilt = [t for t in tags if not t.startswith(_SOURCE_TAG_PREFIX)]
+    rebuilt.append(f"{_SOURCE_TAG_PREFIX}{inferred}")
+    note["tags"] = rebuilt
+
+
 def _raise_unsupported_source(
     note: dict[str, object], *, stage_label: str, source: str
 ) -> None:
@@ -245,6 +379,34 @@ def _raise_unsupported_source(
         f"{stage_label}: source {source!r} not supported",
         stage="unsupported_source",
         detail=f"note id={note.get('id', '?')}",
+    )
+
+
+def _raise_invalid_source_metadata(
+    note: dict[str, object], *, stage_label: str
+) -> None:
+    """Raise ``ExtractionError(stage="invalid_source_metadata")`` (#150).
+
+    Distinct from ``unsupported_source`` (a legitimate future source
+    without a resolver yet): this signals a note whose ``source:*``
+    tag is empty/garbled AND whose URL/path/id provide no fallback,
+    so the same retry will loop forever emitting
+    ``source '' not supported``.  The text-extraction path flips this
+    to terminal via
+    :func:`influx.repair._terminate_invalid_source_metadata`, adding
+    a discoverable ``influx:source-invalid`` tag for later cleanup.
+    """
+    raise ExtractionError(
+        (
+            f"{stage_label}: note has no recoverable source metadata "
+            "(empty/garbled source tag and no arxiv URL / canonical path / id prefix)"
+        ),
+        stage="invalid_source_metadata",
+        detail=(
+            f"note id={note.get('id', '?')} "
+            f"path={note.get('path', '?')!r} "
+            f"existing_source={_note_source_tag(note)!r}"
+        ),
     )
 
 
@@ -584,14 +746,59 @@ def _make_text_extraction_hook(config: AppConfig) -> TextExtractionHook:
 
     Supports ``source:arxiv`` (cascade via
     :func:`extract_arxiv_text`) and ``source:rss-*`` (web article
-    extraction via :func:`extract_article`).  Other sources raise
+    extraction via :func:`extract_article`).
+
+    Source-metadata invariant (#150)
+    --------------------------------
+    Before dispatching, the hook normalises the note's source tag via
+    :func:`infer_note_source`:
+
+    * If the existing ``source:*`` suffix is already dispatchable
+      (``arxiv`` / ``rss-*``), it is used as-is.
+    * If it is empty or garbled but can be inferred from
+      ``source_url`` / note path / note id, the tag is **backfilled
+      in-place** so subsequent sweeps don't re-trigger inference, and
+      dispatch proceeds with the inferred source.
+    * If inference fails entirely, the hook raises
+      ``ExtractionError(stage="invalid_source_metadata")`` — distinct
+      from ``unsupported_source`` (a legitimate future source) — so
+      the sweep can flip the note to terminal via
+      :func:`influx.repair._terminate_invalid_source_metadata` and
+      stop the staging-incident retry loop.
+
+    Other (genuinely unsupported but well-formed) sources raise
     ``ExtractionError(stage="unsupported_source")`` so the sweep
     terminalises the note via
     :func:`influx.repair._terminate_unsupported_text_source`.
     """
 
     def hook(note: dict[str, object]) -> str:
-        source = _note_source_tag(note)
+        existing_source = _note_source_tag(note)
+        source = infer_note_source(note)
+        if source is None:
+            _log.warning(
+                "text_extraction retry: invalid source metadata for %s "
+                "(existing_source=%r, path=%r); marking terminal",
+                note.get("id", "?"),
+                existing_source,
+                note.get("path", ""),
+            )
+            _raise_invalid_source_metadata(note, stage_label="text_extraction retry")
+            raise AssertionError("unreachable")  # pragma: no cover
+
+        # Backfill the tag when inference produced a different (or
+        # newly-populated) value, so the next pass starts from a
+        # clean state and we never re-emit the diagnostic for the
+        # same note.
+        if source != existing_source:
+            _log.info(
+                "text_extraction retry: backfilled source tag for %s (was %r, now %r)",
+                note.get("id", "?"),
+                existing_source,
+                source,
+            )
+            _backfill_source_tag(note, source)
+
         if source == "arxiv":
             tag = _run_arxiv_text_extraction(note, config)
         elif _is_rss_source(source):

--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -318,11 +318,19 @@ def infer_note_source(note: dict[str, object]) -> str | None:
        well-formed metadata" and is handled by the existing
        :func:`_raise_unsupported_source` path; we don't second-guess
        an explicit operator/source label here.
-    2. (When the existing tag is empty/absent.)  A ``source_url`` in
-       the note's frontmatter pointing at arxiv.
-    3. The Lithos note ``path`` (``papers/<source>/...`` or
+    2. (When the existing tag is empty/absent.)  The top-level
+       ``source_url`` field on the note dict pointing at arxiv.
+       This is the canonical persisted shape (see
+       ``influx.repair._rewrite_note_via_lithos`` and the read-note
+       coverage in ``tests/unit/test_repair_sweep.py``); it survives
+       even when the note body / frontmatter has been corrupted or
+       stripped, so we prefer it over the parsed frontmatter copy.
+    3. A ``source_url`` recovered from the note's YAML frontmatter
+       pointing at arxiv — the fallback when the top-level field is
+       absent (e.g. legacy notes, hand-edited dicts in tests).
+    4. The Lithos note ``path`` (``papers/<source>/...`` or
        ``articles/<feed-slug>/...``).
-    4. The Lithos note ``id`` prefix (``arxiv-`` / ``rss-``).
+    5. The Lithos note ``id`` prefix (``arxiv-`` / ``rss-``).
 
     Returns ``None`` only when the source tag is empty AND every
     inference signal is missing/unrecognised — the caller treats
@@ -332,6 +340,12 @@ def infer_note_source(note: dict[str, object]) -> str | None:
     existing = _note_source_tag(note)
     if existing:
         return existing
+
+    top_level_url = note.get("source_url")
+    top_level_url_str = top_level_url if isinstance(top_level_url, str) else ""
+    inferred = _infer_source_from_url(top_level_url_str)
+    if inferred is not None:
+        return inferred
 
     source_url = _parse_source_url_from_note(note) or ""
     inferred = _infer_source_from_url(source_url)

--- a/tests/unit/test_repair_hooks_production.py
+++ b/tests/unit/test_repair_hooks_production.py
@@ -1432,11 +1432,7 @@ class TestInferNoteSource:
         from influx.repair_hooks import infer_note_source
 
         body = (
-            "---\n"
-            "source_url: https://example.com/not-arxiv\n"
-            "tags: []\n"
-            "---\n"
-            "# Paper\n"
+            "---\nsource_url: https://example.com/not-arxiv\ntags: []\n---\n# Paper\n"
         )
         note = {
             "tags": [],

--- a/tests/unit/test_repair_hooks_production.py
+++ b/tests/unit/test_repair_hooks_production.py
@@ -1355,6 +1355,101 @@ class TestInferNoteSource:
         # for a non-arxiv URL — caller treats this as terminal.
         assert infer_note_source(note) is None
 
+    def test_infers_arxiv_from_top_level_source_url_when_frontmatter_missing(
+        self,
+    ) -> None:
+        """Top-level ``source_url`` repairs notes with stripped frontmatter.
+
+        Repair reads/writes ``source_url`` as a first-class top-level
+        field on the note dict (see ``tests/unit/test_repair_sweep.py``
+        coverage of ``test_rewrite_includes_note_fields``).  When the
+        body has been corrupted/stripped and the frontmatter no longer
+        carries the URL, the top-level field must still rescue the
+        note from terminalisation.
+        """
+        from influx.repair_hooks import infer_note_source
+
+        note = {
+            "tags": [],
+            # Body has no frontmatter at all — only top-level field survives.
+            "content": "# Paper\n\nBody text only.\n",
+            "source_url": "https://arxiv.org/abs/2604.26946",
+            "path": "",
+            "id": "",
+        }
+        assert infer_note_source(note) == "arxiv"
+
+    def test_infers_arxiv_from_top_level_source_url_with_malformed_frontmatter(
+        self,
+    ) -> None:
+        """Malformed YAML must not block the top-level fallback."""
+        from influx.repair_hooks import infer_note_source
+
+        note = {
+            "tags": [],
+            # Unbalanced frontmatter / unparsable YAML — parse_note may
+            # return empty frontmatter_raw or raise; top-level wins.
+            "content": "---\nnot: [valid: yaml\n",
+            "source_url": "https://arxiv.org/abs/2604.26946",
+            "path": "",
+            "id": "",
+        }
+        assert infer_note_source(note) == "arxiv"
+
+    def test_top_level_non_arxiv_source_url_falls_through_to_other_signals(
+        self,
+    ) -> None:
+        """Non-arxiv top-level URL must not short-circuit path/id inference.
+
+        ``_infer_source_from_url`` only returns ``"arxiv"`` for arxiv
+        hosts; for anything else it returns ``None``.  The top-level
+        check must therefore fall through to path/id signals so an
+        article from e.g. ``example.com`` whose canonical path lives
+        under ``articles/rss-techcrunch/`` is still dispatched to RSS.
+        """
+        from influx.repair_hooks import infer_note_source
+
+        note = {
+            "tags": [],
+            "content": "# Article\n",
+            "source_url": "https://example.com/post",
+            "path": "articles/rss-techcrunch/2026/04",
+            "id": "",
+        }
+        assert infer_note_source(note) == "rss-techcrunch"
+
+    def test_top_level_source_url_preferred_over_frontmatter(self) -> None:
+        """When both are present, the top-level field wins.
+
+        Rationale: the top-level field is the canonical persisted
+        shape on read/write; the frontmatter copy is a re-derived
+        view that can drift if the body is hand-edited or partially
+        rewritten.  Both happen to map to ``arxiv`` here so the
+        observable assertion is on the return value; the ordering
+        is documented for future signal types where a divergence
+        would matter.
+        """
+        from influx.repair_hooks import infer_note_source
+
+        body = (
+            "---\n"
+            "source_url: https://example.com/not-arxiv\n"
+            "tags: []\n"
+            "---\n"
+            "# Paper\n"
+        )
+        note = {
+            "tags": [],
+            "content": body,
+            # Top-level points at arxiv; frontmatter points elsewhere.
+            "source_url": "https://arxiv.org/abs/2604.26946",
+            "path": "",
+            "id": "",
+        }
+        # Top-level wins → "arxiv".  If ordering were flipped we'd
+        # get None (frontmatter URL is non-arxiv, no other signals).
+        assert infer_note_source(note) == "arxiv"
+
 
 class TestTextExtractionHookSourceInvariant:
     """The text-extraction hook tightens the source-metadata invariant (#150).

--- a/tests/unit/test_repair_hooks_production.py
+++ b/tests/unit/test_repair_hooks_production.py
@@ -1216,3 +1216,252 @@ class TestTextExtractionHookRssMetadataRecovery:
             hooks.text_extraction(note)
         assert exc_info.value.stage == "resolve"
         assert classify_failure(exc_info.value) == "transient"
+
+
+# ── Source metadata invariant (#150) ────────────────────────────────
+
+
+class TestInferNoteSource:
+    """Source inference for notes with missing/empty ``source:*`` tags (#150)."""
+
+    def test_existing_known_source_tag_honoured(self) -> None:
+        from influx.repair_hooks import infer_note_source
+
+        note = {
+            "tags": ["source:arxiv", "profile:ai-robotics"],
+            "source_url": "https://arxiv.org/abs/2604.26946",
+            "path": "papers/arxiv/2026/04",
+            "id": "arxiv-2604.26946",
+        }
+        assert infer_note_source(note) == "arxiv"
+
+    def test_existing_unsupported_source_tag_honoured_verbatim(self) -> None:
+        """An explicit but unsupported source tag is well-formed metadata.
+
+        Inference must not second-guess an operator/source label —
+        ``hackernews`` is the dispatcher's problem, not the
+        invariant's problem (#150 distinguishes invalid-metadata
+        from unsupported-source).
+        """
+        from influx.repair_hooks import infer_note_source
+
+        note = {
+            "tags": ["source:hackernews"],
+            "source_url": "https://arxiv.org/abs/2604.26946",
+            "path": "papers/arxiv/2026/04",
+        }
+        assert infer_note_source(note) == "hackernews"
+
+    def test_infers_arxiv_from_source_url_when_tag_missing(self) -> None:
+        from influx.repair_hooks import infer_note_source
+
+        body = (
+            "---\n"
+            "source_url: https://arxiv.org/abs/2604.26946\n"
+            "tags: []\n"
+            "---\n"
+            "# Paper\n"
+        )
+        note = {
+            "tags": [],
+            "content": body,
+            "path": "",
+            "id": "",
+        }
+        assert infer_note_source(note) == "arxiv"
+
+    def test_infers_arxiv_from_canonical_path(self) -> None:
+        from influx.repair_hooks import infer_note_source
+
+        note = {
+            "tags": [],
+            "content": "---\ntags: []\n---\n",
+            "path": "papers/arxiv/2026/04",
+            "id": "",
+        }
+        assert infer_note_source(note) == "arxiv"
+
+    def test_infers_rss_with_slug_from_articles_path(self) -> None:
+        from influx.repair_hooks import infer_note_source
+
+        note = {
+            "tags": [],
+            "content": "---\ntags: []\n---\n",
+            "path": "articles/rss-techcrunch/2026/04",
+            "id": "",
+        }
+        assert infer_note_source(note) == "rss-techcrunch"
+
+    def test_infers_rss_normalises_bare_slug_path(self) -> None:
+        """``articles/<slug>/`` without ``rss-`` prefix is normalised."""
+        from influx.repair_hooks import infer_note_source
+
+        note = {
+            "tags": [],
+            "content": "---\ntags: []\n---\n",
+            "path": "articles/techcrunch/2026/04",
+            "id": "",
+        }
+        assert infer_note_source(note) == "rss-techcrunch"
+
+    def test_infers_arxiv_from_note_id_prefix(self) -> None:
+        from influx.repair_hooks import infer_note_source
+
+        note = {
+            "tags": [],
+            "content": "---\ntags: []\n---\n",
+            "path": "",
+            "id": "arxiv-2604.26946",
+        }
+        assert infer_note_source(note) == "arxiv"
+
+    def test_infers_bare_rss_from_note_id_prefix(self) -> None:
+        from influx.repair_hooks import infer_note_source
+
+        note = {
+            "tags": [],
+            "content": "---\ntags: []\n---\n",
+            "path": "",
+            "id": "rss-techcrunch-abc123",
+        }
+        # Bare ``rss`` sentinel is accepted by the RSS dispatcher
+        # (see ``_is_rss_source``); the path-based inference produces
+        # the richer ``rss-<slug>`` shape when a path is available.
+        assert infer_note_source(note) == "rss"
+
+    def test_returns_none_when_no_signal_present(self) -> None:
+        """The classic staging-incident shape: empty source, no fallback."""
+        from influx.repair_hooks import infer_note_source
+
+        note = {
+            "tags": ["profile:ai-robotics"],
+            "content": "---\ntags: []\n---\n",
+            "path": "",
+            "id": "",
+        }
+        assert infer_note_source(note) is None
+
+    def test_returns_none_when_url_is_non_arxiv_and_other_signals_empty(self) -> None:
+        from influx.repair_hooks import infer_note_source
+
+        body = "---\nsource_url: https://example.com/something\ntags: []\n---\n"
+        note = {
+            "tags": [],
+            "content": body,
+            "path": "",
+            "id": "",
+        }
+        # Without a tag/path/id we can't safely guess the feed-slug
+        # for a non-arxiv URL — caller treats this as terminal.
+        assert infer_note_source(note) is None
+
+
+class TestTextExtractionHookSourceInvariant:
+    """The text-extraction hook tightens the source-metadata invariant (#150).
+
+    Empty-source notes that *can* be inferred from URL/path/id are
+    backfilled and dispatched; empty-source notes with *no* fallback
+    raise ``invalid_source_metadata`` instead of looping on
+    ``source '' not supported``.
+    """
+
+    def test_backfills_arxiv_source_tag_from_source_url(self, tmp_path: Path) -> None:
+        """Empty source + arxiv URL → backfilled tag + arxiv extraction."""
+        from influx.extraction.pipeline import ArxivExtractionResult
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = _make_textless_note()
+        # Strip the explicit source:* tag — simulate a degraded note.
+        note["tags"] = [t for t in note["tags"] if not t.startswith("source:")]
+
+        with patch("influx.repair_hooks.extract_arxiv_text") as mock_x:
+            mock_x.return_value = ArxivExtractionResult(
+                text="full body",
+                source_tag="text:html",
+            )
+            assert hooks.text_extraction is not None
+            tag = hooks.text_extraction(note)
+
+        assert tag == "text:html"
+        # Tag was backfilled in-place so the next pass starts clean.
+        assert "source:arxiv" in note["tags"]
+
+    def test_invalid_source_metadata_raised_when_inference_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression for the staging incident: empty source AND no fallback.
+
+        Previously this path emitted ``text_extraction retry: source ''
+        not supported`` every sweep (#150).  Now the hook short-
+        circuits with ``stage=invalid_source_metadata`` so the sweep
+        can flip the note terminal with ``influx:source-invalid``.
+        """
+        from influx.repair_counters import classify_failure
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        # Build a note whose source tag is empty AND has no fallback
+        # signals: blank source_url, blank path, blank id.
+        body = (
+            "---\n"
+            "source_url:\n"
+            "tags: []\n"
+            "---\n"
+            "# Paper\n\n"
+            "## Archive\n\n"
+            "## Summary\nSummary\n"
+        )
+        note = {
+            "id": "",
+            "title": "Paper",
+            "path": "",
+            "source_url": "",
+            "content": body,
+            "tags": ["profile:ai-robotics", "influx:repair-needed"],
+            "version": 1,
+        }
+
+        assert hooks.text_extraction is not None
+        with pytest.raises(ExtractionError) as exc_info:
+            hooks.text_extraction(note)
+
+        assert exc_info.value.stage == "invalid_source_metadata"
+        # Distinct from unsupported_source — the per-source resolver
+        # extension can't repair this; only operator metadata-fix can.
+        assert "unsupported_source" not in str(exc_info.value)
+        # Classified as transient at the counter level (no counted
+        # cap), but the sweep handles it specially via the
+        # ``invalid_source_metadata`` discriminator.
+        assert classify_failure(exc_info.value) == "transient"
+
+    def test_logs_invalid_source_metadata_at_warning(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """Logs must clearly distinguish invalid-state from extraction failures."""
+        import logging
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(config)
+        note = {
+            "id": "",
+            "title": "Paper",
+            "path": "",
+            "source_url": "",
+            "content": "---\ntags: []\n---\n",
+            "tags": ["profile:ai-robotics"],
+            "version": 1,
+        }
+
+        assert hooks.text_extraction is not None
+        with (
+            caplog.at_level(logging.WARNING, logger="influx.repair_hooks"),
+            pytest.raises(ExtractionError),
+        ):
+            hooks.text_extraction(note)
+
+        # Logs flag the invalid-state cause, not a generic
+        # extraction-failed message.
+        assert any(
+            "invalid source metadata" in record.message for record in caplog.records
+        )

--- a/tests/unit/test_repair_sweep.py
+++ b/tests/unit/test_repair_sweep.py
@@ -1398,3 +1398,101 @@ class TestSweepTextExtractionRetry:
         assert "text:abstract-only" in rewritten["tags"]
         assert "influx:text-terminal" in rewritten["tags"]
         assert "influx:repair-needed" in rewritten["tags"]
+
+    async def test_invalid_source_metadata_flips_terminal_and_tags_source_invalid(
+        self,
+    ) -> None:
+        """Regression for the #150 staging incident.
+
+        A note with empty/garbled source metadata that the hook
+        cannot infer raises ``ExtractionError(stage=
+        invalid_source_metadata)``.  The sweep flips it terminal AND
+        tags it ``influx:source-invalid`` so the bad-state notes are
+        independently discoverable for operator cleanup, and removes
+        ``influx:repair-needed`` so the note exits the sweep entirely
+        instead of re-logging ``source '' not supported`` every pass.
+        """
+        items = [{"id": "n1", "title": "Paper"}]
+        note = self._note_textless("n1")
+
+        def hook(note: dict[str, object]) -> str:
+            del note
+            raise ExtractionError(
+                "text_extraction retry: note has no recoverable source metadata",
+                stage="invalid_source_metadata",
+            )
+
+        config = _make_config()
+        client = _make_client(list_items=items, read_responses=[note])
+
+        await sweep(
+            "ai-robotics",
+            client=client,
+            config=config,
+            hooks=SweepHooks(text_extraction=hook),
+        )
+
+        rewritten = self._last_write_args(client)
+        assert "text:abstract-only" in rewritten["tags"]
+        assert "influx:text-terminal" in rewritten["tags"]
+        assert "influx:source-invalid" in rewritten["tags"]
+        assert "influx:repair-needed" not in rewritten["tags"]
+
+    async def test_invalid_source_metadata_does_not_retry_next_pass(
+        self,
+    ) -> None:
+        """Once terminal, the note carries ``influx:text-terminal`` and the
+        text-extraction stage is no longer selected (AC: 'repeated runs
+        do not re-log the same warning forever').
+        """
+        from influx.repair import select_stages
+
+        # Tags as they exist *after* the first sweep flipped the note
+        # terminal via _terminate_invalid_source_metadata.
+        post_terminal_tags = [
+            "profile:ai-robotics",
+            "text:abstract-only",
+            "influx:text-terminal",
+            "influx:source-invalid",
+        ]
+        sel = select_stages(
+            tags=post_terminal_tags,
+            archive_path="papers/arxiv/2026/04/x.pdf",
+            max_profile_score=5,
+            full_text_threshold=8,
+            deep_extract_threshold=9,
+        )
+        assert sel.text_extraction_retry is False
+        assert sel.abstract_only_reextraction is False
+        assert sel.tier2_retry is False
+        assert sel.tier3_retry is False
+
+    async def test_backfilled_source_tag_is_persisted_on_success(self) -> None:
+        """When inference backfills ``source:*`` mid-stage, the rewrite
+        persists the new tag so subsequent sweeps don't re-infer."""
+        items = [{"id": "n1", "title": "Paper"}]
+        note = self._note_textless("n1")
+
+        # Note that the textless fixture already lacks a source:* tag.
+        # Simulate a hook that backfills the tag (as the production
+        # hook does via infer_note_source) and then succeeds.
+        def hook(note: dict[str, object]) -> str:
+            tags = list(note.get("tags", []))
+            if not any(t.startswith("source:") for t in tags):
+                tags.append("source:arxiv")
+                note["tags"] = tags
+            return "text:html"
+
+        config = _make_config()
+        client = _make_client(list_items=items, read_responses=[note])
+
+        await sweep(
+            "ai-robotics",
+            client=client,
+            config=config,
+            hooks=SweepHooks(text_extraction=hook),
+        )
+
+        rewritten = self._last_write_args(client)
+        assert "source:arxiv" in rewritten["tags"]
+        assert "text:html" in rewritten["tags"]

--- a/tests/unit/test_repair_sweep.py
+++ b/tests/unit/test_repair_sweep.py
@@ -11,7 +11,7 @@ advancement invariant, §5.4), and handles chronic
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -1477,9 +1477,9 @@ class TestSweepTextExtractionRetry:
         # Simulate a hook that backfills the tag (as the production
         # hook does via infer_note_source) and then succeeds.
         def hook(note: dict[str, object]) -> str:
-            tags = list(note.get("tags", []))
+            tags = cast(list[str], note.get("tags") or [])
             if not any(t.startswith("source:") for t in tags):
-                tags.append("source:arxiv")
+                tags = [*tags, "source:arxiv"]
                 note["tags"] = tags
             return "text:html"
 


### PR DESCRIPTION
## Summary
- New `infer_note_source(note)` resolves a dispatchable `source:*` suffix from existing tag → frontmatter `source_url` (arxiv) → Lithos `path` (papers/articles) → note `id` prefix, and backfills the tag in-place when inference succeeds.
- Failed inference raises a distinct `ExtractionError(stage="invalid_source_metadata")` instead of falling through to the generic `source '' not supported` extraction error.
- `repair._terminate_invalid_source_metadata` pins `text:abstract-only`, adds `influx:text-terminal` + `influx:source-invalid`, and drops `influx:repair-needed` so the note exits the sweep loop.
- `influx:source-invalid` registered in `notes._INFLUX_OWNED_EXACT` so rewrites preserve it for later cleanup.

## Test plan
- [x] `uv run pytest` — 1917 passed
- [x] Ruff + pyright clean on changed files
- [x] 13 new unit tests (10 inference cases + 3 text-extraction-hook invariant cases) + 3 sweep-level tests including the exact staging-incident regression and a `select_stages` test proving terminal notes don't re-enter the stage

Closes #150