### PR TITLE
feat: per-feed RSS timeout cooldown / quarantine (#163)

### DIFF
--- a/src/influx/config.py
+++ b/src/influx/config.py
@@ -580,6 +580,36 @@ class ResilienceConfig(BaseModel):
     # right before the restart.
     arxiv_429_cooldown_threshold: int = 3
     arxiv_429_cooldown_seconds: int = 900
+    # Issue #163: per-feed cooldown for repeated RSS timeouts.
+    #
+    # A single flaky RSS feed (e.g. the staging-observed "Two Stop
+    # Bits" aggregator) emitting ``httpx.ReadTimeout`` on every fetch
+    # degrades every scheduled run with the same
+    # ``source_acquisition`` reason.  The cooldown adds a per-feed-URL
+    # state machine layered on the existing fetch path:
+    #
+    # * Each *timeout* (``NetworkError.kind == "timeout"``) on the
+    #   feed-bytes fetch increments a streak counter for that URL.
+    # * When the streak reaches ``rss_timeout_cooldown_threshold`` the
+    #   feed enters COOLDOWN: subsequent fetches are skipped quickly
+    #   for ``rss_timeout_cooldown_seconds`` and surfaced as a
+    #   ``source_cooldown_skip`` degraded reason rather than the noisy
+    #   per-run ``source_acquisition`` stack trace.
+    # * Cooldown clears on either ``rss_timeout_cooldown_seconds``
+    #   elapse *or* the next successful fetch.  Successful fetch also
+    #   resets the streak counter.
+    # * Setting ``rss_timeout_cooldown_threshold`` to 0 disables the
+    #   feature entirely.
+    # * Only ``timeout`` failures count.  Other failure kinds (DNS,
+    #   network, content_type_mismatch, …) do NOT enter the cooldown
+    #   path so a single transport hiccup cannot quarantine a healthy
+    #   feed.
+    #
+    # State is per-feed-URL and process-local — separate feeds in the
+    # same profile and on the same domain are tracked independently,
+    # and a restart resets every deadline.
+    rss_timeout_cooldown_threshold: int = 3
+    rss_timeout_cooldown_seconds: int = 1800
     lithos_write_conflict_max_retries: int = 1
 
     @field_validator(
@@ -591,6 +621,8 @@ class ResilienceConfig(BaseModel):
         "arxiv_429_max_retries",
         "arxiv_429_cooldown_threshold",
         "arxiv_429_cooldown_seconds",
+        "rss_timeout_cooldown_threshold",
+        "rss_timeout_cooldown_seconds",
         "lithos_write_conflict_max_retries",
     )
     @classmethod

--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -696,9 +696,22 @@ class RunLedger:
                 # ``fetched_total`` was explicitly 0 or the caller
                 # didn't supply one (legacy path) — both fall to
                 # fetch_stall to preserve pre-#85 semantics.
-                consecutive_zero_fetch = 1 + self._consecutive_zero_fetch_runs(
-                    profile=profile, exclude_run_id=run_id
-                )
+                #
+                # Issue #163 review: when the current run also has
+                # ``source_cooldown_skips`` non-empty, the zeros are
+                # fully explained by the cooldown — adding fetch_stall
+                # on top would mis-route the operator to "upstream
+                # drift / lookback problem" when the truth is "we
+                # deliberately did not fetch".  ``_consecutive_zero_fetch_runs``
+                # already skips prior cooldown-skipped runs (see
+                # :meth:`_is_zero_fetch_entry`) so the streak is not
+                # polluted by past cooldown runs either.
+                if cooldown_skips:
+                    consecutive_zero_fetch = 0
+                else:
+                    consecutive_zero_fetch = 1 + self._consecutive_zero_fetch_runs(
+                        profile=profile, exclude_run_id=run_id
+                    )
                 if consecutive_zero_fetch >= 2 and self._has_prior_non_zero_fetch(
                     profile=profile, exclude_run_id=run_id
                 ):
@@ -790,12 +803,24 @@ class RunLedger:
         by construction since the LLM-filter rejection was the only
         new way to land at ``sources_checked == 0`` despite a
         successful fetch).
