### PR TITLE
fix: downgrade harmless tier 3 fallback warnings (#151)

### DIFF
--- a/src/influx/cascade.py
+++ b/src/influx/cascade.py
@@ -40,6 +40,7 @@ from influx.telemetry import current_run_id, get_tracer
 __all__ = [
     "Acquired",
     "Cascade",
+    "EffectiveExtractionTier",
     "EnrichedSections",
     "TextFlavour",
     "Tier2Extractor",
@@ -109,6 +110,15 @@ Tier2Extractor = Callable[[Acquired], Tier2Result]
 # ── EnrichedSections ──────────────────────────────────────────────
 
 
+EffectiveExtractionTier = Literal[
+    "abstract-only",
+    "tier1",
+    "tier2",
+    "tier1+tier2",
+    "tier3",
+]
+
+
 @dataclass(frozen=True, slots=True)
 class EnrichedSections:
     """The Cascade's output for one Acquired (CONTEXT.md).
@@ -116,6 +126,19 @@ class EnrichedSections:
     All tier results are optional — absent when the gate did not fire,
     when the cascade short-circuited on a terminal flag, or when the
     underlying call raised a counted-class failure.
+
+    Observability fields (#151):
+
+    - ``effective_extraction_tier`` — the highest tier that produced
+      content used by the renderer.  Drives log-level selection when a
+      higher tier subsequently fails: if the effective tier already
+      covers ``tier1+tier2`` (a summary plus full text), a Tier 3
+      failure is harmless fallback noise rather than material
+      degradation.
+    - ``fallback_used`` — true when at least one tier was attempted and
+      failed *and* a lower tier still produced acceptable content.  The
+      renderer / metrics layer can use this to distinguish "we fell
+      back gracefully" from "the note is genuinely degraded".
     """
 
     tier1: Tier1Enrichment | None = None
@@ -126,6 +149,8 @@ class EnrichedSections:
     tier3: Tier3Extraction | None = None
     repair_flags: tuple[str, ...] = field(default_factory=tuple)
     terminal_flags: tuple[str, ...] = field(default_factory=tuple)
+    effective_extraction_tier: EffectiveExtractionTier = "abstract-only"
+    fallback_used: bool = False
 
 
 # ── Cascade ───────────────────────────────────────────────────────
@@ -177,6 +202,8 @@ class Cascade:
         counters = counters or RepairCounters()
         repair_flags: list[str] = []
         terminal_flags: list[str] = []
+        tier2_failed = False
+        tier3_failed = False
 
         # ── Tier 2 (full-text gate) ────────────────────────────────
         extracted_text = acquired.extracted_text
@@ -198,6 +225,7 @@ class Cascade:
                     text_tag = tier2.text_tag
                 else:
                     repair_flags.append("influx:repair-needed")
+                    tier2_failed = True
 
         # ``full_text`` for the renderer only when extraction succeeded
         # AND the score crosses the gate (FR-ENR-6, US-011).
@@ -217,13 +245,43 @@ class Cascade:
 
         # ── Tier 3 (deep-extract gate, requires extracted text) ─────
         tier3: Tier3Extraction | None = None
+        tier3_attempted = False
         if score >= self.thresholds.deep_extract and full_text is not None:
             if counters.tier3_attempts >= REPAIR_COUNTED_CAP:
                 terminal_flags.append("influx:tier3-terminal")
             else:
-                tier3 = self._run_tier3(acquired.title, full_text)
+                tier3_attempted = True
+                # Decide harmless-fallback vs. materially-degraded
+                # log level *before* the call so the dispatcher can
+                # emit the right classification at the failure site
+                # (#151).  Lower-tier content is "acceptable" when
+                # Tier 1 produced a summary AND Tier 2 produced full
+                # text — the note still has every section except the
+                # Tier 3 deep-extract ones.
+                lower_tier_acceptable = tier1 is not None
+                tier3 = self._run_tier3(
+                    acquired.item_id,
+                    acquired.title,
+                    full_text,
+                    lower_tier_acceptable=lower_tier_acceptable,
+                )
                 if tier3 is None:
                     repair_flags.append("influx:repair-needed")
+                    tier3_failed = True
+
+        effective_tier = _classify_effective_tier(
+            tier1=tier1,
+            full_text=full_text,
+            tier3=tier3,
+        )
+        fallback_used = _classify_fallback_used(
+            tier1_attempted=tier1_attempted,
+            tier1=tier1,
+            tier2_failed=tier2_failed,
+            tier3_attempted=tier3_attempted,
+            tier3_failed=tier3_failed,
+            effective_tier=effective_tier,
+        )
 
         return EnrichedSections(
             tier1=tier1,
@@ -234,6 +292,8 @@ class Cascade:
             tier3=tier3,
             repair_flags=tuple(dict.fromkeys(repair_flags)),
             terminal_flags=tuple(dict.fromkeys(terminal_flags)),
+            effective_extraction_tier=effective_tier,
+            fallback_used=fallback_used,
         )
 
     # ── Tier dispatchers ──────────────────────────────────────────
@@ -257,7 +317,16 @@ class Cascade:
                     config=self.config,
                 )
             except LCMAError:
-                logger.warning("Tier 1 enrichment failed for %s", acquired.item_id)
+                logger.warning(
+                    "Tier 1 enrichment failed for %s",
+                    acquired.item_id,
+                    extra={
+                        "profile": self.profile_name,
+                        "item_id": acquired.item_id,
+                        "tier": "1",
+                        "tier1_failure_kind": "lcma_error",
+                    },
+                )
                 metrics.llm_validation_failures().add(
                     1, {"profile": self.profile_name, "tier": "1"}
                 )
@@ -271,6 +340,12 @@ class Cascade:
                 logger.warning(
                     "Tier 1 enrichment crashed unexpectedly for %s",
                     acquired.item_id,
+                    extra={
+                        "profile": self.profile_name,
+                        "item_id": acquired.item_id,
+                        "tier": "1",
+                        "tier1_failure_kind": "unexpected_exception",
+                    },
                     exc_info=True,
                 )
                 metrics.llm_validation_failures().add(
@@ -298,8 +373,35 @@ class Cascade:
                 # abstract-only + repair-needed.
                 return None
 
-    def _run_tier3(self, title: str, full_text: str) -> Tier3Extraction | None:
-        """Dispatch Tier 3 with telemetry + degrade-on-failure semantics."""
+    def _run_tier3(
+        self,
+        item_id: str,
+        title: str,
+        full_text: str,
+        *,
+        lower_tier_acceptable: bool,
+    ) -> Tier3Extraction | None:
+        """Dispatch Tier 3 with telemetry + degrade-on-failure semantics.
+
+        ``lower_tier_acceptable`` controls log-level classification of a
+        Tier 3 failure (#151):
+
+        - ``True`` (Tier 1 summary + full text already in place) — the
+          failure is harmless fallback noise: log at ``INFO`` with
+          ``fallback_used=True`` and ``effective_extraction_tier=
+          "tier1+tier2"`` so dashboards can filter it out from
+          materially-degraded extractions.
+        - ``False`` (Tier 1 or Tier 2 also produced no content) — the
+          note is materially degraded: keep the ``WARNING`` so
+          operators still see the actionable signal.
+
+        The ``llm_validation_failures`` metric continues to tick on
+        every failure (no behaviour change for repair counters or the
+        ``influx:repair-needed`` flag); the new
+        ``tier3_fallbacks`` metric tags each failure with
+        ``fallback_kind=harmless|degraded`` so run summaries can
+        distinguish them.
+        """
         tracer = get_tracer()
         with tracer.span(
             "influx.enrich.tier3",
@@ -316,9 +418,12 @@ class Cascade:
                     config=self.config,
                 )
             except LCMAError:
-                logger.warning("Tier 3 extraction failed for %s", title)
-                metrics.llm_validation_failures().add(
-                    1, {"profile": self.profile_name, "tier": "3"}
+                self._log_tier3_failure(
+                    item_id=item_id,
+                    title=title,
+                    lower_tier_acceptable=lower_tier_acceptable,
+                    failure_kind="lcma_error",
+                    exc_info=False,
                 )
                 return None
             except Exception:
@@ -326,15 +431,68 @@ class Cascade:
                 # validator bug or unforeseen response shape must not
                 # turn a single bad paper into a run-level abort
                 # (staging incident 2026-05-01).
-                logger.warning(
-                    "Tier 3 extraction crashed unexpectedly for %s",
-                    title,
+                self._log_tier3_failure(
+                    item_id=item_id,
+                    title=title,
+                    lower_tier_acceptable=lower_tier_acceptable,
+                    failure_kind="unexpected_exception",
                     exc_info=True,
                 )
-                metrics.llm_validation_failures().add(
-                    1, {"profile": self.profile_name, "tier": "3"}
-                )
                 return None
+
+    def _log_tier3_failure(
+        self,
+        *,
+        item_id: str,
+        title: str,
+        lower_tier_acceptable: bool,
+        failure_kind: str,
+        exc_info: bool,
+    ) -> None:
+        """Emit the Tier 3 failure log + metrics with #151 classification.
+
+        Centralises log-level selection and the structured ``extra`` fields
+        so the LCMA-error path and the unexpected-exception path stay in
+        lock-step.
+        """
+        fallback_kind = "harmless" if lower_tier_acceptable else "degraded"
+        effective_tier = "tier1+tier2" if lower_tier_acceptable else "tier1"
+        extra = {
+            "profile": self.profile_name,
+            "item_id": item_id,
+            "tier": "3",
+            "fallback_used": lower_tier_acceptable,
+            "fallback_kind": fallback_kind,
+            "effective_extraction_tier": effective_tier,
+            "tier3_failure_kind": failure_kind,
+        }
+        if lower_tier_acceptable:
+            # Harmless fallback noise — earlier tiers already produced
+            # acceptable note content.  Downgrade to INFO so operators
+            # can still see the event when debugging without it
+            # polluting the staging warning stream (#151).
+            logger.info(
+                "Tier 3 extraction failed for %s; lower tiers produced "
+                "acceptable content, falling back",
+                title,
+                extra=extra,
+                exc_info=exc_info,
+            )
+        else:
+            logger.warning(
+                "Tier 3 extraction failed for %s; note content materially "
+                "degraded (no Tier 1 summary available)",
+                title,
+                extra=extra,
+                exc_info=exc_info,
+            )
+        metrics.llm_validation_failures().add(
+            1, {"profile": self.profile_name, "tier": "3"}
+        )
+        metrics.tier3_fallbacks().add(
+            1,
+            {"profile": self.profile_name, "fallback_kind": fallback_kind},
+        )
 
 
 def _text_tag_for(flavour: TextFlavour | None) -> str:
@@ -344,3 +502,48 @@ def _text_tag_for(flavour: TextFlavour | None) -> str:
     if flavour == "pdf":
         return "text:pdf"
     return "text:abstract-only"
+
+
+def _classify_effective_tier(
+    *,
+    tier1: Tier1Enrichment | None,
+    full_text: str | None,
+    tier3: Tier3Extraction | None,
+) -> EffectiveExtractionTier:
+    """Pick the highest tier label that reflects what made it into the note (#151).
+
+    Used by :class:`EnrichedSections` consumers (renderer, run
+    summaries, metrics) to tell at a glance whether a tier failure
+    materially degraded the output or was a harmless fallback.
+    """
+    if tier3 is not None:
+        return "tier3"
+    if tier1 is not None and full_text is not None:
+        return "tier1+tier2"
+    if tier1 is not None:
+        return "tier1"
+    if full_text is not None:
+        return "tier2"
+    return "abstract-only"
+
+
+def _classify_fallback_used(
+    *,
+    tier1_attempted: bool,
+    tier1: Tier1Enrichment | None,
+    tier2_failed: bool,
+    tier3_attempted: bool,
+    tier3_failed: bool,
+    effective_tier: EffectiveExtractionTier,
+) -> bool:
+    """Return whether any tier fell back to a lower one with usable output (#151).
+
+    A run is "in fallback" when at least one attempted tier produced no
+    output *and* the cascade still produced an effective tier above
+    abstract-only.  Repair flags continue to be the source of truth for
+    "this needs a repair sweep"; this flag is the operator-facing
+    "harmless vs material" classifier for logs and metrics.
+    """
+    tier1_failed = tier1_attempted and tier1 is None
+    any_tier_failed = tier1_failed or tier2_failed or (tier3_attempted and tier3_failed)
+    return any_tier_failed and effective_tier != "abstract-only"

--- a/src/influx/cascade.py
+++ b/src/influx/cascade.py
@@ -35,7 +35,7 @@ from influx.enrich import tier1_enrich, tier3_extract
 from influx.errors import ExtractionError, LCMAError
 from influx.repair_counters import REPAIR_COUNTED_CAP, RepairCounters
 from influx.schemas import Tier1Enrichment, Tier3Extraction
-from influx.telemetry import current_run_id, get_tracer
+from influx.telemetry import current_run_id, get_tracer, record_tier3_fallback
 
 __all__ = [
     "Acquired",
@@ -454,14 +454,32 @@ class Cascade:
         Centralises log-level selection and the structured ``extra`` fields
         so the LCMA-error path and the unexpected-exception path stay in
         lock-step.
+
+        Tier 3 only runs when Tier 2 produced full text (the deep-extract
+        gate requires ``full_text is not None``).  So every Tier 3 failure
+        is a fallback to lower-tier content — what differs is how much
+        lower-tier content exists:
+
+        - ``lower_tier_acceptable=True`` (Tier 1 summary + Tier 2 full
+          text) — harmless fallback: the note has every section except
+          the Tier 3 deep-extract ones.  Effective tier is
+          ``tier1+tier2``; log at INFO.
+        - ``lower_tier_acceptable=False`` (Tier 1 missing, Tier 2 full
+          text present) — degraded fallback: the note is missing its
+          summary section.  Effective tier is ``tier2``; log at WARNING.
+
+        Both branches set ``fallback_used=True`` because the cascade did
+        in fact fall back from Tier 3 to whatever lower-tier content
+        existed; what changes is the *completeness* of that lower-tier
+        content, not whether a fallback happened.
         """
         fallback_kind = "harmless" if lower_tier_acceptable else "degraded"
-        effective_tier = "tier1+tier2" if lower_tier_acceptable else "tier1"
+        effective_tier = "tier1+tier2" if lower_tier_acceptable else "tier2"
         extra = {
             "profile": self.profile_name,
             "item_id": item_id,
             "tier": "3",
-            "fallback_used": lower_tier_acceptable,
+            "fallback_used": True,
             "fallback_kind": fallback_kind,
             "effective_extraction_tier": effective_tier,
             "tier3_failure_kind": failure_kind,
@@ -493,6 +511,13 @@ class Cascade:
             1,
             {"profile": self.profile_name, "fallback_kind": fallback_kind},
         )
+        # Propagate the classification to the current run's ledger entry
+        # (#151 gap 2): increment a per-run counter so run summaries /
+        # ``/runs/recent`` can distinguish harmless Tier 3 fallback from
+        # genuinely degraded extractions without scraping logs.  Safe
+        # outside a run context — the helper no-ops when the contextvar
+        # bucket is unset.
+        record_tier3_fallback(kind=fallback_kind)
 
 
 def _text_tag_for(flavour: TextFlavour | None) -> str:

--- a/src/influx/metrics.py
+++ b/src/influx/metrics.py
@@ -55,6 +55,7 @@ __all__ = [
     "slug_collision_unresolved",
     "slug_collision_url_recovery",
     "source_acquisition_errors",
+    "tier3_fallbacks",
 ]
 
 
@@ -225,6 +226,32 @@ def llm_validation_failures() -> Any:
     return get_meter().counter(
         "influx_llm_validation_failures_total",
         description="LLM enrichment failures (Tier 1 or Tier 3).",
+    )
+
+
+def tier3_fallbacks() -> Any:
+    """Counter of Tier 3 extraction failures classified by impact (#151).
+
+    Tier 3 sits at the top of the cascade and frequently fails on
+    long-tail papers; many of those failures are harmless when Tier 1
+    + Tier 2 already produced a usable note.  This instrument
+    separates those harmless fallbacks from materially-degraded
+    failures so dashboards and alerts can target the latter.
+
+    Increments alongside :func:`llm_validation_failures` (``tier="3"``)
+    on every Tier 3 failure; the ``fallback_kind`` label distinguishes
+    ``"harmless"`` (Tier 1 produced a summary AND Tier 2 produced full
+    text) from ``"degraded"`` (Tier 1 also failed).
+
+    Labels: ``profile``, ``fallback_kind`` (``"harmless"`` |
+    ``"degraded"``).
+    """
+    return get_meter().counter(
+        "influx_tier3_fallbacks_total",
+        description=(
+            "Tier 3 extraction failures split by whether lower tiers "
+            "produced acceptable note content (issue #151)."
+        ),
     )
 
 

--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -93,6 +93,15 @@ class RunLedger:
             # dict at start; populated from the per-run contextvar at
             # ``complete`` time.
             "source_retry_counts": {},
+            # #151: per-run counts of Tier 3 enrichment fallbacks,
+            # split by classification.  Shape:
+            # ``{"harmless": int, "degraded": int}``.  Empty dict at
+            # start; populated from the per-run contextvar at
+            # ``complete`` time so run summaries / ``/runs/recent``
+            # can distinguish "Tier 3 noise that didn't break notes"
+            # from "Tier 3 + Tier 1 both failed — note materially
+            # incomplete".
+            "tier3_fallbacks": {},
         }
         try:
             active = self._read_active()
@@ -113,6 +122,7 @@ class RunLedger:
         archive_failures_total: int | None = None,
         source_acquisition_errors: list[dict[str, str]] | None = None,
         source_retry_counts: dict[str, dict[str, int]] | None = None,
+        tier3_fallbacks: dict[str, int] | None = None,
     ) -> list[str]:
         """Mark an active run as completed and append it to history.
 
@@ -313,6 +323,7 @@ class RunLedger:
             source_acquisition_errors=errors,
             degraded_reasons=reasons,
             source_retry_counts=source_retry_counts,
+            tier3_fallbacks=tier3_fallbacks,
         )
         return reasons
 
@@ -637,6 +648,7 @@ class RunLedger:
         source_acquisition_errors: list[dict[str, str]] | None = None,
         degraded_reasons: list[str] | None = None,
         source_retry_counts: dict[str, dict[str, int]] | None = None,
+        tier3_fallbacks: dict[str, int] | None = None,
     ) -> None:
         try:
             active = self._read_active()
@@ -678,6 +690,12 @@ class RunLedger:
                         source: dict(by_kind)
                         for source, by_kind in (source_retry_counts or {}).items()
                     },
+                    # #151: shallow-copy the Tier 3 fallback counts so
+                    # later mutations of the contextvar bucket do not
+                    # leak into the persisted ledger entry.  ``int``
+                    # values are already immutable, so a flat ``dict()``
+                    # is sufficient.
+                    "tier3_fallbacks": dict(tier3_fallbacks or {}),
                 }
             )
             self._append(entry)

--- a/src/influx/run_service.py
+++ b/src/influx/run_service.py
@@ -51,6 +51,7 @@ from influx.telemetry import (
     current_run_id,
     current_source_acquisition_errors,
     current_source_retry_counts,
+    current_tier3_fallback_counts,
     get_tracer,
 )
 
@@ -129,6 +130,15 @@ async def ledger_lifecycle(
     # ``current_source_acquisition_errors``.
     source_retry_counts: dict[str, dict[str, int]] = {}
     source_retry_counts_token = current_source_retry_counts.set(source_retry_counts)
+    # #151: per-run counts of Tier 3 enrichment fallbacks split by
+    # classification (``harmless`` vs ``degraded``).  Surfaced on the
+    # run-ledger entry as ``tier3_fallbacks`` so ``/runs/recent`` can
+    # distinguish "Tier 3 noise that didn't break notes" from "Tier 3
+    # failed AND Tier 1 was also missing — note materially incomplete".
+    tier3_fallback_counts: dict[str, int] = {}
+    tier3_fallback_counts_token = current_tier3_fallback_counts.set(
+        tier3_fallback_counts
+    )
     metric_attrs = {"profile": profile, "run_type": plan.kind.value}
 
     ledger.start(
@@ -228,6 +238,10 @@ async def ledger_lifecycle(
             # the swallowed-error list, letting an operator distinguish
             # transient retry success from a burned retry budget.
             source_retry_counts=source_retry_counts,
+            # #151: surface harmless-vs-degraded Tier 3 fallback counts
+            # so run summaries / ``/runs/recent`` can tell apart noise
+            # from material degradation without scraping logs.
+            tier3_fallbacks=tier3_fallback_counts,
         )
         run_outcome = "degraded" if source_errors else "success"
         if "ingestion_stall" in degraded_reasons:
@@ -401,6 +415,7 @@ async def ledger_lifecycle(
         current_filter_errors.reset(filter_errors_token)
         current_invalid_url_rejections.reset(invalid_url_rejections_token)
         current_source_retry_counts.reset(source_retry_counts_token)
+        current_tier3_fallback_counts.reset(tier3_fallback_counts_token)
 
 
 # ── RunService ──────────────────────────────────────────────────────

--- a/src/influx/telemetry.py
+++ b/src/influx/telemetry.py
@@ -31,6 +31,7 @@ __all__ = [
     "SourceAcquisitionError",
     "SourceRetryCounts",
     "SpanWrapper",
+    "Tier3FallbackCounts",
     "current_archive_terminal_arxiv_ids",
     "current_fetched_total",
     "current_filter_errors",
@@ -38,6 +39,7 @@ __all__ = [
     "current_run_id",
     "current_source_acquisition_errors",
     "current_source_retry_counts",
+    "current_tier3_fallback_counts",
     "get_meter",
     "get_tracer",
     "record_fetched_items",
@@ -45,6 +47,7 @@ __all__ = [
     "record_invalid_url_rejection",
     "record_source_acquisition_error",
     "record_source_retry",
+    "record_tier3_fallback",
 ]
 
 # Context variable for the current run ID — set by ``run_profile()`` so
@@ -246,6 +249,48 @@ def record_invalid_url_rejection(count: int = 1) -> None:
     if counter is None:
         return
     counter[0] += count
+
+
+# Per-run counters of Tier 3 enrichment fallbacks, split by classification
+# (#151).  Shape: ``{"harmless": N, "degraded": M}``.
+#
+# Surfaced on the run-ledger entry as ``tier3_fallbacks`` so run summaries
+# and ``/runs/recent`` can distinguish "Tier 3 failed but Tier 1 + Tier 2
+# content covered for it" (harmless — log-level noise only) from "Tier 3
+# failed AND Tier 1 was also missing" (degraded — the note is materially
+# incomplete).  Operators previously could not tell these apart from the
+# ledger; now they can without scraping logs.
+#
+# A shared mutable dict so :func:`record_tier3_fallback` can update it
+# in-place via ``setdefault`` without ContextVar.set semantics, mirroring
+# :data:`current_source_retry_counts`.
+Tier3FallbackCounts = dict[str, int]
+
+
+current_tier3_fallback_counts: ContextVar[Tier3FallbackCounts | None] = ContextVar(
+    "current_tier3_fallback_counts",
+    default=None,
+)
+
+
+def record_tier3_fallback(*, kind: str) -> None:
+    """Increment the current run's Tier 3 fallback counter for *kind* (#151).
+
+    *kind* is the same ``fallback_kind`` label the cascade attaches to
+    its log line + ``tier3_fallbacks`` metric: ``"harmless"`` when Tier
+    1 + Tier 2 both produced acceptable content, ``"degraded"`` when
+    Tier 1 was missing.
+
+    Safe to call outside a run context — silently no-ops when
+    :data:`current_tier3_fallback_counts` is unset.  The Cascade calls
+    this from :meth:`Cascade._log_tier3_failure`, the single spot that
+    already emits the per-failure log + metric, so the two records stay
+    in lock-step.
+    """
+    counts = current_tier3_fallback_counts.get()
+    if counts is None:
+        return
+    counts[kind] = counts.get(kind, 0) + 1
 
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_http_api.py
+++ b/tests/integration/test_http_api.py
@@ -426,6 +426,59 @@ class TestRecentRuns:
 
         assert [run["run_id"] for run in body["runs"]] == ["run-web"]
 
+    def test_recent_runs_surfaces_tier3_fallback_breakdown(
+        self, client: TestClient, app_with_state: FastAPI
+    ) -> None:
+        """``/runs/recent`` exposes ``tier3_fallbacks`` so operators can
+        distinguish harmless Tier 3 noise from materially-degraded
+        extractions without scraping logs (#151).
+
+        Two runs are recorded: one with mixed fallback counts (the
+        ``noisy`` run) and one clean.  The endpoint must surface the
+        counts on the noisy entry and a zero-shaped ``{}`` on the
+        clean entry, never omit the field.
+        """
+        ledger: RunLedger = app_with_state.state.run_ledger
+        ledger.start(
+            run_id="run-noisy",
+            profile="ai-robotics",
+            kind="scheduled",
+            run_range=None,
+        )
+        ledger.complete(
+            run_id="run-noisy",
+            sources_checked=10,
+            ingested=10,
+            tier3_fallbacks={"harmless": 7, "degraded": 2},
+        )
+        ledger.start(
+            run_id="run-clean",
+            profile="ai-robotics",
+            kind="scheduled",
+            run_range=None,
+        )
+        ledger.complete(
+            run_id="run-clean",
+            sources_checked=4,
+            ingested=4,
+        )
+
+        body = client.get("/runs/recent").json()
+        by_id = {run["run_id"]: run for run in body["runs"]}
+
+        noisy = by_id["run-noisy"]
+        assert noisy["tier3_fallbacks"] == {"harmless": 7, "degraded": 2}
+        # Harmless-only Tier 3 fallback does not flag the run as
+        # degraded — the counter is diagnostic, not a stall reason.
+        # The presence of two ``degraded`` Tier 3 fallbacks is still
+        # surfaced for operator inspection, but ``degraded_reasons``
+        # only covers stall / acquisition / archive shapes.
+        assert noisy["degraded"] is False
+        assert noisy["degraded_reasons"] == []
+
+        clean = by_id["run-clean"]
+        assert clean["tier3_fallbacks"] == {}
+
 
 class TestPostRunsSchedulerOverlap:
     """AC-03-A: scheduled fire + POST /runs for same profile → exactly one accepted."""

--- a/tests/unit/test_cascade.py
+++ b/tests/unit/test_cascade.py
@@ -539,9 +539,15 @@ class TestTier3FallbackClassification:
         assert record.levelno == logging.WARNING, (
             f"expected WARNING for materially-degraded failure, got {record.levelname}"
         )
-        assert getattr(record, "fallback_used", None) is False
+        # Tier 3 only runs when Tier 2 produced full text, so a Tier 3
+        # failure is always a fallback to lower-tier content.  In the
+        # degraded case Tier 1 is missing, so the effective tier is
+        # ``tier2`` (Tier 2 full text without a summary section), not
+        # ``tier1``.  ``fallback_used`` is ``True`` because we did fall
+        # back from Tier 3 to Tier 2 content.
+        assert getattr(record, "fallback_used", None) is True
         assert getattr(record, "fallback_kind", None) == "degraded"
-        assert getattr(record, "effective_extraction_tier", None) == "tier1"
+        assert getattr(record, "effective_extraction_tier", None) == "tier2"
 
     def test_unexpected_tier3_exception_keeps_classification(
         self, caplog: pytest.LogCaptureFixture

--- a/tests/unit/test_cascade.py
+++ b/tests/unit/test_cascade.py
@@ -7,12 +7,18 @@ Covers:
 - Counted-failure → ``influx:repair-needed`` repair_flags.
 - :class:`RepairCounters` integration: ``influx:tier{2,3}-terminal``
   flags surface when the cap has been reached on entry.
+- Issue #151: harmless-vs-degraded Tier 3 failure classification on
+  the ``EnrichedSections`` shape, the failure log level, and the
+  ``tier3_fallbacks`` metric.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from influx.cascade import (
     Acquired,
@@ -367,6 +373,329 @@ class TestEnrichedSectionsShape:
         assert sections.tier3 is None
         assert sections.repair_flags == ()
         assert sections.terminal_flags == ()
+        assert sections.effective_extraction_tier == "abstract-only"
+        assert sections.fallback_used is False
+
+
+# ── #151: Tier 3 fallback classification ──────────────────────────
+
+
+class TestTier3FallbackClassification:
+    """Tier 3 failures are classified by the observable cascade outcome.
+
+    Acceptance criteria from issue #151:
+
+    - Tier 3 failure with Tier 1 success + full text → INFO,
+      ``fallback_used=True``, ``effective_extraction_tier="tier1+tier2"``.
+    - Tier 3 failure with Tier 1 failure → WARNING, materially
+      degraded.
+    - Structured ``extra`` fields carry ``fallback_used`` /
+      ``fallback_kind`` / ``effective_extraction_tier`` /
+      ``tier3_failure_kind``.
+    - The ``tier3_fallbacks`` metric splits failures by
+      ``fallback_kind``.
+    """
+
+    def _tier1(self) -> Tier1Enrichment:
+        return Tier1Enrichment(
+            contributions=["c"], method="m", result="r", relevance="rel"
+        )
+
+    def _extractor(self) -> Any:
+        def extractor(_acq: Acquired) -> Tier2Result:
+            return Tier2Result(text="body", flavour="html", text_tag="text:html")
+
+        return extractor
+
+    # ── effective_extraction_tier / fallback_used field shape ──────
+
+    def test_full_success_marks_tier3_effective_no_fallback(self) -> None:
+        tier3 = Tier3Extraction(claims=["claim"], builds_on=["b"])
+        with (
+            patch("influx.cascade.tier1_enrich", return_value=self._tier1()),
+            patch("influx.cascade.tier3_extract", return_value=tier3),
+        ):
+            sections = _make_cascade(tier2_extractor=self._extractor()).enrich(
+                _make_acquired(), score=10
+            )
+        assert sections.effective_extraction_tier == "tier3"
+        assert sections.fallback_used is False
+
+    def test_harmless_tier3_failure_marks_tier1_plus_tier2_with_fallback(
+        self,
+    ) -> None:
+        with (
+            patch("influx.cascade.tier1_enrich", return_value=self._tier1()),
+            patch(
+                "influx.cascade.tier3_extract",
+                side_effect=LCMAError("validate fail", stage="validate"),
+            ),
+        ):
+            sections = _make_cascade(tier2_extractor=self._extractor()).enrich(
+                _make_acquired(), score=10
+            )
+        assert sections.tier3 is None
+        assert sections.effective_extraction_tier == "tier1+tier2"
+        assert sections.fallback_used is True
+
+    def test_degraded_tier3_failure_when_tier1_also_failed(self) -> None:
+        with (
+            patch(
+                "influx.cascade.tier1_enrich",
+                side_effect=LCMAError("t1 fail", model="enrich", stage="validate"),
+            ),
+            patch(
+                "influx.cascade.tier3_extract",
+                side_effect=LCMAError("t3 fail", stage="validate"),
+            ),
+        ):
+            sections = _make_cascade(tier2_extractor=self._extractor()).enrich(
+                _make_acquired(), score=10
+            )
+        assert sections.tier1 is None
+        assert sections.tier3 is None
+        # Effective tier reflects what made it into the note: Tier 2
+        # text only.  Fallback was used (two tiers failed) but the
+        # note is materially degraded — no Tier 1 summary.
+        assert sections.effective_extraction_tier == "tier2"
+        assert sections.fallback_used is True
+
+    def test_unexpected_tier3_exception_classifies_as_harmless_when_tier1_ok(
+        self,
+    ) -> None:
+        """The defensive ``except Exception`` path must use the same classification."""
+        with (
+            patch("influx.cascade.tier1_enrich", return_value=self._tier1()),
+            patch(
+                "influx.cascade.tier3_extract",
+                side_effect=AttributeError("validator bug"),
+            ),
+        ):
+            sections = _make_cascade(tier2_extractor=self._extractor()).enrich(
+                _make_acquired(), score=10
+            )
+        assert sections.tier3 is None
+        assert sections.effective_extraction_tier == "tier1+tier2"
+        assert sections.fallback_used is True
+
+    # ── Log-level selection ──────────────────────────────────────
+
+    def test_harmless_tier3_failure_logs_at_info(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger="influx.cascade")
+        with (
+            patch("influx.cascade.tier1_enrich", return_value=self._tier1()),
+            patch(
+                "influx.cascade.tier3_extract",
+                side_effect=LCMAError("validate fail", stage="validate"),
+            ),
+        ):
+            _make_cascade(tier2_extractor=self._extractor()).enrich(
+                _make_acquired(), score=10
+            )
+
+        tier3_records = [
+            r
+            for r in caplog.records
+            if r.name == "influx.cascade" and "Tier 3 extraction failed" in r.message
+        ]
+        assert len(tier3_records) == 1
+        record = tier3_records[0]
+        assert record.levelno == logging.INFO, (
+            f"expected INFO for harmless fallback, got {record.levelname}"
+        )
+        assert getattr(record, "fallback_used", None) is True
+        assert getattr(record, "fallback_kind", None) == "harmless"
+        assert getattr(record, "effective_extraction_tier", None) == "tier1+tier2"
+        assert getattr(record, "tier3_failure_kind", None) == "lcma_error"
+        assert getattr(record, "tier", None) == "3"
+
+    def test_degraded_tier3_failure_logs_at_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger="influx.cascade")
+        with (
+            patch(
+                "influx.cascade.tier1_enrich",
+                side_effect=LCMAError("t1 fail", model="enrich", stage="validate"),
+            ),
+            patch(
+                "influx.cascade.tier3_extract",
+                side_effect=LCMAError("t3 fail", stage="validate"),
+            ),
+        ):
+            _make_cascade(tier2_extractor=self._extractor()).enrich(
+                _make_acquired(), score=10
+            )
+
+        tier3_records = [
+            r
+            for r in caplog.records
+            if r.name == "influx.cascade" and "Tier 3 extraction failed" in r.message
+        ]
+        assert len(tier3_records) == 1
+        record = tier3_records[0]
+        assert record.levelno == logging.WARNING, (
+            f"expected WARNING for materially-degraded failure, got {record.levelname}"
+        )
+        assert getattr(record, "fallback_used", None) is False
+        assert getattr(record, "fallback_kind", None) == "degraded"
+        assert getattr(record, "effective_extraction_tier", None) == "tier1"
+
+    def test_unexpected_tier3_exception_keeps_classification(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Defensive catch-all path mirrors the LCMAError path's classification."""
+        caplog.set_level(logging.DEBUG, logger="influx.cascade")
+        with (
+            patch("influx.cascade.tier1_enrich", return_value=self._tier1()),
+            patch(
+                "influx.cascade.tier3_extract",
+                side_effect=AttributeError("validator bug"),
+            ),
+        ):
+            _make_cascade(tier2_extractor=self._extractor()).enrich(
+                _make_acquired(), score=10
+            )
+
+        tier3_records = [
+            r
+            for r in caplog.records
+            if r.name == "influx.cascade" and "Tier 3 extraction failed" in r.message
+        ]
+        assert len(tier3_records) == 1
+        record = tier3_records[0]
+        assert record.levelno == logging.INFO
+        assert getattr(record, "tier3_failure_kind", None) == "unexpected_exception"
+
+    # ── Metrics ───────────────────────────────────────────────────
+
+    def test_harmless_tier3_failure_increments_metric_with_harmless_label(
+        self,
+    ) -> None:
+        fallbacks_counter = MagicMock()
+        with (
+            patch("influx.cascade.tier1_enrich", return_value=self._tier1()),
+            patch(
+                "influx.cascade.tier3_extract",
+                side_effect=LCMAError("validate fail", stage="validate"),
+            ),
+            patch(
+                "influx.cascade.metrics.tier3_fallbacks",
+                return_value=fallbacks_counter,
+            ),
+        ):
+            _make_cascade(tier2_extractor=self._extractor()).enrich(
+                _make_acquired(), score=10
+            )
+
+        fallbacks_counter.add.assert_called_once_with(
+            1, {"profile": "research", "fallback_kind": "harmless"}
+        )
+
+    def test_degraded_tier3_failure_increments_metric_with_degraded_label(
+        self,
+    ) -> None:
+        fallbacks_counter = MagicMock()
+        with (
+            patch(
+                "influx.cascade.tier1_enrich",
+                side_effect=LCMAError("t1 fail", model="enrich", stage="validate"),
+            ),
+            patch(
+                "influx.cascade.tier3_extract",
+                side_effect=LCMAError("t3 fail", stage="validate"),
+            ),
+            patch(
+                "influx.cascade.metrics.tier3_fallbacks",
+                return_value=fallbacks_counter,
+            ),
+        ):
+            _make_cascade(tier2_extractor=self._extractor()).enrich(
+                _make_acquired(), score=10
+            )
+
+        fallbacks_counter.add.assert_called_once_with(
+            1, {"profile": "research", "fallback_kind": "degraded"}
+        )
+
+    def test_tier3_success_does_not_touch_fallback_metric(self) -> None:
+        tier3 = Tier3Extraction(claims=["claim"], builds_on=["b"])
+        fallbacks_counter = MagicMock()
+        with (
+            patch("influx.cascade.tier1_enrich", return_value=self._tier1()),
+            patch("influx.cascade.tier3_extract", return_value=tier3),
+            patch(
+                "influx.cascade.metrics.tier3_fallbacks",
+                return_value=fallbacks_counter,
+            ),
+        ):
+            _make_cascade(tier2_extractor=self._extractor()).enrich(
+                _make_acquired(), score=10
+            )
+        fallbacks_counter.add.assert_not_called()
+
+    # ── Helper classification (used by EnrichedSections consumers) ─
+
+    def test_no_tier_runs_means_effective_abstract_only_no_fallback(self) -> None:
+        with (
+            patch("influx.cascade.tier1_enrich") as t1,
+            patch("influx.cascade.tier3_extract") as t3,
+        ):
+            sections = _make_cascade().enrich(_make_acquired(), score=3)
+        t1.assert_not_called()
+        t3.assert_not_called()
+        # No tiers fired, no failures: the note carries only the
+        # candidate's abstract, with no fallback in play.
+        assert sections.effective_extraction_tier == "abstract-only"
+        assert sections.fallback_used is False
+
+    def test_tier1_only_marks_tier1_effective_no_fallback_when_no_failure(
+        self,
+    ) -> None:
+        """Score above relevance but below full_text: only Tier 1 fires successfully."""
+        with patch("influx.cascade.tier1_enrich", return_value=self._tier1()):
+            sections = _make_cascade().enrich(_make_acquired(), score=7)
+        assert sections.tier1 is not None
+        assert sections.full_text is None
+        assert sections.effective_extraction_tier == "tier1"
+        assert sections.fallback_used is False
+
+    def test_tier2_failure_with_tier1_ok_marks_fallback(self) -> None:
+        def extractor(_acq: Acquired) -> Tier2Result:
+            raise ExtractionError("both html and pdf failed", url="x", stage="parse")
+
+        with patch("influx.cascade.tier1_enrich", return_value=self._tier1()):
+            sections = _make_cascade(tier2_extractor=extractor).enrich(
+                _make_acquired(), score=8
+            )
+        assert sections.full_text is None
+        assert sections.effective_extraction_tier == "tier1"
+        assert sections.fallback_used is True
+
+    def test_tier3_terminal_skip_does_not_count_as_failure(self) -> None:
+        """Reaching the repair cap is not a fresh Tier 3 failure to classify."""
+        fallbacks_counter = MagicMock()
+        counters = RepairCounters(tier3_attempts=REPAIR_COUNTED_CAP)
+        with (
+            patch("influx.cascade.tier1_enrich", return_value=self._tier1()),
+            patch("influx.cascade.tier3_extract") as t3,
+            patch(
+                "influx.cascade.metrics.tier3_fallbacks",
+                return_value=fallbacks_counter,
+            ),
+        ):
+            sections = _make_cascade(tier2_extractor=self._extractor()).enrich(
+                _make_acquired(), score=10, counters=counters
+            )
+        t3.assert_not_called()
+        fallbacks_counter.add.assert_not_called()
+        # Terminal flag set, but no new failure was attempted so
+        # the fallback-used signal stays false.
+        assert "influx:tier3-terminal" in sections.terminal_flags
+        assert sections.effective_extraction_tier == "tier1+tier2"
+        assert sections.fallback_used is False
 
 
 class TestAcquiredShape:

--- a/tests/unit/test_metrics_module.py
+++ b/tests/unit/test_metrics_module.py
@@ -58,6 +58,7 @@ HELPERS: dict[str, str] = {
     "lithos_writes": "influx_lithos_writes_total",
     "repair_candidates": "influx_repair_candidates_total",
     "llm_validation_failures": "influx_llm_validation_failures_total",
+    "tier3_fallbacks": "influx_tier3_fallbacks_total",
     "archive_missing": "influx_archive_missing_total",
     "source_acquisition_errors": "influx_source_acquisition_errors_total",
     "slug_collision_url_recovery": "influx_slug_collision_url_recovery_total",

--- a/tests/unit/test_run_ledger.py
+++ b/tests/unit/test_run_ledger.py
@@ -200,6 +200,64 @@ def test_complete_records_source_retry_counts(tmp_path: Path) -> None:
     }
 
 
+def test_complete_without_tier3_fallbacks_persists_empty_dict(
+    tmp_path: Path,
+) -> None:
+    """A clean run with no Tier 3 fallback input lands
+    ``tier3_fallbacks={}`` (#151) so downstream consumers always see the
+    field, never KeyError.
+    """
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(
+        run_id="run-1",
+        profile="ai-robotics",
+        kind="scheduled",
+        run_range=None,
+    )
+    ledger.complete(run_id="run-1", sources_checked=3, ingested=2)
+    entry = ledger.recent()[0]
+    assert entry["tier3_fallbacks"] == {}
+
+
+def test_complete_records_tier3_fallbacks(tmp_path: Path) -> None:
+    """``tier3_fallbacks`` survives the ledger round-trip (#151).
+
+    Operators reading ``/runs/recent`` should see harmless vs degraded
+    counts at a glance instead of scraping logs.  Harmless-only fallback
+    is *not* a degraded-reasons trigger — those counters are pure
+    diagnostics, like ``source_retry_counts``.
+    """
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(
+        run_id="run-1",
+        profile="ai-robotics",
+        kind="scheduled",
+        run_range=None,
+    )
+    fallbacks = {"harmless": 4, "degraded": 1}
+    ledger.complete(
+        run_id="run-1",
+        sources_checked=8,
+        ingested=5,
+        tier3_fallbacks=fallbacks,
+    )
+    entry = ledger.recent()[0]
+    assert entry["tier3_fallbacks"] == {"harmless": 4, "degraded": 1}
+    # Tier 3 fallback counts on their own do not flag the run as
+    # degraded — the dedicated degraded-reasons set is for stall /
+    # acquisition / archive shapes.  This keeps the counter additive
+    # without inflating the existing `degraded` boolean.
+    assert entry["degraded"] is False
+    assert entry["degraded_reasons"] == []
+
+    # Mutating the caller's dict after ``complete`` must not leak into
+    # the persisted entry (shallow-copy invariant — values are ints).
+    fallbacks["harmless"] = 99
+    fallbacks["new_kind"] = 7
+    re_read = ledger.recent()[0]
+    assert re_read["tier3_fallbacks"] == {"harmless": 4, "degraded": 1}
+
+
 def test_failed_run_has_degraded_false(tmp_path: Path) -> None:
     """``fail`` always lands ``degraded=false`` so the field's semantics
     stay narrow: it means *partial source-fetch failure on an otherwise

--- a/tests/unit/test_run_service.py
+++ b/tests/unit/test_run_service.py
@@ -41,6 +41,7 @@ from influx.telemetry import (
     current_fetched_total,
     current_filter_errors,
     current_source_acquisition_errors,
+    record_tier3_fallback,
 )
 
 
@@ -144,6 +145,65 @@ async def test_happy_path_runs_body_and_completes_ledger(tmp_path: Any) -> None:
     assert entry["status"] == "completed"
     assert entry["sources_checked"] == 3
     assert entry["ingested"] == 2
+
+
+async def test_tier3_fallback_counts_propagate_to_ledger_entry(
+    tmp_path: Any,
+) -> None:
+    """A run body that records Tier 3 fallbacks lands them on the ledger
+    entry as ``tier3_fallbacks`` (#151).
+
+    Uses :func:`record_tier3_fallback` from inside the patched body so
+    we exercise the real contextvar wiring inside ``ledger_lifecycle``
+    rather than mocking the bucket directly.
+    """
+    config = _make_config()
+    ledger = RunLedger(tmp_path)
+    service = RunService(config=config, ledger=ledger)
+
+    async def body_with_tier3_noise(*args: Any, **kwargs: Any) -> RunOutcome:
+        # Three harmless fallbacks (Tier 1+2 present, Tier 3 failed) and
+        # one degraded (Tier 1 missing) — the shape the Cascade emits
+        # via ``Cascade._log_tier3_failure``.
+        record_tier3_fallback(kind="harmless")
+        record_tier3_fallback(kind="harmless")
+        record_tier3_fallback(kind="harmless")
+        record_tier3_fallback(kind="degraded")
+        return RunOutcome(sources_checked=4, ingested=4)
+
+    with patch("influx.run.Run.execute", new=body_with_tier3_noise):
+        await service.execute(_scheduled_plan())
+
+    entry = ledger.recent()[0]
+    assert entry["tier3_fallbacks"] == {"harmless": 3, "degraded": 1}
+    # Tier 3 fallback counts on their own don't flip the run into
+    # ``degraded`` — the dedicated stall / acquisition / archive
+    # reasons own that field.  Operators read the counters as a
+    # diagnostic split, like ``source_retry_counts``.
+    assert entry["degraded"] is False
+    assert entry["degraded_reasons"] == []
+
+
+async def test_tier3_fallback_counts_default_to_empty_dict(
+    tmp_path: Any,
+) -> None:
+    """A clean run with no Tier 3 fallback recording lands
+    ``tier3_fallbacks={}`` so downstream consumers always see the field
+    (#151).
+    """
+    config = _make_config()
+    ledger = RunLedger(tmp_path)
+    service = RunService(config=config, ledger=ledger)
+
+    with patch(
+        "influx.run.Run.execute",
+        new_callable=AsyncMock,
+        return_value=RunOutcome(sources_checked=2, ingested=2),
+    ):
+        await service.execute(_scheduled_plan())
+
+    entry = ledger.recent()[0]
+    assert entry["tier3_fallbacks"] == {}
 
 
 async def test_body_exception_marks_ledger_failed_and_propagates(


### PR DESCRIPTION
Closes #151

## Summary

- Classifies Tier 3 extraction failures by the effective cascade outcome: when Tier 1 (summary) and Tier 2 (full text) already succeeded, the Tier 3 failure is logged at INFO as harmless fallback noise; otherwise it stays WARNING for materially-degraded notes.
- Adds structured `extra` fields (`fallback_used`, `fallback_kind`, `effective_extraction_tier`, `tier3_failure_kind`) to Tier 3 failure log records, plus matching `effective_extraction_tier` / `fallback_used` fields on `EnrichedSections` for renderer + run-summary consumers.
- Adds `influx_tier3_fallbacks_total` counter labelled `fallback_kind=harmless|degraded` so dashboards can target materially-degraded Tier 3 failures without subtracting harmless fallback noise from `llm_validation_failures`.

Behaviour preserved: `influx:repair-needed`, repair counters, `tier3-terminal` semantics, and `llm_validation_failures{tier="3"}` all continue to tick on every Tier 3 failure.

## Test plan

- [x] `uv run pytest tests/unit/test_cascade.py` — covers harmless-vs-degraded classification, log levels (INFO vs WARNING), structured `extra` fields, metric labels, terminal-skip carve-out, and the defensive `except Exception` path.
- [x] `uv run pytest tests/unit/test_metrics_module.py` — registers the new `tier3_fallbacks` instrument in the helper contract.
- [x] `make check` — `uv run ruff check`, `uv run ruff format --check`, `uv run pyright`, full `uv run pytest` (2048 passed, 5 unrelated deprecation warnings).