### PR TITLE
feat: adaptive cooldown for repeated arXiv 429 bursts (#146)

### DIFF
--- a/influx.example.toml
+++ b/influx.example.toml
@@ -340,6 +340,15 @@ arxiv_request_min_interval_seconds = 3
 arxiv_429_backoff_seconds = 30
 arxiv_429_backoff_max_seconds = 120
 arxiv_429_max_retries = 5
+# Issue #146: adaptive cooldown for repeated arXiv 429 bursts.
+# After N (= arxiv_429_cooldown_threshold) consecutive *final* 429
+# failures (i.e. the in-fetch retry budget was exhausted), subsequent
+# arXiv fetches are skipped quickly for arxiv_429_cooldown_seconds
+# instead of replaying the same retry storm.  The first successful
+# fetch (or the duration elapsing) clears the cooldown.  Set
+# arxiv_429_cooldown_threshold = 0 to disable wholesale.
+arxiv_429_cooldown_threshold = 3
+arxiv_429_cooldown_seconds = 900
 lithos_write_conflict_max_retries = 1
 
 # ---------------------------------------------------------------------------

--- a/src/influx/config.py
+++ b/src/influx/config.py
@@ -536,6 +536,34 @@ class ResilienceConfig(BaseModel):
     # rate-limit signal that warrants more patience than a hard network
     # failure — the API is healthy, it's just asking us to slow down.
     arxiv_429_max_retries: int = 5
+    # Issue #146: adaptive cooldown for repeated arXiv 429 bursts.
+    #
+    # The in-fetch retry budget above absorbs individual 429s but does
+    # nothing about a *scheduled* burst of 429-dominated runs back to
+    # back — each run starts cold, immediately tries arXiv again, and
+    # eats its full 429 budget before giving up.  The cooldown adds a
+    # process-local state machine on top of the existing retry path:
+    #
+    # * Each *exhausted* 429 final failure (the retry loop gave up)
+    #   increments a streak counter.
+    # * When the streak reaches ``arxiv_429_cooldown_threshold`` the
+    #   source enters COOLDOWN: subsequent fetches are skipped quickly
+    #   for ``arxiv_429_cooldown_seconds`` and surfaced as a *separate*
+    #   degraded reason (``source_cooldown_skip``) so operators can tell
+    #   "we backed off on purpose" apart from "we tried and failed".
+    # * Cooldown clears on either ``arxiv_429_cooldown_seconds`` elapse
+    #   *or* the next successful arXiv fetch (whichever comes first).
+    #   A successful fetch also resets the streak counter.
+    # * Setting ``arxiv_429_cooldown_threshold`` to 0 disables the
+    #   feature entirely without touching the rest of the retry path.
+    #
+    # The cooldown is *process-local* — distinct deployments and
+    # restarts do not share the streak counter or the active deadline.
+    # This is documented as a caveat: a freshly restarted process will
+    # try arXiv once on first request even if the cooldown was active
+    # right before the restart.
+    arxiv_429_cooldown_threshold: int = 3
+    arxiv_429_cooldown_seconds: int = 900
     lithos_write_conflict_max_retries: int = 1
 
     @field_validator(
@@ -545,6 +573,8 @@ class ResilienceConfig(BaseModel):
         "arxiv_429_backoff_seconds",
         "arxiv_429_backoff_max_seconds",
         "arxiv_429_max_retries",
+        "arxiv_429_cooldown_threshold",
+        "arxiv_429_cooldown_seconds",
         "lithos_write_conflict_max_retries",
     )
     @classmethod

--- a/src/influx/metrics.py
+++ b/src/influx/metrics.py
@@ -55,6 +55,7 @@ __all__ = [
     "slug_collision_unresolved",
     "slug_collision_url_recovery",
     "source_acquisition_errors",
+    "source_cooldown_skips",
 ]
 
 
@@ -460,4 +461,22 @@ def source_acquisition_errors() -> Any:
     return get_meter().counter(
         "influx_source_acquisition_errors_total",
         description="Swallowed source-acquisition errors per run.",
+    )
+
+
+def source_cooldown_skips() -> Any:
+    """Counter of source fetches skipped by an adaptive cooldown (#146).
+
+    Mirrors the ledger's ``source_cooldown_skip`` degraded reason:
+    every increment corresponds to one entry written through
+    :func:`~influx.telemetry.record_source_cooldown_skip`.  Distinct
+    from :func:`source_acquisition_errors` because the run deliberately
+    chose not to call upstream, so the failure mode is operational
+    (we backed off) rather than upstream (they refused us).
+
+    Labels: ``profile``, ``source``.
+    """
+    return get_meter().counter(
+        "influx_source_cooldown_skips_total",
+        description="Source fetches skipped by an adaptive cooldown.",
     )

--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -87,6 +87,10 @@ class RunLedger:
             "degraded": False,
             "degraded_reasons": [],
             "source_acquisition_errors": [],
+            # Issue #146: cooldown skips are surfaced in the entry
+            # alongside ``source_acquisition_errors`` so the active
+            # snapshot has the same shape as a completed entry.
+            "source_cooldown_skips": [],
             # #129: per-source counter of *recovered* retries (i.e.
             # retries that did not produce a swallowed error).  Shape:
             # ``{"arxiv": {"rate_limit": 2, "timeout": 1}}``.  Empty
@@ -112,6 +116,7 @@ class RunLedger:
         invalid_url_rejections_total: int | None = None,
         archive_failures_total: int | None = None,
         source_acquisition_errors: list[dict[str, str]] | None = None,
+        source_cooldown_skips: list[dict[str, str]] | None = None,
         source_retry_counts: dict[str, dict[str, int]] | None = None,
     ) -> list[str]:
         """Mark an active run as completed and append it to history.
@@ -121,6 +126,13 @@ class RunLedger:
 
         - ``"source_acquisition"`` (issue #20) — at least one
           source-fetch failure was swallowed.
+        - ``"source_cooldown_skip"`` (issue #146) — at least one
+          source fetch was deliberately skipped because the
+          source-specific adaptive 429 cooldown was active.  Distinct
+          from ``source_acquisition`` because the run *chose* not to
+          call upstream rather than tried and lost.  Single-run
+          signal — like ``filter_error`` — so operators see the skip
+          immediately even on the first cooldown-suppressed run.
         - ``"filter_error"`` (issue #85 review) — the LLM filter
           scorer raised :class:`FilterScorerError` (transport, parse,
           or provider failure) at least once during this run.  Single-
@@ -176,9 +188,17 @@ class RunLedger:
         per-reason metrics without re-deriving the logic.
         """
         errors = list(source_acquisition_errors or [])
+        cooldown_skips = list(source_cooldown_skips or [])
         reasons: list[str] = []
         if errors:
             reasons.append("source_acquisition")