+
+        Issue #163 review: prior runs whose zeros are explained by a
+        ``source_cooldown_skip`` (cooldown short-circuited the fetch)
+        are *skipped* — neither counted toward the streak nor used to
+        terminate it.  Continuing past these entries keeps the streak
+        meaningful for the genuine "fetch tried and got nothing"
+        pattern that ``fetch_stall`` exists to surface.
         """
         count = 0
         for prior in self.recent(limit=_STALL_HISTORY_LIMIT, profile=profile):
             if prior.get("run_id") == exclude_run_id:
                 continue
             if prior.get("kind") != "scheduled":
+                continue
+            # Issue #163: don't let cooldown-skipped runs pollute the
+            # zero-fetch streak.  Their zeros are deliberate, not a
+            # symptom of upstream silence.
+            if prior.get("source_cooldown_skips"):
                 continue
             if self._is_zero_fetch_entry(prior):
                 count += 1

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -23,6 +23,8 @@ import calendar
 import json
 import logging
 import os
+import threading
+import time
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -55,11 +57,12 @@ from influx.telemetry import (
     record_filter_error,
     record_invalid_url_rejection,
     record_source_acquisition_error,
+    record_source_cooldown_skip,
 )
 from influx.urls import classify_article_url, normalise_url, url_hash
 
 if TYPE_CHECKING:
-    from influx.config import AppConfig, ProfileConfig, RssSourceEntry
+    from influx.config import AppConfig, ProfileConfig, ResilienceConfig, RssSourceEntry
     from influx.sources import FetchCache
 
 __all__ = [
@@ -71,6 +74,128 @@ __all__ = [
 ]
 
 _log = logging.getLogger(__name__)
+
+
+# ── Per-feed timeout cooldown (issue #163) ─────────────────────────────
+#
+# A single flaky RSS feed (e.g. the staging-observed "Two Stop Bits"
+# aggregator emitting ``httpx.ReadTimeout``) degrades every scheduled
+# run with ``source_acquisition``.  The cooldown is a per-feed-URL
+# state machine layered on top of the existing fetch path:
+#
+#   NORMAL  ── timeout_streak >= threshold ──► COOLDOWN
+#   COOLDOWN ── deadline elapsed ─────────► NORMAL  (lazy clear)
+#   COOLDOWN ── successful fetch ─────────► NORMAL  (eager clear)
+#
+# Only ``timeout`` failures count — other kinds (DNS, network,
+# content_type_mismatch, …) do not enter the cooldown path, so a one-off
+# transport hiccup cannot quarantine a healthy feed.
+#
+# State is per-feed-URL so distinct feeds in the same profile do not
+# share counters: one slow feed never suppresses the rest.  The state
+# map is process-local — a restart resets every deadline (documented as
+# a caveat mirroring the arXiv 429 cooldown in :mod:`influx.sources.arxiv`).
+
+
+@dataclass
+class _RssFeedCooldownState:
+    """Per-feed-URL cooldown bookkeeping (issue #163)."""
+
+    streak: int = 0
+    deadline_monotonic: float | None = None
+
+
+_RSS_COOLDOWN_LOCK = threading.Lock()
+_RSS_COOLDOWN_STATE: dict[str, _RssFeedCooldownState] = {}
+
+
+def _reset_rss_cooldown_for_tests() -> None:
+    """Reset the per-feed cooldown state — test seam only (issue #163).
+
+    Unit and integration tests need a clean baseline between cases;
+    production code never calls this.
+    """
+    with _RSS_COOLDOWN_LOCK:
+        _RSS_COOLDOWN_STATE.clear()
+
+
+def _rss_cooldown_snapshot(url: str) -> tuple[int, float | None]:
+    """Return ``(streak, deadline_monotonic)`` for *url* — test seam only."""
+    with _RSS_COOLDOWN_LOCK:
+        state = _RSS_COOLDOWN_STATE.get(url)
+        if state is None:
+            return 0, None
+        return state.streak, state.deadline_monotonic
+
+
+def _should_skip_rss_for_cooldown(
+    url: str, resilience: ResilienceConfig
+) -> tuple[bool, float | None]:
+    """Inspect the per-feed cooldown state machine before a fetch.
+
+    Returns ``(skip, remaining_seconds)``.  When the threshold is ``0``
+    (feature disabled) or no deadline is set for *url* the helper
+    returns ``(False, None)`` and the caller proceeds normally.
+
+    When an active deadline has elapsed, the state machine transitions
+    back to NORMAL *lazily* — the deadline and streak are both cleared
+    as part of this call so the next timeout starts a fresh streak.
+    """
+    threshold = int(resilience.rss_timeout_cooldown_threshold)
+    if threshold <= 0:
+        return False, None
+    now = time.monotonic()
+    with _RSS_COOLDOWN_LOCK:
+        state = _RSS_COOLDOWN_STATE.get(url)
+        if state is None or state.deadline_monotonic is None:
+            return False, None
+        remaining = state.deadline_monotonic - now
+        if remaining <= 0:
+            # Deadline elapsed — clear state and proceed normally.
+            state.deadline_monotonic = None
+            state.streak = 0
+            return False, None
+        return True, remaining
+
+
+def _record_rss_timeout(url: str, resilience: ResilienceConfig) -> tuple[int, bool]:
+    """Tick the per-feed timeout streak after a timeout fetch failure.
+
+    Returns ``(streak, entered_cooldown)``.  When the resulting streak
+    reaches ``rss_timeout_cooldown_threshold`` the state machine
+    transitions NORMAL → COOLDOWN by setting a fresh deadline; the
+    caller receives ``entered_cooldown=True`` so it can emit a single
+    distinctive WARNING line summarising the quarantine.
+    """
+    threshold = int(resilience.rss_timeout_cooldown_threshold)
+    if threshold <= 0:
+        return 0, False
+    cooldown_seconds = float(resilience.rss_timeout_cooldown_seconds)
+    now = time.monotonic()
+    with _RSS_COOLDOWN_LOCK:
+        state = _RSS_COOLDOWN_STATE.setdefault(url, _RssFeedCooldownState())
+        state.streak += 1
+        streak = state.streak
+        if streak >= threshold and cooldown_seconds > 0:
+            state.deadline_monotonic = now + cooldown_seconds
+            return streak, True
+        return streak, False
+
+
+def _record_rss_fetch_success(url: str) -> None:
+    """Clear the per-feed cooldown state after a successful fetch.
+
+    A successful fetch is the strongest signal that the feed has
+    recovered, so the deadline (if any) is cleared *eagerly* — the
+    streak counter is also reset so an unrelated timeout later starts
+    a fresh streak.
+    """
+    with _RSS_COOLDOWN_LOCK:
+        state = _RSS_COOLDOWN_STATE.get(url)
+        if state is None:
+            return
+        state.streak = 0
+        state.deadline_monotonic = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -636,6 +761,7 @@ class RssSource:
                 max_download_bytes=config.storage.max_download_bytes,
                 timeout_seconds=config.storage.download_timeout_seconds,
                 profile=profile_cfg.name,
+                resilience=config.resilience,
             )
             metrics.candidates_fetched().add(
                 len(items), {"profile": profile_cfg.name, "source": "rss"}
@@ -745,6 +871,7 @@ def make_rss_item_provider(
                     max_download_bytes=config.storage.max_download_bytes,
                     timeout_seconds=config.storage.download_timeout_seconds,
                     profile=profile,
+                    resilience=config.resilience,
                 )
                 metrics.candidates_fetched().add(
                     len(items), {"profile": profile, "source": "rss"}
@@ -899,6 +1026,7 @@ async def _fetch_rss_feed(
     max_download_bytes: int | None = None,
     timeout_seconds: int | None = None,
     profile: str = "",
+    resilience: ResilienceConfig | None = None,
 ) -> list[RssFeedItem]:
     """Fetch raw feed bytes, then parse-and-stamp per *feed_entry*.
 
@@ -911,8 +1039,44 @@ async def _fetch_rss_feed(
     bucket / archive path (review finding 3).  Re-parsing per call keeps
     the network savings of dedup while preserving the FR-SRC-4 rule that
     each item inherits its feed's configured ``source_tag`` verbatim.
+
+    Issue #163: when *resilience* is provided, the helper consults the
+    per-feed timeout cooldown state machine before each fetch.  A feed
+    in active cooldown short-circuits with ``source_cooldown_skip``
+    instead of repeating the upstream timeout and degrading the run
+    with ``source_acquisition``.
     """
     cache_key = f"rss-bytes:{feed_entry.url}"
+
+    # Issue #163: short-circuit fetch when the feed is in active
+    # cooldown.  Records ``source_cooldown_skip`` so the run-ledger
+    # entry distinguishes "throttled on purpose" from "tried and lost"
+    # — mirroring the arXiv 429 cooldown integration (#146).
+    if resilience is not None:
+        skip, remaining = _should_skip_rss_for_cooldown(feed_entry.url, resilience)
+        if skip:
+            remaining_str = f"{remaining:.0f}" if remaining is not None else "?"
+            _log.info(
+                "rss feed skipped (cooldown active) profile=%s feed=%r url=%s "
+                "remaining=%ss "
+                "(repeated ReadTimeout — quarantined until cooldown elapses)",
+                profile,
+                feed_entry.name,
+                feed_entry.url,
+                remaining_str,
+            )
+            record_source_cooldown_skip(
+                source="rss",
+                kind="timeout_cooldown",
+                detail=(
+                    f"{feed_entry.name}: cooldown active, "
+                    f"remaining_seconds={remaining_str}"
+                ),
+            )
+            metrics.source_cooldown_skips().add(
+                1, {"profile": profile, "source": "rss"}
+            )
+            return []
 
     async def _fetch_bytes() -> bytes | None:
         try:
@@ -922,11 +1086,37 @@ async def _fetch_rss_feed(
                 timeout_seconds=timeout_seconds,
             )
         except NetworkError as exc:
-            _log.warning(
-                "RSS feed fetch failed for %r; yielding zero items",
-                feed_entry.name,
-                exc_info=True,
-            )
+            # Issue #163: bump the per-feed timeout streak so repeated
+            # timeouts (the staging "Two Stop Bits" shape) eventually
+            # quarantine this feed.  Other failure kinds (DNS, network,
+            # content_type_mismatch, …) do NOT enter the cooldown
+            # path so a one-off transport hiccup cannot suppress a
+            # healthy feed.
+            entered_cooldown = False
+            cooldown_streak = 0
+            if resilience is not None and exc.kind == "timeout":
+                cooldown_streak, entered_cooldown = _record_rss_timeout(
+                    feed_entry.url, resilience
+                )
+            if entered_cooldown:
+                _log.warning(
+                    "rss feed cooldown engaged after %d consecutive timeouts "
+                    "profile=%s feed=%r url=%s cooldown=%ds "
+                    "(subsequent runs will skip with source_cooldown_skip)",
+                    cooldown_streak,
+                    profile,
+                    feed_entry.name,
+                    feed_entry.url,
+                    int(resilience.rss_timeout_cooldown_seconds)
+                    if resilience is not None
+                    else 0,
+                )
+            else:
+                _log.warning(
+                    "RSS feed fetch failed for %r; yielding zero items",
+                    feed_entry.name,
+                    exc_info=True,
+                )
             # Issue #20: surface to the run ledger so the degraded
             # outcome is distinguishable from a quiet feed.
             record_source_acquisition_error(
@@ -943,6 +1133,11 @@ async def _fetch_rss_feed(
                 },
             )
             return None
+        # Issue #163: a successful fetch clears any accumulated streak
+        # / deadline for this feed.  Cheap no-op when the feed has
+        # never timed out.
+        if resilience is not None:
+            _record_rss_fetch_success(feed_entry.url)
         return result.body
 
     if cache is not None:

--- a/tests/unit/test_rss_cooldown.py
+++ b/tests/unit/test_rss_cooldown.py
@@ -1,0 +1,471 @@
+"""Unit tests for the per-feed RSS timeout cooldown (issue #163).
+
+The cooldown is a per-feed-URL state machine layered on top of the
+``_fetch_rss_feed`` path:
+
+    NORMAL  ── timeout_streak >= threshold ──► COOLDOWN
+    COOLDOWN ── deadline elapsed ────────────► NORMAL  (lazy clear)
+    COOLDOWN ── successful fetch ────────────► NORMAL  (eager clear)
+
+These tests cover the enter/exit transitions, the disable knob, the
+per-feed isolation (one slow feed must not quarantine others on the
+same profile), the kind-restrictive policy (only ``timeout`` counts),
+and the wiring through ``_fetch_rss_feed`` that surfaces a cooldown
+skip as ``source_cooldown_skip`` rather than ``source_acquisition``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from influx.config import ResilienceConfig, RssSourceEntry
+from influx.errors import NetworkError
+from influx.http_client import FetchResult
+from influx.sources.rss import (
+    _fetch_rss_feed,
+    _record_rss_fetch_success,
+    _record_rss_timeout,
+    _reset_rss_cooldown_for_tests,
+    _rss_cooldown_snapshot,
+    _should_skip_rss_for_cooldown,
+)
+from influx.telemetry import (
+    current_source_acquisition_errors,
+    current_source_cooldown_skips,
+)
+
+_FEED_URL = "https://example.com/feed.xml"
+_FEED_URL_OTHER = "https://example.com/other-feed.xml"
+
+
+@pytest.fixture(autouse=True)
+def _reset_cooldown_state() -> None:
+    """Clear per-feed cooldown state between cases."""
+    _reset_rss_cooldown_for_tests()
+
+
+def _resilience(
+    *,
+    threshold: int = 3,
+    cooldown_seconds: int = 600,
+) -> ResilienceConfig:
+    return ResilienceConfig(
+        rss_timeout_cooldown_threshold=threshold,
+        rss_timeout_cooldown_seconds=cooldown_seconds,
+    )
+
+
+def _feed(url: str = _FEED_URL, name: str = "test-feed") -> RssSourceEntry:
+    return RssSourceEntry(name=name, url=url, source_tag="rss")
+
+
+def _timeout_error(url: str = _FEED_URL) -> NetworkError:
+    # Mirrors the staging shape: ``httpx.ReadTimeout`` wrapped by the
+    # guarded client into a ``NetworkError`` with ``kind="timeout"``.
+    return NetworkError(
+        "The read operation timed out",
+        url=url,
+        kind="timeout",
+        reason="ReadTimeout",
+    )
+
+
+# ── State machine: bookkeeping helpers ────────────────────────────────
+
+
+class TestRecordRssTimeout:
+    """``_record_rss_timeout`` ticks a per-URL streak and engages cooldown."""
+
+    def test_streak_increments_on_each_call(self) -> None:
+        res = _resilience(threshold=5)
+        streak1, entered1 = _record_rss_timeout(_FEED_URL, res)
+        streak2, entered2 = _record_rss_timeout(_FEED_URL, res)
+
+        assert (streak1, entered1) == (1, False)
+        assert (streak2, entered2) == (2, False)
+
+    def test_crossing_threshold_engages_cooldown(self) -> None:
+        res = _resilience(threshold=2, cooldown_seconds=300)
+        _record_rss_timeout(_FEED_URL, res)
+        streak, entered = _record_rss_timeout(_FEED_URL, res)
+
+        assert (streak, entered) == (2, True)
+        snap_streak, deadline = _rss_cooldown_snapshot(_FEED_URL)
+        assert snap_streak == 2
+        assert deadline is not None
+
+    def test_per_url_isolation(self) -> None:
+        # A timeout on one feed must not raise another feed's streak.
+        res = _resilience(threshold=2)
+        _record_rss_timeout(_FEED_URL, res)
+        _record_rss_timeout(_FEED_URL, res)
+
+        other_streak, other_deadline = _rss_cooldown_snapshot(_FEED_URL_OTHER)
+        assert other_streak == 0
+        assert other_deadline is None
+
+        primary_streak, primary_deadline = _rss_cooldown_snapshot(_FEED_URL)
+        assert primary_streak == 2
+        assert primary_deadline is not None
+
+    def test_disabled_when_threshold_zero(self) -> None:
+        res = _resilience(threshold=0)
+        for _ in range(10):
+            streak, entered = _record_rss_timeout(_FEED_URL, res)
+            assert (streak, entered) == (0, False)
+
+        snap_streak, deadline = _rss_cooldown_snapshot(_FEED_URL)
+        assert snap_streak == 0
+        assert deadline is None
+
+    def test_zero_cooldown_seconds_disables_deadline(self) -> None:
+        # ``rss_timeout_cooldown_seconds = 0`` lets streak tick but
+        # never engages a deadline.
+        res = _resilience(threshold=1, cooldown_seconds=0)
+        streak, entered = _record_rss_timeout(_FEED_URL, res)
+
+        assert streak == 1
+        assert entered is False
+        _, deadline = _rss_cooldown_snapshot(_FEED_URL)
+        assert deadline is None
+
+
+class TestShouldSkipRssForCooldown:
+    def test_returns_false_when_no_deadline(self) -> None:
+        res = _resilience()
+        skip, remaining = _should_skip_rss_for_cooldown(_FEED_URL, res)
+        assert skip is False
+        assert remaining is None
+
+    def test_returns_true_while_deadline_active(self) -> None:
+        res = _resilience(threshold=1, cooldown_seconds=600)
+        _record_rss_timeout(_FEED_URL, res)
+        skip, remaining = _should_skip_rss_for_cooldown(_FEED_URL, res)
+        assert skip is True
+        assert remaining is not None and remaining > 0
+
+    def test_lazy_clear_after_deadline_elapsed(self) -> None:
+        # A cooldown set in the past clears itself on next inspection
+        # and lets the caller proceed normally.
+        res = _resilience(threshold=1, cooldown_seconds=600)
+        _record_rss_timeout(_FEED_URL, res)
+
+        # Force the deadline into the past by manipulating internal
+        # state directly via the snapshot/record helpers.
+        from influx.sources import rss as rss_module
+
+        with rss_module._RSS_COOLDOWN_LOCK:
+            state = rss_module._RSS_COOLDOWN_STATE[_FEED_URL]
+            state.deadline_monotonic = (state.deadline_monotonic or 0) - 10_000.0
+
+        skip, remaining = _should_skip_rss_for_cooldown(_FEED_URL, res)
+        assert skip is False
+        assert remaining is None
+        # State self-healed.
+        snap_streak, deadline = _rss_cooldown_snapshot(_FEED_URL)
+        assert snap_streak == 0
+        assert deadline is None
+
+    def test_disabled_when_threshold_zero(self) -> None:
+        # Even if state is set (e.g. carried over from a config flip),
+        # the feature gate must not skip.
+        res = _resilience(threshold=0)
+        skip, remaining = _should_skip_rss_for_cooldown(_FEED_URL, res)
+        assert skip is False
+        assert remaining is None
+
+
+class TestRecordRssFetchSuccess:
+    def test_eager_clear_resets_streak_and_deadline(self) -> None:
+        res = _resilience(threshold=2, cooldown_seconds=600)
+        _record_rss_timeout(_FEED_URL, res)
+        _record_rss_timeout(_FEED_URL, res)
+        # Cooldown engaged.
+        snap_streak, deadline = _rss_cooldown_snapshot(_FEED_URL)
+        assert snap_streak == 2
+        assert deadline is not None
+
+        _record_rss_fetch_success(_FEED_URL)
+
+        snap_streak, deadline = _rss_cooldown_snapshot(_FEED_URL)
+        assert snap_streak == 0
+        assert deadline is None
+
+    def test_no_op_for_unknown_url(self) -> None:
+        # Calling success on a feed we've never seen does not raise.
+        _record_rss_fetch_success("https://never-seen.example/feed")
+        snap_streak, deadline = _rss_cooldown_snapshot(
+            "https://never-seen.example/feed"
+        )
+        assert snap_streak == 0
+        assert deadline is None
+
+
+# ── Integration: _fetch_rss_feed wiring ───────────────────────────────
+
+
+async def _run_with_telemetry_buckets(
+    coro_fn: Any,
+) -> tuple[list[Any], list[Any]]:
+    """Run *coro_fn()* with telemetry context vars set up so the test
+    can inspect ``source_acquisition_errors`` and ``source_cooldown_skips``
+    after the fetch completes.
+    """
+    acquisition: list[Any] = []
+    cooldown: list[Any] = []
+    acquisition_token = current_source_acquisition_errors.set(acquisition)
+    cooldown_token = current_source_cooldown_skips.set(cooldown)
+    try:
+        await coro_fn()
+    finally:
+        current_source_acquisition_errors.reset(acquisition_token)
+        current_source_cooldown_skips.reset(cooldown_token)
+    return acquisition, cooldown
+
+
+class TestFetchRssFeedCooldownIntegration:
+    """``_fetch_rss_feed`` records cooldown skips and resets on success.
+
+    Staging-evidence parallel: the "Two Stop Bits" aggregator emits
+    ``httpx.ReadTimeout`` on every fetch.  After three consecutive
+    timeouts the feed is quarantined; subsequent runs short-circuit
+    with ``source_cooldown_skip`` instead of repeating the timeout.
+    """
+
+    async def test_timeouts_below_threshold_record_acquisition_only(self) -> None:
+        feed = _feed(name="Two Stop Bits (retro aggregator)")
+        res = _resilience(threshold=3)
+
+        async def run() -> None:
+            with patch(
+                "influx.sources.rss._aguarded_fetch",
+                new=AsyncMock(side_effect=_timeout_error(feed.url)),
+            ):
+                items = await _fetch_rss_feed(
+                    feed, cache=None, profile="retro-computing", resilience=res
+                )
+            assert items == []
+
+        acquisition, cooldown = await _run_with_telemetry_buckets(run)
+
+        # Single timeout below threshold → counted as source_acquisition,
+        # not source_cooldown_skip.
+        assert len(acquisition) == 1
+        assert acquisition[0]["kind"] == "timeout"
+        assert "Two Stop Bits" in acquisition[0]["detail"]
+        assert cooldown == []
+
+        snap_streak, _ = _rss_cooldown_snapshot(feed.url)
+        assert snap_streak == 1
+
+    async def test_third_timeout_engages_cooldown_and_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        feed = _feed(name="Two Stop Bits (retro aggregator)")
+        res = _resilience(threshold=3, cooldown_seconds=1800)
+
+        async def run() -> None:
+            with (
+                patch(
+                    "influx.sources.rss._aguarded_fetch",
+                    new=AsyncMock(side_effect=_timeout_error(feed.url)),
+                ),
+                caplog.at_level(logging.WARNING, logger="influx.sources.rss"),
+            ):
+                for _ in range(3):
+                    await _fetch_rss_feed(
+                        feed,
+                        cache=None,
+                        profile="retro-computing",
+                        resilience=res,
+                    )
+
+        await _run_with_telemetry_buckets(run)
+
+        # Cooldown engaged on the 3rd timeout.
+        snap_streak, deadline = _rss_cooldown_snapshot(feed.url)
+        assert snap_streak == 3
+        assert deadline is not None
+
+        # The cooldown-engagement WARNING is emitted once.
+        engagement_logs = [
+            r
+            for r in caplog.records
+            if "cooldown engaged" in r.message and "rss" in r.message
+        ]
+        assert len(engagement_logs) == 1
+        assert "Two Stop Bits" in engagement_logs[0].message
+
+    async def test_subsequent_fetch_in_cooldown_skips_and_records_cooldown_skip(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        feed = _feed()
+        res = _resilience(threshold=1, cooldown_seconds=600)
+
+        # Force the cooldown via direct bookkeeping (avoid wall-time).
+        _record_rss_timeout(feed.url, res)
+        snap_streak, deadline = _rss_cooldown_snapshot(feed.url)
+        assert snap_streak == 1 and deadline is not None
+
+        async def run() -> None:
+            fetch_mock = AsyncMock()
+            with (
+                patch("influx.sources.rss._aguarded_fetch", new=fetch_mock),
+                caplog.at_level(logging.INFO, logger="influx.sources.rss"),
+            ):
+                items = await _fetch_rss_feed(
+                    feed, cache=None, profile="retro-computing", resilience=res
+                )
+            assert items == []
+            # The fetch was NOT made — the cooldown short-circuited.
+            fetch_mock.assert_not_called()
+
+        acquisition, cooldown = await _run_with_telemetry_buckets(run)
+
+        # The skip routes through ``source_cooldown_skip``, NOT
+        # ``source_acquisition``.
+        assert cooldown and cooldown[0]["kind"] == "timeout_cooldown"
+        assert acquisition == []
+
+        # The skip log is a single INFO line — no repeated stack
+        # traces while the cooldown is active.
+        skip_logs = [
+            r
+            for r in caplog.records
+            if "rss feed skipped (cooldown active)" in r.message
+        ]
+        assert len(skip_logs) == 1
+        assert skip_logs[0].levelname == "INFO"
+
+    async def test_successful_fetch_clears_cooldown(self) -> None:
+        feed = _feed()
+        res = _resilience(threshold=1, cooldown_seconds=600)
+        _record_rss_timeout(feed.url, res)
+
+        # Force the deadline into the past so the next fetch is allowed.
+        from influx.sources import rss as rss_module
+
+        with rss_module._RSS_COOLDOWN_LOCK:
+            state = rss_module._RSS_COOLDOWN_STATE[feed.url]
+            state.deadline_monotonic = (state.deadline_monotonic or 0) - 10_000.0
+
+        async def run() -> None:
+            with patch(
+                "influx.sources.rss._aguarded_fetch",
+                new=AsyncMock(
+                    return_value=FetchResult(
+                        body=b"<rss version='2.0'><channel></channel></rss>",
+                        status_code=200,
+                        content_type="application/rss+xml",
+                        final_url=feed.url,
+                    )
+                ),
+            ):
+                await _fetch_rss_feed(
+                    feed, cache=None, profile="retro-computing", resilience=res
+                )
+
+        await _run_with_telemetry_buckets(run)
+
+        # Streak and deadline both cleared by the successful fetch.
+        snap_streak, deadline = _rss_cooldown_snapshot(feed.url)
+        assert snap_streak == 0
+        assert deadline is None
+
+    async def test_other_feed_not_quarantined_by_neighbour(self) -> None:
+        # One feed in cooldown must not suppress a sibling feed on
+        # the same profile — per-feed-URL isolation.
+        bad_feed = _feed(url=_FEED_URL, name="bad")
+        good_feed = _feed(url=_FEED_URL_OTHER, name="good")
+        res = _resilience(threshold=1, cooldown_seconds=600)
+        _record_rss_timeout(bad_feed.url, res)
+
+        good_response = FetchResult(
+            body=b"<rss version='2.0'><channel></channel></rss>",
+            status_code=200,
+            content_type="application/rss+xml",
+            final_url=good_feed.url,
+        )
+
+        async def run() -> None:
+            with patch(
+                "influx.sources.rss._aguarded_fetch",
+                new=AsyncMock(return_value=good_response),
+            ) as fetch_mock:
+                items_good = await _fetch_rss_feed(
+                    good_feed,
+                    cache=None,
+                    profile="retro-computing",
+                    resilience=res,
+                )
+                # The healthy feed fetched — the bad feed's cooldown
+                # did not bleed onto it.
+                fetch_mock.assert_called_once()
+            # Healthy fetch returned (parsed item list — empty is OK
+            # for the empty channel fixture above).
+            assert items_good == []
+
+        acquisition, cooldown = await _run_with_telemetry_buckets(run)
+        # No degradation recorded for the healthy feed's fetch.
+        assert acquisition == []
+        assert cooldown == []
+
+    async def test_non_timeout_failure_does_not_increment_streak(self) -> None:
+        # A DNS / network / content-type failure must NOT enter the
+        # cooldown path — only ``timeout`` counts.  Otherwise a one-off
+        # transport hiccup could quarantine a healthy feed.
+        feed = _feed()
+        res = _resilience(threshold=2)
+
+        async def run() -> None:
+            dns_error = NetworkError(
+                "DNS resolution failed",
+                url=feed.url,
+                kind="dns",
+                reason="NXDOMAIN",
+            )
+            with patch(
+                "influx.sources.rss._aguarded_fetch",
+                new=AsyncMock(side_effect=dns_error),
+            ):
+                for _ in range(5):
+                    await _fetch_rss_feed(
+                        feed,
+                        cache=None,
+                        profile="retro-computing",
+                        resilience=res,
+                    )
+
+        await _run_with_telemetry_buckets(run)
+
+        snap_streak, deadline = _rss_cooldown_snapshot(feed.url)
+        assert snap_streak == 0
+        assert deadline is None
+
+    async def test_resilience_none_keeps_legacy_behaviour(self) -> None:
+        # Backwards-compat seam: callers that do not pass ``resilience``
+        # see the pre-#163 behaviour — timeouts produce a single
+        # WARNING + acquisition error, no streak tracking.
+        feed = _feed()
+
+        async def run() -> None:
+            with patch(
+                "influx.sources.rss._aguarded_fetch",
+                new=AsyncMock(side_effect=_timeout_error(feed.url)),
+            ):
+                await _fetch_rss_feed(
+                    feed, cache=None, profile="retro-computing", resilience=None
+                )
+
+        await _run_with_telemetry_buckets(run)
+
+        snap_streak, deadline = _rss_cooldown_snapshot(feed.url)
+        assert snap_streak == 0
+        assert deadline is None

--- a/tests/unit/test_run_ledger.py
+++ b/tests/unit/test_run_ledger.py
@@ -356,6 +356,7 @@ def _start_complete(
     invalid_url_rejections_total: int | None = None,
     archive_failures_total: int | None = None,
     source_acquisition_errors: list[dict[str, str]] | None = None,
+    source_cooldown_skips: list[dict[str, str]] | None = None,
 ) -> list[str]:
     """Helper: start + complete a run, return the degraded_reasons list.
 
@@ -369,6 +370,8 @@ def _start_complete(
     ``filter_errors_total`` defaults to ``None`` (no scorer failures).
     ``invalid_url_rejections_total`` defaults to ``None`` (no
     pre-acquire URL rejections — issue #131).
+    ``source_cooldown_skips`` defaults to ``None`` (no cooldown
+    short-circuits this run — issues #146 / #163).
     """
     if fetched_total is None:
         fetched_total = sources_checked if isinstance(sources_checked, int) else 0
@@ -382,6 +385,7 @@ def _start_complete(
         invalid_url_rejections_total=invalid_url_rejections_total,
         archive_failures_total=archive_failures_total,
         source_acquisition_errors=source_acquisition_errors,
+        source_cooldown_skips=source_cooldown_skips,
     )
 
 
@@ -571,6 +575,105 @@ def test_two_consecutive_zero_fetch_runs_after_history_flag_fetch_stall(
     entry = ledger.recent()[0]
     assert entry["degraded"] is True
     assert entry["degraded_reasons"] == ["fetch_stall"]
+
+
+def test_cooldown_skipped_priors_are_skipped_in_fetch_stall_streak(
+    tmp_path: Path,
+) -> None:
+    """Issue #163 review: cooldown-skipped prior runs do not pollute the streak.
+
+    Once a cooldown ends, the next run might legitimately fetch zero
+    items (genuine upstream silence).  In that case ``fetch_stall``
+    should require TWO consecutive *genuine* zero-fetch runs, not be
+    short-circuited by past cooldown runs that simply chose not to
+    fetch.
+
+    Scenario:
+      r-0: healthy (seeds history)
+      r-1: cooldown-skipped     ← not a zero-fetch for streak purposes
+      r-2: cooldown-skipped     ← not a zero-fetch for streak purposes
+      r-3: cooldown ended, fetch returned zero items (genuine silence)
+           — only ONE real zero-fetch run; fetch_stall must NOT fire yet.
+    """
+    ledger = RunLedger(tmp_path / "state")
+    cooldown_skip = [{"source": "rss", "kind": "timeout_cooldown", "detail": "feed"}]
+
+    _start_complete(ledger, run_id="r-0", profile="p", sources_checked=5, ingested=2)
+    _start_complete(
+        ledger,
+        run_id="r-1",
+        profile="p",
+        sources_checked=0,
+        ingested=0,
+        source_cooldown_skips=cooldown_skip,
+    )
+    _start_complete(
+        ledger,
+        run_id="r-2",
+        profile="p",
+        sources_checked=0,
+        ingested=0,
+        source_cooldown_skips=cooldown_skip,
+    )
+    # r-3: genuine zero-fetch after cooldown ended.  Without the
+    # streak-skip, this would see r-1 and r-2 as priors and fire
+    # fetch_stall immediately.  With the skip, only r-3 itself counts
+    # — one zero-fetch is not yet a stall (needs the streak >= 2).
+    reasons = _start_complete(
+        ledger,
+        run_id="r-3",
+        profile="p",
+        sources_checked=0,
+        ingested=0,
+    )
+    assert "fetch_stall" not in reasons
+
+
+def test_zero_fetch_runs_with_cooldown_skips_do_not_ratchet_fetch_stall(
+    tmp_path: Path,
+) -> None:
+    """Issue #163 review: repeated cooldown-skipped runs must not flag fetch_stall.
+
+    Reproduces the exact scenario raised in PR #169 review:
+
+    1. ``r-0``: healthy fetch with ``sources_checked > 0`` seeds history.
+    2. ``r-1``: feed in cooldown → ``sources_checked == 0``,
+       ``fetched_total == 0``, ``source_cooldown_skips`` non-empty.
+    3. ``r-2``: feed still in cooldown → same shape as r-1.
+
+    Without the guard, r-2 ratchets into ``fetch_stall`` on top of
+    ``source_cooldown_skip``, telling the operator both "quarantined on
+    purpose" AND "nothing fetched, upstream drift?".  The latter is
+    misleading — the zeros are fully explained by the cooldown.
+    """
+    ledger = RunLedger(tmp_path / "state")
+    cooldown_skip = [{"source": "rss", "kind": "timeout_cooldown", "detail": "feed"}]
+
+    # Healthy run seeds history.
+    _start_complete(ledger, run_id="r-0", profile="p", sources_checked=5, ingested=2)
+    # First cooldown-skipped run.
+    _start_complete(
+        ledger,
+        run_id="r-1",
+        profile="p",
+        sources_checked=0,
+        ingested=0,
+        source_cooldown_skips=cooldown_skip,
+    )
+    # Second cooldown-skipped run.
+    reasons = _start_complete(
+        ledger,
+        run_id="r-2",
+        profile="p",
+        sources_checked=0,
+        ingested=0,
+        source_cooldown_skips=cooldown_skip,
+    )
+
+    # Cooldown skip stays; fetch_stall must NOT also fire (the zeros
+    # are fully explained by the cooldown).
+    assert "source_cooldown_skip" in reasons
+    assert "fetch_stall" not in reasons
 
 
 def test_two_consecutive_zero_fetch_with_no_history_does_not_flag(


### PR DESCRIPTION
## Summary

A single flaky RSS feed emitting ``httpx.ReadTimeout`` on every fetch (staging-observed: "Two Stop Bits (retro aggregator)") was degrading every scheduled run with the same ``source_acquisition`` reason. Adds a per-feed-URL cooldown state machine to ``_fetch_rss_feed``, mirroring the arXiv 429 cooldown shape (#146):

```
NORMAL  ── timeout_streak >= threshold ──► COOLDOWN
COOLDOWN ── deadline elapsed ─────────► NORMAL  (lazy clear)
COOLDOWN ── successful fetch ─────────► NORMAL  (eager clear)
```

**Behaviour:**

- Only ``timeout`` failures count — DNS / network / content-type-mismatch don't enter the cooldown path, so a one-off transport hiccup cannot quarantine a healthy feed.
- State is **per-feed-URL**, so a slow feed never suppresses sibling feeds on the same profile.
- While in cooldown, ``_fetch_rss_feed`` short-circuits without a network call and records ``source_cooldown_skip`` (already wired through the run ledger) instead of repeating the noisy ``source_acquisition`` stack trace.
- Threshold-crossing emits exactly one WARNING line summarising the quarantine. Subsequent skips emit a single INFO line each.
- A successful fetch eagerly clears both the streak and the deadline.

**New ``[resilience]`` knobs:**

- ``rss_timeout_cooldown_threshold`` (default ``3``)
- ``rss_timeout_cooldown_seconds`` (default ``1800`` = 30min)
- Setting threshold to ``0`` disables the feature wholesale.

Closes #163.

## Test plan

New ``tests/unit/test_rss_cooldown.py`` (18 tests):

- [x] ``TestRecordRssTimeout`` — streak increments, threshold engages cooldown, per-URL isolation, ``threshold=0`` disables, ``cooldown_seconds=0`` keeps streak but never engages deadline.
- [x] ``TestShouldSkipRssForCooldown`` — no-deadline returns false, active deadline returns ``(True, remaining)``, elapsed deadline lazy-clears state, disable-knob respected.
- [x] ``TestRecordRssFetchSuccess`` — eager clear resets streak + deadline; no-op for unknown URL.
- [x] ``TestFetchRssFeedCooldownIntegration``:
  - timeouts below threshold record ``source_acquisition`` only (no cooldown yet)
  - threshold-crossing emits the WARNING and engages cooldown ("Two Stop Bits" staging case)
  - subsequent fetch in cooldown short-circuits (``fetch_mock.assert_not_called()``), records ``source_cooldown_skip``, emits a single INFO line
  - successful fetch clears state
  - a healthy sibling feed is NOT quarantined by a noisy neighbour
  - DNS / non-timeout failures do NOT enter the cooldown path
  - ``resilience=None`` preserves pre-#163 behaviour

Full suite: **2175 passed**.