### PR TITLE
fix: classify arXiv 429 as local vs upstream-capacity (#145)

### DIFF
--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -153,9 +153,7 @@ def _extract_arxiv_429_classification(error: NetworkError) -> str | None:
     return rest.split(" ", 1)[0] or None
 
 
-def _classify_arxiv_429(
-    *, body: bytes, headers: dict[str, str]
-) -> tuple[str, bool]:
+def _classify_arxiv_429(*, body: bytes, headers: dict[str, str]) -> tuple[str, bool]:
     """Classify an arXiv 429 into a refined retry/error kind (issue #145).
 
     Returns a ``(kind, retry_after_present)`` pair.  *kind* is one of:
@@ -182,10 +180,7 @@ def _classify_arxiv_429(
     on the header signal.
     """
     retry_after_present = _header_value(headers, "Retry-After") is not None
-    body_marker = (
-        body is not None
-        and _ARXIV_UPSTREAM_CAPACITY_MARKER in body.lower()
-    )
+    body_marker = body is not None and _ARXIV_UPSTREAM_CAPACITY_MARKER in body.lower()
     if body_marker:
         return "rate_limit_upstream_capacity", retry_after_present
     if retry_after_present:
@@ -1102,9 +1097,7 @@ class ArxivSource:
                 # generic ``rate_limit``.  Non-429 errors fall back
                 # to ``exc.kind`` unchanged.
                 ledger_kind = (
-                    _extract_arxiv_429_classification(exc)
-                    or exc.kind
-                    or "unknown"
+                    _extract_arxiv_429_classification(exc) or exc.kind or "unknown"
                 )
                 _log.warning(
                     "arxiv fetch failed for profile %r kind=%s; yielding zero items",

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -97,6 +97,102 @@ _XML_CONTENT_TYPES: frozenset[str] = frozenset(
 _RETRY_AFTER_MAX_SECONDS = 300.0
 
 
+# ── 429 classification (issue #145) ────────────────────────────────
+#
+# arXiv staff (November 2025) clarified that ``429 Rate exceeded.``
+# responses today often reflect *shared* upstream capacity rather than
+# a single client's abuse.  The classifier inspects the response body
+# and headers to refine the generic ``rate_limit`` retry kind into one
+# of:
+#
+# * ``rate_limit_upstream_capacity`` — the response body contains the
+#   canonical arXiv ``Rate exceeded.`` marker (case-insensitive), which
+#   the staff guidance attributes to total user load on the public API
+#   rather than per-client throttling.  This is the strongest signal we
+#   have today; operators interpret it as "back off harder, this is not
+#   us".
+# * ``rate_limit_local`` — a 429 with a ``Retry-After`` header but
+#   without the shared-capacity body marker.  Conventional per-client
+#   throttling: the server told us exactly how long to wait, so we
+#   treat it as a local pacing issue (likely fixed by tighter
+#   ``arxiv_request_min_interval_seconds`` or fewer concurrent
+#   profiles).
+# * ``rate_limit_unknown`` — neither signal is present.  Behaviour is
+#   unchanged from the legacy ``rate_limit`` path; the label exists so
+#   operators can still see "we hit a 429 but couldn't tell why" in the
+#   ledger instead of having to inspect raw logs.
+#
+# The classification is what we record into telemetry / the run ledger.
+# The thrown ``NetworkError.kind`` remains the legacy ``"rate_limit"``
+# so any external consumer keyed on that kind continues to work — the
+# refined kind is additive context, not a breaking rename.
+_ARXIV_UPSTREAM_CAPACITY_MARKER = b"rate exceeded"
+
+
+_ARXIV_429_CLASSIFICATION_PREFIX = "classification="
+
+
+def _extract_arxiv_429_classification(error: NetworkError) -> str | None:
+    """Recover the refined 429 classification from a ``NetworkError`` reason.
+
+    ``_fetch_with_retry`` raises 429 failures with the legacy
+    ``kind="rate_limit"`` for backward-compatibility with downstream
+    consumers, but stashes the refined classification (e.g.
+    ``rate_limit_upstream_capacity``) at the head of the *reason*
+    string.  Returns ``None`` for non-429 errors so callers can fall
+    back to ``error.kind`` unchanged.
+    """
+    if error.kind != "rate_limit" or not error.reason:
+        return None
+    reason = error.reason
+    if not reason.startswith(_ARXIV_429_CLASSIFICATION_PREFIX):
+        return None
+    rest = reason[len(_ARXIV_429_CLASSIFICATION_PREFIX) :]
+    # ``classification=<kind> retry_after_present=<bool>``; split on the
+    # first whitespace so refined kinds with underscores survive intact.
+    return rest.split(" ", 1)[0] or None
+
+
+def _classify_arxiv_429(
+    *, body: bytes, headers: dict[str, str]
+) -> tuple[str, bool]:
+    """Classify an arXiv 429 into a refined retry/error kind (issue #145).
+
+    Returns a ``(kind, retry_after_present)`` pair.  *kind* is one of:
+
+    * ``"rate_limit_upstream_capacity"`` — the response body carries the
+      known arXiv ``Rate exceeded.`` marker (case-insensitive); per
+      arXiv staff guidance this signals shared upstream capacity rather
+      than a per-client abuse event.
+    * ``"rate_limit_local"`` — a 429 with a ``Retry-After`` header but
+      no shared-capacity body marker; treated as classical per-client
+      throttling.
+    * ``"rate_limit_unknown"`` — neither signal is present.
+
+    *retry_after_present* is ``True`` exactly when a ``Retry-After``
+    header was supplied by the upstream — surfaced to log call sites
+    so operators can see at a glance whether the upstream nominated a
+    wait time.
+
+    The classification is intentionally tolerant of small variations:
+    a body of ``b"Rate exceeded."`` matches, and so does
+    ``b"<html>...Rate exceeded...</html>"`` or a body whose case differs
+    (``b"rate exceeded"``).  Empty bodies and non-decodable bodies fall
+    through to ``rate_limit_unknown`` / ``rate_limit_local`` based only
+    on the header signal.
+    """
+    retry_after_present = _header_value(headers, "Retry-After") is not None
+    body_marker = (
+        body is not None
+        and _ARXIV_UPSTREAM_CAPACITY_MARKER in body.lower()
+    )
+    if body_marker:
+        return "rate_limit_upstream_capacity", retry_after_present
+    if retry_after_present:
+        return "rate_limit_local", retry_after_present
+    return "rate_limit_unknown", retry_after_present
+
+
 @dataclass(frozen=True, slots=True)
 class ArxivItem:
     """A single parsed arXiv entry from the Atom feed."""
@@ -620,20 +716,40 @@ def _fetch_with_retry(
             raise
 
         if result.status_code == 429:
+            # Issue #145: classify the 429 into a more specific kind so
+            # operators can tell shared-capacity upstream events apart
+            # from local per-client throttling.  The thrown
+            # ``NetworkError.kind`` keeps the legacy ``"rate_limit"``
+            # value so downstream consumers don't break; the refined
+            # kind flows into ``record_source_retry`` /
+            # ``record_source_acquisition_error`` (via ``reason``) so the
+            # run-ledger entry and telemetry counters carry the
+            # classification.
+            kind_refined, retry_after_present = _classify_arxiv_429(
+                body=result.body,
+                headers=result.headers,
+            )
             last_error = NetworkError(
                 f"HTTP 429 from arXiv API at {url}",
                 url=url,
                 kind="rate_limit",
+                reason=(
+                    f"classification={kind_refined} "
+                    f"retry_after_present={str(retry_after_present).lower()}"
+                ),
             )
             if attempt < rate_limit_max_retries:
                 delay = _arxiv_429_delay(result.headers, resilience, attempt=attempt)
                 _log.warning(
-                    "arXiv 429 on attempt %d/%d, backing off %.1fs (FR-RES-2)",
+                    "arXiv 429 on attempt %d/%d, backing off %.1fs "
+                    "(FR-RES-2 classification=%s retry_after_present=%s)",
                     attempt + 1,
                     rate_limit_max_retries + 1,
                     delay,
+                    kind_refined,
+                    retry_after_present,
                 )
-                record_source_retry(source="arxiv", kind="rate_limit")
+                record_source_retry(source="arxiv", kind=kind_refined)
                 _sleep(delay)
                 continue
             raise last_error
@@ -979,14 +1095,26 @@ class ArxivSource:
                 else:
                     items = await _do_fetch()
             except NetworkError as exc:
+                # Issue #145: prefer the refined 429 classification
+                # stashed on the reason field so the run-ledger and
+                # metric counters surface "shared-capacity upstream"
+                # vs "local pacing" vs "unknown 429" instead of a
+                # generic ``rate_limit``.  Non-429 errors fall back
+                # to ``exc.kind`` unchanged.
+                ledger_kind = (
+                    _extract_arxiv_429_classification(exc)
+                    or exc.kind
+                    or "unknown"
+                )
                 _log.warning(
-                    "arxiv fetch failed for profile %r; yielding zero items",
+                    "arxiv fetch failed for profile %r kind=%s; yielding zero items",
                     profile,
+                    ledger_kind,
                     exc_info=True,
                 )
                 record_source_acquisition_error(
                     source="arxiv",
-                    kind=exc.kind or "unknown",
+                    kind=ledger_kind,
                     detail=str(exc),
                 )
                 metrics.source_acquisition_errors().add(
@@ -994,7 +1122,7 @@ class ArxivSource:
                     {
                         "profile": profile,
                         "source": "arxiv",
-                        "kind": exc.kind or "unknown",
+                        "kind": ledger_kind,
                     },
                 )
                 return []

--- a/tests/unit/test_arxiv_fetcher.py
+++ b/tests/unit/test_arxiv_fetcher.py
@@ -16,6 +16,8 @@ from influx.sources.arxiv import (
     ArxivItem,
     BackfillRange,
     _apply_min_interval,
+    _classify_arxiv_429,
+    _extract_arxiv_429_classification,
     _extract_arxiv_id,
     _filter_by_lookback,
     _parse_atom,
@@ -910,6 +912,10 @@ class TestArxivHardening:
         """Each retry — 429 or network — calls ``record_source_retry``
         with the correct kind so the run-ledger entry can surface
         recovered-retry counts (#129).
+
+        Issue #145: the 429 retry kind is now the refined classification
+        (``rate_limit_unknown`` here because the mock 429 has neither
+        the upstream-capacity body marker nor a ``Retry-After`` header).
         """
         del mock_sleep
         body = _load_fixture("empty_feed.atom")
@@ -931,7 +937,7 @@ class TestArxivHardening:
             fetch_arxiv(arxiv_config=cfg, resilience=resilience)
         kinds = [c.kwargs["kind"] for c in mock_record.call_args_list]
         sources = [c.kwargs["source"] for c in mock_record.call_args_list]
-        assert kinds == ["timeout", "rate_limit"]
+        assert kinds == ["timeout", "rate_limit_unknown"]
         assert sources == ["arxiv", "arxiv"]
 
 
@@ -1006,3 +1012,329 @@ class TestApplyMinInterval:
         mock_sleep.reset_mock()
         _apply_min_interval(3.0)
         mock_sleep.assert_not_called()
+
+
+class TestClassifyArxiv429:
+    """Issue #145 — refine arXiv 429 into a more specific kind.
+
+    The classifier inspects the response body and headers and returns
+    one of ``rate_limit_upstream_capacity``, ``rate_limit_local``, or
+    ``rate_limit_unknown`` so operators can distinguish shared-capacity
+    upstream events from local per-client throttling without trawling
+    raw logs.
+    """
+
+    def test_body_marker_wins_even_with_retry_after(self) -> None:
+        """The canonical ``Rate exceeded.`` body is the strongest signal.
+        Even when a ``Retry-After`` header is present, the body marker
+        wins — arXiv staff (Nov 2025) said this body indicates total
+        load on the public API, not a per-client abuse event.
+        """
+        kind, retry_after_present = _classify_arxiv_429(
+            body=b"Rate exceeded.",
+            headers={"Retry-After": "30"},
+        )
+        assert kind == "rate_limit_upstream_capacity"
+        assert retry_after_present is True
+
+    def test_body_marker_case_insensitive(self) -> None:
+        kind, _present = _classify_arxiv_429(
+            body=b"<html><body>RATE EXCEEDED</body></html>",
+            headers={},
+        )
+        assert kind == "rate_limit_upstream_capacity"
+
+    def test_body_marker_embedded_in_larger_body(self) -> None:
+        kind, _present = _classify_arxiv_429(
+            body=b"<html><h1>Whoops</h1><p>Rate exceeded. Try later.</p></html>",
+            headers={},
+        )
+        assert kind == "rate_limit_upstream_capacity"
+
+    def test_retry_after_without_body_marker_is_local(self) -> None:
+        """A ``Retry-After`` header without the shared-capacity body
+        marker is classical per-client throttling.
+        """
+        kind, retry_after_present = _classify_arxiv_429(
+            body=b"Too many requests",
+            headers={"Retry-After": "30"},
+        )
+        assert kind == "rate_limit_local"
+        assert retry_after_present is True
+
+    def test_retry_after_lookup_is_case_insensitive(self) -> None:
+        kind, retry_after_present = _classify_arxiv_429(
+            body=b"",
+            headers={"retry-after": "60"},
+        )
+        assert kind == "rate_limit_local"
+        assert retry_after_present is True
+
+    def test_no_signal_is_unknown(self) -> None:
+        kind, retry_after_present = _classify_arxiv_429(
+            body=b"",
+            headers={},
+        )
+        assert kind == "rate_limit_unknown"
+        assert retry_after_present is False
+
+    def test_unrelated_body_is_unknown(self) -> None:
+        kind, _present = _classify_arxiv_429(
+            body=b"Something else entirely",
+            headers={},
+        )
+        assert kind == "rate_limit_unknown"
+
+
+class TestArxiv429ClassificationIntegration:
+    """Issue #145 — the refined kind reaches telemetry and the ledger.
+
+    These tests drive the full ``_fetch_with_retry`` loop with mocked
+    HTTP, then assert that ``record_source_retry`` (recovered-retry
+    counts) and the ``NetworkError`` raised on budget exhaustion carry
+    the refined classification.
+    """
+
+    @patch("influx.sources.arxiv._sleep")
+    @patch("influx.sources.arxiv.guarded_fetch")
+    def test_upstream_capacity_body_recorded_on_retry(
+        self,
+        mock_fetch: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        """A 429 whose body matches ``Rate exceeded.`` records the
+        recovered retry under the ``rate_limit_upstream_capacity`` kind.
+        """
+        del mock_sleep
+        body = _load_fixture("recent_two.atom")
+        mock_fetch.side_effect = [
+            _make_fetch_result(b"Rate exceeded.", status_code=429),
+            _make_fetch_result(body),
+        ]
+        resilience = ResilienceConfig(
+            arxiv_429_backoff_seconds=1,
+            arxiv_429_backoff_max_seconds=2,
+            max_retries=2,
+            arxiv_429_max_retries=2,
+            arxiv_request_min_interval_seconds=0,
+        )
+        cfg = ArxivSourceConfig(categories=["cs.AI"], lookback_days=365)
+        with patch("influx.sources.arxiv.record_source_retry") as mock_record:
+            fetch_arxiv(arxiv_config=cfg, resilience=resilience)
+        kinds = [c.kwargs["kind"] for c in mock_record.call_args_list]
+        assert kinds == ["rate_limit_upstream_capacity"]
+
+    @patch("influx.sources.arxiv._sleep")
+    @patch("influx.sources.arxiv.guarded_fetch")
+    def test_local_pacing_kind_recorded_on_retry(
+        self,
+        mock_fetch: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        """A 429 with a ``Retry-After`` header but no shared-capacity
+        body marker records the recovered retry under
+        ``rate_limit_local``.
+        """
+        del mock_sleep
+        body = _load_fixture("recent_two.atom")
+        mock_fetch.side_effect = [
+            _make_fetch_result(
+                b"Too many requests",
+                status_code=429,
+                headers={"Retry-After": "5"},
+            ),
+            _make_fetch_result(body),
+        ]
+        resilience = ResilienceConfig(
+            arxiv_429_backoff_seconds=1,
+            arxiv_429_backoff_max_seconds=10,
+            max_retries=2,
+            arxiv_429_max_retries=2,
+            arxiv_request_min_interval_seconds=0,
+        )
+        cfg = ArxivSourceConfig(categories=["cs.AI"], lookback_days=365)
+        with patch("influx.sources.arxiv.record_source_retry") as mock_record:
+            fetch_arxiv(arxiv_config=cfg, resilience=resilience)
+        kinds = [c.kwargs["kind"] for c in mock_record.call_args_list]
+        assert kinds == ["rate_limit_local"]
+
+    @patch("influx.sources.arxiv._sleep")
+    @patch("influx.sources.arxiv.guarded_fetch")
+    def test_unknown_kind_recorded_on_retry(
+        self,
+        mock_fetch: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        """A 429 with neither the shared-capacity body marker nor a
+        ``Retry-After`` header records the recovered retry under
+        ``rate_limit_unknown``.
+        """
+        del mock_sleep
+        body = _load_fixture("recent_two.atom")
+        mock_fetch.side_effect = [
+            _make_fetch_result(b"", status_code=429),
+            _make_fetch_result(body),
+        ]
+        resilience = ResilienceConfig(
+            arxiv_429_backoff_seconds=1,
+            arxiv_429_backoff_max_seconds=10,
+            max_retries=2,
+            arxiv_429_max_retries=2,
+            arxiv_request_min_interval_seconds=0,
+        )
+        cfg = ArxivSourceConfig(categories=["cs.AI"], lookback_days=365)
+        with patch("influx.sources.arxiv.record_source_retry") as mock_record:
+            fetch_arxiv(arxiv_config=cfg, resilience=resilience)
+        kinds = [c.kwargs["kind"] for c in mock_record.call_args_list]
+        assert kinds == ["rate_limit_unknown"]
+
+    @patch("influx.sources.arxiv._sleep")
+    @patch("influx.sources.arxiv.guarded_fetch")
+    def test_exhausted_budget_carries_classification_on_exception(
+        self,
+        mock_fetch: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        """When the 429 retry budget exhausts, the raised ``NetworkError``
+        keeps ``kind='rate_limit'`` (legacy contract) but the refined
+        classification is recoverable from its ``reason``.
+        """
+        del mock_sleep
+        mock_fetch.side_effect = [
+            _make_fetch_result(b"Rate exceeded.", status_code=429),
+            _make_fetch_result(b"Rate exceeded.", status_code=429),
+            _make_fetch_result(b"Rate exceeded.", status_code=429),
+        ]
+        resilience = ResilienceConfig(
+            arxiv_429_backoff_seconds=1,
+            arxiv_429_backoff_max_seconds=2,
+            max_retries=2,
+            arxiv_429_max_retries=2,
+            arxiv_request_min_interval_seconds=0,
+        )
+        cfg = ArxivSourceConfig(categories=["cs.AI"])
+        with pytest.raises(NetworkError) as exc_info:
+            fetch_arxiv(arxiv_config=cfg, resilience=resilience)
+        err = exc_info.value
+        # Legacy ``kind`` is preserved for any downstream consumer that
+        # keyed on it before #145 landed.
+        assert err.kind == "rate_limit"
+        # Refined classification survives on ``reason`` so
+        # ``ArxivSource.fetch_candidates`` can surface it to the ledger.
+        assert _extract_arxiv_429_classification(err) == (
+            "rate_limit_upstream_capacity"
+        )
+
+    def test_extract_classification_returns_none_for_non_429(self) -> None:
+        """The reason-recovery helper returns ``None`` for non-429 errors
+        so callers fall back to ``error.kind`` unchanged.
+        """
+        err = NetworkError(
+            "boom", url="http://x", kind="timeout", reason="connect timeout"
+        )
+        assert _extract_arxiv_429_classification(err) is None
+
+    def test_extract_classification_returns_none_when_reason_unstructured(
+        self,
+    ) -> None:
+        """A legacy 429 ``NetworkError`` without the structured
+        ``classification=...`` prefix falls through to ``None``.
+        """
+        err = NetworkError("oops", url="http://x", kind="rate_limit", reason="")
+        assert _extract_arxiv_429_classification(err) is None
+
+
+class TestArxiv429ClassificationLedger:
+    """Issue #145 — refined classification reaches the run ledger via
+    ``ArxivSource.fetch_candidates``.
+
+    The 429 retry budget is exhausted so the source-acquisition path
+    runs, then we assert that the recorded error / metric carry the
+    refined classification rather than the generic ``rate_limit``.
+    """
+
+    @patch("influx.sources.arxiv._sleep")
+    @patch("influx.sources.arxiv.guarded_fetch")
+    def test_swallowed_error_records_refined_kind(
+        self,
+        mock_fetch: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        """When the 429 budget exhausts and ``ArxivSource.fetch_candidates``
+        swallows the error, the run-ledger entry recorded via
+        :func:`record_source_acquisition_error` carries
+        ``rate_limit_upstream_capacity`` (or ``_local`` / ``_unknown``)
+        rather than the legacy ``rate_limit``.
+        """
+        import asyncio
+
+        from influx.config import (
+            AppConfig,
+            ProfileConfig,
+            ProfileSources,
+            PromptEntryConfig,
+            PromptsConfig,
+            ResilienceConfig,
+            ScheduleConfig,
+        )
+        from influx.coordinator import RunKind
+        from influx.sources.arxiv import ArxivSource
+        from influx.telemetry import current_source_acquisition_errors
+
+        del mock_sleep
+        mock_fetch.side_effect = [
+            _make_fetch_result(b"Rate exceeded.", status_code=429),
+            _make_fetch_result(b"Rate exceeded.", status_code=429),
+            _make_fetch_result(b"Rate exceeded.", status_code=429),
+        ]
+
+        resilience = ResilienceConfig(
+            arxiv_429_backoff_seconds=1,
+            arxiv_429_backoff_max_seconds=2,
+            max_retries=2,
+            arxiv_429_max_retries=2,
+            arxiv_request_min_interval_seconds=0,
+        )
+
+        profile_cfg = ProfileConfig(
+            name="ai",
+            description="test",
+            sources=ProfileSources(
+                arxiv=ArxivSourceConfig(
+                    enabled=True,
+                    categories=["cs.AI"],
+                    max_results_per_category=10,
+                    lookback_days=7,
+                )
+            ),
+        )
+        cfg = AppConfig(
+            schedule=ScheduleConfig(cron="0 6 * * *", timezone="UTC"),
+            profiles=[profile_cfg],
+            prompts=PromptsConfig(
+                filter=PromptEntryConfig(text="x"),
+                tier1_enrich=PromptEntryConfig(text="x"),
+                tier3_extract=PromptEntryConfig(text="x"),
+            ),
+            resilience=resilience,
+        )
+
+        source = ArxivSource(cfg)
+
+        errors: list[dict[str, str]] = []
+        token = current_source_acquisition_errors.set(errors)
+        try:
+            result = asyncio.run(
+                source.fetch_candidates(
+                    profile_cfg=profile_cfg,
+                    kind=RunKind.SCHEDULED,
+                    run_range=None,
+                )
+            )
+        finally:
+            current_source_acquisition_errors.reset(token)
+
+        assert result == []
+        assert len(errors) == 1
+        assert errors[0]["source"] == "arxiv"
+        assert errors[0]["kind"] == "rate_limit_upstream_capacity"


### PR DESCRIPTION
## Summary
- Refine arXiv 429 classification via new `_classify_arxiv_429`:
  - `rate_limit_upstream_capacity` — response body contains case-insensitive `rate exceeded` (canonical shared-capacity marker per Nov 2025 staff guidance)
  - `rate_limit_local` — `Retry-After` header present AND no upstream-capacity body marker
  - `rate_limit_unknown` — neither signal
  - Body wins over header when both are present.
- Per-retry log now includes `classification=...` and `retry_after_present=...`.
- Refined kind flows into `record_source_retry` and is recovered from `NetworkError.reason` on retry-budget exhaustion so the run ledger + `influx_source_acquisition_errors_total` counter preserve the distinction.
- `NetworkError.kind` stays `"rate_limit"` to keep the legacy contract intact.

## Test plan
- [x] `uv run pytest` — 1915 passed
- [x] arXiv fetcher suite — 69 passed
- [x] New unit coverage: `TestClassifyArxiv429` (7 cases), `TestArxiv429ClassificationIntegration` (5 cases incl. exhausted-budget exception and helper fallbacks), `TestArxiv429ClassificationLedger` (end-to-end ledger assertion)

Closes #145