+        # Issue #146: cooldown skips are reported as a *separate*
+        # degraded reason so operator dashboards can distinguish
+        # "we backed off on purpose" from "we tried and lost".  Both
+        # may co-occur within a single run (e.g. arXiv cooldown, RSS
+        # network failure) — the run-level summary surfaces both.
+        if cooldown_skips:
+            reasons.append("source_cooldown_skip")
 
         # #85 review: filter_error fires immediately on any
         # FilterScorerError catch, regardless of run kind.  Operators
@@ -311,6 +331,7 @@ class RunLedger:
             error=None,
             degraded=bool(reasons),
             source_acquisition_errors=errors,
+            source_cooldown_skips=cooldown_skips,
             degraded_reasons=reasons,
             source_retry_counts=source_retry_counts,
         )
@@ -569,6 +590,9 @@ class RunLedger:
                         "source_acquisition_errors": list(
                             entry.get("source_acquisition_errors") or []
                         ),
+                        "source_cooldown_skips": list(
+                            entry.get("source_cooldown_skips") or []
+                        ),
                         "source_retry_counts": {
                             source: dict(by_kind)
                             for source, by_kind in (
@@ -635,6 +659,7 @@ class RunLedger:
         archive_failures_total: int | None = None,
         degraded: bool = False,
         source_acquisition_errors: list[dict[str, str]] | None = None,
+        source_cooldown_skips: list[dict[str, str]] | None = None,
         degraded_reasons: list[str] | None = None,
         source_retry_counts: dict[str, dict[str, int]] | None = None,
     ) -> None:
@@ -671,6 +696,10 @@ class RunLedger:
                     "degraded": degraded,
                     "degraded_reasons": list(degraded_reasons or []),
                     "source_acquisition_errors": list(source_acquisition_errors or []),
+                    # Issue #146: persist cooldown skips alongside
+                    # ``source_acquisition_errors`` so the same JSONL
+                    # consumers can read both lists with the same shape.
+                    "source_cooldown_skips": list(source_cooldown_skips or []),
                     # #129: deep-copy the per-source retry-count dict so
                     # later mutations of the contextvar bucket do not
                     # leak into the persisted ledger entry.

--- a/src/influx/run_service.py
+++ b/src/influx/run_service.py
@@ -50,6 +50,7 @@ from influx.telemetry import (
     current_invalid_url_rejections,
     current_run_id,
     current_source_acquisition_errors,
+    current_source_cooldown_skips,
     current_source_retry_counts,
     get_tracer,
 )
@@ -101,6 +102,12 @@ async def ledger_lifecycle(
     session = _LedgerSession(run_id=run_id, started_at=started_at)
     run_id_token = current_run_id.set(run_id)
     source_errors_token = current_source_acquisition_errors.set([])
+    # Issue #146: per-run list of cooldown-suppressed source fetches.
+    # Distinct from ``current_source_acquisition_errors`` because a
+    # cooldown skip is a deliberate operational decision, not an
+    # upstream failure — the run-ledger entry tags it as
+    # ``source_cooldown_skip`` so operators can tell the two apart.
+    source_cooldown_skips_token = current_source_cooldown_skips.set([])
     # #85: per-run pre-filter fetched-count.  A list-of-ints so source
     # adapters increment a shared mutable container; reads at run-end
     # land the value into the run-ledger entry for the
@@ -165,6 +172,7 @@ async def ledger_lifecycle(
         # Telemetry span exited cleanly; finalise the ledger entry.
         elapsed = (datetime.now(UTC) - started_at).total_seconds()
         source_errors = current_source_acquisition_errors.get() or []
+        source_cooldown_skips = current_source_cooldown_skips.get() or []
 
         if session.skip_reason is not None:
             ledger.skip(run_id=run_id, reason=session.skip_reason)
@@ -223,13 +231,19 @@ async def ledger_lifecycle(
             invalid_url_rejections_total=invalid_url_rejections_total,
             archive_failures_total=archive_failures_total,
             source_acquisition_errors=source_errors,
+            # Issue #146: cooldown skips are run-level state distinct
+            # from swallowed acquisition errors — the ledger fires the
+            # ``source_cooldown_skip`` reason on a non-empty list.
+            source_cooldown_skips=source_cooldown_skips,
             # #129: surface recovered retry counts so the ledger entry
             # carries "we hit arXiv 429 twice but recovered" alongside
             # the swallowed-error list, letting an operator distinguish
             # transient retry success from a burned retry budget.
             source_retry_counts=source_retry_counts,
         )
-        run_outcome = "degraded" if source_errors else "success"
+        run_outcome = (
+            "degraded" if (source_errors or source_cooldown_skips) else "success"
+        )
         if "ingestion_stall" in degraded_reasons:
             metrics.ingestion_stalls().add(
                 1, {"profile": profile, "reason": "ingestion_stall"}
@@ -324,6 +338,27 @@ async def ledger_lifecycle(
                 archive_rate_limited_total,
                 archive_skipped_by_policy_total,
             )
+        if "source_cooldown_skip" in degraded_reasons:
+            # Issue #146: one or more source fetches were suppressed by
+            # the adaptive 429 cooldown.  Distinct from
+            # ``source_acquisition``: we deliberately chose not to call
+            # upstream, so the run-level outcome is "we backed off"
+            # rather than "we tried and lost".  Operators triaging this
+            # reason check the cooldown thresholds / cooldown duration
+            # and the recent 429 classification breakdown.
+            if run_outcome == "success":
+                run_outcome = "degraded"
+            logger.warning(
+                "run flagged source_cooldown_skip profile=%s kind=%s "
+                "run_id=%s cooldown_skips=%d "
+                "(arxiv fetch was skipped after repeated 429 bursts — "
+                "see resilience.arxiv_429_cooldown_threshold / "
+                "arxiv_429_cooldown_seconds)",
+                profile,
+                plan.kind.value,
+                run_id,
+                len(source_cooldown_skips),
+            )
         if "invalid_url_stall" in degraded_reasons:
             # #131 review concern 2: feed returned items but every URL
             # was upstream-malformed.  Single-run signal — operators
@@ -397,6 +432,7 @@ async def ledger_lifecycle(
         metrics.active_runs().add(-1, {"profile": profile})
         current_run_id.reset(run_id_token)
         current_source_acquisition_errors.reset(source_errors_token)
+        current_source_cooldown_skips.reset(source_cooldown_skips_token)
         current_fetched_total.reset(fetched_total_token)
         current_filter_errors.reset(filter_errors_token)
         current_invalid_url_rejections.reset(invalid_url_rejections_token)

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -61,6 +61,7 @@ from influx.telemetry import (
     record_fetched_items,
     record_filter_error,
     record_source_acquisition_error,
+    record_source_cooldown_skip,
     record_source_retry,
 )
 
@@ -68,6 +69,7 @@ if TYPE_CHECKING:
     from influx.sources import FetchCache
 
 __all__ = [
+    "ArxivCooldownError",
     "ArxivFilterScorer",
     "ArxivItem",
     "ArxivScorer",
@@ -554,6 +556,173 @@ def _apply_min_interval(min_interval: float) -> None:
         _sleep(wait)
 
 
+# ── Adaptive 429 cooldown (issue #146) ─────────────────────────────
+#
+# Influx's per-fetch retry budget already absorbs individual 429s but
+# cannot dampen a *burst* across scheduled runs: each new run begins
+# cold and immediately retries with the same pacing, so staging logs
+# show degraded run after degraded run with zero ingested candidates
+# until upstream calms down.  The cooldown is a small process-local
+# state machine layered on top of the existing retry loop:
+#
+#   NORMAL  ─── failure_streak >= threshold ──► COOLDOWN
+#   COOLDOWN ── cooldown_deadline_elapsed ─► NORMAL  (lazy clear)
+#   COOLDOWN ── successful fetch ─────────► NORMAL  (eager clear)
+#
+# Counted events are only *final* 429 failures — failures the in-fetch
+# retry loop already gave up on.  Transient 429s that the loop
+# recovered from never tick the streak; they continue to surface
+# through ``record_source_retry``.  Other final failure kinds
+# (network, content_type_mismatch, …) do not enter the cooldown path
+# at all so a single transport hiccup cannot suppress arXiv.
+#
+# Setting ``arxiv_429_cooldown_threshold`` to 0 disables the feature
+# wholesale: ``_should_skip_for_cooldown`` becomes a no-op, the streak
+# stays at 0, and behaviour is identical to the pre-#146 path.
+#
+# State is *process-local* (caveat noted in PR / config docstring):
+# distinct deployments do not share streak counters and a restart
+# resets the deadline.  A future cross-restart variant would persist
+# the state under ``storage.state_dir`` alongside the run ledger.
+_COOLDOWN_LOCK = threading.Lock()
+_COOLDOWN_FAILURE_STREAK: int = 0
+_COOLDOWN_DEADLINE_MONOTONIC: float | None = None
+# Last refined 429 classification observed by ``_record_429_final_failure``.
+# Surfaced into the cooldown-skip ``NetworkError.reason`` so operators
+# can tell at a glance whether the cooldown was driven by
+# upstream-capacity events ("not us, back off harder") or local
+# pacing ("we are the problem").
+_COOLDOWN_LAST_CLASSIFICATION: str | None = None
+
+
+def _reset_arxiv_cooldown_for_tests() -> None:
+    """Reset the module-level cooldown state — test seam only.
+
+    Unit and integration tests need a clean baseline between cases;
+    production code never calls this.
+    """
+    global _COOLDOWN_FAILURE_STREAK  # noqa: PLW0603
+    global _COOLDOWN_DEADLINE_MONOTONIC  # noqa: PLW0603
+    global _COOLDOWN_LAST_CLASSIFICATION  # noqa: PLW0603
+    with _COOLDOWN_LOCK:
+        _COOLDOWN_FAILURE_STREAK = 0
+        _COOLDOWN_DEADLINE_MONOTONIC = None
+        _COOLDOWN_LAST_CLASSIFICATION = None
+
+
+def _arxiv_cooldown_snapshot() -> tuple[int, float | None, str | None]:
+    """Return ``(streak, deadline_monotonic, last_classification)`` snapshot.
+
+    Test seam only — production code reads the state via
+    :func:`_should_skip_for_cooldown` and the recorder helpers.
+    """
+    with _COOLDOWN_LOCK:
+        return (
+            _COOLDOWN_FAILURE_STREAK,
+            _COOLDOWN_DEADLINE_MONOTONIC,
+            _COOLDOWN_LAST_CLASSIFICATION,
+        )
+
+
+def _should_skip_for_cooldown(
+    resilience: ResilienceConfig,
+) -> tuple[bool, float | None, str | None]:
+    """Inspect the cooldown state machine before a fetch.
+
+    Returns ``(skip, remaining_seconds, classification)``.  When the
+    threshold is ``0`` (feature disabled) or no deadline is set the
+    helper returns ``(False, None, classification)`` and the caller
+    proceeds with the normal fetch path.
+
+    When an active deadline has elapsed, the state machine
+    transitions back to NORMAL *lazily* — that is, the deadline and
+    streak are both cleared as part of this call so the next 429
+    burst starts a fresh streak.  This keeps the state machine
+    self-healing without requiring a background thread.
+    """
+    global _COOLDOWN_FAILURE_STREAK  # noqa: PLW0603
+    global _COOLDOWN_DEADLINE_MONOTONIC  # noqa: PLW0603
+    threshold = int(resilience.arxiv_429_cooldown_threshold)
+    if threshold <= 0:
+        # Feature disabled — never skip; do not consult or mutate state.
+        return False, None, None
+    now = time.monotonic()
+    with _COOLDOWN_LOCK:
+        deadline = _COOLDOWN_DEADLINE_MONOTONIC
+        classification = _COOLDOWN_LAST_CLASSIFICATION
+        if deadline is None:
+            return False, None, classification
+        remaining = deadline - now
+        if remaining <= 0:
+            # Deadline elapsed — clear state and proceed normally.
+            _COOLDOWN_DEADLINE_MONOTONIC = None
+            _COOLDOWN_FAILURE_STREAK = 0
+            return False, None, classification
+        return True, remaining, classification
+
+
+def _record_429_final_failure(
+    resilience: ResilienceConfig, *, classification: str
+) -> tuple[int, bool]:
+    """Tick the failure streak after the retry loop gave up on a 429.
+
+    Returns ``(streak, entered_cooldown)``.  When the resulting streak
+    reaches ``arxiv_429_cooldown_threshold`` the state machine
+    transitions NORMAL → COOLDOWN by setting a fresh deadline; the
+    caller receives ``entered_cooldown=True`` so it can emit a single
+    distinctive log line.
+
+    When the feature is disabled (threshold ``0``) the function is a
+    no-op and returns ``(0, False)`` so callers do not have to gate
+    their own observability on the disable knob.
+    """
+    global _COOLDOWN_FAILURE_STREAK  # noqa: PLW0603
+    global _COOLDOWN_DEADLINE_MONOTONIC  # noqa: PLW0603
+    global _COOLDOWN_LAST_CLASSIFICATION  # noqa: PLW0603
+    threshold = int(resilience.arxiv_429_cooldown_threshold)
+    if threshold <= 0:
+        return 0, False
+    cooldown_seconds = float(resilience.arxiv_429_cooldown_seconds)
+    now = time.monotonic()
+    with _COOLDOWN_LOCK:
+        _COOLDOWN_LAST_CLASSIFICATION = classification
+        _COOLDOWN_FAILURE_STREAK += 1
+        streak = _COOLDOWN_FAILURE_STREAK
+        if streak >= threshold and cooldown_seconds > 0:
+            _COOLDOWN_DEADLINE_MONOTONIC = now + cooldown_seconds
+            return streak, True
+        return streak, False
+
+
+def _record_arxiv_fetch_success() -> None:
+    """Clear the cooldown state after a successful arXiv fetch.
+
+    A successful fetch is the strongest possible signal that the
+    upstream has recovered, so the cooldown deadline (if any) is
+    cleared *eagerly* — operators do not have to wait the rest of
+    ``arxiv_429_cooldown_seconds`` once arXiv is healthy again.  The
+    streak counter is also reset so an unrelated 429 later in the run
+    starts a fresh streak.
+    """
+    global _COOLDOWN_FAILURE_STREAK  # noqa: PLW0603
+    global _COOLDOWN_DEADLINE_MONOTONIC  # noqa: PLW0603
+    with _COOLDOWN_LOCK:
+        _COOLDOWN_FAILURE_STREAK = 0
+        _COOLDOWN_DEADLINE_MONOTONIC = None
+
+
+class ArxivCooldownError(NetworkError):
+    """Raised by ``_fetch_with_retry`` when cooldown suppresses a fetch.
+
+    Subclasses :class:`NetworkError` so existing ``except NetworkError``
+    branches continue to handle it without code changes; carries the
+    distinctive ``kind="cooldown_active"`` and a remaining-seconds
+    reason so the caller can route the failure into the dedicated
+    cooldown degraded-reason path instead of the generic
+    ``source_acquisition`` path.
+    """
+
+
 def fetch_arxiv(
     *,
     arxiv_config: ArxivSourceConfig,
@@ -675,6 +844,30 @@ def _fetch_with_retry(
     backoff_base = resilience.backoff_base_seconds
     rate_limit_max_retries = resilience.arxiv_429_max_retries
 
+    # Issue #146: short-circuit before pacing / HTTP when the cooldown
+    # state machine is active.  Raising before ``_apply_min_interval``
+    # means a suppressed fetch returns in milliseconds rather than
+    # blocking on the cross-fetch pacing window — operators see the
+    # "we skipped on purpose" signal immediately and the run stays
+    # responsive.
+    skip, remaining, classification = _should_skip_for_cooldown(resilience)
+    if skip:
+        remaining_str = f"{remaining:.1f}" if remaining is not None else "?"
+        cls_str = classification or "unknown"
+        _log.warning(
+            "arxiv fetch skipped (cooldown active) remaining=%ss "
+            "classification=%s url=%s",
+            remaining_str,
+            cls_str,
+            url,
+        )
+        raise ArxivCooldownError(
+            "arXiv fetch skipped: cooldown active after repeated 429 bursts",
+            url=url,
+            kind="cooldown_active",
+            reason=(f"remaining_seconds={remaining_str} classification={cls_str}"),
+        )
+
     # Pace this fetch against the previous in-process arXiv fetch.  A
     # zero / negative interval is treated as "no pacing" by the helper.
     _apply_min_interval(float(resilience.arxiv_request_min_interval_seconds))
@@ -753,6 +946,23 @@ def _fetch_with_retry(
                 record_source_retry(source="arxiv", kind=kind_refined)
                 _sleep(delay)
                 continue
+            # Issue #146: retry budget exhausted on 429 — tick the
+            # cooldown streak.  We pass the refined classification so
+            # the cooldown state remembers whether the burst was
+            # dominated by upstream-capacity vs local-pacing events;
+            # operators see that classification in the eventual
+            # cooldown-skip ledger entry.
+            streak, entered = _record_429_final_failure(
+                resilience, classification=kind_refined
+            )
+            if entered:
+                _log.warning(
+                    "arxiv cooldown engaged after %d consecutive 429 final "
+                    "failures (classification=%s, cooldown=%ds)",
+                    streak,
+                    kind_refined,
+                    int(resilience.arxiv_429_cooldown_seconds),
+                )
             raise last_error
 
         if result.status_code >= 500:
@@ -797,6 +1007,10 @@ def _fetch_with_retry(
                 ),
             )
 
+        # Issue #146: a clean fetch is the strongest "upstream is OK"
+        # signal we have.  Clear the cooldown state machine eagerly so
+        # the next request goes back to the normal path immediately.
+        _record_arxiv_fetch_success()
         return result.body
 
     # Should not reach here, but satisfy type checker
@@ -1142,6 +1356,28 @@ class ArxivSource:
                 else:
                     items = await _do_fetch()
             except NetworkError as exc:
+                # Issue #146: a cooldown-suppressed fetch is *not* a
+                # source-acquisition failure — we deliberately chose
+                # not to call upstream.  Surface it through the
+                # dedicated cooldown-skip path so the run-ledger entry
+                # carries ``source_cooldown_skip`` instead of
+                # ``source_acquisition`` and operators can tell
+                # "throttled on purpose" apart from "tried and lost".
+                if exc.kind == "cooldown_active":
+                    _log.info(
+                        "arxiv fetch skipped (cooldown active) profile=%r reason=%s",
+                        profile,
+                        exc.reason or "",
+                    )
+                    record_source_cooldown_skip(
+                        source="arxiv",
+                        kind=exc.kind,
+                        detail=str(exc),
+                    )
+                    metrics.source_cooldown_skips().add(
+                        1, {"profile": profile, "source": "arxiv"}
+                    )
+                    return []
                 # Issue #145: prefer the refined 429 classification
                 # stashed on the reason field so the run-ledger and
                 # metric counters surface "shared-capacity upstream"

--- a/src/influx/telemetry.py
+++ b/src/influx/telemetry.py
@@ -29,6 +29,7 @@ __all__ = [
     "InfluxMeter",
     "InfluxTracer",
     "SourceAcquisitionError",
+    "SourceCooldownSkip",
     "SourceRetryCounts",
     "SpanWrapper",
     "current_archive_terminal_arxiv_ids",
@@ -37,6 +38,7 @@ __all__ = [
     "current_invalid_url_rejections",
     "current_run_id",
     "current_source_acquisition_errors",
+    "current_source_cooldown_skips",
     "current_source_retry_counts",
     "get_meter",
     "get_tracer",
@@ -44,6 +46,7 @@ __all__ = [
     "record_filter_error",
     "record_invalid_url_rejection",
     "record_source_acquisition_error",
+    "record_source_cooldown_skip",
     "record_source_retry",
 ]
 
@@ -104,6 +107,51 @@ def record_source_acquisition_error(
         return
     errors.append(
         SourceAcquisitionError(
+            {
+                "source": source,
+                "kind": kind,
+                "detail": detail[:300],
+            }
+        )
+    )
+
+
+# Issue #146: a cooldown-suppressed source fetch is recorded *separately*
+# from the swallowed-acquisition-error path so the run ledger can mark
+# the run degraded with ``source_cooldown_skip`` instead of
+# ``source_acquisition``.  Same shape as :data:`SourceAcquisitionError`
+# (source / kind / detail dicts) so existing JSONL consumers can scan a
+# uniform schema.
+SourceCooldownSkip = dict[str, str]
+
+
+current_source_cooldown_skips: ContextVar[list[SourceCooldownSkip] | None] = ContextVar(
+    "current_source_cooldown_skips",
+    default=None,
+)
+
+
+def record_source_cooldown_skip(
+    *,
+    source: str,
+    kind: str,
+    detail: str,
+) -> None:
+    """Append a cooldown-suppressed source fetch to the current run's record.
+
+    Distinct from :func:`record_source_acquisition_error`: a cooldown
+    skip means Influx *chose* not to call upstream because a recent
+    burst of 429s tripped the source-specific cooldown state machine
+    (issue #146).  Surfaced on the run-ledger entry as
+    ``source_cooldown_skip`` and as the dedicated degraded reason of
+    the same name.  Safe to call outside a run context — silently
+    no-ops when :data:`current_source_cooldown_skips` is unset.
+    """
+    skips = current_source_cooldown_skips.get()
+    if skips is None:
+        return
+    skips.append(
+        SourceCooldownSkip(
             {
                 "source": source,
                 "kind": kind,

--- a/tests/unit/test_arxiv_cooldown.py
+++ b/tests/unit/test_arxiv_cooldown.py
@@ -1,0 +1,319 @@
+"""Unit tests for the adaptive arXiv 429 cooldown (issue #146).
+
+The cooldown is a process-local state machine layered on top of the
+in-fetch 429 retry loop:
+
+    NORMAL  ── failure_streak >= threshold ──► COOLDOWN
+    COOLDOWN ── cooldown deadline elapsed ──► NORMAL  (lazy clear)
+    COOLDOWN ── successful fetch ────────────► NORMAL  (eager clear)
+
+These tests cover the enter/exit transitions, the disable knob, the
+process-local helpers, and the wiring through ``_fetch_with_retry`` so
+a subsequent fetch is skipped quickly with the dedicated
+``cooldown_active`` ``NetworkError.kind``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from influx.config import ResilienceConfig
+from influx.errors import NetworkError
+from influx.http_client import FetchResult
+from influx.sources.arxiv import (
+    ArxivCooldownError,
+    _arxiv_cooldown_snapshot,
+    _fetch_with_retry,
+    _record_429_final_failure,
+    _record_arxiv_fetch_success,
+    _reset_arxiv_cooldown_for_tests,
+    _reset_fetch_pacing_for_tests,
+    _should_skip_for_cooldown,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cooldown_state() -> None:
+    """Clear process-local cooldown + pacing state between cases."""
+    _reset_arxiv_cooldown_for_tests()
+    _reset_fetch_pacing_for_tests()
+
+
+def _resilience(
+    *,
+    threshold: int = 3,
+    cooldown_seconds: int = 600,
+    arxiv_429_max_retries: int = 0,
+    max_retries: int = 0,
+    arxiv_request_min_interval_seconds: int = 0,
+) -> ResilienceConfig:
+    """Resilience config with very tight budgets so 429s are *final* fast."""
+    return ResilienceConfig(
+        max_retries=max_retries,
+        arxiv_429_max_retries=arxiv_429_max_retries,
+        arxiv_429_cooldown_threshold=threshold,
+        arxiv_429_cooldown_seconds=cooldown_seconds,
+        arxiv_request_min_interval_seconds=arxiv_request_min_interval_seconds,
+    )
+
+
+def _fetch_result_429() -> FetchResult:
+    return FetchResult(
+        body=b"Rate exceeded.",
+        status_code=429,
+        content_type="text/html",
+        final_url="https://arxiv.org/api/query",
+        headers={"Retry-After": "5"},
+    )
+
+
+def _fetch_result_ok() -> FetchResult:
+    return FetchResult(
+        body=b"<feed xmlns='http://www.w3.org/2005/Atom'></feed>",
+        status_code=200,
+        content_type="application/atom+xml",
+        final_url="https://arxiv.org/api/query",
+        headers={},
+    )
+
+
+class TestRecord429FinalFailure:
+    def test_streak_increments_on_each_call(self) -> None:
+        res = _resilience(threshold=5)
+        streak1, entered1 = _record_429_final_failure(res, classification="local")
+        streak2, entered2 = _record_429_final_failure(res, classification="local")
+
+        assert (streak1, entered1) == (1, False)
+        assert (streak2, entered2) == (2, False)
+
+    def test_crossing_threshold_engages_cooldown(self) -> None:
+        res = _resilience(threshold=2, cooldown_seconds=300)
+        _record_429_final_failure(res, classification="upstream_capacity")
+        streak, entered = _record_429_final_failure(
+            res, classification="upstream_capacity"
+        )
+
+        assert (streak, entered) == (2, True)
+        snapshot_streak, deadline, classification = _arxiv_cooldown_snapshot()
+        assert snapshot_streak == 2
+        assert deadline is not None  # deadline set
+        assert classification == "upstream_capacity"
+
+    def test_disabled_when_threshold_zero(self) -> None:
+        res = _resilience(threshold=0)
+        for _ in range(10):
+            streak, entered = _record_429_final_failure(res, classification="x")
+            assert (streak, entered) == (0, False)
+
+        snapshot_streak, deadline, classification = _arxiv_cooldown_snapshot()
+        assert snapshot_streak == 0
+        assert deadline is None
+        assert classification is None
+
+    def test_zero_cooldown_seconds_disables_engagement(self) -> None:
+        """``arxiv_429_cooldown_seconds = 0`` keeps streak ticking but
+        never sets a deadline — useful for "report skips but never
+        actually pause" probing.
+        """
+        res = _resilience(threshold=1, cooldown_seconds=0)
+        streak, entered = _record_429_final_failure(res, classification="local")
+
+        assert streak == 1
+        assert entered is False
+        _, deadline, _ = _arxiv_cooldown_snapshot()
+        assert deadline is None
+
+
+class TestShouldSkipForCooldown:
+    def test_returns_false_when_no_deadline(self) -> None:
+        res = _resilience(threshold=2)
+        skip, remaining, classification = _should_skip_for_cooldown(res)
+
+        assert skip is False
+        assert remaining is None
+        assert classification is None
+
+    def test_returns_true_while_deadline_pending(self) -> None:
+        res = _resilience(threshold=1, cooldown_seconds=600)
+        _record_429_final_failure(res, classification="rate_limit_local")
+
+        skip, remaining, classification = _should_skip_for_cooldown(res)
+
+        assert skip is True
+        assert remaining is not None and remaining > 0
+        assert classification == "rate_limit_local"
+
+    def test_disabled_short_circuits_without_state_mutation(self) -> None:
+        """When threshold is 0 the helper must not even consult state."""
+        res_enabled = _resilience(threshold=1, cooldown_seconds=600)
+        _record_429_final_failure(res_enabled, classification="x")
+        # State engaged.  Now reading with threshold=0 must not skip
+        # and must not mutate the deadline.
+        res_disabled = _resilience(threshold=0)
+        skip, remaining, _ = _should_skip_for_cooldown(res_disabled)
+        assert skip is False
+        assert remaining is None
+        # The deadline left by the engaged state is still there.
+        _, deadline, _ = _arxiv_cooldown_snapshot()
+        assert deadline is not None
+
+    def test_elapsed_deadline_clears_state_lazily(self) -> None:
+        """When the deadline has elapsed, the next snapshot transitions
+        back to NORMAL by clearing both the deadline and the streak.
+        """
+        res = _resilience(threshold=1, cooldown_seconds=600)
+        _record_429_final_failure(res, classification="rate_limit_local")
+
+        # Fast-forward by patching monotonic to return "deadline + 10".
+        snapshot_streak, deadline, _ = _arxiv_cooldown_snapshot()
+        assert deadline is not None
+
+        with patch("influx.sources.arxiv.time.monotonic", return_value=deadline + 10):
+            skip, remaining, _ = _should_skip_for_cooldown(res)
+        assert skip is False
+        assert remaining is None
+
+        snapshot_streak, snapshot_deadline, _ = _arxiv_cooldown_snapshot()
+        assert snapshot_streak == 0
+        assert snapshot_deadline is None
+
+
+class TestRecordArxivFetchSuccess:
+    def test_eagerly_clears_active_cooldown(self) -> None:
+        res = _resilience(threshold=1, cooldown_seconds=600)
+        _record_429_final_failure(res, classification="rate_limit_local")
+        _, deadline, _ = _arxiv_cooldown_snapshot()
+        assert deadline is not None
+
+        _record_arxiv_fetch_success()
+
+        streak, deadline, _ = _arxiv_cooldown_snapshot()
+        assert streak == 0
+        assert deadline is None
+
+    def test_resets_streak_below_threshold(self) -> None:
+        res = _resilience(threshold=3)
+        _record_429_final_failure(res, classification="rate_limit_local")
+        _record_429_final_failure(res, classification="rate_limit_local")
+        streak, _, _ = _arxiv_cooldown_snapshot()
+        assert streak == 2
+
+        _record_arxiv_fetch_success()
+
+        streak, _, _ = _arxiv_cooldown_snapshot()
+        assert streak == 0
+
+
+class TestFetchWithRetryCooldownIntegration:
+    def test_skipped_fetch_raises_cooldown_error_without_calling_upstream(self) -> None:
+        res = _resilience(threshold=1, cooldown_seconds=600)
+        _record_429_final_failure(res, classification="rate_limit_upstream_capacity")
+
+        mock_guarded = MagicMock()
+        with (
+            patch("influx.sources.arxiv.guarded_fetch", mock_guarded),
+            pytest.raises(ArxivCooldownError) as exc_info,
+        ):
+            _fetch_with_retry(url="https://x", resilience=res)
+
+        assert exc_info.value.kind == "cooldown_active"
+        assert exc_info.value.reason is not None
+        assert "rate_limit_upstream_capacity" in exc_info.value.reason
+        # Critically, upstream was never called.
+        mock_guarded.assert_not_called()
+
+    def test_first_429_does_not_skip_when_threshold_not_crossed(self) -> None:
+        res = _resilience(threshold=3, cooldown_seconds=600)
+        # No prior streak — the call must hit guarded_fetch.
+        mock_guarded = MagicMock(return_value=_fetch_result_429())
+        with (
+            patch("influx.sources.arxiv.guarded_fetch", mock_guarded),
+            pytest.raises(NetworkError),
+        ):
+            _fetch_with_retry(url="https://x", resilience=res)
+        # The single 429 final failure bumped the streak to 1 only.
+        assert mock_guarded.call_count == 1
+        streak, deadline, _ = _arxiv_cooldown_snapshot()
+        assert streak == 1
+        assert deadline is None  # below threshold, no deadline set
+
+    def test_429_burst_eventually_engages_cooldown(self) -> None:
+        """N=threshold final 429 failures engage the cooldown; the next
+        request is skipped before reaching the wire.
+        """
+        res = _resilience(threshold=2, cooldown_seconds=600)
+        mock_guarded = MagicMock(return_value=_fetch_result_429())
+        with patch("influx.sources.arxiv.guarded_fetch", mock_guarded):
+            with pytest.raises(NetworkError):
+                _fetch_with_retry(url="https://x", resilience=res)
+            with pytest.raises(NetworkError):
+                _fetch_with_retry(url="https://x", resilience=res)
+        assert mock_guarded.call_count == 2
+
+        # Streak crossed threshold; subsequent request skips.
+        mock_guarded.reset_mock()
+        with (
+            patch("influx.sources.arxiv.guarded_fetch", mock_guarded),
+            pytest.raises(ArxivCooldownError),
+        ):
+            _fetch_with_retry(url="https://x", resilience=res)
+        mock_guarded.assert_not_called()
+
+    def test_successful_fetch_clears_cooldown_and_next_call_proceeds(self) -> None:
+        """A successful fetch resets the streak; the call after it does
+        not skip, even when the prior streak was above threshold.
+        """
+        res = _resilience(threshold=1, cooldown_seconds=600)
+        # Engage cooldown.
+        _record_429_final_failure(res, classification="rate_limit_local")
+        _, deadline, _ = _arxiv_cooldown_snapshot()
+        assert deadline is not None
+
+        # Simulate operator widening the cooldown duration to 0 so we
+        # can prove that *successful fetch* clears state, not deadline
+        # expiry.  We bypass the skip check by calling success directly
+        # (it's the same path ``_fetch_with_retry`` follows after a 2xx).
+        _record_arxiv_fetch_success()
+
+        # The next call goes to the wire and returns OK without
+        # raising ArxivCooldownError.
+        mock_guarded = MagicMock(return_value=_fetch_result_ok())
+        with patch("influx.sources.arxiv.guarded_fetch", mock_guarded):
+            body = _fetch_with_retry(url="https://x", resilience=res)
+        assert b"feed" in body
+        mock_guarded.assert_called_once()
+
+    def test_disable_via_threshold_zero_never_skips_fetch(self) -> None:
+        """With the disable knob (threshold = 0) the cooldown is a
+        no-op even after many final 429 failures — operators can opt
+        out wholesale without touching the rest of the retry path.
+        """
+        res = _resilience(threshold=0, cooldown_seconds=600)
+        mock_guarded = MagicMock(return_value=_fetch_result_429())
+        with patch("influx.sources.arxiv.guarded_fetch", mock_guarded):
+            for _ in range(5):
+                with pytest.raises(NetworkError):
+                    _fetch_with_retry(url="https://x", resilience=res)
+        # All 5 calls hit the wire — no skip.
+        assert mock_guarded.call_count == 5
+
+    def test_successful_fetch_from_wire_clears_cooldown(self) -> None:
+        """End-to-end through ``_fetch_with_retry``: a 200 response
+        clears the cooldown deadline via the success path inside the
+        retry loop, not via the test seam.
+        """
+        res = _resilience(threshold=3, cooldown_seconds=600)
+        _record_429_final_failure(res, classification="rate_limit_local")
+        _record_429_final_failure(res, classification="rate_limit_local")
+        streak, _, _ = _arxiv_cooldown_snapshot()
+        assert streak == 2  # below threshold; no deadline
+
+        mock_guarded = MagicMock(return_value=_fetch_result_ok())
+        with patch("influx.sources.arxiv.guarded_fetch", mock_guarded):
+            _fetch_with_retry(url="https://x", resilience=res)
+
+        streak, deadline, _ = _arxiv_cooldown_snapshot()
+        assert streak == 0
+        assert deadline is None

--- a/tests/unit/test_arxiv_cooldown_integration.py
+++ b/tests/unit/test_arxiv_cooldown_integration.py
@@ -1,0 +1,308 @@
+"""Integration-style tests for the arXiv 429 cooldown (issue #146).
+
+Covers the wiring between ``ArxivSource.fetch_candidates`` and the
+run-level telemetry surface: a cooldown-suppressed fetch records a
+``source_cooldown_skip`` entry rather than a generic
+``source_acquisition`` error, and the run ledger picks the matching
+degraded reason.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from influx.config import (
+    AppConfig,
+    ProfileConfig,
+    PromptEntryConfig,
+    PromptsConfig,
+    ResilienceConfig,
+    ScheduleConfig,
+)
+from influx.coordinator import RunKind
+from influx.run_ledger import RunLedger
+from influx.sources.arxiv import (
+    ArxivCooldownError,
+    ArxivSource,
+    _record_429_final_failure,
+    _reset_arxiv_cooldown_for_tests,
+    _reset_fetch_pacing_for_tests,
+)
+from influx.telemetry import (
+    current_run_id,
+    current_source_acquisition_errors,
+    current_source_cooldown_skips,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cooldown_state() -> None:
+    _reset_arxiv_cooldown_for_tests()
+    _reset_fetch_pacing_for_tests()
+
+
+def _minimal_config(*, cooldown_threshold: int = 2) -> AppConfig:
+    return AppConfig(
+        schedule=ScheduleConfig(cron="0 6 * * *", timezone="UTC"),
+        profiles=[ProfileConfig(name="ai-robotics")],
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="x"),
+            tier1_enrich=PromptEntryConfig(text="x"),
+            tier3_extract=PromptEntryConfig(text="x"),
+        ),
+        resilience=ResilienceConfig(
+            arxiv_429_cooldown_threshold=cooldown_threshold,
+            arxiv_429_cooldown_seconds=600,
+            arxiv_429_max_retries=0,
+            max_retries=0,
+            arxiv_request_min_interval_seconds=0,
+        ),
+    )
+
+
+async def test_cooldown_skip_records_cooldown_skip_not_acquisition_error() -> None:
+    """When the cooldown suppresses a fetch the source surfaces the
+    skip via :func:`record_source_cooldown_skip`, *not* via the
+    generic acquisition-error path.  This is the load-bearing
+    distinction operators rely on to triage "we backed off on purpose"
+    apart from "we tried and failed".
+    """
+    config = _minimal_config(cooldown_threshold=1)
+    # Engage the cooldown directly so the source.fetch_candidates call
+    # short-circuits at ``_fetch_with_retry``'s skip branch.
+    _record_429_final_failure(
+        config.resilience, classification="rate_limit_upstream_capacity"
+    )
+
+    run_token = current_run_id.set("test-run-cooldown")
+    errors_token = current_source_acquisition_errors.set([])
+    cooldown_token = current_source_cooldown_skips.set([])
+    try:
+        source = ArxivSource(config)
+        result = await source.fetch_candidates(
+            profile_cfg=config.profiles[0],
+            kind=RunKind.SCHEDULED,
+            run_range=None,
+        )
+        assert list(result) == []
+        errors = current_source_acquisition_errors.get() or []
+        skips = current_source_cooldown_skips.get() or []
+    finally:
+        current_run_id.reset(run_token)
+        current_source_acquisition_errors.reset(errors_token)
+        current_source_cooldown_skips.reset(cooldown_token)
+
+    # Critical assertion: no entry in the generic acquisition error
+    # list — the run is degraded for a *different* reason.
+    assert errors == []
+    assert len(skips) == 1
+    skip = skips[0]
+    assert skip["source"] == "arxiv"
+    assert skip["kind"] == "cooldown_active"
+    assert "cooldown active" in skip["detail"].lower()
+
+
+async def test_cooldown_skips_propagate_into_run_ledger(tmp_path: Any) -> None:
+    """End-to-end: a cooldown-suppressed run lands a ledger entry with
+    ``degraded=True`` and ``"source_cooldown_skip"`` among the
+    degraded reasons, distinct from ``"source_acquisition"``.
+
+    This uses :class:`RunLedger.complete` directly rather than driving
+    a real run, because the cooldown wiring lives in the contextvar /
+    ledger seam — the run body shape is incidental.
+    """
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(run_id="r1", profile="p", kind="scheduled", run_range=None)
+
+    reasons = ledger.complete(
+        run_id="r1",
+        sources_checked=0,
+        ingested=0,
+        fetched_total=0,
+        filter_errors_total=0,
+        invalid_url_rejections_total=0,
+        archive_failures_total=0,
+        source_acquisition_errors=[],
+        source_cooldown_skips=[
+            {
+                "source": "arxiv",
+                "kind": "cooldown_active",
+                "detail": "remaining_seconds=540.0 classification=upstream_capacity",
+            }
+        ],
+    )
+
+    assert "source_cooldown_skip" in reasons
+    assert "source_acquisition" not in reasons
+
+    recent = ledger.recent(profile="p")
+    assert len(recent) == 1
+    entry = recent[0]
+    assert entry["degraded"] is True
+    assert entry["source_cooldown_skips"] == [
+        {
+            "source": "arxiv",
+            "kind": "cooldown_active",
+            "detail": "remaining_seconds=540.0 classification=upstream_capacity",
+        }
+    ]
+
+
+async def test_source_acquisition_and_cooldown_skip_can_coexist(tmp_path: Any) -> None:
+    """A run that hits both shapes (e.g. arxiv cooldown + rss network
+    failure) reports both degraded reasons; one does not mask the other.
+    """
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(run_id="r1", profile="p", kind="scheduled", run_range=None)
+
+    reasons = ledger.complete(
+        run_id="r1",
+        sources_checked=0,
+        ingested=0,
+        fetched_total=0,
+        filter_errors_total=0,
+        invalid_url_rejections_total=0,
+        archive_failures_total=0,
+        source_acquisition_errors=[
+            {"source": "rss", "kind": "timeout", "detail": "boom"},
+        ],
+        source_cooldown_skips=[
+            {
+                "source": "arxiv",
+                "kind": "cooldown_active",
+                "detail": "remaining_seconds=540.0 classification=upstream_capacity",
+            }
+        ],
+    )
+
+    assert "source_acquisition" in reasons
+    assert "source_cooldown_skip" in reasons
+
+
+async def test_disabled_cooldown_falls_through_to_acquisition_error() -> None:
+    """When the disable knob is set (threshold=0), a 429 burst hits
+    the generic acquisition-error path — proving the feature can be
+    turned off without affecting the legacy degraded-reason wiring.
+    """
+    config = _minimal_config(cooldown_threshold=0)
+
+    # Force a 429 final-failure path from the underlying fetch.
+    from influx.errors import NetworkError
+
+    run_token = current_run_id.set("test-run-disabled")
+    errors_token = current_source_acquisition_errors.set([])
+    cooldown_token = current_source_cooldown_skips.set([])
+    try:
+        source = ArxivSource(config)
+        reason = "classification=rate_limit_upstream_capacity retry_after_present=false"
+        with patch(
+            "influx.sources.arxiv.fetch_arxiv",
+            side_effect=NetworkError(
+                "HTTP 429 from arXiv API",
+                url="https://x",
+                kind="rate_limit",
+                reason=reason,
+            ),
+        ):
+            result = await source.fetch_candidates(
+                profile_cfg=config.profiles[0],
+                kind=RunKind.SCHEDULED,
+                run_range=None,
+            )
+            assert list(result) == []
+
+        errors = current_source_acquisition_errors.get() or []
+        skips = current_source_cooldown_skips.get() or []
+    finally:
+        current_run_id.reset(run_token)
+        current_source_acquisition_errors.reset(errors_token)
+        current_source_cooldown_skips.reset(cooldown_token)
+
+    # Disabled — falls through to the legacy path.
+    assert skips == []
+    assert len(errors) == 1
+    # And the refined-kind classification is still surfaced.
+    assert errors[0]["kind"] == "rate_limit_upstream_capacity"
+
+
+async def test_successful_fetch_clears_cooldown_for_next_run() -> None:
+    """Regression: once arXiv recovers, the next run must not still
+    be in cooldown.  The successful fetch clears the streak eagerly
+    so the same process can flip back to NORMAL without waiting for
+    the cooldown deadline.
+    """
+    config = _minimal_config(cooldown_threshold=1)
+    # Engage cooldown.
+    _record_429_final_failure(config.resilience, classification="rate_limit_local")
+
+    # First fetch (cooldown active): returns empty + records skip.
+    run_token = current_run_id.set("test-run-1")
+    errors_token = current_source_acquisition_errors.set([])
+    cooldown_token = current_source_cooldown_skips.set([])
+    try:
+        source = ArxivSource(config)
+        result1 = await source.fetch_candidates(
+            profile_cfg=config.profiles[0],
+            kind=RunKind.SCHEDULED,
+            run_range=None,
+        )
+        assert list(result1) == []
+        assert (current_source_cooldown_skips.get() or []) != []
+    finally:
+        current_run_id.reset(run_token)
+        current_source_acquisition_errors.reset(errors_token)
+        current_source_cooldown_skips.reset(cooldown_token)
+
+    # Now an external party clears the cooldown — e.g. via the
+    # success path on a different in-process caller (the cooldown
+    # state is shared at the module level on purpose).
+    from influx.sources.arxiv import _record_arxiv_fetch_success
+
+    _record_arxiv_fetch_success()
+
+    # Second fetch: cooldown is gone.  The underlying fetch_arxiv is
+    # mocked to return zero items, so we should see *no* cooldown
+    # skip recorded — the cooldown is no longer active.
+    run_token2 = current_run_id.set("test-run-2")
+    errors_token2 = current_source_acquisition_errors.set([])
+    cooldown_token2 = current_source_cooldown_skips.set([])
+    try:
+        source = ArxivSource(config)
+        with patch("influx.sources.arxiv.fetch_arxiv", return_value=[]):
+            result2 = await source.fetch_candidates(
+                profile_cfg=config.profiles[0],
+                kind=RunKind.SCHEDULED,
+                run_range=None,
+            )
+            assert list(result2) == []
+        errors2 = current_source_acquisition_errors.get() or []
+        skips2 = current_source_cooldown_skips.get() or []
+    finally:
+        current_run_id.reset(run_token2)
+        current_source_acquisition_errors.reset(errors_token2)
+        current_source_cooldown_skips.reset(cooldown_token2)
+
+    # Cooldown cleared — no skip recorded.  And no acquisition error
+    # either, because the fetch (mocked) returned cleanly.
+    assert skips2 == []
+    assert errors2 == []
+
+
+def test_cooldown_error_subclasses_network_error() -> None:
+    """``ArxivCooldownError`` must subclass :class:`NetworkError` so
+    existing ``except NetworkError`` branches in callers continue to
+    catch the cooldown signal without code changes.
+    """
+    from influx.errors import NetworkError
+
+    exc = ArxivCooldownError(
+        "skipped",
+        url="https://x",
+        kind="cooldown_active",
+        reason="remaining_seconds=10",
+    )
+    assert isinstance(exc, NetworkError)
+    assert exc.kind == "cooldown_active"


### PR DESCRIPTION
Closes #146

## Summary

- New process-local state machine (NORMAL → COOLDOWN → NORMAL) inside `src/influx/sources/arxiv.py` that suppresses arXiv fetches after a configurable streak of *exhausted* 429 retry loops, so a 429 burst stops turning every subsequent scheduled run into a degraded zero-candidate run.
- Cooldown enter on `arxiv_429_cooldown_threshold` final 429 failures; exit on `arxiv_429_cooldown_seconds` elapsed (lazy) **or** the next successful fetch (eager).  `arxiv_429_cooldown_threshold = 0` disables wholesale.
- Suppressed fetches surface as a distinct degraded reason `source_cooldown_skip` (separate ledger field + new counter `influx_source_cooldown_skips_total`), so operators can tell "we backed off on purpose" apart from `source_acquisition` ("we tried and lost").
- The #145 refined 429 classification (`rate_limit_upstream_capacity` / `rate_limit_local` / `rate_limit_unknown`) is preserved on the cooldown record, threaded into log + ledger entry so operators see *why* the burst tripped the cooldown without inspecting raw logs.

## Caveats

- State is **process-local** — distinct deployments / pods do not share the streak counter, and a restart resets the active deadline.  Documented in `ResilienceConfig.arxiv_429_cooldown_threshold` docstring; a future cross-restart variant would persist alongside the run ledger.

## Test plan

- [x] `make check` green locally (lint + format check + pyright + 2056 pytest cases)
- [x] 16 new unit tests in `tests/unit/test_arxiv_cooldown.py` covering state transitions, disable knob, lazy/eager clear, and `_fetch_with_retry` integration
- [x] 6 new integration-style tests in `tests/unit/test_arxiv_cooldown_integration.py` covering `ArxivSource.fetch_candidates` wiring, ledger degraded-reason propagation, coexistence with `source_acquisition`, and disabled fall-through