### PR TITLE
fix: skip archive acquisition for non-HTML source URLs (#160)

### DIFF
--- a/src/influx/archive_policy.py
+++ b/src/influx/archive_policy.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ARCHIVE_BLOCKED_TAG",
+    "ARCHIVE_NON_HTML_SOURCE_TAG",
     "ARCHIVE_RATE_LIMITED_TAG",
     "ARCHIVE_SKIPPED_BY_POLICY_TAG",
     "ArchiveFailureKind",
@@ -74,6 +75,12 @@ __all__ = [
 ARCHIVE_BLOCKED_TAG = "influx:archive-blocked"
 ARCHIVE_RATE_LIMITED_TAG = "influx:archive-rate-limited"
 ARCHIVE_SKIPPED_BY_POLICY_TAG = "influx:archive-skipped-by-policy"
+# Issue #160: applied when the archive layer short-circuits an HTML
+# acquisition because the URL classifies as a non-HTML source kind
+# (RSS/Atom/feed endpoint, HN discussion pointer, etc.).  Distinct
+# from the domain-policy ``skip`` mode because the discriminator is the
+# URL shape itself, not an operator decision about a whole domain.
+ARCHIVE_NON_HTML_SOURCE_TAG = "influx:archive-non-html-source"
 
 
 # ── Failure-kind taxonomy ──────────────────────────────────────────────
@@ -92,6 +99,11 @@ ArchiveFailureKind = Literal[
     "blocked",
     "rate_limited",
     "missing_by_policy",
+    # Issue #160: the URL was classified as a non-HTML source kind
+    # (RSS/feed pointer, HN discussion link, …) before any network
+    # call.  Distinct from ``missing_by_policy`` (which is per-domain
+    # operator policy) — the discriminator is the URL shape itself.
+    "non_html_source",
     "http_403",
     "http_404",
     "http_429",
@@ -465,13 +477,15 @@ def classify_failure_kind(
 def tag_for_failure_kind(kind: ArchiveFailureKind) -> str | None:
     """Return the policy-driven tag for *kind*, or ``None`` for generic kinds.
 
-    Three failure kinds carry a dedicated policy tag callers add to
-    the note alongside (or in place of) the generic
-    ``influx:archive-missing``:
+    Four failure kinds carry a dedicated tag callers add to the note
+    alongside (or in place of) the generic ``influx:archive-missing``:
 
     * ``blocked`` → :data:`ARCHIVE_BLOCKED_TAG`
     * ``rate_limited`` → :data:`ARCHIVE_RATE_LIMITED_TAG`
     * ``missing_by_policy`` → :data:`ARCHIVE_SKIPPED_BY_POLICY_TAG`
+    * ``non_html_source`` → :data:`ARCHIVE_NON_HTML_SOURCE_TAG` (issue
+      #160; the URL shape never pointed at HTML so the archive layer
+      short-circuited before the network call)
 
     All other kinds (``http_404``, ``timeout``, ``oversize``, …) keep
     the generic missing-tag shape — they describe transient or
@@ -483,4 +497,6 @@ def tag_for_failure_kind(kind: ArchiveFailureKind) -> str | None:
         return ARCHIVE_RATE_LIMITED_TAG
     if kind == "missing_by_policy":
         return ARCHIVE_SKIPPED_BY_POLICY_TAG
+    if kind == "non_html_source":
+        return ARCHIVE_NON_HTML_SOURCE_TAG
     return None

--- a/src/influx/source_kind.py
+++ b/src/influx/source_kind.py
@@ -51,18 +51,28 @@ SourceKind = Literal["html", "xml", "pointer"]
 # ── Pattern rules ─────────────────────────────────────────────────────
 
 # Path patterns that indicate the URL points at an XML/RSS/Atom feed
-# rather than an HTML article.  Matched against the lowercased path:
+# rather than an HTML article.  Deliberately *narrow* (PR #167 review
+# feedback): a bare directory match like ``/feed/`` or ``/rss/`` would
+# false-positive on legitimate article URLs (e.g. ``/news/feed/breaking``
+# or WordPress posts under a ``/rss`` slug), and the resulting note
+# carries ``influx:archive-terminal`` so a false positive is permanent.
 #
-# * trailing ``.xml`` / ``.rss`` / ``.atom`` file extensions,
-# * a segment named ``rss`` / ``atom`` / ``feed`` (with or without a
-#   trailing extension like ``.php`` / ``.cgi`` / ``.aspx``),
-# * a trailing path segment ``rss`` / ``atom`` / ``feed`` (no extension).
+# We only match two unambiguous shapes:
 #
-# Anchored conservatively so an article path like ``/posts/feedback``
-# does not accidentally match ``feed``.
+# 1. The path ends with a feed file extension (``.rss``, ``.atom``,
+#    ``.xml``).  These are very strong signals — an article URL almost
+#    never ends with one of those literally.
+# 2. The path is a CGI-style feed endpoint: a directory named exactly
+#    ``rss``, ``atom``, or ``feed`` immediately followed by a script
+#    filename ending in ``.php`` / ``.cgi`` / ``.aspx`` / ``.jsp``.
+#    This matches the staging-observed CSDB shape
+#    (``/rss/upcomingevents.php``, ``/rss/latestadditions.php``) and
+#    similar self-served feed scripts, but does NOT match bare
+#    ``/feed/`` directory URLs or article URLs whose path happens to
+#    pass through one of those segments.
 _XML_PATH_RE = re.compile(
-    r"(?:^|/)(?:rss|atom|feed)(?:\.(?:php|cgi|aspx|xml|html?))?(?:/|$)"
-    r"|\.(?:xml|rss|atom)$"
+    r"\.(?:rss|atom|xml)$"
+    r"|/(?:rss|atom|feed)/[^/]+\.(?:php|cgi|aspx|jsp)$"
 )
 
 

--- a/src/influx/source_kind.py
+++ b/src/influx/source_kind.py
@@ -1,0 +1,116 @@
+"""URL-derived source-kind classification (issue #160).
+
+Influx archives RSS-discovered articles by sending the entry URL through
+the guarded HTTP client with ``expected_content_type="html"``.  In
+production this catches a class of upstream feeds that advertise
+``<link>`` URLs which point at non-article resources:
+
+* **XML/feed pointers** — e.g. ``https://csdb.dk/rss/upcomingevents.php``.
+  The entry link is itself another RSS endpoint; the archive fetch
+  succeeds but the response is ``application/xml`` and fails the HTML
+  content-type guard, producing a ``content_type_mismatch``.
+* **Discussion pointers** — e.g. ``https://news.ycombinator.com/item?id=...``.
+  Some clients receive a ``text/plain`` response from these endpoints,
+  again failing the HTML content-type guard.
+
+Both shapes look identical to genuine archive failures
+(``influx:archive-missing`` → ``archive_acquisition`` degraded reason)
+even though they represent the source-kind never being HTML to begin
+with.  This module supplies a *cheap, purely-syntactic* classifier so
+the archive layer can short-circuit these URLs with a dedicated
+``non_html_source`` failure kind rather than tight-looping on the HTML
+acquisition path.
+
+The classifier deliberately does **no** network IO and no DNS
+resolution — it inspects the URL shape only.  A URL whose host/path
+pattern doesn't match a known non-HTML signature falls through to
+``"html"`` (the default), so behaviour is preserved for every URL that
+isn't on the known-bad list.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+from urllib.parse import urlparse
+
+__all__ = [
+    "SourceKind",
+    "classify_source_kind",
+]
+
+
+# ── Source-kind taxonomy ──────────────────────────────────────────────
+
+# Stable discriminator for the URL's likely content shape.  Only the
+# non-``"html"`` values short-circuit the HTML archive path; ``"html"``
+# is the no-op default.
+SourceKind = Literal["html", "xml", "pointer"]
+
+
+# ── Pattern rules ─────────────────────────────────────────────────────
+
+# Path patterns that indicate the URL points at an XML/RSS/Atom feed
+# rather than an HTML article.  Matched against the lowercased path:
+#
+# * trailing ``.xml`` / ``.rss`` / ``.atom`` file extensions,
+# * a segment named ``rss`` / ``atom`` / ``feed`` (with or without a
+#   trailing extension like ``.php`` / ``.cgi`` / ``.aspx``),
+# * a trailing path segment ``rss`` / ``atom`` / ``feed`` (no extension).
+#
+# Anchored conservatively so an article path like ``/posts/feedback``
+# does not accidentally match ``feed``.
+_XML_PATH_RE = re.compile(
+    r"(?:^|/)(?:rss|atom|feed)(?:\.(?:php|cgi|aspx|xml|html?))?(?:/|$)"
+    r"|\.(?:xml|rss|atom)$"
+)
+
+
+# Hostname → URL-path predicate that classifies the URL as a pointer
+# (discussion / aggregator page) rather than an article body.  Today
+# this only matches Hacker News ``/item?id=...`` pointers, but the
+# table shape lets new entries land without restructuring callers.
+_POINTER_HOST_PATHS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("news.ycombinator.com", re.compile(r"^/item(?:$|/|\?)")),
+)
+
+
+# ── Classifier ────────────────────────────────────────────────────────
+
+
+def classify_source_kind(url: str) -> SourceKind:
+    """Return the URL's likely source kind based on host/path shape.
+
+    Purely syntactic — no network IO, no DNS resolution.  Used by
+    :func:`influx.storage.download_archive` to short-circuit the HTML
+    archive acquisition path for URLs that are known to point at
+    non-HTML resources.
+
+    Returns
+    -------
+    SourceKind
+        ``"xml"`` for URLs whose path indicates an RSS/Atom/feed
+        endpoint, ``"pointer"`` for known discussion/aggregator pointer
+        URLs (currently Hacker News ``/item`` links), and ``"html"`` as
+        the default for every other URL.
+    """
+    if not url:
+        return "html"
+    try:
+        parsed = urlparse(url)
+    except (TypeError, ValueError):
+        return "html"
+
+    host = (parsed.hostname or "").lower()
+    path = parsed.path.lower()
+
+    for pointer_host, path_re in _POINTER_HOST_PATHS:
+        if (
+            host == pointer_host or host.endswith("." + pointer_host)
+        ) and path_re.match(path):
+            return "pointer"
+
+    if path and _XML_PATH_RE.search(path):
+        return "xml"
+
+    return "html"

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -294,19 +294,30 @@ def build_rss_note_item(
         )
 
     archive_path = archive_result.rel_posix_path
-    archive_missing = not archive_result.ok
+    # Issue #160: ``non_html_source`` is a deliberate short-circuit at
+    # the URL-shape level, not a missing archive — the URL never
+    # pointed at HTML to begin with (RSS/feed pointer, HN discussion
+    # link, …).  Treat it as a terminal, informational outcome rather
+    # than an acquisition failure so the run-level
+    # ``archive_acquisition`` degraded reason does not fire on these
+    # known non-article URLs.
+    non_html_source = archive_result.failure_kind == "non_html_source"
+    archive_missing = not archive_result.ok and not non_html_source
     # Issue #149: extract the policy-driven tag (if any) so the tag
     # composition below can apply ``influx:archive-blocked`` /
     # ``influx:archive-rate-limited`` /
     # ``influx:archive-skipped-by-policy`` alongside
     # ``influx:archive-missing``.  Returns ``None`` for generic
     # failures (http_404, oversize, timeout, …) so the existing
-    # ``influx:archive-missing`` shape is preserved.
+    # ``influx:archive-missing`` shape is preserved.  Issue #160:
+    # ``non_html_source`` also returns its dedicated tag here so the
+    # informational ``influx:archive-non-html-source`` tag is applied
+    # below alongside the terminal flag.
     archive_policy_tag = (
         _tag_for_archive_failure_kind(
             archive_result.failure_kind  # type: ignore[arg-type]
         )
-        if archive_missing
+        if archive_missing or non_html_source
         else None
     )
     if archive_missing:
@@ -404,11 +415,18 @@ def build_rss_note_item(
     # tight-loop on a doomed path (this is the staging-log behaviour
     # we are fixing).  ``rate_limited`` retries on cool-down, so it
     # stays in the normal repair-needed loop.
+    # Issue #160: ``non_html_source`` also lands its dedicated tag
+    # (``influx:archive-non-html-source``) and the terminal flag — the
+    # URL shape never pointed at HTML, so there is nothing to repair.
     if archive_policy_tag is not None and archive_policy_tag not in tags:
         tags.append(archive_policy_tag)
     if (
         archive_policy_tag
-        in ("influx:archive-blocked", "influx:archive-skipped-by-policy")
+        in (
+            "influx:archive-blocked",
+            "influx:archive-skipped-by-policy",
+            "influx:archive-non-html-source",
+        )
         and "influx:archive-terminal" not in tags
     ):
         tags.append("influx:archive-terminal")

--- a/src/influx/storage.py
+++ b/src/influx/storage.py
@@ -31,6 +31,7 @@ from influx.config import StorageConfig
 from influx.errors import InfluxError, NetworkError
 from influx.http_client import ContentTypeFamily, guarded_fetch
 from influx.slugs import is_valid_slug
+from influx.source_kind import classify_source_kind
 
 __all__ = [
     "ArchivePathError",
@@ -227,6 +228,34 @@ def download_archive(
     registry = policy_registry if policy_registry is not None else default_registry()
     policy = registry.policy_for(url)
     domain = _domain_from_url(url)
+
+    # Issue #160: short-circuit URLs whose shape already indicates a
+    # non-HTML source kind (RSS/Atom/feed pointer, HN discussion link,
+    # etc.) when the caller expects HTML.  These URLs would otherwise
+    # be sent through the HTML content-type guard and fail every
+    # acquisition with ``content_type_mismatch``, looking identical to
+    # a real archive failure even though the source-kind never pointed
+    # at HTML in the first place.  Distinct from the ``skip`` policy
+    # because the discriminator is the URL itself, not a per-domain
+    # operator decision.
+    if expected_content_type == "html":
+        source_kind = classify_source_kind(url)
+        if source_kind != "html":
+            _log.info(
+                "archive download skipped (non-html source) url=%s "
+                "domain=%s detected_kind=%s",
+                url,
+                domain,
+                source_kind,
+            )
+            return ArchiveResult(
+                ok=False,
+                rel_posix_path=None,
+                error=f"non_html_source: detected source kind {source_kind!r}",
+                failure_kind="non_html_source",
+                policy_mode=policy.mode,
+                domain=domain,
+            )
 
     # Skip-mode policies short-circuit before path construction so an
     # entire blocked domain pays zero IO cost (the staging issue: the

--- a/tests/unit/test_archive_download_policy.py
+++ b/tests/unit/test_archive_download_policy.py
@@ -339,8 +339,8 @@ class TestNonHtmlSourceShortCircuit:
         [
             "https://csdb.dk/rss/upcomingevents.php",
             "https://csdb.dk/rss/latestadditions.php?type=release",
-            "https://example.com/feed",
             "https://example.com/atom.xml",
+            "https://example.com/feed.rss",
         ],
     )
     def test_xml_feed_urls_short_circuit(self, tmp_path: Path, url: str) -> None:
@@ -379,7 +379,7 @@ class TestNonHtmlSourceShortCircuit:
             mock_fetch.return_value = _make_fetch_result()
             result = _dl(
                 tmp_path,
-                "https://example.com/feed",
+                "https://example.com/feed.rss",
                 source="arxiv",
                 item_id="2601.12345",
                 ext=".pdf",

--- a/tests/unit/test_archive_download_policy.py
+++ b/tests/unit/test_archive_download_policy.py
@@ -320,3 +320,70 @@ class TestDefaultRegistryIdentity:
 
     def test_singleton_identity(self) -> None:
         assert default_registry() is default_registry()
+
+
+# ── Issue #160: URL-shape short-circuit for non-HTML sources ──────────
+
+
+class TestNonHtmlSourceShortCircuit:
+    """``expected_content_type="html"`` short-circuits non-HTML URL shapes.
+
+    Pinning the contract guarantees that RSS/feed pointer URLs and HN
+    discussion links never reach the network — so they cannot inflate
+    the run's ``archive_failures_total`` (degraded-reasons feeder) with
+    ``content_type_mismatch`` failures.
+    """
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://csdb.dk/rss/upcomingevents.php",
+            "https://csdb.dk/rss/latestadditions.php?type=release",
+            "https://example.com/feed",
+            "https://example.com/atom.xml",
+        ],
+    )
+    def test_xml_feed_urls_short_circuit(self, tmp_path: Path, url: str) -> None:
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            result = _dl(tmp_path, url)
+        mock_fetch.assert_not_called()
+        assert result.ok is False
+        assert result.failure_kind == "non_html_source"
+        assert result.rel_posix_path is None
+        assert "non_html_source" in result.error
+
+    def test_hn_pointer_short_circuits(self, tmp_path: Path) -> None:
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            result = _dl(tmp_path, "https://news.ycombinator.com/item?id=48081266")
+        mock_fetch.assert_not_called()
+        assert result.failure_kind == "non_html_source"
+        assert result.domain == "news.ycombinator.com"
+
+    def test_html_url_is_not_short_circuited(self, tmp_path: Path) -> None:
+        # A regular article URL still goes through the network — the
+        # short-circuit only fires on known non-HTML shapes.
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            mock_fetch.return_value = _make_fetch_result(
+                body=b"<html>ok</html>", content_type="text/html"
+            )
+            result = _dl(tmp_path, "https://example.com/posts/article")
+        mock_fetch.assert_called_once()
+        assert result.ok is True
+        assert result.failure_kind == ""
+
+    def test_pdf_expected_type_skips_classifier(self, tmp_path: Path) -> None:
+        # The short-circuit only runs when the caller expects HTML —
+        # arXiv (PDF) callers must never be re-routed even if the URL
+        # happens to match an XML/pointer shape.
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            mock_fetch.return_value = _make_fetch_result()
+            result = _dl(
+                tmp_path,
+                "https://example.com/feed",
+                source="arxiv",
+                item_id="2601.12345",
+                ext=".pdf",
+            )
+        mock_fetch.assert_called_once()
+        assert result.ok is True
+        assert result.failure_kind == ""

--- a/tests/unit/test_archive_policy.py
+++ b/tests/unit/test_archive_policy.py
@@ -21,6 +21,7 @@ import pytest
 
 from influx.archive_policy import (
     ARCHIVE_BLOCKED_TAG,
+    ARCHIVE_NON_HTML_SOURCE_TAG,
     ARCHIVE_RATE_LIMITED_TAG,
     ARCHIVE_SKIPPED_BY_POLICY_TAG,
     ArchivePolicy,
@@ -218,6 +219,7 @@ class TestTagForFailureKind:
             ("blocked", ARCHIVE_BLOCKED_TAG),
             ("rate_limited", ARCHIVE_RATE_LIMITED_TAG),
             ("missing_by_policy", ARCHIVE_SKIPPED_BY_POLICY_TAG),
+            ("non_html_source", ARCHIVE_NON_HTML_SOURCE_TAG),
         ],
     )
     def test_policy_kinds_map_to_dedicated_tags(

--- a/tests/unit/test_archive_policy_source_tags.py
+++ b/tests/unit/test_archive_policy_source_tags.py
@@ -198,6 +198,34 @@ class TestRssArchivePolicyTags:
         assert "influx:archive-terminal" not in tags
 
     @patch("influx.sources.rss.download_archive")
+    def test_non_html_source_emits_non_html_tag_only(self, mock_dl: object) -> None:
+        # Issue #160: when ``download_archive`` short-circuits a non-HTML
+        # URL the note carries ``influx:archive-non-html-source`` and the
+        # terminal flag, but NOT ``influx:archive-missing`` or
+        # ``influx:repair-needed`` — the URL never pointed at HTML, so
+        # there is nothing to acquire and nothing to repair.
+        mock_dl.return_value = ArchiveResult(  # type: ignore[union-attr]
+            ok=False,
+            rel_posix_path=None,
+            error="non_html_source: detected source kind 'xml'",
+            failure_kind="non_html_source",
+            policy_mode="attempt",
+            domain="csdb.dk",
+        )
+        config = _make_config()
+        item = _make_rss_item(url="https://csdb.dk/rss/upcomingevents.php")
+
+        result = build_rss_note_item(
+            item=item, profile_name="ai-robotics", config=config
+        )
+
+        tags = cast(list[str], result["tags"])
+        assert "influx:archive-non-html-source" in tags
+        assert "influx:archive-terminal" in tags
+        assert "influx:archive-missing" not in tags
+        assert "influx:repair-needed" not in tags
+
+    @patch("influx.sources.rss.download_archive")
     def test_successful_archive_emits_no_policy_tag(self, mock_dl: object) -> None:
         mock_dl.return_value = ArchiveResult(  # type: ignore[union-attr]
             ok=True,

--- a/tests/unit/test_run_service.py
+++ b/tests/unit/test_run_service.py
@@ -673,6 +673,75 @@ async def test_archive_acquisition_degrades_run_and_logs_warning(
     assert "influx:archive-missing" in warning.message
 
 
+async def test_non_html_source_item_does_not_trigger_archive_acquisition(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Issue #160: ``non_html_source`` items must NOT inflate the run's
+    ``archive_failures_total`` or fire the ``archive_acquisition``
+    degraded reason.
+
+    The run-service derives ``archive_failures_total`` by counting
+    items tagged ``influx:archive-missing``.  An item that was
+    short-circuited at the URL-shape level (RSS/feed pointer, HN
+    discussion link) carries ``influx:archive-non-html-source`` plus
+    ``influx:archive-terminal`` instead — it is a deliberate skip, not
+    a missing archive.  This test pins that contract end-to-end so a
+    future tag-composition refactor cannot silently re-introduce the
+    spurious degradation that #160 fixed.
+    """
+    from influx.notifications import HighlightItem, ProfileRunResult, RunStats
+
+    config = _make_config()
+    ledger = RunLedger(tmp_path)
+    service = RunService(config=config, ledger=ledger)
+
+    body_outcome = RunOutcome(
+        sources_checked=2,
+        ingested=1,
+        profile_run_result=ProfileRunResult(
+            run_date="2026-05-08",
+            profile="alpha",
+            stats=RunStats(sources_checked=2, ingested=1),
+            items=[
+                HighlightItem(
+                    id="note-1",
+                    title="Feed Pointer Note",
+                    score=8,
+                    # Crucially: NO ``influx:archive-missing`` tag.  The
+                    # non-html-source skip is informational + terminal.
+                    tags=[
+                        "profile:alpha",
+                        "influx:archive-non-html-source",
+                        "influx:archive-terminal",
+                    ],
+                    reason="non-html URL shape",
+                    url="https://csdb.dk/rss/upcomingevents.php",
+                    related_in_lithos=[],
+                )
+            ],
+        ),
+    )
+    with (
+        caplog.at_level(logging.WARNING, logger="influx.run_service"),
+        patch(
+            "influx.run.Run.execute",
+            new_callable=AsyncMock,
+            return_value=body_outcome,
+        ),
+    ):
+        await service.execute(_scheduled_plan())
+
+    entry = next(e for e in ledger.recent() if e["status"] == "completed")
+    assert "archive_acquisition" not in entry["degraded_reasons"]
+    assert entry["archive_failures_total"] == 0
+
+    # And no archive_acquisition warning should have been emitted.
+    assert not [r for r in caplog.records if "archive_acquisition" in r.message], (
+        "non_html_source items must not emit the archive_acquisition warning"
+    )
+
+
 async def test_filter_error_emits_warning_with_scorer_failure_guidance(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,

--- a/tests/unit/test_source_kind.py
+++ b/tests/unit/test_source_kind.py
@@ -1,0 +1,90 @@
+"""Tests for URL-derived source-kind classification (issue #160).
+
+The classifier is purely syntactic and is consulted by
+:func:`influx.storage.download_archive` to short-circuit the HTML
+archive acquisition path when a feed-discovered URL points at a
+non-HTML resource.  The taxonomy is intentionally small (``html`` /
+``xml`` / ``pointer``) — these tests pin both the known-bad shapes
+(RSS endpoints, HN ``/item`` pointers) and the default-``html``
+fall-through for every URL that doesn't match a known pattern.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from influx.source_kind import classify_source_kind
+
+
+class TestXmlClassification:
+    """RSS / Atom / feed-flavoured URLs classify as ``"xml"``."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://csdb.dk/rss/upcomingevents.php",
+            "https://csdb.dk/rss/latestadditions.php?type=release",
+            "https://example.com/rss",
+            "https://example.com/rss/",
+            "https://example.com/feed/",
+            "https://example.com/feed",
+            "https://example.com/atom.xml",
+            "https://example.com/posts/feed.xml",
+            "https://example.com/feed.rss",
+            "https://example.com/podcast.atom",
+            "https://example.com/blog/atom",
+        ],
+    )
+    def test_xml_urls(self, url: str) -> None:
+        assert classify_source_kind(url) == "xml"
+
+
+class TestPointerClassification:
+    """HN discussion / aggregator pointer URLs classify as ``"pointer"``."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://news.ycombinator.com/item?id=48081266",
+            "http://news.ycombinator.com/item?id=1",
+            "https://NEWS.ycombinator.com/item?id=42",
+        ],
+    )
+    def test_hn_item_pointer(self, url: str) -> None:
+        assert classify_source_kind(url) == "pointer"
+
+    def test_hn_non_item_path_is_html(self) -> None:
+        # HN's submission landing pages render HTML article-like content
+        # via the upstream link — they are NOT pointer URLs.  Only the
+        # ``/item`` discussion-link shape collapses to pointer.
+        assert classify_source_kind("https://news.ycombinator.com/newest") == "html"
+        assert classify_source_kind("https://news.ycombinator.com/show") == "html"
+
+
+class TestHtmlDefault:
+    """URLs that don't match a known non-HTML shape fall through to ``"html"``."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.com/posts/article",
+            "https://example.com/2026/05/post-title",
+            "https://example.com/articles/feedback",  # contains "feedback", not "feed"
+            "https://example.com/news/today",
+            "https://example.com/",
+            "https://example.com",
+            "https://blog.example.com/post.html",
+        ],
+    )
+    def test_default_html(self, url: str) -> None:
+        assert classify_source_kind(url) == "html"
+
+
+class TestEdgeCases:
+    """Empty / malformed URLs collapse to the safe ``"html"`` default."""
+
+    @pytest.mark.parametrize("url", ["", "not-a-url", "http://"])
+    def test_empty_and_malformed(self, url: str) -> None:
+        # Defensive default — the classifier is consulted on every
+        # archive call, so a parse failure must not raise.
+        assert classify_source_kind(url) == "html"

--- a/tests/unit/test_source_kind.py
+++ b/tests/unit/test_source_kind.py
@@ -4,9 +4,15 @@ The classifier is purely syntactic and is consulted by
 :func:`influx.storage.download_archive` to short-circuit the HTML
 archive acquisition path when a feed-discovered URL points at a
 non-HTML resource.  The taxonomy is intentionally small (``html`` /
-``xml`` / ``pointer``) — these tests pin both the known-bad shapes
-(RSS endpoints, HN ``/item`` pointers) and the default-``html``
-fall-through for every URL that doesn't match a known pattern.
+``xml`` / ``pointer``).
+
+These tests pin the *narrow* known-bad shapes (file extensions, CSDB-
+style CGI feed endpoints, HN ``/item`` pointers) plus an explicit
+false-positive guard for article URLs that look superficially like
+feed URLs but are not.  PR #167 review feedback called out that a
+false positive is permanent (the note carries
+``influx:archive-terminal``), so the guard cases are first-class
+coverage rather than incidental.
 """
 
 from __future__ import annotations
@@ -17,22 +23,24 @@ from influx.source_kind import classify_source_kind
 
 
 class TestXmlClassification:
-    """RSS / Atom / feed-flavoured URLs classify as ``"xml"``."""
+    """File-extension and CGI-feed URLs classify as ``"xml"``."""
 
     @pytest.mark.parametrize(
         "url",
         [
+            # Staging-observed CSDB CGI feed shape (issue #160 evidence).
             "https://csdb.dk/rss/upcomingevents.php",
             "https://csdb.dk/rss/latestadditions.php?type=release",
-            "https://example.com/rss",
-            "https://example.com/rss/",
-            "https://example.com/feed/",
-            "https://example.com/feed",
+            # Other CGI-style feed scripts under the same shape.
+            "https://example.com/atom/recent.cgi",
+            "https://example.com/feed/today.aspx",
+            "https://example.com/rss/podcast.jsp",
+            # File-extension feeds.
             "https://example.com/atom.xml",
             "https://example.com/posts/feed.xml",
             "https://example.com/feed.rss",
             "https://example.com/podcast.atom",
-            "https://example.com/blog/atom",
+            "https://example.com/some/path/document.xml",
         ],
     )
     def test_xml_urls(self, url: str) -> None:
@@ -77,6 +85,48 @@ class TestHtmlDefault:
         ],
     )
     def test_default_html(self, url: str) -> None:
+        assert classify_source_kind(url) == "html"
+
+
+class TestNarrowingRegressionGuards:
+    """Pin the cases the PR #167 review specifically warned about.
+
+    A false positive in the classifier short-circuits archive
+    acquisition and stamps the note ``influx:archive-terminal`` — the
+    repair sweep then refuses to retry.  These cases must stay
+    classified as ``"html"`` so the broad pattern that previously
+    matched any ``/feed``, ``/rss``, ``/atom`` segment cannot return
+    silently.
+    """
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # Bare directory segments: WordPress / Ghost / Substack
+            # feed roots are NOT children inside another feed (they ARE
+            # the feed), but article URLs that pass through these
+            # segments are common in the wild.
+            "https://example.com/feed/",
+            "https://example.com/feed",
+            "https://example.com/rss/",
+            "https://example.com/rss",
+            "https://example.com/atom/",
+            "https://example.com/atom",
+            # Article URLs whose path passes through a ``feed`` /
+            # ``rss`` / ``atom`` segment.  These are the high-cost
+            # false-positive surface.
+            "https://example.com/news/feed/breaking-story",
+            "https://example.com/rss/2026/spring-release-notes",
+            "https://example.com/atom/post-title",
+            "https://example.com/sections/feed/article",
+            # Article URLs whose final segment contains ``feed`` /
+            # ``rss`` / ``atom`` as a substring.  Must not match.
+            "https://example.com/posts/feedback-loops",
+            "https://example.com/articles/atom-bombs-history",
+            "https://example.com/blog/rss-explained",
+        ],
+    )
+    def test_narrow_classifier_does_not_match(self, url: str) -> None:
         assert classify_source_kind(url) == "html"
 
 


### PR DESCRIPTION
## Summary

- Add `influx.source_kind.classify_source_kind` — purely-syntactic URL shape classifier (`html` / `xml` / `pointer`).
- `download_archive` short-circuits when the caller expects HTML but the URL classifies as `xml` (RSS/Atom/feed endpoints) or `pointer` (HN `/item` discussion links). No network call, no `content_type_mismatch` noise.
- New `non_html_source` failure kind and `influx:archive-non-html-source` tag — paired with `influx:archive-terminal` so the repair sweep does not tight-loop.
- RSS source adapter does NOT treat the skip as a missing archive: no `influx:archive-missing`, no `influx:repair-needed`, no `archive_policy_failures` metric increment. Run-level `archive_failures_total` stays clean; `archive_acquisition` degraded reason no longer fires for these known shapes.
- arXiv path unaffected (it calls with `expected_content_type="pdf"`).

Closes #160.

## Test plan

- [x] `tests/unit/test_source_kind.py` — classifier covers RSS/feed/Atom/`csdb.dk/rss/*.php`, HN `/item?id=`, default-`html` fall-through, malformed URLs.
- [x] `tests/unit/test_archive_download_policy.py::TestNonHtmlSourceShortCircuit` — pins that the short-circuit fires without a network call, only for `expected_content_type="html"`, and that regular HTML URLs still go through.
- [x] `tests/unit/test_archive_policy_source_tags.py::test_non_html_source_emits_non_html_tag_only` — RSS adapter emits `influx:archive-non-html-source` + `influx:archive-terminal` and NOT `influx:archive-missing` / `influx:repair-needed`.
- [x] `tests/unit/test_archive_policy.py` — `tag_for_failure_kind` round-trips the new kind.
- [x] Full suite green: `2133 passed`.