### PR TITLE
feat: add archive-unsupported policy mode for systematic 403 domains (#161)

### DIFF
--- a/src/influx/archive_policy.py
+++ b/src/influx/archive_policy.py
@@ -53,6 +53,7 @@ __all__ = [
     "ARCHIVE_NON_HTML_SOURCE_TAG",
     "ARCHIVE_RATE_LIMITED_TAG",
     "ARCHIVE_SKIPPED_BY_POLICY_TAG",
+    "ARCHIVE_UNSUPPORTED_TAG",
     "ArchiveFailureKind",
     "ArchivePolicy",
     "ArchivePolicyMode",
@@ -81,6 +82,13 @@ ARCHIVE_SKIPPED_BY_POLICY_TAG = "influx:archive-skipped-by-policy"
 # from the domain-policy ``skip`` mode because the discriminator is the
 # URL shape itself, not an operator decision about a whole domain.
 ARCHIVE_NON_HTML_SOURCE_TAG = "influx:archive-non-html-source"
+# Issue #161: applied when a domain is declared archive-unsupported via
+# the ``unsupported`` policy mode.  Distinct from
+# ``ARCHIVE_SKIPPED_BY_POLICY_TAG``: the unsupported tag deliberately
+# does NOT accompany ``influx:archive-missing``, so a run with
+# otherwise-successful ingestion is not degraded solely because an
+# unsupported domain (``openai.com``) refused archive acquisition.
+ARCHIVE_UNSUPPORTED_TAG = "influx:archive-unsupported"
 
 
 # ── Failure-kind taxonomy ──────────────────────────────────────────────
@@ -104,6 +112,13 @@ ArchiveFailureKind = Literal[
     # call.  Distinct from ``missing_by_policy`` (which is per-domain
     # operator policy) — the discriminator is the URL shape itself.
     "non_html_source",
+    # Issue #161: the domain is declared archive-unsupported via the
+    # ``unsupported`` policy mode.  Like ``missing_by_policy`` in that
+    # no network call is made, but distinct because the run-level
+    # ``archive_acquisition`` degraded reason does NOT fire on
+    # unsupported items (the operator has already said "this domain
+    # has no archive surface").
+    "unsupported",
     "http_403",
     "http_404",
     "http_429",
@@ -131,7 +146,7 @@ _KIND_PREFIX_RE = re.compile(r"^([a-z_]+):")
 # ── Policy taxonomy ────────────────────────────────────────────────────
 
 
-# Three modes for an archive policy:
+# Modes for an archive policy:
 #
 # * ``attempt``: the default — try the download, classify failure
 #   generically.  Equivalent to "no policy registered".
@@ -147,10 +162,19 @@ _KIND_PREFIX_RE = re.compile(r"^([a-z_]+):")
 #   ``influx:archive-missing`` exactly once rather than re-attempting
 #   the same doomed path every sweep.
 # * ``skip``: do not attempt the download at all.  The note is
-#   tagged ``influx:archive-skipped-by-policy`` and never produces a
-#   network call.  Reserved for domains where every observed attempt
-#   over weeks of operation has produced 403 / 401 / WAF challenge.
-ArchivePolicyMode = Literal["attempt", "rate_limited", "blocked", "skip"]
+#   tagged ``influx:archive-skipped-by-policy`` + ``influx:archive-missing``
+#   and never produces a network call.  Contributes to the run-level
+#   ``archive_acquisition`` degraded reason — the operator declared
+#   the domain as "skip and surface as missing."
+# * ``unsupported``: (issue #161) treat the domain as having no
+#   archive surface at all.  No network call.  The note is tagged
+#   ``influx:archive-unsupported`` + ``influx:archive-terminal`` but
+#   NOT ``influx:archive-missing``, so it does NOT contribute to the
+#   run-level ``archive_acquisition`` degraded reason.  Use for
+#   domains where 403 is the expected permanent contract
+#   (``openai.com``) and the operator does not want quiet acquisitions
+#   on these domains polluting run health.
+ArchivePolicyMode = Literal["attempt", "rate_limited", "blocked", "skip", "unsupported"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -175,12 +199,12 @@ class ArchivePolicy:
     def should_attempt(self) -> bool:
         """Return ``True`` when the policy permits an archive download attempt.
 
-        ``skip`` mode is the only one that short-circuits before a
-        network call.  ``blocked`` and ``rate_limited`` still attempt
-        the download so a domain that lifts its restriction recovers
+        ``skip`` and ``unsupported`` short-circuit before a network
+        call.  ``blocked`` and ``rate_limited`` still attempt the
+        download so a domain that lifts its restriction recovers
         without an operator hand-edit.
         """
-        return self.mode != "skip"
+        return self.mode not in ("skip", "unsupported")
 
 
 # Single sentinel for the default "no specific policy, attempt the
@@ -227,6 +251,21 @@ _DEFAULT_RATE_LIMITED_DOMAINS: tuple[tuple[str, str], ...] = (
     # Reserved for sites observed to throttle archive downloads under
     # production cadence.  Empty for now; populated as staging logs
     # identify candidates.
+)
+
+
+# Issue #161: domains that systematically refuse archive acquisition
+# with HTTP 403 — the archive layer should treat them as having no
+# archive surface at all rather than repeatedly retrying and degrading
+# runs.  The observed offender is ``openai.com``, whose blog/index
+# pages return 403 to every unauthenticated archive request even
+# though the public pages render HTML when visited via a browser.
+_DEFAULT_UNSUPPORTED_DOMAINS: tuple[tuple[str, str], ...] = (
+    (
+        "openai.com",
+        "Archive download returns HTTP 403 to unauthenticated clients; "
+        "OpenAI publishes content via the website only, no archive surface.",
+    ),
 )
 
 
@@ -286,6 +325,7 @@ def build_registry(
     blocked: dict[str, str] | None = None,
     rate_limited: dict[str, str] | None = None,
     skip: dict[str, str] | None = None,
+    unsupported: dict[str, str] | None = None,
     include_defaults: bool = True,
 ) -> ArchivePolicyRegistry:
     """Construct an :class:`ArchivePolicyRegistry` from policy overrides.
@@ -304,9 +344,13 @@ def build_registry(
         Same shape, for ``"rate_limited"`` entries.
     skip:
         Same shape, for ``"skip"`` entries (no archive attempt at all).
+    unsupported:
+        Same shape, for ``"unsupported"`` entries (no archive attempt;
+        does not contribute to ``archive_acquisition`` degraded reason).
     include_defaults:
-        Include the built-in :data:`_DEFAULT_BLOCKED_DOMAINS` and
-        :data:`_DEFAULT_RATE_LIMITED_DOMAINS` (overridable per-suffix
+        Include the built-in :data:`_DEFAULT_BLOCKED_DOMAINS`,
+        :data:`_DEFAULT_RATE_LIMITED_DOMAINS`, and
+        :data:`_DEFAULT_UNSUPPORTED_DOMAINS` (overridable per-suffix
         by the explicit mappings).  Defaults to ``True`` so production
         behaviour is "ship with sensible defaults" out of the box.
     """
@@ -316,14 +360,18 @@ def build_registry(
             merged[suffix.lower()] = ArchivePolicy(mode="blocked", note=note)
         for suffix, note in _DEFAULT_RATE_LIMITED_DOMAINS:
             merged[suffix.lower()] = ArchivePolicy(mode="rate_limited", note=note)
+        for suffix, note in _DEFAULT_UNSUPPORTED_DOMAINS:
+            merged[suffix.lower()] = ArchivePolicy(mode="unsupported", note=note)
 
-    # Operator overrides win.  ``skip`` then ``blocked`` then
-    # ``rate_limited`` so that a later-declared mode beats an earlier
-    # mode for the same suffix (last-write-wins discipline).
+    # Operator overrides win.  Order matters: a later-declared mode
+    # beats an earlier mode for the same suffix (last-write-wins).
+    # ``unsupported`` is listed last so it beats ``skip`` when both
+    # are declared, mirroring the "more terminal" intent of the mode.
     overrides: tuple[tuple[Mapping[str, str] | None, ArchivePolicyMode], ...] = (
         (rate_limited, "rate_limited"),
         (blocked, "blocked"),
         (skip, "skip"),
+        (unsupported, "unsupported"),
     )
     for table, mode in overrides:
         if not table:
@@ -374,6 +422,7 @@ def registry_from_config(
         blocked=dict(archive_policy.blocked),
         rate_limited=dict(archive_policy.rate_limited),
         skip=dict(archive_policy.skip),
+        unsupported=dict(archive_policy.unsupported),
         include_defaults=archive_policy.include_defaults,
     )
 
@@ -477,7 +526,7 @@ def classify_failure_kind(
 def tag_for_failure_kind(kind: ArchiveFailureKind) -> str | None:
     """Return the policy-driven tag for *kind*, or ``None`` for generic kinds.
 
-    Four failure kinds carry a dedicated tag callers add to the note
+    Five failure kinds carry a dedicated tag callers add to the note
     alongside (or in place of) the generic ``influx:archive-missing``:
 
     * ``blocked`` → :data:`ARCHIVE_BLOCKED_TAG`
@@ -486,6 +535,10 @@ def tag_for_failure_kind(kind: ArchiveFailureKind) -> str | None:
     * ``non_html_source`` → :data:`ARCHIVE_NON_HTML_SOURCE_TAG` (issue
       #160; the URL shape never pointed at HTML so the archive layer
       short-circuited before the network call)
+    * ``unsupported`` → :data:`ARCHIVE_UNSUPPORTED_TAG` (issue #161;
+      the domain is declared archive-unsupported and does NOT
+      contribute to the run-level ``archive_acquisition`` degraded
+      reason)
 
     All other kinds (``http_404``, ``timeout``, ``oversize``, …) keep
     the generic missing-tag shape — they describe transient or
@@ -499,4 +552,6 @@ def tag_for_failure_kind(kind: ArchiveFailureKind) -> str | None:
         return ARCHIVE_SKIPPED_BY_POLICY_TAG
     if kind == "non_html_source":
         return ARCHIVE_NON_HTML_SOURCE_TAG
+    if kind == "unsupported":
+        return ARCHIVE_UNSUPPORTED_TAG
     return None

--- a/src/influx/config.py
+++ b/src/influx/config.py
@@ -118,8 +118,20 @@ class ArchivePolicyConfig(BaseModel):
       tagged ``influx:archive-rate-limited``; the repair sweep applies
       a bounded cool-down on this kind.
     * ``skip``: do not attempt the download.  The note is tagged
-      ``influx:archive-skipped-by-policy`` and never produces a
-      network call.
+      ``influx:archive-skipped-by-policy`` and ``influx:archive-missing``
+      and never produces a network call.  Still contributes to the
+      run-level ``archive_acquisition`` degraded reason — the operator
+      explicitly declared the domain as "skip and surface as a missing
+      archive."
+    * ``unsupported``: (issue #161) do not attempt the download and
+      treat the domain as having no archive surface at all.  The note
+      is tagged ``influx:archive-unsupported`` (and
+      ``influx:archive-terminal``) but NOT ``influx:archive-missing``,
+      so the run is not degraded by domains that systematically refuse
+      archive acquisition (e.g. ``openai.com``).  Use this for domains
+      where 403 is the expected, permanent contract — distinct from
+      ``skip`` which still wants the operator to see "this acquisition
+      did not happen" as a flagged event.
 
     ``include_defaults = false`` opts out of the built-in
     staging-defaults set — primarily a test-injection lever.
@@ -128,6 +140,10 @@ class ArchivePolicyConfig(BaseModel):
     blocked: dict[str, str] = Field(default_factory=dict)
     rate_limited: dict[str, str] = Field(default_factory=dict)
     skip: dict[str, str] = Field(default_factory=dict)
+    # Issue #161: per-domain "this domain does not support archive
+    # acquisition" overrides — like ``skip`` but never contributes to
+    # the run-level ``archive_acquisition`` degraded reason.
+    unsupported: dict[str, str] = Field(default_factory=dict)
     include_defaults: bool = True
 
 

--- a/src/influx/run_service.py
+++ b/src/influx/run_service.py
@@ -287,6 +287,13 @@ async def ledger_lifecycle(
         archive_blocked_total = 0
         archive_rate_limited_total = 0
         archive_skipped_by_policy_total = 0
+        # Issue #161: separate counter for ``unsupported`` policy items.
+        # These deliberately do NOT contribute to
+        # ``archive_failures_total`` (the operator declared the domain
+        # has no archive surface), but the per-run total still needs to
+        # surface so an operator sees "we hit N unsupported-policy
+        # items this run" in the INFO log line below.
+        archive_unsupported_total = 0
         # #152: per-item archive-failure records (url + tags) so the
         # ledger's degradation summary can compute the by-domain and
         # by-kind top-N.  One entry per item that landed
@@ -304,6 +311,8 @@ async def ledger_lifecycle(
                     archive_rate_limited_total += 1
                 if "influx:archive-skipped-by-policy" in item.tags:
                     archive_skipped_by_policy_total += 1
+                if "influx:archive-unsupported" in item.tags:
+                    archive_unsupported_total += 1
         # #85: pull the pre-filter fetched-count from the contextvar
         # bucket the source layer accumulated into.  ``outcome`` may be
         # ``None`` on the early-skip / abort paths; in that case we
@@ -540,6 +549,24 @@ async def ledger_lifecycle(
                 run_id,
                 invalid_note_state_summary or "<none>",
             )
+        # Issue #161: surface the unsupported-policy total at INFO so an
+        # operator can see "we hit N items on archive-unsupported
+        # domains this run" without the run being flagged as degraded.
+        # Distinct from the ``archive_acquisition`` WARNING above —
+        # ``unsupported`` is the expected, declared-terminal outcome,
+        # not a failure.
+        if archive_unsupported_total > 0:
+            logger.info(
+                "run archive_unsupported profile=%s kind=%s run_id=%s "
+                "unsupported_items=%d "
+                "(items on archive-unsupported policy domains — "
+                "expected, not counted toward archive_acquisition)",
+                profile,
+                plan.kind.value,
+                run_id,
+                archive_unsupported_total,
+            )
+
         metrics.run_duration().record(elapsed, metric_attrs)
         metrics.run_completions().add(1, {**metric_attrs, "outcome": run_outcome})
 

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -1127,27 +1127,35 @@ def build_arxiv_note_item(
         if archive_result.ok:
             archive_path = archive_result.rel_posix_path
         else:
-            archive_missing = True
-            metrics.archive_missing().add(
-                1, {"profile": profile_name, "source": "arxiv"}
-            )
-            # Issue #149: reclassify the failure into a policy tag
-            # when the failure_kind is one of blocked / rate_limited /
-            # missing_by_policy.  Generic failures (http_404, oversize,
-            # timeout, …) keep the default ``influx:archive-missing``
-            # shape so repair-sweep behaviour is unchanged for them.
+            # Issue #161: ``unsupported`` is a deliberate "this domain
+            # has no archive surface" outcome — not a missing archive.
+            # Don't tag the note with ``influx:archive-missing``, and
+            # don't increment the archive-failure metric.  Still
+            # emit the dedicated tag below so an operator can see the
+            # policy fired.
+            archive_unsupported = archive_result.failure_kind == "unsupported"
+            archive_missing = not archive_unsupported
             archive_policy_tag = _tag_for_archive_failure_kind(
                 # ArchiveFailureKind is a Literal; mypy needs a cast.
                 archive_result.failure_kind  # type: ignore[arg-type]
             )
-            metrics.archive_policy_failures().add(
-                1,
-                {
-                    "profile": profile_name,
-                    "source": "arxiv",
-                    "kind": archive_result.failure_kind or "unknown",
-                },
-            )
+            if archive_missing:
+                metrics.archive_missing().add(
+                    1, {"profile": profile_name, "source": "arxiv"}
+                )
+                # Issue #149: reclassify the failure into a policy tag
+                # when the failure_kind is one of blocked / rate_limited /
+                # missing_by_policy.  Generic failures (http_404, oversize,
+                # timeout, …) keep the default ``influx:archive-missing``
+                # shape so repair-sweep behaviour is unchanged for them.
+                metrics.archive_policy_failures().add(
+                    1,
+                    {
+                        "profile": profile_name,
+                        "source": "arxiv",
+                        "kind": archive_result.failure_kind or "unknown",
+                    },
+                )
 
     acquired = Acquired(
         item_id=item.arxiv_id,
@@ -1196,7 +1204,11 @@ def build_arxiv_note_item(
         tags.append(archive_policy_tag)
     if (
         archive_policy_tag
-        in ("influx:archive-blocked", "influx:archive-skipped-by-policy")
+        in (
+            "influx:archive-blocked",
+            "influx:archive-skipped-by-policy",
+            "influx:archive-unsupported",
+        )
         and "influx:archive-terminal" not in tags
     ):
         tags.append("influx:archive-terminal")

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -301,23 +301,33 @@ def build_rss_note_item(
     # than an acquisition failure so the run-level
     # ``archive_acquisition`` degraded reason does not fire on these
     # known non-article URLs.
-    non_html_source = archive_result.failure_kind == "non_html_source"
-    archive_missing = not archive_result.ok and not non_html_source
+    # Issue #161: ``unsupported`` is the same shape but the
+    # discriminator is the domain policy (``openai.com`` etc.) rather
+    # than the URL shape.  Both share the "not a missing archive"
+    # semantics — they get a dedicated tag + terminal flag, but no
+    # ``influx:archive-missing`` and no contribution to
+    # ``archive_failures_total``.
+    archive_skipped_no_failure = archive_result.failure_kind in (
+        "non_html_source",
+        "unsupported",
+    )
+    archive_missing = not archive_result.ok and not archive_skipped_no_failure
     # Issue #149: extract the policy-driven tag (if any) so the tag
     # composition below can apply ``influx:archive-blocked`` /
     # ``influx:archive-rate-limited`` /
     # ``influx:archive-skipped-by-policy`` alongside
     # ``influx:archive-missing``.  Returns ``None`` for generic
     # failures (http_404, oversize, timeout, …) so the existing
-    # ``influx:archive-missing`` shape is preserved.  Issue #160:
-    # ``non_html_source`` also returns its dedicated tag here so the
-    # informational ``influx:archive-non-html-source`` tag is applied
-    # below alongside the terminal flag.
+    # ``influx:archive-missing`` shape is preserved.  Issues #160/#161:
+    # ``non_html_source`` / ``unsupported`` also return their dedicated
+    # tags here so the informational ``influx:archive-non-html-source``
+    # / ``influx:archive-unsupported`` tag is applied below alongside
+    # the terminal flag.
     archive_policy_tag = (
         _tag_for_archive_failure_kind(
             archive_result.failure_kind  # type: ignore[arg-type]
         )
-        if archive_missing or non_html_source
+        if archive_missing or archive_skipped_no_failure
         else None
     )
     if archive_missing:
@@ -418,6 +428,9 @@ def build_rss_note_item(
     # Issue #160: ``non_html_source`` also lands its dedicated tag
     # (``influx:archive-non-html-source``) and the terminal flag — the
     # URL shape never pointed at HTML, so there is nothing to repair.
+    # Issue #161: ``unsupported`` lands its dedicated tag
+    # (``influx:archive-unsupported``) and the terminal flag — the
+    # domain has no archive surface.
     if archive_policy_tag is not None and archive_policy_tag not in tags:
         tags.append(archive_policy_tag)
     if (
@@ -426,6 +439,7 @@ def build_rss_note_item(
             "influx:archive-blocked",
             "influx:archive-skipped-by-policy",
             "influx:archive-non-html-source",
+            "influx:archive-unsupported",
         )
         and "influx:archive-terminal" not in tags
     ):

--- a/src/influx/storage.py
+++ b/src/influx/storage.py
@@ -214,6 +214,14 @@ def download_archive(
     :func:`~influx.archive_policy.default_registry` is used so even
     untargeted callers (CLI smoke commands, repair sweep) honour the
     staging-defaults set.
+
+    Issue #161: ``unsupported``-mode policies also short-circuit
+    before any network call.  Distinct from ``skip`` because the
+    caller treats it as "this domain has no archive surface" —
+    callers do NOT tag ``influx:archive-missing`` on the resulting
+    note, so the item does not contribute to the run-level
+    ``archive_acquisition`` degraded reason.  The default registry
+    includes ``openai.com`` under this mode.
     """
     if max_download_bytes is None or timeout_seconds is None:
         _storage_defaults = StorageConfig()
@@ -273,6 +281,29 @@ def download_archive(
             rel_posix_path=None,
             error=f"missing_by_policy: {policy.note or 'archive disabled by policy'}",
             failure_kind="missing_by_policy",
+            policy_mode=policy.mode,
+            domain=domain,
+        )
+
+    # Issue #161: ``unsupported`` mode also short-circuits before any
+    # network call.  Distinct from ``skip``: the caller treats the
+    # result as "this domain has no archive surface, that's fine" — no
+    # ``influx:archive-missing`` tag, no contribution to the run-level
+    # ``archive_acquisition`` degraded reason.  Logged at INFO once per
+    # acquisition so an operator sees the policy decision was applied
+    # without producing the WARNING-level archive-failure noise.
+    if policy.mode == "unsupported":
+        _log.info(
+            "archive download skipped (policy=unsupported) url=%s domain=%s note=%s",
+            url,
+            domain,
+            policy.note,
+        )
+        return ArchiveResult(
+            ok=False,
+            rel_posix_path=None,
+            error=f"unsupported: {policy.note or 'archive unsupported by policy'}",
+            failure_kind="unsupported",
             policy_mode=policy.mode,
             domain=domain,
         )

--- a/tests/meta/test_v1_gate.py
+++ b/tests/meta/test_v1_gate.py
@@ -509,13 +509,18 @@ class TestACX6LithosContractTests:
 # prompts, slug.  Mapped to one or more corresponding unit test files.
 # The "path" pure module is the archive-path logic in ``storage.py``
 # (``build_archive_path`` plus path-safety helpers); ``storage.py`` also
-# carries the thin ``download_archive`` IO wrapper, so coverage for that
-# module is driven by ``test_archive_path.py`` and
-# ``test_archive_download.py`` together.
+# carries the thin ``download_archive`` IO wrapper plus the per-domain
+# policy short-circuits (issues #149, #160, #161), so coverage for that
+# module is driven by ``test_archive_path.py``, ``test_archive_download.py``,
+# and ``test_archive_download_policy.py`` together.
 _PURE_MODULE_TESTS: dict[str, tuple[str, ...]] = {
     "config.py": ("test_config.py",),
     "urls.py": ("test_url_normalisation.py",),
-    "storage.py": ("test_archive_path.py", "test_archive_download.py"),
+    "storage.py": (
+        "test_archive_path.py",
+        "test_archive_download.py",
+        "test_archive_download_policy.py",
+    ),
     "slugs.py": ("test_slugs.py",),
     "schemas.py": ("test_schemas.py",),
     "prompts.py": ("test_prompts.py",),

--- a/tests/unit/test_archive_download_policy.py
+++ b/tests/unit/test_archive_download_policy.py
@@ -322,6 +322,89 @@ class TestDefaultRegistryIdentity:
         assert default_registry() is default_registry()
 
 
+# ── Issue #161: ``unsupported`` mode short-circuits without degradation ──
+
+
+class TestUnsupportedModePolicy:
+    """``unsupported`` mode never reaches the network and emits its own kind.
+
+    The contract is the same shape as ``skip`` (no network call) but
+    the result carries ``failure_kind="unsupported"`` and ``policy_mode
+    == "unsupported"``, so callers can route around the
+    ``archive-missing`` tag composition that would otherwise contribute
+    to the run-level ``archive_acquisition`` degraded reason.
+    """
+
+    def test_unsupported_short_circuits_without_network(self, tmp_path: Path) -> None:
+        registry = build_registry(
+            unsupported={"openai.example": "no archive surface"},
+            include_defaults=False,
+        )
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            result = _dl(
+                tmp_path,
+                "https://openai.example/index/article",
+                registry=registry,
+            )
+        mock_fetch.assert_not_called()
+        assert result.ok is False
+        assert result.failure_kind == "unsupported"
+        assert result.policy_mode == "unsupported"
+        assert result.domain == "openai.example"
+        assert result.rel_posix_path is None
+        assert "unsupported" in result.error
+
+    def test_unsupported_default_includes_openai_com(self, tmp_path: Path) -> None:
+        # Production default — openai.com is in the staging-defaults
+        # ``unsupported`` list and short-circuits without a network call.
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            result = _dl(tmp_path, "https://openai.com/index/x")
+        mock_fetch.assert_not_called()
+        assert result.failure_kind == "unsupported"
+        assert result.policy_mode == "unsupported"
+
+    def test_unsupported_does_not_create_archive_file(self, tmp_path: Path) -> None:
+        registry = build_registry(
+            unsupported={"openai.example": ""},
+            include_defaults=False,
+        )
+        with patch("influx.storage.guarded_fetch"):
+            _dl(tmp_path, "https://openai.example/x", registry=registry)
+        # Like ``skip``, ``unsupported`` short-circuits before path
+        # construction.
+        assert not (tmp_path / "rss").exists()
+
+    def test_unsupported_logs_policy_decision(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # Acceptance criterion #4: logs make the policy decision
+        # explicit.  An ``unsupported`` short-circuit emits an INFO
+        # log carrying ``policy=unsupported`` and the operator note
+        # so support triage can see why no archive was attempted.
+        import logging
+
+        registry = build_registry(
+            unsupported={"openai.example": "no archive surface"},
+            include_defaults=False,
+        )
+        with (
+            patch("influx.storage.guarded_fetch"),
+            caplog.at_level(logging.INFO, logger="influx.storage"),
+        ):
+            _dl(
+                tmp_path,
+                "https://openai.example/index/article",
+                registry=registry,
+            )
+
+        relevant = [r for r in caplog.records if "policy=unsupported" in r.message]
+        assert relevant, "expected an INFO log line marked policy=unsupported"
+        assert any("no archive surface" in r.message for r in relevant)
+        assert any("openai.example" in r.message for r in relevant)
+
+
 # ── Issue #160: URL-shape short-circuit for non-HTML sources ──────────
 
 

--- a/tests/unit/test_archive_policy.py
+++ b/tests/unit/test_archive_policy.py
@@ -24,6 +24,7 @@ from influx.archive_policy import (
     ARCHIVE_NON_HTML_SOURCE_TAG,
     ARCHIVE_RATE_LIMITED_TAG,
     ARCHIVE_SKIPPED_BY_POLICY_TAG,
+    ARCHIVE_UNSUPPORTED_TAG,
     ArchivePolicy,
     ArchivePolicyRegistry,
     build_registry,
@@ -80,6 +81,15 @@ class TestRegistryDefaults:
         policy = default_registry().policy_for("https://www.alignmentforum.org/posts/x")
         assert policy.mode == "blocked"
 
+    def test_openai_is_unsupported(self) -> None:
+        # Issue #161: ``openai.com`` is in the staging-defaults
+        # ``unsupported`` list because its blog/index pages return
+        # HTTP 403 to every unauthenticated archive attempt.
+        policy = default_registry().policy_for("https://openai.com/index/x")
+        assert policy.mode == "unsupported"
+        assert policy.should_attempt is False
+        assert policy.note
+
 
 class TestRegistryMatching:
     """Suffix matching is longest-first and case-insensitive."""
@@ -123,7 +133,7 @@ class TestRegistryMatching:
 
 
 class TestArchivePolicyShouldAttempt:
-    """``should_attempt`` short-circuits for the skip mode only."""
+    """``should_attempt`` short-circuits for skip and unsupported modes."""
 
     @pytest.mark.parametrize(
         "mode, should_attempt",
@@ -132,6 +142,10 @@ class TestArchivePolicyShouldAttempt:
             ("rate_limited", True),
             ("blocked", True),
             ("skip", False),
+            # Issue #161: ``unsupported`` also short-circuits the
+            # download attempt, since the operator has declared the
+            # domain has no archive surface.
+            ("unsupported", False),
         ],
     )
     def test_should_attempt(self, mode: str, should_attempt: bool) -> None:
@@ -220,6 +234,7 @@ class TestTagForFailureKind:
             ("rate_limited", ARCHIVE_RATE_LIMITED_TAG),
             ("missing_by_policy", ARCHIVE_SKIPPED_BY_POLICY_TAG),
             ("non_html_source", ARCHIVE_NON_HTML_SOURCE_TAG),
+            ("unsupported", ARCHIVE_UNSUPPORTED_TAG),
         ],
     )
     def test_policy_kinds_map_to_dedicated_tags(
@@ -285,6 +300,33 @@ class TestRegistryFromConfig:
         assert registry.policy_for("https://www.science.org/x").mode == "attempt"
         assert registry.domains() == ()
 
+    def test_operator_unsupported_entry_round_trips(self) -> None:
+        # Issue #161: ``unsupported`` overrides land via TOML the same
+        # way the older ``skip`` overrides do.
+        cfg = ArchivePolicyConfig(
+            unsupported={"intranet.example": "no archive surface"},
+            include_defaults=False,
+        )
+        registry = registry_from_config(cfg)
+        policy = registry.policy_for("https://intranet.example/article")
+        assert policy.mode == "unsupported"
+        assert policy.should_attempt is False
+        assert policy.note == "no archive surface"
+
+    def test_unsupported_supersedes_skip_for_same_suffix(self) -> None:
+        # Issue #161: when both ``skip`` and ``unsupported`` declare
+        # the same suffix, the more-terminal ``unsupported`` mode wins
+        # (mirrors the existing skip-over-blocked precedence).
+        cfg = ArchivePolicyConfig(
+            skip={"example.com": "skip note"},
+            unsupported={"example.com": "unsupported note"},
+            include_defaults=False,
+        )
+        registry = registry_from_config(cfg)
+        policy = registry.policy_for("https://example.com/x")
+        assert policy.mode == "unsupported"
+        assert policy.note == "unsupported note"
+
 
 class TestRegistryDomainsListing:
     """``ArchivePolicyRegistry.domains`` exposes the registered suffix set."""
@@ -293,6 +335,9 @@ class TestRegistryDomainsListing:
         domains = default_registry().domains()
         assert "science.org" in domains
         assert "alignmentforum.org" in domains
+        # Issue #161: ``openai.com`` joins the staging-defaults set
+        # under the new ``unsupported`` mode.
+        assert "openai.com" in domains
 
     def test_no_duplicates_after_merge(self) -> None:
         # If an operator override re-declares a default suffix the

--- a/tests/unit/test_archive_policy_source_tags.py
+++ b/tests/unit/test_archive_policy_source_tags.py
@@ -56,6 +56,7 @@ def _make_config(
     blocked: dict[str, str] | None = None,
     rate_limited: dict[str, str] | None = None,
     skip: dict[str, str] | None = None,
+    unsupported: dict[str, str] | None = None,
     include_defaults: bool = False,
     archive_dir: str = "/archive",
 ) -> AppConfig:
@@ -68,6 +69,7 @@ def _make_config(
                 blocked=blocked or {},
                 rate_limited=rate_limited or {},
                 skip=skip or {},
+                unsupported=unsupported or {},
                 include_defaults=include_defaults,
             ),
         ),
@@ -196,6 +198,34 @@ class TestRssArchivePolicyTags:
         assert "influx:archive-skipped-by-policy" not in tags
         # Not flipped terminal.
         assert "influx:archive-terminal" not in tags
+
+    @patch("influx.sources.rss.download_archive")
+    def test_unsupported_emits_unsupported_tag_only(self, mock_dl: object) -> None:
+        # Issue #161: ``unsupported`` mode short-circuits without
+        # producing ``influx:archive-missing`` / ``influx:repair-needed``
+        # — the operator declared the domain has no archive surface,
+        # so the run is not degraded by it.  The note carries the
+        # dedicated ``influx:archive-unsupported`` + terminal flag.
+        mock_dl.return_value = ArchiveResult(  # type: ignore[union-attr]
+            ok=False,
+            rel_posix_path=None,
+            error="unsupported: archive unsupported by policy",
+            failure_kind="unsupported",
+            policy_mode="unsupported",
+            domain="openai.com",
+        )
+        config = _make_config(unsupported={"openai.com": "no archive"})
+        item = _make_rss_item(url="https://openai.com/index/article")
+
+        result = build_rss_note_item(
+            item=item, profile_name="ai-robotics", config=config
+        )
+
+        tags = cast(list[str], result["tags"])
+        assert "influx:archive-unsupported" in tags
+        assert "influx:archive-terminal" in tags
+        assert "influx:archive-missing" not in tags
+        assert "influx:repair-needed" not in tags
 
     @patch("influx.sources.rss.download_archive")
     def test_non_html_source_emits_non_html_tag_only(self, mock_dl: object) -> None:

--- a/tests/unit/test_run_service.py
+++ b/tests/unit/test_run_service.py
@@ -673,6 +673,93 @@ async def test_archive_acquisition_degrades_run_and_logs_warning(
     assert "influx:archive-missing" in warning.message
 
 
+async def test_archive_unsupported_item_does_not_trigger_archive_acquisition(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Issue #161: items from ``unsupported`` policy domains must NOT
+    contribute to ``archive_failures_total`` or fire the
+    ``archive_acquisition`` degraded reason.
+
+    The run-service derives ``archive_failures_total`` by counting
+    items tagged ``influx:archive-missing``.  A note ingested from a
+    domain on the ``unsupported`` policy list carries
+    ``influx:archive-unsupported`` plus ``influx:archive-terminal``
+    instead — the operator has already declared the domain has no
+    archive surface, so the run must not degrade purely because that
+    expected outcome was observed.  Pins the contract end-to-end so a
+    later tag-composition refactor cannot silently re-introduce the
+    spurious degradation that #161 fixes for ``openai.com``-style
+    domains.
+    """
+    from influx.notifications import HighlightItem, ProfileRunResult, RunStats
+
+    config = _make_config()
+    ledger = RunLedger(tmp_path)
+    service = RunService(config=config, ledger=ledger)
+
+    body_outcome = RunOutcome(
+        sources_checked=2,
+        ingested=1,
+        profile_run_result=ProfileRunResult(
+            run_date="2026-05-08",
+            profile="alpha",
+            stats=RunStats(sources_checked=2, ingested=1),
+            items=[
+                HighlightItem(
+                    id="note-1",
+                    title="OpenAI Blog Post",
+                    score=8,
+                    # Crucially: NO ``influx:archive-missing`` tag.
+                    # ``unsupported`` is an expected, terminal outcome
+                    # for declared-unsupported domains.
+                    tags=[
+                        "profile:alpha",
+                        "influx:archive-unsupported",
+                        "influx:archive-terminal",
+                    ],
+                    reason="domain policy unsupported",
+                    url="https://openai.com/index/some-post",
+                    related_in_lithos=[],
+                )
+            ],
+        ),
+    )
+    with (
+        caplog.at_level(logging.INFO, logger="influx.run_service"),
+        patch(
+            "influx.run.Run.execute",
+            new_callable=AsyncMock,
+            return_value=body_outcome,
+        ),
+    ):
+        await service.execute(_scheduled_plan())
+
+    entry = next(e for e in ledger.recent() if e["status"] == "completed")
+    assert "archive_acquisition" not in entry["degraded_reasons"]
+    assert entry["archive_failures_total"] == 0
+
+    # No archive_acquisition WARNING should have been emitted.  The
+    # informational INFO line below mentions ``archive_acquisition`` in
+    # its explanatory tail; restrict the check to WARNING records so
+    # the explainer text doesn't false-positive.
+    assert not [
+        r
+        for r in caplog.records
+        if "archive_acquisition" in r.message and r.levelname == "WARNING"
+    ], "unsupported items must not emit the archive_acquisition warning"
+
+    # But the explicit INFO summary should fire so an operator sees
+    # the policy decision in the log stream (acceptance criterion #4).
+    info_logs = [
+        r
+        for r in caplog.records
+        if "archive_unsupported" in r.message and r.levelname == "INFO"
+    ]
+    assert info_logs, "expected an INFO archive_unsupported summary line"
+    assert "unsupported_items=1" in info_logs[0].message
+
+
 async def test_non_html_source_item_does_not_trigger_archive_acquisition(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
## Summary

Add a new ``unsupported`` archive policy mode for domains that systematically refuse archive acquisition with HTTP 403 (staging evidence: ``openai.com``). Distinct from existing ``blocked`` (which still attempts and tags missing) and ``skip`` (which tags ``influx:archive-missing`` and thus still degrades the run).

**Behaviour:**

- No network call (like ``skip``).
- New ``failure_kind="unsupported"`` and tags ``influx:archive-unsupported`` + ``influx:archive-terminal``.
- Does **not** tag ``influx:archive-missing`` — so unsupported items do not contribute to ``archive_failures_total`` or fire the ``archive_acquisition`` degraded reason. Runs with otherwise-successful ingestion stop degrading because an ``openai.com`` URL refused archival.
- TOML override surface via ``[storage.archive_policy].unsupported`` (mirrors the existing ``blocked`` / ``rate_limited`` / ``skip`` shape).
- Built-in default for ``openai.com``.

**Observability (acceptance criterion #4):**

- ``download_archive`` short-circuit logs an INFO line with ``policy=unsupported`` and the operator note.
- Run-level INFO line ``run archive_unsupported ... unsupported_items=N`` fires when the run touched any unsupported domain, so operators see the policy decision explicitly without it counting as degradation.

Both source adapters (RSS + arXiv) updated to skip the ``archive-missing`` / ``repair-needed`` tag composition for ``unsupported`` failures.

Closes #161.

## Test plan

- [x] ``test_archive_policy.py`` — default registry contains ``openai.com`` as ``unsupported``; ``should_attempt`` returns False; ``tag_for_failure_kind`` round-trips the new kind; ``registry_from_config`` round-trips operator overrides; ``unsupported`` supersedes ``skip`` for the same suffix.
- [x] ``test_archive_download_policy.py::TestUnsupportedModePolicy`` — pins no-network short-circuit, default ``openai.com`` behaviour, no archive file created, and the INFO log with ``policy=unsupported`` + note.
- [x] ``test_archive_policy_source_tags.py::test_unsupported_emits_unsupported_tag_only`` — RSS adapter emits ``influx:archive-unsupported`` + terminal flag without ``influx:archive-missing`` / ``influx:repair-needed``.
- [x] ``test_run_service.py::test_archive_unsupported_item_does_not_trigger_archive_acquisition`` — pins end-to-end that unsupported items have ``archive_failures_total=0``, ``archive_acquisition`` not in degraded reasons, no WARNING emitted, and the INFO ``archive_unsupported`` summary line fires with ``unsupported_items=1``.
- [x] V1 gate fixed: ``test_archive_download_policy.py`` added to the pure-module coverage map for ``storage.py``.
- [x] Full suite green: ``2157 passed``.