### PR TITLE
feat: expand run degradation summaries with source/domain breakdowns (#152)

### DIFF
--- a/src/influx/run.py
+++ b/src/influx/run.py
@@ -60,6 +60,7 @@ from influx.telemetry import (
     current_source_acquisition_errors,
     get_tracer,
     record_cache_hit,
+    record_write_outcome,
 )
 
 __all__ = [
@@ -614,6 +615,18 @@ async def _run_ingest_stage(
                 "status": write_result.status,
             },
         )
+        # #152 review: feed every write outcome (success, duplicate,
+        # and write-time failures) into the per-run write-outcome
+        # counter so the run ledger can surface the duplicate/dedupe
+        # volume AND the invalid-note-state failures
+        # (``invalid_input`` / ``version_conflict`` / ``slug_collision``
+        # / ``content_too_large*``) in the degradation summary without
+        # operators having to grep the lithos_writes log.  ``duplicate``
+        # is counted here BUT excluded from the invalid-note-state
+        # bucket downstream — it is expected behaviour on re-runs and
+        # must not inflate degradation counts (issue #152 acceptance
+        # criteria).
+        record_write_outcome(outcome=write_result.status, source=item_source)
 
         if write_result.status in ("created", "updated"):
             logger.info(

--- a/src/influx/run.py
+++ b/src/influx/run.py
@@ -59,6 +59,7 @@ from influx.telemetry import (
     current_run_id,
     current_source_acquisition_errors,
     get_tracer,
+    record_cache_hit,
 )
 
 __all__ = [
@@ -531,9 +532,20 @@ async def _run_ingest_stage(
             cache_hit_reason: str | None = "primary" if cache_hit else None
             if cache_hit:
                 metrics.cache_hits().add(1, {"profile": profile, "source": item_source})
+                # #152: per-run cache-hit count for the degradation
+                # summary's ``totals.cache_hits``.  Mirrors the metrics
+                # tick so the ledger's dedupe-volume signal stays in
+                # sync with the metric.
+                record_cache_hit()
         else:
             cache_hit = bool(cache_hit_meta)
             cache_hit_reason = item.get("cache_hit_reason") if cache_hit else None
+            # #152: the Acquire-stage primary lookup short-circuits the
+            # legacy in-loop branch above, so its hits are counted here
+            # to keep the ledger total in lockstep with metrics.cache_hits
+            # which Acquire already ticked.
+            if cache_hit:
+                record_cache_hit()
 
         # #128: defensive source_url-only fallback when the primary
         # title+abstract dedup misses.  Catches notes whose source_url
@@ -549,6 +561,12 @@ async def _run_ingest_stage(
                 metrics.cache_hits_via_url_fallback().add(
                     1, {"profile": profile, "source": item_source}
                 )
+                # #152: count the source_url fallback as a cache hit
+                # for the ledger's degradation summary — it represents
+                # the same dedupe outcome (a write that would have
+                # been rejected as ``duplicate``) and must NOT inflate
+                # the degraded-event counts.
+                record_cache_hit()
 
         if cache_hit:
             logger.info(

--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -110,6 +110,60 @@ def _domain_from_url(url: str) -> str:
 ArchiveFailureRecord = dict[str, Any]
 
 
+# Write-outcome strings that represent a materially-failed write that
+# the run continued past — issue #152 review.  These count toward the
+# ``invalid_note_state.by_kind`` breakdown AND the ``invalid_note_state``
+# degraded reason.  Anything else (``created``, ``updated``,
+# ``duplicate`` …) is recorded under ``writes.by_outcome`` for
+# operational visibility but does NOT count as degradation.
+#
+# Membership rationale:
+#
+# - ``invalid_input`` — Lithos rejected the payload as malformed
+#   (missing required field / bad schema); the item was skipped.
+# - ``version_conflict`` — both retries exhausted; the write was
+#   skipped.
+# - ``slug_collision`` — the slug-collision recovery chain
+#   (#31 / #148) gave up; the item was skipped and a backlog entry
+#   was appended.
+# - ``content_too_large`` — the Tier-2 trim retry was not invoked or
+#   bubbled out of the trimming retry path; the item was skipped.
+# - ``content_too_large_skipped`` — the Tier-2 trim retry also
+#   produced ``content_too_large``; the item was skipped.
+#
+# ``duplicate`` is deliberately NOT in this set: PR #153 / issue #148
+# formalised that duplicate writes are the expected outcome of
+# scheduled re-runs and must not be treated as degradation.
+_INVALID_NOTE_STATE_OUTCOMES: frozenset[str] = frozenset(
+    {
+        "invalid_input",
+        "version_conflict",
+        "slug_collision",
+        "content_too_large",
+        "content_too_large_skipped",
+    }
+)
+
+
+def _is_invalid_note_state_outcome(outcome: str) -> bool:
+    """Return ``True`` when *outcome* counts as a real write failure (#152).
+
+    Used by :func:`build_degradation_summary` to gate the
+    ``invalid_note_state`` bucket so duplicate / created / updated
+    outcomes do not inflate degradation counts.
+    """
+    return outcome in _INVALID_NOTE_STATE_OUTCOMES
+
+
+# Per-run write-outcome counter shape consumed by
+# :func:`build_degradation_summary`.  Keyed by ``(outcome, source)``
+# tuples to keep the per-source attribution (an arXiv ``duplicate`` is
+# operationally different from an RSS ``duplicate`` even though the
+# outcome string is the same).  Mirrors
+# :data:`influx.telemetry.WriteOutcomeCounts`.
+WriteOutcomeCounts = dict[tuple[str, str], int]
+
+
 def build_degradation_summary(
     *,
     source_acquisition_errors: list[dict[str, str]] | None,
@@ -118,6 +172,7 @@ def build_degradation_summary(
     filter_errors_total: int | None,
     invalid_url_rejections_total: int | None,
     cache_hits_total: int | None,
+    write_outcomes: WriteOutcomeCounts | None = None,
     top_n: int = _DEGRADATION_SUMMARY_TOP_N,
 ) -> dict[str, Any]:
     """Build the bounded ``degradation_summary`` block for one run (#152).
@@ -140,6 +195,8 @@ def build_degradation_summary(
                 "invalid_url_rejections": int,
                 "cache_hits": int,
                 "retries_recovered": int,
+                "writes": int,
+                "invalid_note_state": int,
             },
             "archive": {
                 "by_kind":   [{"kind": "...", "count": N}, ...],
@@ -153,6 +210,14 @@ def build_degradation_summary(
                 "by_kind":   [{"kind": "...", "count": N}, ...],
                 "by_source": [{"source": "...", "count": N}, ...],
             },
+            "writes": {
+                "by_outcome": [{"outcome": "...", "count": N}, ...],
+                "by_source":  [{"source":  "...", "count": N}, ...],
+            },
+            "invalid_note_state": {
+                "by_kind":   [{"kind":   "...", "count": N}, ...],
+                "by_source": [{"source": "...", "count": N}, ...],
+            },
         }
 
     Design notes:
@@ -162,6 +227,16 @@ def build_degradation_summary(
       deliberately segregated from the archive / source-acquisition
       breakdowns.  A run whose only "issue" is cache hits is not a
       degraded run (#152 acceptance criteria).
+    - **Write-time duplicate outcomes are not degradation either.**
+      Every write outcome — including ``created`` / ``updated`` /
+      ``duplicate`` — is surfaced under ``writes.by_outcome`` so the
+      dedupe volume is visible to operators, but only the
+      invalid-note-state outcomes (``invalid_input``,
+      ``version_conflict``, ``slug_collision``,
+      ``content_too_large*``) feed into the ``invalid_note_state``
+      bucket.  PR #153 / issue #148 formalised the duplicate-is-OK
+      contract: a scheduled re-run whose every write returns
+      ``duplicate`` is steady-state, not a regression (#152 review).
     - **Top-N bounded.**  Each breakdown is truncated to *top_n* entries
       sorted descending by count.  The long tail is intentionally
       dropped — operators inspecting recent runs need to see the
@@ -179,6 +254,7 @@ def build_degradation_summary(
     errors = source_acquisition_errors or []
     archive = archive_failures or []
     retries = source_retry_counts or {}
+    writes = write_outcomes or {}
 
     archive_by_kind: dict[str, int] = {}
     archive_by_domain: dict[str, int] = {}
@@ -206,6 +282,35 @@ def build_degradation_summary(
             retries_by_source[source] = retries_by_source.get(source, 0) + count
             retries_total += count
 
+    # #152 review: aggregate per-(outcome, source) write counts into the
+    # two parallel views the ledger surfaces.  ``writes.*`` carries
+    # every outcome — including the benign ``created`` / ``updated`` /
+    # ``duplicate`` cases — so operators see the dedupe volume at the
+    # write layer alongside the cache-hit total.  ``invalid_note_state.*``
+    # filters down to the materially-failed outcomes
+    # (:data:`_INVALID_NOTE_STATE_OUTCOMES`) so a duplicate-heavy run
+    # doesn't inflate the degradation reason list.
+    writes_by_outcome: dict[str, int] = {}
+    writes_by_source: dict[str, int] = {}
+    writes_total = 0
+    invalid_note_state_by_kind: dict[str, int] = {}
+    invalid_note_state_by_source: dict[str, int] = {}
+    invalid_note_state_total = 0
+    for (outcome, source), count in writes.items():
+        if count <= 0:
+            continue
+        writes_by_outcome[outcome] = writes_by_outcome.get(outcome, 0) + count
+        writes_by_source[source] = writes_by_source.get(source, 0) + count
+        writes_total += count
+        if _is_invalid_note_state_outcome(outcome):
+            invalid_note_state_by_kind[outcome] = (
+                invalid_note_state_by_kind.get(outcome, 0) + count
+            )
+            invalid_note_state_by_source[source] = (
+                invalid_note_state_by_source.get(source, 0) + count
+            )
+            invalid_note_state_total += count
+
     def _renamed(rows: list[dict[str, Any]], key_name: str) -> list[dict[str, Any]]:
         """Rename the helper's neutral ``"key"`` field to the caller's label."""
         return [{key_name: row["key"], "count": row["count"]} for row in rows]
@@ -218,6 +323,12 @@ def build_degradation_summary(
             "invalid_url_rejections": int(invalid_url_rejections_total or 0),
             "cache_hits": int(cache_hits_total or 0),
             "retries_recovered": retries_total,
+            # #152 review: write-layer totals.  ``writes`` covers every
+            # outcome (including duplicate / created / updated);
+            # ``invalid_note_state`` is the strict subset that feeds the
+            # degraded-reasons list.
+            "writes": writes_total,
+            "invalid_note_state": invalid_note_state_total,
         },
         "archive": {
             "by_kind": _renamed(_top_n_by_count(archive_by_kind, n=top_n), "kind"),
@@ -233,6 +344,28 @@ def build_degradation_summary(
             "by_kind": _renamed(_top_n_by_count(retries_by_kind, n=top_n), "kind"),
             "by_source": _renamed(
                 _top_n_by_count(retries_by_source, n=top_n), "source"
+            ),
+        },
+        # #152 review: all write outcomes including duplicate / dedupe.
+        # NOT a degradation driver — operators consult this to see the
+        # dedupe volume at the write layer (complementing
+        # ``totals.cache_hits`` which counts the pre-write cache).
+        "writes": {
+            "by_outcome": _renamed(
+                _top_n_by_count(writes_by_outcome, n=top_n), "outcome"
+            ),
+            "by_source": _renamed(_top_n_by_count(writes_by_source, n=top_n), "source"),
+        },
+        # #152 review: degrading write-time outcomes only
+        # (``invalid_input`` / ``version_conflict`` / ``slug_collision``
+        # / ``content_too_large*``).  When the total is non-zero, the
+        # caller appends ``invalid_note_state`` to the degraded reasons.
+        "invalid_note_state": {
+            "by_kind": _renamed(
+                _top_n_by_count(invalid_note_state_by_kind, n=top_n), "kind"
+            ),
+            "by_source": _renamed(
+                _top_n_by_count(invalid_note_state_by_source, n=top_n), "source"
             ),
         },
     }
@@ -327,6 +460,7 @@ class RunLedger:
         source_retry_counts: dict[str, dict[str, int]] | None = None,
         archive_failures: list[ArchiveFailureRecord] | None = None,
         cache_hits_total: int | None = None,
+        write_outcomes: WriteOutcomeCounts | None = None,
     ) -> list[str]:
         """Mark an active run as completed and append it to history.
 
@@ -374,6 +508,17 @@ class RunLedger:
           disallowed-scheme), so nothing reached the LLM filter.
           Single-run signal — like ``filter_error`` — because URL
           malformation is an immediately actionable upstream bug.
+        - ``"invalid_note_state"`` (issue #152 review) — at least one
+          write-time outcome landed in the materially-failed set
+          (``invalid_input``, ``version_conflict``, ``slug_collision``,
+          or ``content_too_large*``) so an accepted item was dropped at
+          the write layer.  Distinct from ``duplicate``, which is the
+          expected steady-state outcome of scheduled re-runs and
+          deliberately does NOT count toward degradation (PR #153 /
+          issue #148 contract).  Single-run signal — these failure
+          shapes are immediately actionable (schema drift / repair
+          backlog / upstream id collision) and do not need a
+          consecutive-runs ratchet.
 
         ``fetch_stall`` and ``filter_stall`` partition the
         ``sources_checked == 0`` space by ``fetched_total``: they are
@@ -407,6 +552,22 @@ class RunLedger:
             reasons.append("filter_error")
         if isinstance(archive_failures_total, int) and archive_failures_total > 0:
             reasons.append("archive_acquisition")
+
+        # #152 review: ``invalid_note_state`` fires when any write-time
+        # outcome lands in the materially-failed set (see
+        # :data:`_INVALID_NOTE_STATE_OUTCOMES`).  ``duplicate`` outcomes
+        # are deliberately excluded — they are the contract-expected
+        # outcome of scheduled re-runs (PR #153 / issue #148).
+        # Single-run signal because the underlying shapes (schema
+        # drift, repair backlog, version conflict) are immediately
+        # actionable, not noisy/transient.
+        invalid_note_state_total = sum(
+            count
+            for (outcome, _source), count in (write_outcomes or {}).items()
+            if _is_invalid_note_state_outcome(outcome) and count > 0
+        )
+        if invalid_note_state_total > 0:
+            reasons.append("invalid_note_state")
 
         # #131 review concern 2: ``invalid_url_stall`` fires when the
         # feed returned items but every URL was upstream-malformed
@@ -529,6 +690,7 @@ class RunLedger:
             filter_errors_total=filter_errors_total,
             invalid_url_rejections_total=invalid_url_rejections_total,
             cache_hits_total=cache_hits_total,
+            write_outcomes=write_outcomes,
         )
 
         self._finish(

--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -32,6 +32,212 @@ RunEntry = dict[str, Any]
 _STALL_HISTORY_LIMIT = 20
 
 
+# How many entries to surface in each top-N breakdown inside the
+# ``degradation_summary`` (#152).  Five is enough to spotlight the main
+# drivers (typically a single domain or kind dominates) without dumping
+# the long tail of one-off failures into the ledger and the
+# ``/runs/recent`` payload.  Tied to a constant so the bound is
+# discoverable from one place.
+_DEGRADATION_SUMMARY_TOP_N = 5
+
+
+def _top_n_by_count(counts: dict[str, int], *, n: int) -> list[dict[str, Any]]:
+    """Return *counts* as a bounded, sorted ``[{"key": ..., "count": ...}, ...]`` list.
+
+    Sorted descending by count then ascending by key so the top-N is
+    deterministic across runs with the same shape.  Only positive
+    counts are surfaced (zero-count keys are noise).  Caller supplies
+    the wrapping key name (``"kind"`` / ``"domain"`` / ``"source"``)
+    by mapping the result; this helper keeps the sort + truncate
+    discipline in one place.
+    """
+    filtered = [(k, v) for k, v in counts.items() if v > 0]
+    filtered.sort(key=lambda kv: (-kv[1], kv[0]))
+    return [{"key": k, "count": v} for k, v in filtered[:n]]
+
+
+def _archive_failure_kind_from_tags(tags: list[str]) -> str:
+    """Classify a degraded item's archive failure kind from its note tags.
+
+    Returns one of: ``"blocked"``, ``"rate_limited"``,
+    ``"missing_by_policy"``, or ``"unspecified"``.  The classification
+    is structural (it mirrors the tag taxonomy from
+    :mod:`influx.archive_policy`) rather than parsing free-form error
+    detail strings, so future taxonomy refinements only need to add
+    cases here.
+
+    ``"unspecified"`` is the default for items that landed
+    ``influx:archive-missing`` without a more specific policy tag —
+    these are generic upstream failures (HTTP 5xx, timeouts, content
+    type mismatches) that the archive policy did not classify into a
+    structural bucket.
+    """
+    tag_set = set(tags)
+    if "influx:archive-skipped-by-policy" in tag_set:
+        return "missing_by_policy"
+    if "influx:archive-blocked" in tag_set:
+        return "blocked"
+    if "influx:archive-rate-limited" in tag_set:
+        return "rate_limited"
+    return "unspecified"
+
+
+def _domain_from_url(url: str) -> str:
+    """Return the lowercase host of *url* or ``""`` when unparseable.
+
+    Duplicated locally so :mod:`influx.run_ledger` does not depend on
+    :mod:`influx.archive_policy` (and indirectly :mod:`re`/parsers it
+    pulls).  Mirror of
+    :func:`influx.archive_policy.extract_domain`.
+    """
+    if not url:
+        return ""
+    try:
+        from urllib.parse import urlparse
+
+        host = urlparse(url).hostname or ""
+    except (TypeError, ValueError):
+        return ""
+    return host.lower()
+
+
+# Concrete archive-failure record consumed by
+# :func:`build_degradation_summary` — one entry per item the run ingested
+# with ``influx:archive-missing``.  ``url`` is used to derive the domain;
+# ``tags`` are scanned for the per-policy archive tags so the summary
+# can split blocked / rate-limited / skipped-by-policy from the long
+# tail of generic ``unspecified`` failures.
+ArchiveFailureRecord = dict[str, Any]
+
+
+def build_degradation_summary(
+    *,
+    source_acquisition_errors: list[dict[str, str]] | None,
+    archive_failures: list[ArchiveFailureRecord] | None,
+    source_retry_counts: dict[str, dict[str, int]] | None,
+    filter_errors_total: int | None,
+    invalid_url_rejections_total: int | None,
+    cache_hits_total: int | None,
+    top_n: int = _DEGRADATION_SUMMARY_TOP_N,
+) -> dict[str, Any]:
+    """Build the bounded ``degradation_summary`` block for one run (#152).
+
+    The summary is additive over the existing per-reason totals on the
+    ledger entry: it does not replace ``degraded`` /
+    ``degraded_reasons`` / ``source_acquisition_errors`` /
+    ``archive_failures_total`` — it provides the per-source / per-domain
+    / per-failure-class top-N breakdowns operators need to identify
+    drivers (arXiv 429s, IEEE 403s, slow timeouts) without grepping
+    raw event logs.
+
+    Shape::
+
+        {
+            "totals": {
+                "source_acquisition_errors": int,
+                "archive_failures": int,
+                "filter_errors": int,
+                "invalid_url_rejections": int,
+                "cache_hits": int,
+                "retries_recovered": int,
+            },
+            "archive": {
+                "by_kind":   [{"kind": "...", "count": N}, ...],
+                "by_domain": [{"domain": "...", "count": N}, ...],
+            },
+            "source_acquisition": {
+                "by_kind":   [{"kind": "...", "count": N}, ...],
+                "by_source": [{"source": "...", "count": N}, ...],
+            },
+            "retries_recovered": {
+                "by_kind":   [{"kind": "...", "count": N}, ...],
+                "by_source": [{"source": "...", "count": N}, ...],
+            },
+        }
+
+    Design notes:
+
+    - **Dedupe is not degradation.**  ``cache_hits`` is reported under
+      ``totals`` so operators can see the dedupe volume, but it is
+      deliberately segregated from the archive / source-acquisition
+      breakdowns.  A run whose only "issue" is cache hits is not a
+      degraded run (#152 acceptance criteria).
+    - **Top-N bounded.**  Each breakdown is truncated to *top_n* entries
+      sorted descending by count.  The long tail is intentionally
+      dropped — operators inspecting recent runs need to see the
+      dominant drivers, not the every-warning histogram.
+    - **Failure-class taxonomy is shallow.**  Archive failures are
+      bucketed by ``blocked`` / ``rate_limited`` / ``missing_by_policy``
+      / ``unspecified``; source-acquisition failures use the refined
+      ``kind`` already attached by the source adapter (``rate_limit``,
+      ``rate_limit_upstream_capacity``, ``rate_limit_local``,
+      ``rate_limit_unknown``, ``timeout``, ``network``, ``ssrf``,
+      ``oversize``, etc.).  New refinements (e.g. issue #145's
+      arXiv 429 split) flow through automatically because the
+      classification is captured at error-record time, not here.
+    """
+    errors = source_acquisition_errors or []
+    archive = archive_failures or []
+    retries = source_retry_counts or {}
+
+    archive_by_kind: dict[str, int] = {}
+    archive_by_domain: dict[str, int] = {}
+    for record in archive:
+        kind = _archive_failure_kind_from_tags(list(record.get("tags") or []))
+        archive_by_kind[kind] = archive_by_kind.get(kind, 0) + 1
+        domain = _domain_from_url(str(record.get("url") or ""))
+        if domain:
+            archive_by_domain[domain] = archive_by_domain.get(domain, 0) + 1
+
+    source_by_kind: dict[str, int] = {}
+    source_by_source: dict[str, int] = {}
+    for err in errors:
+        kind = str(err.get("kind") or "unknown")
+        source_by_kind[kind] = source_by_kind.get(kind, 0) + 1
+        source = str(err.get("source") or "unknown")
+        source_by_source[source] = source_by_source.get(source, 0) + 1
+
+    retries_by_kind: dict[str, int] = {}
+    retries_by_source: dict[str, int] = {}
+    retries_total = 0
+    for source, by_kind in retries.items():
+        for kind, count in by_kind.items():
+            retries_by_kind[kind] = retries_by_kind.get(kind, 0) + count
+            retries_by_source[source] = retries_by_source.get(source, 0) + count
+            retries_total += count
+
+    def _renamed(rows: list[dict[str, Any]], key_name: str) -> list[dict[str, Any]]:
+        """Rename the helper's neutral ``"key"`` field to the caller's label."""
+        return [{key_name: row["key"], "count": row["count"]} for row in rows]
+
+    return {
+        "totals": {
+            "source_acquisition_errors": len(errors),
+            "archive_failures": len(archive),
+            "filter_errors": int(filter_errors_total or 0),
+            "invalid_url_rejections": int(invalid_url_rejections_total or 0),
+            "cache_hits": int(cache_hits_total or 0),
+            "retries_recovered": retries_total,
+        },
+        "archive": {
+            "by_kind": _renamed(_top_n_by_count(archive_by_kind, n=top_n), "kind"),
+            "by_domain": _renamed(
+                _top_n_by_count(archive_by_domain, n=top_n), "domain"
+            ),
+        },
+        "source_acquisition": {
+            "by_kind": _renamed(_top_n_by_count(source_by_kind, n=top_n), "kind"),
+            "by_source": _renamed(_top_n_by_count(source_by_source, n=top_n), "source"),
+        },
+        "retries_recovered": {
+            "by_kind": _renamed(_top_n_by_count(retries_by_kind, n=top_n), "kind"),
+            "by_source": _renamed(
+                _top_n_by_count(retries_by_source, n=top_n), "source"
+            ),
+        },
+    }
+
+
 @dataclass(frozen=True)
 class RunLedger:
     """Append-only local run ledger backed by JSON files."""
@@ -93,6 +299,12 @@ class RunLedger:
             # dict at start; populated from the per-run contextvar at
             # ``complete`` time.
             "source_retry_counts": {},
+            # #152: bounded, top-N degradation summary aggregated at
+            # ``complete`` time.  Stays ``None`` while the run is in
+            # flight; populated by ``complete`` with archive +
+            # source-acquisition + retry breakdowns.  See
+            # :func:`build_degradation_summary` for the full shape.
+            "degradation_summary": None,
         }
         try:
             active = self._read_active()
@@ -113,6 +325,8 @@ class RunLedger:
         archive_failures_total: int | None = None,
         source_acquisition_errors: list[dict[str, str]] | None = None,
         source_retry_counts: dict[str, dict[str, int]] | None = None,
+        archive_failures: list[ArchiveFailureRecord] | None = None,
+        cache_hits_total: int | None = None,
     ) -> list[str]:
         """Mark an active run as completed and append it to history.
 
@@ -299,6 +513,24 @@ class RunLedger:
                 ):
                     reasons.append("fetch_stall")
 
+        # #152: build the bounded degradation summary alongside the
+        # existing per-reason totals.  Computed at ``complete`` time so
+        # the persisted entry carries a stable snapshot — downstream
+        # consumers (``/runs/recent``) don't need to re-derive it from
+        # raw event logs.  Dedupe cache-hits are surfaced under
+        # ``totals.cache_hits`` but deliberately NOT folded into the
+        # archive / source-acquisition breakdowns (#152 acceptance
+        # criteria: a run whose only "issue" is cache hits is not
+        # degraded).
+        degradation_summary = build_degradation_summary(
+            source_acquisition_errors=errors,
+            archive_failures=archive_failures,
+            source_retry_counts=source_retry_counts,
+            filter_errors_total=filter_errors_total,
+            invalid_url_rejections_total=invalid_url_rejections_total,
+            cache_hits_total=cache_hits_total,
+        )
+
         self._finish(
             run_id=run_id,
             status="completed",
@@ -313,6 +545,7 @@ class RunLedger:
             source_acquisition_errors=errors,
             degraded_reasons=reasons,
             source_retry_counts=source_retry_counts,
+            degradation_summary=degradation_summary,
         )
         return reasons
 
@@ -575,6 +808,12 @@ class RunLedger:
                                 entry.get("source_retry_counts") or {}
                             ).items()
                         },
+                        # #152: preserve any in-flight degradation
+                        # summary on abandon (typically ``None`` since
+                        # the summary is only populated by ``complete``,
+                        # but allow restart hand-offs to keep partial
+                        # data).
+                        "degradation_summary": entry.get("degradation_summary"),
                     }
                 )
                 self._append(entry)
@@ -637,6 +876,7 @@ class RunLedger:
         source_acquisition_errors: list[dict[str, str]] | None = None,
         degraded_reasons: list[str] | None = None,
         source_retry_counts: dict[str, dict[str, int]] | None = None,
+        degradation_summary: dict[str, Any] | None = None,
     ) -> None:
         try:
             active = self._read_active()
@@ -678,6 +918,12 @@ class RunLedger:
                         source: dict(by_kind)
                         for source, by_kind in (source_retry_counts or {}).items()
                     },
+                    # #152: persist the precomputed degradation summary
+                    # so downstream consumers (``/runs/recent``) see the
+                    # top-N breakdowns without re-aggregating.  ``None``
+                    # on the fail / skip / abandon paths — those use
+                    # the legacy zero-data shape.
+                    "degradation_summary": degradation_summary,
                 }
             )
             self._append(entry)

--- a/src/influx/run_service.py
+++ b/src/influx/run_service.py
@@ -45,6 +45,7 @@ from influx.run import (
 )
 from influx.run_ledger import RunLedger
 from influx.telemetry import (
+    current_cache_hits,
     current_fetched_total,
     current_filter_errors,
     current_invalid_url_rejections,
@@ -57,6 +58,62 @@ from influx.telemetry import (
 __all__ = ["RunService", "ledger_lifecycle"]
 
 logger = logging.getLogger(__name__)
+
+
+def _format_top_drivers_tail(
+    *,
+    archive_failures: list[dict[str, Any]],
+    source_acquisition_errors: list[dict[str, str]],
+    reasons: list[str],
+    top_n: int = 3,
+) -> str:
+    """Return a compact log tail summarising the top degradation drivers (#152).
+
+    Builds a short string like
+    ``"archive:ieee.org=4,arxiv.org=2;source:arxiv/rate_limit_upstream_capacity=1"``
+    so a single log line carries the dominant per-domain / per-kind
+    drivers without the operator having to fetch ``/runs/recent`` to
+    triage.  Returns ``""`` for non-degraded runs (``reasons`` empty).
+
+    Bounded to *top_n* entries per category to keep the line readable.
+    """
+    if not reasons:
+        return ""
+
+    # Build a tiny on-the-fly aggregation rather than re-running the
+    # full ``build_degradation_summary`` — the log line only needs the
+    # one-line top-N digest, not the full structured shape.
+    archive_by_domain: dict[str, int] = {}
+    for record in archive_failures:
+        url = str(record.get("url") or "")
+        if not url:
+            continue
+        try:
+            from urllib.parse import urlparse
+
+            host = (urlparse(url).hostname or "").lower()
+        except (TypeError, ValueError):
+            host = ""
+        if host:
+            archive_by_domain[host] = archive_by_domain.get(host, 0) + 1
+
+    source_by_pair: dict[str, int] = {}
+    for err in source_acquisition_errors:
+        source = str(err.get("source") or "unknown")
+        kind = str(err.get("kind") or "unknown")
+        key = f"{source}/{kind}"
+        source_by_pair[key] = source_by_pair.get(key, 0) + 1
+
+    parts: list[str] = []
+    if archive_by_domain:
+        items = sorted(archive_by_domain.items(), key=lambda kv: (-kv[1], kv[0]))[
+            :top_n
+        ]
+        parts.append("archive:" + ",".join(f"{k}={v}" for k, v in items))
+    if source_by_pair:
+        items = sorted(source_by_pair.items(), key=lambda kv: (-kv[1], kv[0]))[:top_n]
+        parts.append("source:" + ",".join(f"{k}={v}" for k, v in items))
+    return ";".join(parts)
 
 
 # ── Outer ledger lifecycle (Q2 grilling — Option B, structural CM) ──
@@ -129,6 +186,14 @@ async def ledger_lifecycle(
     # ``current_source_acquisition_errors``.
     source_retry_counts: dict[str, dict[str, int]] = {}
     source_retry_counts_token = current_source_retry_counts.set(source_retry_counts)
+    # #152: per-run cache-hit counter so the ledger's
+    # ``degradation_summary.totals.cache_hits`` carries the dedupe
+    # volume.  Deliberately segregated from the degradation-driving
+    # counters: cache hits are expected behaviour (especially on
+    # backfills) and must NOT show up in archive / source-acquisition
+    # breakdowns.
+    cache_hits_counter: list[int] = [0]
+    cache_hits_token = current_cache_hits.set(cache_hits_counter)
     metric_attrs = {"profile": profile, "run_type": plan.kind.value}
 
     ledger.start(
@@ -194,10 +259,17 @@ async def ledger_lifecycle(
         archive_blocked_total = 0
         archive_rate_limited_total = 0
         archive_skipped_by_policy_total = 0
+        # #152: per-item archive-failure records (url + tags) so the
+        # ledger's degradation summary can compute the by-domain and
+        # by-kind top-N.  One entry per item that landed
+        # ``influx:archive-missing`` regardless of which (if any) more
+        # specific policy tag accompanies it.
+        archive_failures: list[dict[str, Any]] = []
         if outcome is not None and outcome.profile_run_result is not None:
             for item in outcome.profile_run_result.items:
                 if "influx:archive-missing" in item.tags:
                     archive_failures_total += 1
+                    archive_failures.append({"url": item.url, "tags": list(item.tags)})
                 if "influx:archive-blocked" in item.tags:
                     archive_blocked_total += 1
                 if "influx:archive-rate-limited" in item.tags:
@@ -214,6 +286,9 @@ async def ledger_lifecycle(
         filter_errors_total = filter_errors_counter[0]
         # #131: total per-run pre-acquire URL rejections.
         invalid_url_rejections_total = invalid_url_rejections_counter[0]
+        # #152: total cache hits this run, surfaced under the
+        # degradation summary's ``totals.cache_hits``.
+        cache_hits_total = cache_hits_counter[0]
         degraded_reasons = ledger.complete(
             run_id=run_id,
             sources_checked=sources_checked,
@@ -228,6 +303,11 @@ async def ledger_lifecycle(
             # the swallowed-error list, letting an operator distinguish
             # transient retry success from a burned retry budget.
             source_retry_counts=source_retry_counts,
+            # #152: feed per-item archive failures + cache-hit total
+            # into the bounded top-N degradation summary computed by
+            # ``ledger.complete``.
+            archive_failures=archive_failures,
+            cache_hits_total=cache_hits_total,
         )
         run_outcome = "degraded" if source_errors else "success"
         if "ingestion_stall" in degraded_reasons:
@@ -355,9 +435,21 @@ async def ledger_lifecycle(
             # future stall-reason additions stay in sync without touching
             # this call site.  ``reasons=...`` is appended for the
             # ``influx-diagnose failures`` grep path.
+            #
+            # #152: when degraded, append a compact ``top_drivers=...``
+            # tail with the dominant archive-by-domain / source-by-kind
+            # entries so the log line itself answers "what's actually
+            # broken?" without requiring a ledger fetch.  Computed in
+            # one shot via :func:`build_degradation_summary` so the log
+            # tail and the persisted summary stay in lockstep.
+            top_drivers = _format_top_drivers_tail(
+                archive_failures=archive_failures,
+                source_acquisition_errors=source_errors,
+                reasons=degraded_reasons,
+            )
             logger.info(
                 "run completed profile=%s kind=%s run_id=%s duration=%.1fs "
-                "sources_checked=%d ingested=%d degraded=%s reasons=%s",
+                "sources_checked=%d ingested=%d degraded=%s reasons=%s%s",
                 profile,
                 plan.kind.value,
                 run_id,
@@ -366,6 +458,7 @@ async def ledger_lifecycle(
                 outcome.ingested,
                 run_outcome == "degraded",
                 ",".join(degraded_reasons) if degraded_reasons else "",
+                f" top_drivers={top_drivers}" if top_drivers else "",
             )
         else:
             logger.info(
@@ -401,6 +494,7 @@ async def ledger_lifecycle(
         current_filter_errors.reset(filter_errors_token)
         current_invalid_url_rejections.reset(invalid_url_rejections_token)
         current_source_retry_counts.reset(source_retry_counts_token)
+        current_cache_hits.reset(cache_hits_token)
 
 
 # ── RunService ──────────────────────────────────────────────────────

--- a/src/influx/run_service.py
+++ b/src/influx/run_service.py
@@ -52,6 +52,7 @@ from influx.telemetry import (
     current_run_id,
     current_source_acquisition_errors,
     current_source_retry_counts,
+    current_write_outcomes,
     get_tracer,
 )
 
@@ -194,6 +195,15 @@ async def ledger_lifecycle(
     # breakdowns.
     cache_hits_counter: list[int] = [0]
     cache_hits_token = current_cache_hits.set(cache_hits_counter)
+    # #152 review: per-run write-outcome counter so the ledger's
+    # ``degradation_summary.writes.by_outcome`` /
+    # ``degradation_summary.invalid_note_state.by_kind`` carry the
+    # write-time breakdowns.  Shared mutable dict so the Ingest stage
+    # can increment via :func:`record_write_outcome` without re-setting
+    # the ContextVar — same pattern as
+    # ``current_source_acquisition_errors``.
+    write_outcomes_counter: dict[tuple[str, str], int] = {}
+    write_outcomes_token = current_write_outcomes.set(write_outcomes_counter)
     metric_attrs = {"profile": profile, "run_type": plan.kind.value}
 
     ledger.start(
@@ -308,6 +318,14 @@ async def ledger_lifecycle(
             # ``ledger.complete``.
             archive_failures=archive_failures,
             cache_hits_total=cache_hits_total,
+            # #152 review: per-(outcome, source) write counts collected
+            # at the Ingest stage drive
+            # ``degradation_summary.writes.by_outcome`` (all outcomes
+            # including duplicate) and
+            # ``degradation_summary.invalid_note_state.by_kind`` (only
+            # materially-failed outcomes — feeds the
+            # ``invalid_note_state`` degraded reason when non-zero).
+            write_outcomes=write_outcomes_counter,
         )
         run_outcome = "degraded" if source_errors else "success"
         if "ingestion_stall" in degraded_reasons:
@@ -426,6 +444,53 @@ async def ledger_lifecycle(
                 invalid_url_rejections_total,
                 fetched_total,
             )
+        if "invalid_note_state" in degraded_reasons:
+            # #152 review: at least one write-time outcome was a real
+            # write failure (``invalid_input`` / ``version_conflict`` /
+            # ``slug_collision`` / ``content_too_large*``).  Distinct
+            # from duplicates (the contract-expected outcome of
+            # scheduled re-runs, PR #153) — operators should look at
+            # schema drift, repair backlog, or id collisions, not
+            # the dedupe pipeline.
+            if run_outcome == "success":
+                run_outcome = "degraded"
+            # Build the by-kind digest locally from the counter to
+            # avoid re-reading the ledger entry we just appended.
+            invalid_kind_counts: dict[str, int] = {}
+            for (
+                write_outcome_kind,
+                _write_outcome_source,
+            ), count in write_outcomes_counter.items():
+                if count <= 0:
+                    continue
+                if write_outcome_kind in (
+                    "invalid_input",
+                    "version_conflict",
+                    "slug_collision",
+                    "content_too_large",
+                    "content_too_large_skipped",
+                ):
+                    invalid_kind_counts[write_outcome_kind] = (
+                        invalid_kind_counts.get(write_outcome_kind, 0) + count
+                    )
+            invalid_note_state_summary = ",".join(
+                f"{kind}={count}"
+                for kind, count in sorted(
+                    invalid_kind_counts.items(), key=lambda kv: (-kv[1], kv[0])
+                )
+            )
+            logger.warning(
+                "run flagged invalid_note_state profile=%s kind=%s run_id=%s "
+                "by_kind=%s "
+                "(write-time failures landed in the materially-failed set "
+                "— check schema drift, repair backlog, or upstream id "
+                "collisions; duplicate outcomes are deliberately excluded "
+                "from this flag)",
+                profile,
+                plan.kind.value,
+                run_id,
+                invalid_note_state_summary or "<none>",
+            )
         metrics.run_duration().record(elapsed, metric_attrs)
         metrics.run_completions().add(1, {**metric_attrs, "outcome": run_outcome})
 
@@ -495,6 +560,7 @@ async def ledger_lifecycle(
         current_invalid_url_rejections.reset(invalid_url_rejections_token)
         current_source_retry_counts.reset(source_retry_counts_token)
         current_cache_hits.reset(cache_hits_token)
+        current_write_outcomes.reset(write_outcomes_token)
 
 
 # ── RunService ──────────────────────────────────────────────────────

--- a/src/influx/telemetry.py
+++ b/src/influx/telemetry.py
@@ -31,6 +31,7 @@ __all__ = [
     "SourceAcquisitionError",
     "SourceRetryCounts",
     "SpanWrapper",
+    "WriteOutcomeCounts",
     "current_archive_terminal_arxiv_ids",
     "current_cache_hits",
     "current_fetched_total",
@@ -39,6 +40,7 @@ __all__ = [
     "current_run_id",
     "current_source_acquisition_errors",
     "current_source_retry_counts",
+    "current_write_outcomes",
     "get_meter",
     "get_tracer",
     "record_cache_hit",
@@ -47,6 +49,7 @@ __all__ = [
     "record_invalid_url_rejection",
     "record_source_acquisition_error",
     "record_source_retry",
+    "record_write_outcome",
 ]
 
 # Context variable for the current run ID — set by ``run_profile()`` so
@@ -282,6 +285,57 @@ def record_cache_hit(count: int = 1) -> None:
     if counter is None:
         return
     counter[0] += count
+
+
+# Per-run counter of ``lithos_write`` outcomes keyed by ``(outcome, source)``
+# — issue #152 review.  Set to an empty dict at run start by
+# :func:`run_service.ledger_lifecycle`; the Ingest stage of
+# :mod:`influx.run` increments via :func:`record_write_outcome` after each
+# ``LithosClient.write_note`` call.
+#
+# Surfaced on the run-ledger entry as
+# ``degradation_summary.writes.by_outcome`` (the full top-N including
+# ``created`` / ``updated`` / ``duplicate`` so operators see the dedupe
+# volume) and ``degradation_summary.invalid_note_state.by_kind`` (only
+# the degrading outcomes — ``invalid_input``, ``version_conflict``,
+# ``slug_collision``, ``content_too_large*``).  Duplicate / dedupe
+# outcomes are deliberately segregated from the invalid-note-state
+# bucket: they are expected behaviour on scheduled re-runs and must NOT
+# inflate the degradation reason list (issue #152 acceptance criteria —
+# mirrors :data:`current_cache_hits` discipline).
+#
+# Plain ``dict[(outcome, source) -> count]`` so source / outcome pairs
+# stay distinct in the ledger entry (e.g. ``duplicate`` from arXiv
+# differs operationally from ``duplicate`` from RSS).
+WriteOutcomeCounts = dict[tuple[str, str], int]
+
+
+current_write_outcomes: ContextVar[WriteOutcomeCounts | None] = ContextVar(
+    "current_write_outcomes",
+    default=None,
+)
+
+
+def record_write_outcome(*, outcome: str, source: str) -> None:
+    """Increment the current run's write-outcome counter for *outcome*/*source*.
+
+    Safe to call outside a run context — silently no-ops when
+    :data:`current_write_outcomes` is unset.  Callers invoke this once
+    per :meth:`LithosClient.write_note` return, regardless of whether
+    the outcome was a success (``created`` / ``updated``), a benign
+    dedupe (``duplicate``), or a write failure (``invalid_input`` /
+    ``version_conflict`` / ``slug_collision`` / ``content_too_large*``).
+
+    ``outcome`` is the :class:`WriteResult.status` string.  ``source``
+    is the per-item source bucket (``arxiv`` / ``rss`` / ...) so the
+    ledger entry can attribute write failures back to the upstream
+    feed.
+    """
+    counts = current_write_outcomes.get()
+    if counts is None:
+        return
+    key = (outcome, source)
+    counts[key] = counts.get(key, 0) + 1
 
 
 logger = logging.getLogger(__name__)

--- a/src/influx/telemetry.py
+++ b/src/influx/telemetry.py
@@ -32,6 +32,7 @@ __all__ = [
     "SourceRetryCounts",
     "SpanWrapper",
     "current_archive_terminal_arxiv_ids",
+    "current_cache_hits",
     "current_fetched_total",
     "current_filter_errors",
     "current_invalid_url_rejections",
@@ -40,6 +41,7 @@ __all__ = [
     "current_source_retry_counts",
     "get_meter",
     "get_tracer",
+    "record_cache_hit",
     "record_fetched_items",
     "record_filter_error",
     "record_invalid_url_rejection",
@@ -243,6 +245,40 @@ def record_invalid_url_rejection(count: int = 1) -> None:
     if count <= 0:
         return
     counter = current_invalid_url_rejections.get()
+    if counter is None:
+        return
+    counter[0] += count
+
+
+# Per-run counter of items that matched in the Lithos cache lookup
+# (primary or ``source_url`` fallback) — issue #152.  Set to ``[0]`` at
+# run start by ``run_service.ledger_lifecycle``; incremented by the
+# Ingest stage on every cache hit (skip or multi-profile merge).
+#
+# Surfaced on the run-ledger entry as
+# ``degradation_summary.totals.cache_hits`` so a backfill that
+# legitimately skipped 90% of candidates is visibly distinct from a
+# fresh fetch run.  Deliberately NOT folded into degraded_reasons:
+# cache hits are expected behaviour, not degradation (#152 acceptance
+# criteria — dedupe must not dominate the degradation summary).
+current_cache_hits: ContextVar[list[int] | None] = ContextVar(
+    "current_cache_hits",
+    default=None,
+)
+
+
+def record_cache_hit(count: int = 1) -> None:
+    """Add *count* to the current run's ``cache_hits`` counter (#152).
+
+    Safe to call outside a run context — silently no-ops when
+    :data:`current_cache_hits` is unset.  Ingest-stage callers
+    increment on every cache lookup that returned ``hit=true``
+    (primary or ``source_url`` fallback); multi-profile merges count
+    once each because each merge consumes one lookup.
+    """
+    if count <= 0:
+        return
+    counter = current_cache_hits.get()
     if counter is None:
         return
     counter[0] += count

--- a/tests/integration/test_http_api.py
+++ b/tests/integration/test_http_api.py
@@ -426,6 +426,86 @@ class TestRecentRuns:
 
         assert [run["run_id"] for run in body["runs"]] == ["run-web"]
 
+    def test_recent_runs_exposes_degradation_summary(
+        self, client: TestClient, app_with_state: FastAPI
+    ) -> None:
+        """``/runs/recent`` carries the bounded ``degradation_summary``
+        so operators can identify drivers without raw event logs (#152).
+        """
+        ledger: RunLedger = app_with_state.state.run_ledger
+        ledger.start(
+            run_id="run-degraded",
+            profile="ai-robotics",
+            kind="scheduled",
+            run_range=None,
+        )
+        ledger.complete(
+            run_id="run-degraded",
+            sources_checked=4,
+            ingested=2,
+            archive_failures_total=2,
+            archive_failures=[
+                {
+                    "url": "https://ieee.org/a",
+                    "tags": ["influx:archive-missing", "influx:archive-blocked"],
+                },
+                {
+                    "url": "https://ieee.org/b",
+                    "tags": ["influx:archive-missing", "influx:archive-blocked"],
+                },
+            ],
+            source_acquisition_errors=[
+                {
+                    "source": "arxiv",
+                    "kind": "rate_limit_upstream_capacity",
+                    "detail": "429",
+                }
+            ],
+            cache_hits_total=12,
+        )
+
+        body = client.get("/runs/recent").json()
+        entry = body["runs"][0]
+        assert entry["run_id"] == "run-degraded"
+        summary = entry["degradation_summary"]
+        assert summary["totals"]["archive_failures"] == 2
+        assert summary["totals"]["cache_hits"] == 12
+        assert summary["archive"]["by_domain"][0] == {
+            "domain": "ieee.org",
+            "count": 2,
+        }
+        # Cache-hit total must NOT be folded into the archive or
+        # source-acquisition breakdowns (#152 acceptance criteria).
+        kinds = {row["kind"]: row["count"] for row in summary["archive"]["by_kind"]}
+        assert kinds == {"blocked": 2}
+        assert summary["source_acquisition"]["by_kind"][0] == {
+            "kind": "rate_limit_upstream_capacity",
+            "count": 1,
+        }
+
+    def test_recent_runs_degradation_summary_on_clean_run(
+        self, client: TestClient, app_with_state: FastAPI
+    ) -> None:
+        """Even clean runs expose a zero-shaped ``degradation_summary``
+        so API consumers never have to defend against ``None`` (#152).
+        """
+        ledger: RunLedger = app_with_state.state.run_ledger
+        ledger.start(
+            run_id="run-clean",
+            profile="ai-robotics",
+            kind="scheduled",
+            run_range=None,
+        )
+        ledger.complete(run_id="run-clean", sources_checked=3, ingested=2)
+
+        body = client.get("/runs/recent").json()
+        entry = body["runs"][0]
+        summary = entry["degradation_summary"]
+        assert summary is not None
+        assert summary["totals"]["archive_failures"] == 0
+        assert summary["totals"]["source_acquisition_errors"] == 0
+        assert summary["archive"]["by_domain"] == []
+
 
 class TestPostRunsSchedulerOverlap:
     """AC-03-A: scheduled fire + POST /runs for same profile → exactly one accepted."""

--- a/tests/unit/test_run_ledger.py
+++ b/tests/unit/test_run_ledger.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from influx.run_ledger import RunLedger
 
@@ -1286,3 +1287,354 @@ def test_invalid_url_stall_fires_on_first_run(tmp_path: Path) -> None:
         invalid_url_rejections_total=2,
     )
     assert "invalid_url_stall" in reasons
+
+
+# ── #152: degradation summary ────────────────────────────────────────
+
+
+def test_degradation_summary_present_on_clean_run(tmp_path: Path) -> None:
+    """Clean runs still carry a ``degradation_summary`` so consumers
+    never need to defend against a missing field (#152)."""
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(run_id="r-1", profile="p", kind="scheduled", run_range=None)
+    ledger.complete(run_id="r-1", sources_checked=5, ingested=3)
+
+    entry = ledger.recent()[0]
+    summary = entry["degradation_summary"]
+    assert summary is not None
+    assert summary["totals"]["archive_failures"] == 0
+    assert summary["totals"]["source_acquisition_errors"] == 0
+    assert summary["totals"]["cache_hits"] == 0
+    assert summary["archive"]["by_kind"] == []
+    assert summary["archive"]["by_domain"] == []
+    assert summary["source_acquisition"]["by_kind"] == []
+    assert summary["source_acquisition"]["by_source"] == []
+    assert summary["retries_recovered"]["by_kind"] == []
+
+
+def test_degradation_summary_top_archive_by_domain(tmp_path: Path) -> None:
+    """Archive failures group by URL domain so operators see WHICH
+    domain dominates, not just the total (#152)."""
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(run_id="r-1", profile="p", kind="scheduled", run_range=None)
+    archive = [
+        {"url": "https://ieee.org/a", "tags": ["influx:archive-missing"]},
+        {"url": "https://ieee.org/b", "tags": ["influx:archive-missing"]},
+        {"url": "https://ieee.org/c", "tags": ["influx:archive-missing"]},
+        {"url": "https://acm.org/x", "tags": ["influx:archive-missing"]},
+        {"url": "https://acm.org/y", "tags": ["influx:archive-missing"]},
+        {"url": "https://other.example/z", "tags": ["influx:archive-missing"]},
+    ]
+    ledger.complete(
+        run_id="r-1",
+        sources_checked=10,
+        ingested=4,
+        archive_failures_total=len(archive),
+        archive_failures=archive,
+    )
+
+    summary = ledger.recent()[0]["degradation_summary"]
+    domains = summary["archive"]["by_domain"]
+    assert domains[0] == {"domain": "ieee.org", "count": 3}
+    assert domains[1] == {"domain": "acm.org", "count": 2}
+    assert domains[2] == {"domain": "other.example", "count": 1}
+    assert summary["totals"]["archive_failures"] == 6
+
+
+def test_degradation_summary_archive_by_kind_uses_policy_tags(
+    tmp_path: Path,
+) -> None:
+    """Archive ``by_kind`` distinguishes blocked / rate_limited /
+    missing_by_policy / unspecified from the tag taxonomy (#152)."""
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(run_id="r-1", profile="p", kind="scheduled", run_range=None)
+    archive = [
+        {
+            "url": "https://a.example/1",
+            "tags": ["influx:archive-missing", "influx:archive-blocked"],
+        },
+        {
+            "url": "https://a.example/2",
+            "tags": ["influx:archive-missing", "influx:archive-blocked"],
+        },
+        {
+            "url": "https://b.example/1",
+            "tags": ["influx:archive-missing", "influx:archive-rate-limited"],
+        },
+        {
+            "url": "https://c.example/1",
+            "tags": ["influx:archive-missing", "influx:archive-skipped-by-policy"],
+        },
+        {
+            # Generic upstream failure (no policy tag): bucketed as
+            # "unspecified" so the long tail stays visible.
+            "url": "https://d.example/1",
+            "tags": ["influx:archive-missing"],
+        },
+    ]
+    ledger.complete(
+        run_id="r-1",
+        sources_checked=10,
+        ingested=5,
+        archive_failures_total=len(archive),
+        archive_failures=archive,
+    )
+
+    by_kind = ledger.recent()[0]["degradation_summary"]["archive"]["by_kind"]
+    kinds = {row["kind"]: row["count"] for row in by_kind}
+    assert kinds == {
+        "blocked": 2,
+        "rate_limited": 1,
+        "missing_by_policy": 1,
+        "unspecified": 1,
+    }
+
+
+def test_degradation_summary_source_acquisition_breakdown(tmp_path: Path) -> None:
+    """Source-acquisition failures break down by source AND by kind so
+    operators can distinguish "arXiv-only rate-limit storm" from
+    "every source is timing out" (#152)."""
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(run_id="r-1", profile="p", kind="scheduled", run_range=None)
+    errors = [
+        {
+            "source": "arxiv",
+            "kind": "rate_limit_upstream_capacity",
+            "detail": "429",
+        },
+        {
+            "source": "arxiv",
+            "kind": "rate_limit_upstream_capacity",
+            "detail": "429",
+        },
+        {"source": "arxiv", "kind": "rate_limit_local", "detail": "429"},
+        {"source": "rss", "kind": "timeout", "detail": "slow"},
+    ]
+    ledger.complete(
+        run_id="r-1",
+        sources_checked=2,
+        ingested=0,
+        source_acquisition_errors=errors,
+    )
+
+    summary = ledger.recent()[0]["degradation_summary"]
+    kinds = {
+        row["kind"]: row["count"] for row in summary["source_acquisition"]["by_kind"]
+    }
+    sources = {
+        row["source"]: row["count"]
+        for row in summary["source_acquisition"]["by_source"]
+    }
+    assert kinds == {
+        "rate_limit_upstream_capacity": 2,
+        "rate_limit_local": 1,
+        "timeout": 1,
+    }
+    assert sources == {"arxiv": 3, "rss": 1}
+
+
+def test_degradation_summary_caps_breakdowns_at_top_n(tmp_path: Path) -> None:
+    """Long tails get truncated — operators need top drivers, not every
+    one-off failure (#152)."""
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(run_id="r-1", profile="p", kind="scheduled", run_range=None)
+    # 10 distinct domains, descending counts 10..1
+    archive: list[dict[str, Any]] = []
+    for i, count in enumerate(range(10, 0, -1)):
+        for _ in range(count):
+            archive.append(
+                {
+                    "url": f"https://host-{i:02d}.example/p",
+                    "tags": ["influx:archive-missing"],
+                }
+            )
+    ledger.complete(
+        run_id="r-1",
+        sources_checked=20,
+        ingested=10,
+        archive_failures_total=len(archive),
+        archive_failures=archive,
+    )
+
+    domains = ledger.recent()[0]["degradation_summary"]["archive"]["by_domain"]
+    # Bounded to top 5; first entry is the heaviest hitter.
+    assert len(domains) == 5
+    assert domains[0]["count"] == 10
+    assert domains[-1]["count"] == 6
+
+
+def test_degradation_summary_does_not_count_cache_hits_as_degradation(
+    tmp_path: Path,
+) -> None:
+    """A run whose only "issue" is dedupe is NOT degraded — cache hits
+    must NOT inflate the archive or source-acquisition breakdowns
+    (#152 acceptance criteria)."""
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(run_id="r-1", profile="p", kind="backfill", run_range=None)
+    reasons = ledger.complete(
+        run_id="r-1",
+        sources_checked=0,
+        ingested=0,
+        cache_hits_total=100,
+    )
+
+    entry = ledger.recent()[0]
+    assert reasons == []
+    assert entry["degraded"] is False
+    summary = entry["degradation_summary"]
+    assert summary["totals"]["cache_hits"] == 100
+    # Cache hits MUST NOT show up in archive / source-acquisition
+    # breakdowns — they are not failures.
+    assert summary["archive"]["by_domain"] == []
+    assert summary["archive"]["by_kind"] == []
+    assert summary["source_acquisition"]["by_kind"] == []
+
+
+def test_degradation_summary_includes_retries_recovered(tmp_path: Path) -> None:
+    """Recovered retries are surfaced so operators see "we burned the
+    retry budget" patterns even on otherwise-clean runs (#152 +
+    #129)."""
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(run_id="r-1", profile="p", kind="scheduled", run_range=None)
+    ledger.complete(
+        run_id="r-1",
+        sources_checked=4,
+        ingested=2,
+        source_retry_counts={
+            "arxiv": {"rate_limit_upstream_capacity": 3, "network": 1},
+            "rss": {"timeout": 2},
+        },
+    )
+
+    summary = ledger.recent()[0]["degradation_summary"]
+    assert summary["totals"]["retries_recovered"] == 6
+    by_kind = {
+        row["kind"]: row["count"] for row in summary["retries_recovered"]["by_kind"]
+    }
+    by_source = {
+        row["source"]: row["count"] for row in summary["retries_recovered"]["by_source"]
+    }
+    assert by_kind == {
+        "rate_limit_upstream_capacity": 3,
+        "timeout": 2,
+        "network": 1,
+    }
+    assert by_source == {"arxiv": 4, "rss": 2}
+
+
+def test_degradation_summary_distinguishes_all_failure_classes(
+    tmp_path: Path,
+) -> None:
+    """Run mixing archive / source-acquisition / timeouts / invalid-url
+    stay distinguishable in the totals block (#152 acceptance
+    criteria)."""
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(run_id="r-1", profile="p", kind="scheduled", run_range=None)
+    ledger.complete(
+        run_id="r-1",
+        sources_checked=3,
+        ingested=1,
+        filter_errors_total=2,
+        invalid_url_rejections_total=4,
+        archive_failures_total=2,
+        archive_failures=[
+            {"url": "https://x.example/1", "tags": ["influx:archive-missing"]},
+            {
+                "url": "https://x.example/2",
+                "tags": ["influx:archive-missing", "influx:archive-rate-limited"],
+            },
+        ],
+        source_acquisition_errors=[
+            {"source": "arxiv", "kind": "timeout", "detail": "slow"},
+        ],
+        cache_hits_total=7,
+    )
+
+    totals = ledger.recent()[0]["degradation_summary"]["totals"]
+    assert totals == {
+        "archive_failures": 2,
+        "source_acquisition_errors": 1,
+        "filter_errors": 2,
+        "invalid_url_rejections": 4,
+        "cache_hits": 7,
+        "retries_recovered": 0,
+    }
+
+
+def test_degradation_summary_top_n_is_deterministic_on_ties(
+    tmp_path: Path,
+) -> None:
+    """Ties in count break to the lower-keyed entry so two operators
+    inspecting the same run see the same ordering (#152)."""
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(run_id="r-1", profile="p", kind="scheduled", run_range=None)
+    archive = [
+        {"url": "https://b.example/1", "tags": ["influx:archive-missing"]},
+        {"url": "https://a.example/1", "tags": ["influx:archive-missing"]},
+    ]
+    ledger.complete(
+        run_id="r-1",
+        sources_checked=2,
+        ingested=0,
+        archive_failures_total=len(archive),
+        archive_failures=archive,
+    )
+
+    domains = [
+        row["domain"]
+        for row in ledger.recent()[0]["degradation_summary"]["archive"]["by_domain"]
+    ]
+    # Both at count=1; ``a.example`` sorts first because count is tied
+    # and we fall back to ascending key.
+    assert domains == ["a.example", "b.example"]
+
+
+# ── #152: build_degradation_summary unit coverage ───────────────────
+
+
+def test_build_degradation_summary_handles_all_none(tmp_path: Path) -> None:
+    """All-``None`` inputs produce a zero-shaped summary so the
+    ``ledger.complete`` happy path doesn't have to defend (#152)."""
+    from influx.run_ledger import build_degradation_summary
+
+    summary = build_degradation_summary(
+        source_acquisition_errors=None,
+        archive_failures=None,
+        source_retry_counts=None,
+        filter_errors_total=None,
+        invalid_url_rejections_total=None,
+        cache_hits_total=None,
+    )
+    assert summary["totals"]["archive_failures"] == 0
+    assert summary["totals"]["source_acquisition_errors"] == 0
+    assert summary["totals"]["retries_recovered"] == 0
+    assert summary["archive"]["by_domain"] == []
+    assert summary["source_acquisition"]["by_source"] == []
+    assert summary["retries_recovered"]["by_kind"] == []
+
+
+def test_build_degradation_summary_ignores_unparseable_archive_urls(
+    tmp_path: Path,
+) -> None:
+    """Items with empty / malformed URLs still show up in by_kind
+    (they're real failures) but do not pollute by_domain (#152)."""
+    from influx.run_ledger import build_degradation_summary
+
+    summary = build_degradation_summary(
+        source_acquisition_errors=None,
+        archive_failures=[
+            {"url": "", "tags": ["influx:archive-missing"]},
+            {"url": "not-a-url", "tags": ["influx:archive-missing"]},
+            {"url": "https://real.example/x", "tags": ["influx:archive-missing"]},
+        ],
+        source_retry_counts=None,
+        filter_errors_total=None,
+        invalid_url_rejections_total=None,
+        cache_hits_total=None,
+    )
+    assert summary["totals"]["archive_failures"] == 3
+    by_kind = {row["kind"]: row["count"] for row in summary["archive"]["by_kind"]}
+    assert by_kind == {"unspecified": 3}
+    # Only the one parseable URL contributes to ``by_domain``.
+    by_domain = {row["domain"]: row["count"] for row in summary["archive"]["by_domain"]}
+    assert by_domain == {"real.example": 1}

--- a/tests/unit/test_run_ledger.py
+++ b/tests/unit/test_run_ledger.py
@@ -1558,6 +1558,11 @@ def test_degradation_summary_distinguishes_all_failure_classes(
         "invalid_url_rejections": 4,
         "cache_hits": 7,
         "retries_recovered": 0,
+        # #152 review: write-layer totals.  This run passed no
+        # write_outcomes so both stay zero — but the keys are present so
+        # downstream consumers don't need to defend against absence.
+        "writes": 0,
+        "invalid_note_state": 0,
     }
 
 
@@ -1638,3 +1643,155 @@ def test_build_degradation_summary_ignores_unparseable_archive_urls(
     # Only the one parseable URL contributes to ``by_domain``.
     by_domain = {row["domain"]: row["count"] for row in summary["archive"]["by_domain"]}
     assert by_domain == {"real.example": 1}
+
+
+# ── #152 review: write-outcome + invalid-note-state breakdowns ──────
+
+
+def test_degradation_summary_aggregates_writes_by_outcome(tmp_path: Path) -> None:
+    """``writes.by_outcome`` surfaces every write outcome (including
+    duplicates and successes) so operators see the dedupe volume and
+    write-time failures in one place (#152 review)."""
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(run_id="r-1", profile="p", kind="scheduled", run_range=None)
+    ledger.complete(
+        run_id="r-1",
+        sources_checked=4,
+        ingested=2,
+        write_outcomes={
+            ("created", "arxiv"): 2,
+            ("duplicate", "arxiv"): 3,
+            ("duplicate", "rss"): 1,
+            ("invalid_input", "rss"): 1,
+        },
+    )
+
+    summary = ledger.recent()[0]["degradation_summary"]
+    by_outcome = {
+        row["outcome"]: row["count"] for row in summary["writes"]["by_outcome"]
+    }
+    assert by_outcome == {
+        "created": 2,
+        "duplicate": 4,
+        "invalid_input": 1,
+    }
+    by_source = {row["source"]: row["count"] for row in summary["writes"]["by_source"]}
+    assert by_source == {"arxiv": 5, "rss": 2}
+    assert summary["totals"]["writes"] == 7
+
+
+def test_degradation_summary_duplicate_only_run_is_not_degraded(
+    tmp_path: Path,
+) -> None:
+    """Regression (#152 review): a run whose every write is a
+    ``duplicate`` is the contract-expected outcome of scheduled re-runs
+    (PR #153 / issue #148) and MUST NOT be flagged as degraded.
+
+    Duplicate counts must appear under ``writes.by_outcome`` for
+    visibility but stay out of every degradation driver — including
+    the new ``invalid_note_state`` bucket — so the dedupe contract is
+    not silently re-broken by the write-outcome plumbing."""
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(run_id="r-1", profile="p", kind="scheduled", run_range=None)
+    reasons = ledger.complete(
+        run_id="r-1",
+        sources_checked=5,
+        ingested=0,
+        write_outcomes={
+            ("duplicate", "arxiv"): 4,
+            ("duplicate", "rss"): 1,
+        },
+    )
+
+    entry = ledger.recent()[0]
+    # Not degraded — duplicates are expected steady state.
+    assert reasons == []
+    assert entry["degraded"] is False
+    assert entry["degraded_reasons"] == []
+
+    summary = entry["degradation_summary"]
+    # Duplicates are visible to operators under writes.by_outcome ...
+    by_outcome = {
+        row["outcome"]: row["count"] for row in summary["writes"]["by_outcome"]
+    }
+    assert by_outcome == {"duplicate": 5}
+    assert summary["totals"]["writes"] == 5
+    # ... but they do NOT inflate any degradation driver, including
+    # the new invalid_note_state bucket and the existing archive /
+    # source-acquisition counters.
+    assert summary["totals"]["invalid_note_state"] == 0
+    assert summary["totals"]["archive_failures"] == 0
+    assert summary["totals"]["source_acquisition_errors"] == 0
+    assert summary["invalid_note_state"]["by_kind"] == []
+    assert summary["invalid_note_state"]["by_source"] == []
+    assert summary["archive"]["by_kind"] == []
+    assert summary["source_acquisition"]["by_kind"] == []
+
+
+def test_degradation_summary_invalid_note_state_drives_degradation(
+    tmp_path: Path,
+) -> None:
+    """Invalid-note-state outcomes (``invalid_input`` /
+    ``version_conflict`` / ``slug_collision`` / ``content_too_large*``)
+    are degrading write failures and must show up in
+    ``degraded_reasons`` (#152 review acceptance criteria)."""
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(run_id="r-1", profile="p", kind="scheduled", run_range=None)
+    reasons = ledger.complete(
+        run_id="r-1",
+        sources_checked=5,
+        ingested=2,
+        write_outcomes={
+            ("created", "arxiv"): 2,
+            ("duplicate", "arxiv"): 1,  # NOT degrading
+            ("invalid_input", "rss"): 1,
+            ("version_conflict", "arxiv"): 1,
+            ("slug_collision", "arxiv"): 1,
+            ("content_too_large_skipped", "rss"): 1,
+        },
+    )
+
+    entry = ledger.recent()[0]
+    assert "invalid_note_state" in reasons
+    assert entry["degraded"] is True
+
+    summary = entry["degradation_summary"]
+    by_kind = {
+        row["kind"]: row["count"] for row in summary["invalid_note_state"]["by_kind"]
+    }
+    # Only the materially-failed outcomes are bucketed — created /
+    # duplicate stay out.
+    assert by_kind == {
+        "invalid_input": 1,
+        "version_conflict": 1,
+        "slug_collision": 1,
+        "content_too_large_skipped": 1,
+    }
+    assert summary["totals"]["invalid_note_state"] == 4
+    by_source = {
+        row["source"]: row["count"]
+        for row in summary["invalid_note_state"]["by_source"]
+    }
+    assert by_source == {"arxiv": 2, "rss": 2}
+
+
+def test_build_degradation_summary_accepts_no_write_outcomes(tmp_path: Path) -> None:
+    """``write_outcomes=None`` produces a zero-shaped writes /
+    invalid_note_state block so legacy callers (and the ``fail`` /
+    ``skip`` paths) don't break (#152 review)."""
+    from influx.run_ledger import build_degradation_summary
+
+    summary = build_degradation_summary(
+        source_acquisition_errors=None,
+        archive_failures=None,
+        source_retry_counts=None,
+        filter_errors_total=None,
+        invalid_url_rejections_total=None,
+        cache_hits_total=None,
+    )
+    assert summary["totals"]["writes"] == 0
+    assert summary["totals"]["invalid_note_state"] == 0
+    assert summary["writes"]["by_outcome"] == []
+    assert summary["writes"]["by_source"] == []
+    assert summary["invalid_note_state"]["by_kind"] == []
+    assert summary["invalid_note_state"]["by_source"] == []

--- a/tests/unit/test_run_service.py
+++ b/tests/unit/test_run_service.py
@@ -887,3 +887,120 @@ async def test_degradation_summary_log_tail_absent_on_clean_run(
 
     record = _extract_run_completed_record(caplog)
     assert "top_drivers=" not in record.message
+
+
+# ── #152 review: write-outcome end-to-end plumbing ──────────────────
+
+
+async def test_write_outcomes_recorded_during_run_flow_into_ledger(
+    tmp_path: Path,
+) -> None:
+    """End-to-end: the Ingest stage's :func:`record_write_outcome` calls
+    accumulate into the per-run ContextVar and the ledger entry's
+    ``degradation_summary`` surfaces both the duplicate volume and the
+    invalid-note-state failures (#152 review)."""
+    from influx.telemetry import current_write_outcomes, record_write_outcome
+
+    config = _make_config()
+    ledger = RunLedger(tmp_path)
+    service = RunService(config=config, ledger=ledger)
+
+    async def body(self: Any) -> RunOutcome:
+        # The CM set the counter to an empty dict — record a mix of
+        # success / duplicate / invalid_input outcomes.
+        assert current_write_outcomes.get() is not None
+        record_write_outcome(outcome="created", source="arxiv")
+        record_write_outcome(outcome="duplicate", source="arxiv")
+        record_write_outcome(outcome="duplicate", source="rss")
+        record_write_outcome(outcome="invalid_input", source="rss")
+        return RunOutcome(sources_checked=4, ingested=1)
+
+    with patch("influx.run.Run.execute", new=body):
+        await service.execute(_scheduled_plan())
+
+    entry = next(e for e in ledger.recent() if e["status"] == "completed")
+    summary = entry["degradation_summary"]
+    by_outcome = {
+        row["outcome"]: row["count"] for row in summary["writes"]["by_outcome"]
+    }
+    assert by_outcome == {"created": 1, "duplicate": 2, "invalid_input": 1}
+    invalid_by_kind = {
+        row["kind"]: row["count"] for row in summary["invalid_note_state"]["by_kind"]
+    }
+    assert invalid_by_kind == {"invalid_input": 1}
+    # Single invalid_input is degrading; duplicates are not.
+    assert "invalid_note_state" in entry["degraded_reasons"]
+    assert entry["degraded"] is True
+
+
+async def test_duplicate_only_run_via_service_not_degraded(
+    tmp_path: Path,
+) -> None:
+    """End-to-end regression (#152 review / PR #153 contract): a
+    scheduled re-run whose every write is ``duplicate`` is NOT
+    degraded and the duplicate volume does not bleed into archive /
+    source-acquisition / invalid-note-state counters."""
+    from influx.telemetry import record_write_outcome
+
+    config = _make_config()
+    ledger = RunLedger(tmp_path)
+    service = RunService(config=config, ledger=ledger)
+
+    async def body(self: Any) -> RunOutcome:
+        # Simulate the backfill / scheduled re-run shape: every
+        # candidate already exists in Lithos.
+        for _ in range(7):
+            record_write_outcome(outcome="duplicate", source="arxiv")
+        return RunOutcome(sources_checked=7, ingested=0)
+
+    with patch("influx.run.Run.execute", new=body):
+        await service.execute(_scheduled_plan())
+
+    entry = next(e for e in ledger.recent() if e["status"] == "completed")
+    assert entry["degraded"] is False
+    assert entry["degraded_reasons"] == []
+
+    summary = entry["degradation_summary"]
+    # Visible to operators: 7 duplicates surfaced under writes.
+    by_outcome = {
+        row["outcome"]: row["count"] for row in summary["writes"]["by_outcome"]
+    }
+    assert by_outcome == {"duplicate": 7}
+    # NOT visible (= zero) in any degradation driver.
+    assert summary["totals"]["invalid_note_state"] == 0
+    assert summary["totals"]["archive_failures"] == 0
+    assert summary["totals"]["source_acquisition_errors"] == 0
+    assert summary["invalid_note_state"]["by_kind"] == []
+    assert summary["invalid_note_state"]["by_source"] == []
+
+
+async def test_invalid_note_state_emits_warning_log(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When the run is flagged ``invalid_note_state``, the log tail
+    carries the by-kind digest so single-log triage is possible
+    without fetching the ledger (#152 review)."""
+    from influx.telemetry import record_write_outcome
+
+    config = _make_config()
+    ledger = RunLedger(tmp_path)
+    service = RunService(config=config, ledger=ledger)
+
+    async def body(self: Any) -> RunOutcome:
+        record_write_outcome(outcome="version_conflict", source="arxiv")
+        record_write_outcome(outcome="version_conflict", source="arxiv")
+        record_write_outcome(outcome="slug_collision", source="rss")
+        return RunOutcome(sources_checked=3, ingested=0)
+
+    with (
+        caplog.at_level(logging.WARNING, logger="influx.run_service"),
+        patch("influx.run.Run.execute", new=body),
+    ):
+        await service.execute(_scheduled_plan())
+
+    matches = [r for r in caplog.records if "invalid_note_state" in r.getMessage()]
+    assert matches, "expected an invalid_note_state warning to be emitted"
+    message = matches[-1].getMessage()
+    assert "version_conflict=2" in message
+    assert "slug_collision=1" in message

--- a/tests/unit/test_run_service.py
+++ b/tests/unit/test_run_service.py
@@ -693,3 +693,197 @@ async def test_filter_error_does_not_collide_with_filter_stall(
     assert "filter_error" in entry["degraded_reasons"]
     assert "filter_stall" not in entry["degraded_reasons"]
     assert "fetch_stall" not in entry["degraded_reasons"]
+
+
+# ── #152: degradation summary flows from RunService into the ledger ─
+
+
+async def test_degradation_summary_aggregates_archive_failures_by_domain(
+    tmp_path: Path,
+) -> None:
+    """End-to-end: the RunService passes per-item archive failures into
+    the ledger so the persisted ``degradation_summary.archive.by_domain``
+    spotlights the dominant host (#152)."""
+    from influx.notifications import HighlightItem, ProfileRunResult, RunStats
+
+    config = _make_config()
+    ledger = RunLedger(tmp_path)
+    service = RunService(config=config, ledger=ledger)
+
+    body_outcome = RunOutcome(
+        sources_checked=4,
+        ingested=3,
+        profile_run_result=ProfileRunResult(
+            run_date="2026-05-12",
+            profile="alpha",
+            stats=RunStats(sources_checked=4, ingested=3),
+            items=[
+                HighlightItem(
+                    id="note-1",
+                    title="A",
+                    score=8,
+                    tags=["profile:alpha", "influx:archive-missing"],
+                    reason="x",
+                    url="https://ieee.org/a",
+                ),
+                HighlightItem(
+                    id="note-2",
+                    title="B",
+                    score=8,
+                    tags=[
+                        "profile:alpha",
+                        "influx:archive-missing",
+                        "influx:archive-blocked",
+                    ],
+                    reason="x",
+                    url="https://ieee.org/b",
+                ),
+                HighlightItem(
+                    id="note-3",
+                    title="C",
+                    score=8,
+                    tags=["profile:alpha", "influx:archive-missing"],
+                    reason="x",
+                    url="https://acm.org/c",
+                ),
+            ],
+        ),
+    )
+    with patch(
+        "influx.run.Run.execute",
+        new_callable=AsyncMock,
+        return_value=body_outcome,
+    ):
+        await service.execute(_scheduled_plan())
+
+    entry = next(e for e in ledger.recent() if e["status"] == "completed")
+    summary = entry["degradation_summary"]
+    assert summary is not None
+    by_domain = {row["domain"]: row["count"] for row in summary["archive"]["by_domain"]}
+    assert by_domain == {"ieee.org": 2, "acm.org": 1}
+    by_kind = {row["kind"]: row["count"] for row in summary["archive"]["by_kind"]}
+    # 1 item carries the ``influx:archive-blocked`` policy tag, 2 do not
+    # → bucketed as "unspecified".
+    assert by_kind == {"unspecified": 2, "blocked": 1}
+
+
+async def test_degradation_summary_cache_hits_do_not_inflate_breakdowns(
+    tmp_path: Path,
+) -> None:
+    """Backfill regression: a run whose only "issue" is duplicate/dedupe
+    cache hits must NOT show degradation breakdowns dominated by cache
+    activity.  The ledger's ``degraded`` flag stays false and the
+    degradation breakdowns stay empty (#152 acceptance criteria —
+    "duplicate/dedupe outcomes don't dominate the degradation summary").
+    """
+    from influx.telemetry import current_cache_hits
+
+    config = _make_config()
+    ledger = RunLedger(tmp_path)
+    service = RunService(config=config, ledger=ledger)
+
+    async def body_with_only_cache_hits(self: Any) -> RunOutcome:
+        # Simulate 25 cache hits in the Ingest stage (typical
+        # backfill shape where every candidate already exists).
+        cache_hits_counter = current_cache_hits.get()
+        assert cache_hits_counter is not None
+        cache_hits_counter[0] = 25
+        return RunOutcome(sources_checked=0, ingested=0)
+
+    with patch("influx.run.Run.execute", new=body_with_only_cache_hits):
+        await service.execute(_scheduled_plan())
+
+    entry = next(e for e in ledger.recent() if e["status"] == "completed")
+    summary = entry["degradation_summary"]
+    # Run is NOT degraded — cache hits are expected behaviour.
+    assert entry["degraded"] is False
+    # The dedupe volume is visible to operators...
+    assert summary["totals"]["cache_hits"] == 25
+    # ...but it does NOT pollute the degradation breakdowns.
+    assert summary["totals"]["archive_failures"] == 0
+    assert summary["totals"]["source_acquisition_errors"] == 0
+    assert summary["archive"]["by_domain"] == []
+    assert summary["archive"]["by_kind"] == []
+    assert summary["source_acquisition"]["by_kind"] == []
+
+
+async def test_degradation_summary_log_tail_includes_top_drivers(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The ``run completed`` log line carries a compact ``top_drivers=``
+    tail when the run is degraded so single-log triage is possible
+    without fetching the ledger (#152)."""
+    from influx.notifications import HighlightItem, ProfileRunResult, RunStats
+
+    config = _make_config()
+    ledger = RunLedger(tmp_path)
+    service = RunService(config=config, ledger=ledger)
+
+    body_outcome = RunOutcome(
+        sources_checked=2,
+        ingested=1,
+        profile_run_result=ProfileRunResult(
+            run_date="2026-05-12",
+            profile="alpha",
+            stats=RunStats(sources_checked=2, ingested=1),
+            items=[
+                HighlightItem(
+                    id="note-1",
+                    title="t",
+                    score=8,
+                    tags=["profile:alpha", "influx:archive-missing"],
+                    reason="x",
+                    url="https://ieee.org/a",
+                ),
+            ],
+        ),
+    )
+
+    async def body(self: Any) -> RunOutcome:
+        errors = current_source_acquisition_errors.get()
+        assert errors is not None
+        errors.append(
+            {
+                "source": "arxiv",
+                "kind": "rate_limit_upstream_capacity",
+                "detail": "429",
+            }
+        )
+        return body_outcome
+
+    with (
+        caplog.at_level(logging.INFO, logger="influx.run_service"),
+        patch("influx.run.Run.execute", new=body),
+    ):
+        await service.execute(_scheduled_plan())
+
+    record = _extract_run_completed_record(caplog)
+    assert "top_drivers=" in record.message
+    assert "ieee.org=1" in record.message
+    assert "arxiv/rate_limit_upstream_capacity=1" in record.message
+
+
+async def test_degradation_summary_log_tail_absent_on_clean_run(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No ``top_drivers=`` tail on clean runs — keeps the log line lean
+    when there's nothing to triage (#152)."""
+    config = _make_config()
+    ledger = RunLedger(tmp_path)
+    service = RunService(config=config, ledger=ledger)
+
+    body_outcome = RunOutcome(sources_checked=2, ingested=1)
+    with (
+        caplog.at_level(logging.INFO, logger="influx.run_service"),
+        patch(
+            "influx.run.Run.execute",
+            new_callable=AsyncMock,
+            return_value=body_outcome,
+        ),
+    ):
+        await service.execute(_scheduled_plan())
+
+    record = _extract_run_completed_record(caplog)
+    assert "top_drivers=" not in record.message


### PR DESCRIPTION
## Summary

- Adds a bounded, top-N ``degradation_summary`` to every completed run-ledger entry (and the ``GET /runs/recent`` payload) so operators can identify the actual drivers — top archive domains, top policy-kinds (``blocked`` / ``rate_limited`` / ``missing_by_policy`` / ``unspecified``), top source-acquisition kinds (using the refined kinds from #145, e.g. ``rate_limit_upstream_capacity``), and recovered retries — without grepping raw event logs.
- Dedupe cache-hit volume is surfaced under ``degradation_summary.totals.cache_hits`` but **deliberately segregated** from the archive and source-acquisition breakdowns so a backfill that legitimately skipped 90% of candidates does not look degraded.
- The ``run completed`` log line gains a compact ``top_drivers=`` tail (e.g. ``archive:ieee.org=2;source:arxiv/rate_limit_upstream_capacity=1``) when the run is degraded so single-log triage works without fetching the ledger.

### Summary shape

```json
{
  "totals": {
    "archive_failures": 2,
    "source_acquisition_errors": 1,
    "filter_errors": 0,
    "invalid_url_rejections": 0,
    "cache_hits": 12,
    "retries_recovered": 0
  },
  "archive": {
    "by_kind":   [{"kind": "blocked", "count": 2}],
    "by_domain": [{"domain": "ieee.org", "count": 2}]
  },
  "source_acquisition": {
    "by_kind":   [{"kind": "rate_limit_upstream_capacity", "count": 1}],
    "by_source": [{"source": "arxiv", "count": 1}]
  },
  "retries_recovered": { "by_kind": [], "by_source": [] }
}
```

Backwards-compatible: ``degraded`` / ``degraded_reasons`` / ``source_acquisition_errors`` / ``archive_failures_total`` are untouched; ``degradation_summary`` is additive and is ``None`` for fail / skip / abandon entries.

## Test plan

- [x] ``make check`` (ruff + ruff format --check + pyright + pytest) — 2051 passed locally
- [x] New unit tests in ``tests/unit/test_run_ledger.py`` covering: clean run shape, top-by-domain, top-by-kind from policy tags, source-acquisition breakdown by source/kind, top-N truncation, deterministic tie-breaking, cache-hits-not-degradation regression, retries_recovered, and ``build_degradation_summary`` edge cases (all-``None`` and unparseable URLs).
- [x] New unit tests in ``tests/unit/test_run_service.py`` covering: per-item archive failures flow end-to-end into the ledger, cache-hit-only backfills stay non-degraded with empty breakdowns, ``top_drivers=`` log tail appears on degraded runs and is absent on clean runs.
- [x] New API tests in ``tests/integration/test_http_api.py`` verifying ``/runs/recent`` exposes ``degradation_summary`` for both degraded and clean runs.

Closes #152