### PR TITLE
feat: invalid-source-metadata audit + cleanup workflow (#162)

### DIFF
--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -361,6 +361,60 @@ the unsuffixed-slug squatter, which can be removed the same way.
 surfacing both squatters in a single WARNING so they can be cleaned
 in one pass.
 
+## 8b. Cleaning up invalid-source-metadata notes (issue #162)
+
+After an `invalid_source_metadata` repair incident (#150), notes whose
+`source:*` metadata was empty/garbled and whose URL/path/id provided no
+inference fallback were terminalised in-band — they carry
+`influx:source-invalid` + `influx:text-terminal`, and the sweep no
+longer loops on them.  The bad-state notes themselves still need
+operator cleanup; the `invalid-source` subcommand surfaces them and
+applies the recommended action.
+
+When to run it:
+- After a repair-related incident that mentioned `invalid_source_metadata`
+  in WARNINGs, the related notes will carry `influx:source-invalid`.
+- Periodically as a hygiene check (the tag has a clear semantic so a
+  zero-result scan is the expected steady state).
+
+```bash
+# 1. Read-only audit — list every note tagged influx:source-invalid
+#    along with the recommended action (RECONSTRUCT vs TOMBSTONE).
+./scripts/influx-diagnose.py invalid-source
+
+# 2. Inspect one specific note's classification without scanning the
+#    whole index.
+./scripts/influx-diagnose.py invalid-source --id <doc-id>
+
+# 3. Apply the recommended action to one note.
+./scripts/influx-diagnose.py invalid-source --apply --yes <doc-id>
+
+# 4. Apply to every note in the audit (use after reviewing output).
+./scripts/influx-diagnose.py invalid-source --apply --yes-to-all
+```
+
+Action semantics:
+- **RECONSTRUCT** (recoverable note: URL/path/id implies a source).
+  Backfills the `source:*` tag, drops `influx:source-invalid` and
+  `influx:text-terminal`, re-arms `influx:repair-needed`.  The next
+  scheduled sweep picks the note up and re-runs text extraction with
+  the repaired metadata.
+- **TOMBSTONE** (unrecoverable: no inference fallback exists).
+  Adds `influx:tombstone` on top of the existing terminal state and
+  drops `influx:repair-needed`.  The in-band terminal flags
+  (`influx:source-invalid`, `influx:text-terminal`) are preserved as
+  audit history.  Operators can later filter `influx:tombstone` in
+  dashboards / search to exclude operator-cleaned notes.
+
+Safety properties:
+- Default mode is read-only.
+- `--apply` requires either `--yes <doc-id>` (repeatable),
+  `--yes-to-all`, or `--id <doc-id>`.  Passing `--apply` alone aborts.
+- Each rewrite is recorded in Lithos with `agent=influx-diagnose`
+  (override with `--agent <name>`).
+- The subcommand never deletes notes — use the `squatters` subcommand
+  when actual removal is required.
+
 ## 9. Scheduling stagger (issue #87)
 
 Profiles share a single global `[schedule].cron` expression. Within

--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -410,6 +410,11 @@ Safety properties:
 - Default mode is read-only.
 - `--apply` requires either `--yes <doc-id>` (repeatable),
   `--yes-to-all`, or `--id <doc-id>`.  Passing `--apply` alone aborts.
+- **`--apply` refuses any note that does not actually carry
+  `influx:source-invalid`** even when the operator names it via
+  `--id`.  This prevents an off-target id from rewriting an
+  unrelated note's tags.  The read-only audit flags such notes
+  upfront with an `INELIGIBLE` banner.
 - Each rewrite is recorded in Lithos with `agent=influx-diagnose`
   (override with `--agent <name>`).
 - The subcommand never deletes notes — use the `squatters` subcommand

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -1162,6 +1162,11 @@ async def _fetch_invalid_source_notes(
         for note_id in ids:
             try:
                 doc = await client.read_note(note_id=note_id)
+            except (KeyboardInterrupt, SystemExit):
+                # Operator-initiated cancellation must propagate so
+                # the script can stop cleanly instead of looping over
+                # remaining ids.
+                raise
             except BaseException as exc:  # noqa: BLE001
                 chain = _format_exception_chain(exc)
                 print(
@@ -1226,6 +1231,10 @@ async def _apply_invalid_source_action(
                 note_type=str(note.get("note_type") or "summary"),
                 namespace=str(note.get("namespace") or "influx"),
             )
+        except (KeyboardInterrupt, SystemExit):
+            # Operator cancellation must abort the apply pass cleanly
+            # rather than being demoted to a "refused" result.
+            raise
         except BaseException as exc:  # noqa: BLE001
             return "refused", f"write failed: {_format_exception_chain(exc)}"
         status = getattr(result, "status", "") or getattr(result, "outcome", "")

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -23,6 +23,10 @@ Subcommands
                     recovery chain (squatter-shape dispatch + suffix
                     retry); read from
                     ${INFLUX_STATE_PATH}/unresolved-slug-collisions.jsonl
+    invalid-source  Audit / clean up notes tagged
+                    ``influx:source-invalid`` (issue #162); default
+                    read-only, ``--apply`` reconstructs recoverable
+                    notes or tombstones unrecoverable ones
     cancel          Print the curl line for cancelling an in-flight run
                     (this script never sends destructive HTTP itself)
 
@@ -1128,6 +1132,214 @@ def cmd_slug_collision_backlog(args: argparse.Namespace) -> int:
     return 0
 
 
+async def _fetch_invalid_source_notes(
+    *,
+    lithos_url: str,
+    note_ids: list[str] | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Fetch notes carrying ``influx:source-invalid`` (issue #162).
+
+    When *note_ids* is provided, fetches those specific notes via
+    ``lithos_read`` and skips the tag-based list scan.  Otherwise
+    lists every note tagged ``influx:source-invalid`` (across all
+    profiles — this is operator cleanup, not a per-profile sweep)
+    and reads each one to obtain the full body for inference.
+    """
+    client = _make_lithos_client(lithos_url)
+    try:
+        if note_ids:
+            ids = list(note_ids)
+        else:
+            body = await client.list_notes_body(
+                tags=["influx:source-invalid"],
+                limit=limit,
+            )
+            items = body.get("items", [])
+            ids = [str(item.get("id", "")) for item in items if item.get("id")]
+
+        notes: list[dict[str, Any]] = []
+        for note_id in ids:
+            try:
+                doc = await client.read_note(note_id=note_id)
+            except BaseException as exc:  # noqa: BLE001
+                chain = _format_exception_chain(exc)
+                print(
+                    f"warning: read failed for {note_id}: {chain} — skipping",
+                    file=sys.stderr,
+                )
+                continue
+            notes.append(doc)
+        return notes
+    finally:
+        await client.close()
+
+
+async def _apply_invalid_source_action(
+    *,
+    lithos_url: str,
+    note: dict[str, Any],
+    new_tags: list[str],
+    agent: str,
+) -> tuple[str, str]:
+    """Rewrite *note* with *new_tags* via ``lithos_write`` (issue #162).
+
+    Returns ``(outcome, reason)`` where ``outcome`` is one of
+    ``"applied"`` (rewrite succeeded), ``"already_clean"`` (the tag set
+    was already in the target shape — no rewrite needed), or
+    ``"refused"`` (write failed; ``reason`` carries the diagnostic).
+
+    Mirrors the per-id confirmation shape of :func:`_delete_squatter`
+    so the operator workflow is consistent across cleanup subcommands.
+    """
+    existing_tags = [t for t in (note.get("tags") or []) if isinstance(t, str)]
+    if sorted(existing_tags) == sorted(new_tags):
+        return "already_clean", "no tag change required"
+
+    client = _make_lithos_client(lithos_url)
+    try:
+        try:
+            result = await client.write_note(
+                title=str(note.get("title", "")),
+                content=str(note.get("content", "")),
+                agent=agent,
+                path=str(note.get("path", "")),
+                source_url=str(note.get("source_url", "")),
+                tags=list(new_tags),
+                confidence=float(note.get("confidence") or 0.0),
+                note_type=str(note.get("note_type") or "summary"),
+                namespace=str(note.get("namespace") or "influx"),
+            )
+        except BaseException as exc:  # noqa: BLE001
+            return "refused", f"write failed: {_format_exception_chain(exc)}"
+        status = getattr(result, "status", "") or getattr(result, "outcome", "")
+        if str(status) in {"created", "updated"}:
+            return "applied", str(status)
+        # Surface anything else (slug_collision survivor, invalid_input, …)
+        # so the operator can decide how to proceed.
+        return "refused", f"unexpected write status: {status!r} ({result!r})"
+    finally:
+        await client.close()
+
+
+def cmd_invalid_source(args: argparse.Namespace) -> int:
+    """Audit and clean up notes tagged ``influx:source-invalid`` (issue #162).
+
+    Default mode (no ``--apply``): scans Lithos for notes carrying the
+    invalid-source-metadata terminal tag and prints a per-note action
+    recommendation.  Read-only — no writes.
+
+    ``--apply`` enables the rewrite path:
+
+    * Recoverable notes (URL / path / id hints support inference) are
+      *reconstructed*: the ``source:*`` tag is backfilled, in-band
+      terminal flags are dropped, and ``influx:repair-needed`` is
+      re-armed so the next sweep retries text extraction cleanly.
+    * Unrecoverable notes are *tombstoned*: an ``influx:tombstone``
+      tag is added on top of the existing terminal state so the note
+      is filterable as "operator-cleaned".
+
+    ``--yes <doc-id>`` (repeatable) or ``--yes-to-all`` are required
+    alongside ``--apply``, mirroring the ``squatters`` subcommand's
+    confirmation discipline.
+    """
+    env = _load_env(args.env)
+    _ensure_project_runtime_or_reexec()
+    lithos_url = _read_lithos_url(args, env)
+
+    import asyncio
+
+    from influx.audit_invalid_source import (
+        audit_notes,
+        format_audit_report,
+        reconstruct_tags,
+        tombstone_tags,
+    )
+
+    notes = asyncio.run(
+        _fetch_invalid_source_notes(
+            lithos_url=lithos_url,
+            note_ids=list(args.id or []),
+            limit=args.limit,
+        )
+    )
+    findings = audit_notes(notes)
+
+    print(format_audit_report(findings))
+
+    if not args.apply:
+        print(
+            "Default mode is read-only.  To apply the recommended action, "
+            "re-run with:\n"
+            "    --apply --yes <doc-id>      (per-id confirmation, repeatable)\n"
+            "    --apply --id <doc-id>       (skip list scan; targets one note)\n"
+            "    --apply --yes-to-all        (apply to every note listed above)"
+        )
+        return 0
+
+    # ── Apply path ─────────────────────────────────────────────────
+    if args.id:
+        confirmed = {str(i) for i in args.id}
+    else:
+        confirmed = set(args.yes or [])
+        if args.yes_to_all:
+            confirmed.update(f.note_id for f in findings)
+        if not confirmed:
+            sys.exit(
+                "--apply requires at least one --yes <doc-id>, --yes-to-all, "
+                "or --id <doc-id>.  Aborted."
+            )
+
+    finding_by_id = {f.note_id: f for f in findings}
+    note_by_id = {str(n.get("id", "")): n for n in notes}
+
+    unknown = confirmed - finding_by_id.keys()
+    if unknown:
+        print(
+            "Warning: --yes ids not present in audit results: "
+            + ", ".join(sorted(unknown))
+        )
+        confirmed -= unknown
+    if not confirmed:
+        sys.exit("No matching ids; nothing to apply.")
+
+    applied = 0
+    already_clean = 0
+    refused = 0
+    for note_id in sorted(confirmed):
+        finding = finding_by_id[note_id]
+        note = note_by_id[note_id]
+        if finding.recoverable:
+            assert finding.inferred_source is not None  # narrowed
+            new_tags = reconstruct_tags(note, inferred_source=finding.inferred_source)
+            action_label = "RECONSTRUCT"
+        else:
+            new_tags = tombstone_tags(note)
+            action_label = "TOMBSTONE"
+
+        outcome, reason = asyncio.run(
+            _apply_invalid_source_action(
+                lithos_url=lithos_url,
+                note=note,
+                new_tags=new_tags,
+                agent=args.agent,
+            )
+        )
+        if outcome == "applied":
+            print(f"{action_label}  doc_id={note_id}  ({reason})")
+            applied += 1
+        elif outcome == "already_clean":
+            print(f"SKIPPED       doc_id={note_id}  ({reason})")
+            already_clean += 1
+        else:
+            print(f"REFUSED       doc_id={note_id}  reason={reason}")
+            refused += 1
+
+    print()
+    print(f"Summary: applied={applied} already_clean={already_clean} refused={refused}")
+    return 0 if refused == 0 else 1
+
+
 def cmd_cancel(args: argparse.Namespace) -> int:
     env = _load_env(args.env)
     host = env.get("INFLUX_ADMIN_BIND_HOST", "127.0.0.1")
@@ -1306,6 +1518,76 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     p_backlog.set_defaults(func=cmd_slug_collision_backlog)
+
+    p_invalid = sub.add_parser(
+        "invalid-source",
+        help=(
+            "audit / clean up notes tagged 'influx:source-invalid' "
+            "(persisted notes with empty or garbled source metadata, "
+            "issue #162).  Default is read-only; --apply enables rewrite."
+        ),
+    )
+    p_invalid.add_argument(
+        "--id",
+        action="append",
+        metavar="DOC_ID",
+        help=(
+            "act on a known note-id directly, bypassing the lithos_list scan "
+            "(repeatable).  Without --apply, fetches each note and reports "
+            "the recommended action.  With --apply, applies that action "
+            "without an extra --yes."
+        ),
+    )
+    p_invalid.add_argument(
+        "--limit",
+        type=int,
+        help=(
+            "cap the number of notes returned by the lithos_list scan (default: no cap)"
+        ),
+    )
+    p_invalid.add_argument(
+        "--apply",
+        action="store_true",
+        help=(
+            "actually apply the recommended action (reconstruct for "
+            "recoverable notes, tombstone for unrecoverable ones).  "
+            "Default is read-only audit.  Must be combined with --yes "
+            "<doc-id>, --yes-to-all, or --id."
+        ),
+    )
+    p_invalid.add_argument(
+        "--yes",
+        action="append",
+        metavar="DOC_ID",
+        help=(
+            "with --apply, confirm a specific doc-id for rewrite "
+            "(repeatable).  Required unless --yes-to-all or --id is used."
+        ),
+    )
+    p_invalid.add_argument(
+        "--yes-to-all",
+        action="store_true",
+        help=(
+            "with --apply, apply the recommended action to every note "
+            "listed in the audit.  Use after reviewing the read-only output."
+        ),
+    )
+    p_invalid.add_argument(
+        "--agent",
+        default="influx-diagnose",
+        help=(
+            "agent name passed to lithos_write for the audit trail "
+            "(default: influx-diagnose)"
+        ),
+    )
+    p_invalid.add_argument(
+        "--lithos-url",
+        help=(
+            "override the Lithos MCP/SSE URL.  Default resolution: "
+            "$LITHOS_URL, then [lithos] url in $INFLUX_DATA_PATH/influx.toml."
+        ),
+    )
+    p_invalid.set_defaults(func=cmd_invalid_source)
 
     p_cancel = sub.add_parser(
         "cancel",

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -1191,8 +1191,24 @@ async def _apply_invalid_source_action(
 
     Mirrors the per-id confirmation shape of :func:`_delete_squatter`
     so the operator workflow is consistent across cleanup subcommands.
+
+    Safety boundary (PR #170 review)
+    --------------------------------
+    Refuses any note whose existing tag list does NOT contain
+    ``influx:source-invalid``.  The ``--id`` targeting shortcut
+    bypasses the tag-filtered ``lithos_list`` scan, so a healthy note
+    could otherwise be fetched, classified, and rewritten — for an
+    operator cleanup tool the blast radius is too large.  Refusing at
+    the write boundary makes the eligibility check unmissable from
+    every caller path.
     """
     existing_tags = [t for t in (note.get("tags") or []) if isinstance(t, str)]
+    if "influx:source-invalid" not in existing_tags:
+        return (
+            "refused",
+            "note is not tagged influx:source-invalid; apply refuses to rewrite "
+            "outside the invalid-source-metadata cleanup scope",
+        )
     if sorted(existing_tags) == sorted(new_tags):
         return "already_clean", "no tag change required"
 
@@ -1264,6 +1280,27 @@ def cmd_invalid_source(args: argparse.Namespace) -> int:
         )
     )
     findings = audit_notes(notes)
+
+    # PR #170 review: when ``--id`` is used, the helper bypasses the
+    # tag-filtered ``lithos_list`` scan.  Surface any fetched note that
+    # does not actually carry ``influx:source-invalid`` so the operator
+    # sees the ineligibility before reading the (possibly misleading)
+    # RECONSTRUCT / TOMBSTONE recommendation — and so it's clear why
+    # ``--apply`` will refuse below.
+    ineligible_ids = [
+        f.note_id for f in findings if "influx:source-invalid" not in f.tags
+    ]
+    if ineligible_ids:
+        print(
+            "WARNING: the following notes do not carry "
+            "'influx:source-invalid' and are INELIGIBLE for this workflow.  "
+            "--apply will refuse them.  Suspected cause: an --id targeting a "
+            "note that was never in the invalid-source-metadata terminal "
+            "state, or was already operator-cleaned.\n"
+        )
+        for nid in ineligible_ids:
+            print(f"  INELIGIBLE  {nid}")
+        print()
 
     print(format_audit_report(findings))
 

--- a/src/influx/audit_invalid_source.py
+++ b/src/influx/audit_invalid_source.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from influx.repair_hooks import _note_source_tag, infer_note_source
+from influx.repair_hooks import infer_note_source, note_source_tag
 
 __all__ = [
     "INVALID_SOURCE_TAG",
@@ -114,7 +114,7 @@ def audit_one_note(note: dict[str, Any]) -> AuditFinding:
         title=str(note.get("title", "")),
         path=str(note.get("path", "")),
         source_url=str(note.get("source_url", "")),
-        existing_source_tag=_note_source_tag(note),
+        existing_source_tag=note_source_tag(note),
         inferred_source=infer_note_source(note),
         tags=tags,
     )
@@ -150,12 +150,18 @@ def reconstruct_tags(note: dict[str, Any], *, inferred_source: str) -> list[str]
     ``rewrite``).  Does NOT mutate the input note.
     """
     tags = [str(t) for t in note.get("tags", []) if isinstance(t, str)]
+    # ``TOMBSTONE_TAG`` is dropped here because a note that was
+    # previously tombstoned may become recoverable as new inference
+    # paths land — leaving the tombstone tag in place would conflict
+    # with the reconstruct semantics ("re-arm for the next sweep")
+    # and keep dashboards / filters treating the note as
+    # permanently excluded.
     rebuilt = [
         t
         for t in tags
         if not t.startswith("source:")
         and not t.startswith("text:")
-        and t not in {INVALID_SOURCE_TAG, TEXT_TERMINAL_TAG}
+        and t not in {INVALID_SOURCE_TAG, TEXT_TERMINAL_TAG, TOMBSTONE_TAG}
     ]
     rebuilt.append(f"source:{inferred_source}")
     if REPAIR_NEEDED_TAG not in rebuilt:
@@ -195,7 +201,7 @@ def format_audit_report(findings: list[AuditFinding]) -> str:
     to ``less``.
     """
     if not findings:
-        return "No notes carry influx:source-invalid — nothing to clean up."
+        return f"No notes carry {INVALID_SOURCE_TAG} — nothing to clean up."
 
     reconstructable = sum(1 for f in findings if f.recoverable)
     tombstoneable = len(findings) - reconstructable

--- a/src/influx/audit_invalid_source.py
+++ b/src/influx/audit_invalid_source.py
@@ -1,0 +1,227 @@
+"""Audit and cleanup of notes with invalid source metadata (issue #162).
+
+Companion to the in-band repair fix in #150 (which terminalised
+mid-flight ``invalid_source_metadata`` failures so the sweep stopped
+looping).  This module is the *after-incident* operator path:
+already-persisted notes that carry the ``influx:source-invalid`` tag
+need a separate audit + cleanup workflow because the in-band path
+only stops the retry loop — it does NOT remove or repair the
+historical noise.
+
+Concepts
+--------
+* **Finding** — one note's audit classification.  ``recoverable`` when
+  :func:`influx.repair_hooks.infer_note_source` can derive a
+  dispatchable source from URL / path / id hints; ``unrecoverable``
+  otherwise.
+* **Recommended action** — derived from the finding:
+
+  * ``reconstruct`` for recoverable notes — backfill the ``source:*``
+    tag, drop ``influx:source-invalid`` + ``influx:text-terminal``,
+    re-arm ``influx:repair-needed`` so the next sweep picks the note
+    up and re-extracts cleanly.
+  * ``tombstone`` for unrecoverable notes — leave the existing
+    terminal state in place and add an explicit
+    ``influx:tombstone`` tag so the note is discoverable as
+    "operator-cleaned, do not re-process".
+
+Both actions are tag-level (no destructive deletes).  Deletion lives
+in :mod:`influx-diagnose squatters` for the rare cases where the note
+must be removed entirely.
+
+Pure module — no Lithos client dependency, no async, no IO.  The
+operator entrypoint in ``scripts/influx-diagnose.py`` wraps it with
+the MCP fetch / write plumbing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from influx.repair_hooks import _note_source_tag, infer_note_source
+
+__all__ = [
+    "INVALID_SOURCE_TAG",
+    "TEXT_TERMINAL_TAG",
+    "TOMBSTONE_TAG",
+    "AuditFinding",
+    "audit_one_note",
+    "audit_notes",
+    "format_audit_report",
+    "reconstruct_tags",
+    "tombstone_tags",
+]
+
+
+# Tag literals — single source of truth for the audit/cleanup contract.
+INVALID_SOURCE_TAG = "influx:source-invalid"
+TEXT_TERMINAL_TAG = "influx:text-terminal"
+REPAIR_NEEDED_TAG = "influx:repair-needed"
+# Issue #162: applied by the cleanup workflow on unrecoverable notes
+# (no URL / path / id hint to infer a source from).  Distinct from
+# ``influx:source-invalid`` (which the in-band repair sets) because
+# the tombstone signals "operator has reviewed this and decided no
+# recovery is possible" — a permanent, post-cleanup state.  Future
+# sweeps and dashboards can filter on this tag to exclude
+# operator-cleaned notes from "what's still broken?" queries.
+TOMBSTONE_TAG = "influx:tombstone"
+
+
+AuditAction = Literal["reconstruct", "tombstone"]
+
+
+@dataclass(frozen=True, slots=True)
+class AuditFinding:
+    """Audit classification for one note.
+
+    ``recoverable`` mirrors :func:`infer_note_source`'s return value:
+    when inference yields a dispatchable ``source:*`` suffix the note
+    can be reconstructed in-place; otherwise it is tombstoned.
+    """
+
+    note_id: str
+    title: str
+    path: str
+    source_url: str
+    existing_source_tag: str
+    inferred_source: str | None
+    tags: tuple[str, ...]
+
+    @property
+    def recoverable(self) -> bool:
+        """Whether the note has enough metadata to reconstruct."""
+        return self.inferred_source is not None
+
+    @property
+    def recommended_action(self) -> AuditAction:
+        """Default action implied by :attr:`recoverable`."""
+        return "reconstruct" if self.recoverable else "tombstone"
+
+
+def audit_one_note(note: dict[str, Any]) -> AuditFinding:
+    """Inspect one note (as returned by ``lithos_read``) and classify it.
+
+    Returns an :class:`AuditFinding` regardless of whether the note
+    carries the ``influx:source-invalid`` tag; the caller is expected
+    to filter the candidate set upstream (the CLI does this via
+    ``lithos_list``).  Accepting any note dict here keeps the helper
+    test-friendly.
+    """
+    tags = tuple(str(t) for t in note.get("tags", []) if isinstance(t, str))
+    return AuditFinding(
+        note_id=str(note.get("id", "")),
+        title=str(note.get("title", "")),
+        path=str(note.get("path", "")),
+        source_url=str(note.get("source_url", "")),
+        existing_source_tag=_note_source_tag(note),
+        inferred_source=infer_note_source(note),
+        tags=tags,
+    )
+
+
+def audit_notes(notes: list[dict[str, Any]]) -> list[AuditFinding]:
+    """Vectorised :func:`audit_one_note` over a list of notes.
+
+    Convenience wrapper — the CLI scans pages of notes returned by
+    ``lithos_list`` + ``lithos_read``.  Order-preserving.
+    """
+    return [audit_one_note(note) for note in notes]
+
+
+def reconstruct_tags(note: dict[str, Any], *, inferred_source: str) -> list[str]:
+    """Compute the tag set for a *reconstruct* action.
+
+    Operations applied to the existing tag list, in order:
+
+    1. Drop any existing ``source:*`` tag.
+    2. Append ``source:<inferred_source>`` (the backfilled tag).
+    3. Drop ``influx:source-invalid`` and ``influx:text-terminal`` so
+       the next sweep re-runs text extraction with a valid source.
+    4. Add ``influx:repair-needed`` so the next sweep actually picks
+       the note up (the in-band terminal flip cleared it; we re-arm
+       it here because the metadata is now repaired).
+    5. Drop any pre-existing ``text:*`` tag (e.g.
+       ``text:abstract-only``) so the next sweep re-derives the text
+       provenance from the cascade rather than carrying over the
+       degraded marker.
+
+    Returns the new tag list (caller passes it to ``lithos_write`` /
+    ``rewrite``).  Does NOT mutate the input note.
+    """
+    tags = [str(t) for t in note.get("tags", []) if isinstance(t, str)]
+    rebuilt = [
+        t
+        for t in tags
+        if not t.startswith("source:")
+        and not t.startswith("text:")
+        and t not in {INVALID_SOURCE_TAG, TEXT_TERMINAL_TAG}
+    ]
+    rebuilt.append(f"source:{inferred_source}")
+    if REPAIR_NEEDED_TAG not in rebuilt:
+        rebuilt.append(REPAIR_NEEDED_TAG)
+    return rebuilt
+
+
+def tombstone_tags(note: dict[str, Any]) -> list[str]:
+    """Compute the tag set for a *tombstone* action.
+
+    Adds ``influx:tombstone`` to the existing tags and removes
+    ``influx:repair-needed`` (if present) so subsequent sweeps
+    immediately skip the note.  The in-band terminal tags
+    (``influx:text-terminal``, ``influx:source-invalid``) are
+    *preserved* — they document the original state, and the
+    tombstone tag layers on top to signal "operator-cleaned".
+
+    Returns the new tag list.  Does NOT mutate the input note.
+    """
+    tags = [str(t) for t in note.get("tags", []) if isinstance(t, str)]
+    rebuilt = [t for t in tags if t != REPAIR_NEEDED_TAG]
+    if TOMBSTONE_TAG not in rebuilt:
+        rebuilt.append(TOMBSTONE_TAG)
+    return rebuilt
+
+
+def format_audit_report(findings: list[AuditFinding]) -> str:
+    """Return a concise human-readable report of *findings*.
+
+    Layout:
+
+    * Header summary line: counts of recoverable / unrecoverable.
+    * One block per finding: id, title, path, action, hints.
+
+    Designed for terminal consumption (``influx-diagnose`` print
+    stream).  Stable, line-oriented so operators can ``grep`` or pipe
+    to ``less``.
+    """
+    if not findings:
+        return "No notes carry influx:source-invalid — nothing to clean up."
+
+    reconstructable = sum(1 for f in findings if f.recoverable)
+    tombstoneable = len(findings) - reconstructable
+
+    lines: list[str] = []
+    lines.append(
+        f"Found {len(findings)} note(s) tagged {INVALID_SOURCE_TAG}: "
+        f"{reconstructable} recoverable, {tombstoneable} unrecoverable.\n"
+    )
+    for f in findings:
+        action = f.recommended_action.upper()
+        lines.append(f"  [{action}] {f.note_id}")
+        lines.append(f"      title       : {f.title!r}")
+        lines.append(f"      path        : {f.path or '(empty)'}")
+        if f.source_url:
+            lines.append(f"      source_url  : {f.source_url}")
+        existing = f.existing_source_tag or "(empty)"
+        lines.append(f"      existing tag: source:{existing}")
+        if f.recoverable:
+            lines.append(
+                f"      inferred    : source:{f.inferred_source}  "
+                f"(reconstruct will backfill this tag)"
+            )
+        else:
+            lines.append(
+                "      inferred    : (none — URL / path / id provide no fallback)"
+            )
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -226,6 +226,15 @@ def _note_source_tag(note: dict[str, object]) -> str:
     return _find_tag(_note_tags(note), _SOURCE_TAG_PREFIX) or ""
 
 
+# Public alias: cross-module callers (e.g. ``influx.audit_invalid_source``,
+# #162) should import :func:`note_source_tag` rather than the leading-
+# underscore variant so a future refactor inside this module does not
+# break them.  The bare function above is retained because it is
+# referenced from many internal helpers in this module and renaming
+# them all is needless churn.
+note_source_tag = _note_source_tag
+
+
 def _is_rss_source(source: str) -> bool:
     """Return whether *source* names an RSS feed source tag.
 

--- a/tests/unit/test_audit_invalid_source.py
+++ b/tests/unit/test_audit_invalid_source.py
@@ -1,0 +1,321 @@
+"""Tests for the invalid-source-metadata audit + cleanup helpers (#162).
+
+The module is the post-incident operator path for notes that have
+already been persisted with empty/garbled ``source:*`` metadata.  These
+tests pin:
+
+* Classification: recoverable (URL / path / id hints present) vs
+  unrecoverable (genuine metadata loss).
+* Tag rewrites: ``reconstruct_tags`` backfills the source tag,
+  drops the in-band terminal flags, and re-arms ``influx:repair-needed``;
+  ``tombstone_tags`` layers ``influx:tombstone`` on top of the existing
+  terminal state.
+* Report formatting: per-note action label, hint preview, and the
+  recoverable / unrecoverable totals.
+"""
+
+from __future__ import annotations
+
+from influx.audit_invalid_source import (
+    INVALID_SOURCE_TAG,
+    REPAIR_NEEDED_TAG,
+    TEXT_TERMINAL_TAG,
+    TOMBSTONE_TAG,
+    AuditFinding,
+    audit_notes,
+    audit_one_note,
+    format_audit_report,
+    reconstruct_tags,
+    tombstone_tags,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _make_invalid_note(
+    *,
+    note_id: str = "27d6b6f5-b3ce-4d0a-97c9-4acecc0cb3b8",
+    title: str = "Orphan note",
+    path: str = "",
+    source_url: str = "",
+    extra_tags: list[str] | None = None,
+) -> dict[str, object]:
+    """Build a staging-shaped invalid-source note dict."""
+    return {
+        "id": note_id,
+        "title": title,
+        "path": path,
+        "source_url": source_url,
+        "tags": [
+            "profile:retro-computing",
+            "text:abstract-only",
+            TEXT_TERMINAL_TAG,
+            INVALID_SOURCE_TAG,
+            *(extra_tags or []),
+        ],
+    }
+
+
+# ── Classification ────────────────────────────────────────────────────
+
+
+class TestAuditOneNote:
+    """Classification covers the recoverable / unrecoverable split."""
+
+    def test_unrecoverable_when_no_metadata_signals(self) -> None:
+        # Mirrors the staging evidence verbatim: empty source, empty
+        # path, no source_url, no recognisable id prefix.
+        note = _make_invalid_note(path="", source_url="")
+        finding = audit_one_note(note)
+        assert finding.recoverable is False
+        assert finding.recommended_action == "tombstone"
+        assert finding.inferred_source is None
+        assert finding.existing_source_tag == ""
+
+    def test_recoverable_when_source_url_points_to_arxiv(self) -> None:
+        note = _make_invalid_note(source_url="https://arxiv.org/abs/2601.12345")
+        finding = audit_one_note(note)
+        assert finding.recoverable is True
+        assert finding.recommended_action == "reconstruct"
+        assert finding.inferred_source == "arxiv"
+
+    def test_recoverable_when_note_path_implies_source(self) -> None:
+        note = _make_invalid_note(path="papers/arxiv/2026/04")
+        finding = audit_one_note(note)
+        assert finding.recoverable is True
+        assert finding.inferred_source == "arxiv"
+
+    def test_recoverable_when_note_id_prefix_is_recognisable(self) -> None:
+        # arXiv notes have id prefix ``arxiv-``.  Path/url-empty notes
+        # that still carry the id prefix recover cleanly.
+        note = _make_invalid_note(note_id="arxiv-2601.12345")
+        finding = audit_one_note(note)
+        assert finding.recoverable is True
+        assert finding.inferred_source == "arxiv"
+
+    def test_existing_non_empty_source_tag_is_preserved(self) -> None:
+        # If the existing source tag has a value (even one we don't
+        # currently dispatch — e.g. "hackernews") the audit honours it.
+        # The text-extraction path handles unsupported but well-formed
+        # sources separately; that's not this workflow's job.
+        note = _make_invalid_note(
+            extra_tags=["source:hackernews"],
+        )
+        finding = audit_one_note(note)
+        assert finding.existing_source_tag == "hackernews"
+        assert finding.inferred_source == "hackernews"
+        assert finding.recoverable is True
+
+
+class TestAuditNotes:
+    """``audit_notes`` runs over a list preserving order."""
+
+    def test_returns_one_finding_per_note(self) -> None:
+        notes = [
+            _make_invalid_note(note_id="a"),
+            _make_invalid_note(note_id="b", path="papers/arxiv/2026/04"),
+        ]
+        findings = audit_notes(notes)
+        assert len(findings) == 2
+        assert [f.note_id for f in findings] == ["a", "b"]
+        # a is unrecoverable, b is recoverable.
+        assert findings[0].recoverable is False
+        assert findings[1].recoverable is True
+
+
+# ── Tag rewrites ──────────────────────────────────────────────────────
+
+
+class TestReconstructTags:
+    """``reconstruct_tags`` re-arms the note for the next sweep."""
+
+    def test_backfills_source_tag_and_clears_terminal_flags(self) -> None:
+        note = _make_invalid_note()
+        result = reconstruct_tags(note, inferred_source="arxiv")
+
+        assert "source:arxiv" in result
+        assert INVALID_SOURCE_TAG not in result
+        assert TEXT_TERMINAL_TAG not in result
+        assert REPAIR_NEEDED_TAG in result
+
+    def test_drops_existing_empty_or_garbled_source_tag(self) -> None:
+        # A note may carry an empty ``source:`` tag from the bad-state
+        # write — the reconstruct must replace it, not duplicate it.
+        note = _make_invalid_note(extra_tags=["source:"])
+        result = reconstruct_tags(note, inferred_source="arxiv")
+        # Exactly one source:* tag in the rebuilt list.
+        source_tags = [t for t in result if t.startswith("source:")]
+        assert source_tags == ["source:arxiv"]
+
+    def test_drops_existing_text_tag(self) -> None:
+        # The note carries ``text:abstract-only`` from the in-band
+        # terminal flip.  Reconstruct must drop it so the next sweep
+        # re-derives the text provenance from a clean cascade.
+        note = _make_invalid_note()
+        result = reconstruct_tags(note, inferred_source="arxiv")
+        assert not any(t.startswith("text:") for t in result)
+
+    def test_preserves_unrelated_tags(self) -> None:
+        note = _make_invalid_note(
+            extra_tags=["profile:other", "schema:1", "ingested-by:influx"],
+        )
+        result = reconstruct_tags(note, inferred_source="arxiv")
+        for tag in ("profile:other", "schema:1", "ingested-by:influx"):
+            assert tag in result
+
+    def test_does_not_mutate_input_note(self) -> None:
+        note = _make_invalid_note()
+        original_tags = list(note["tags"])  # type: ignore[arg-type]
+        reconstruct_tags(note, inferred_source="arxiv")
+        assert note["tags"] == original_tags
+
+
+class TestTombstoneTags:
+    """``tombstone_tags`` adds the tombstone marker and drops repair-needed."""
+
+    def test_adds_tombstone_tag(self) -> None:
+        note = _make_invalid_note()
+        result = tombstone_tags(note)
+        assert TOMBSTONE_TAG in result
+
+    def test_preserves_in_band_terminal_state(self) -> None:
+        # The in-band terminal flags document the original state; the
+        # tombstone tag layers on top.  Operators reading the note's
+        # tags later see the full lifecycle: invalid → text-terminal →
+        # tombstone.
+        note = _make_invalid_note()
+        result = tombstone_tags(note)
+        assert INVALID_SOURCE_TAG in result
+        assert TEXT_TERMINAL_TAG in result
+
+    def test_drops_repair_needed_if_present(self) -> None:
+        note = _make_invalid_note(extra_tags=[REPAIR_NEEDED_TAG])
+        result = tombstone_tags(note)
+        assert REPAIR_NEEDED_TAG not in result
+
+    def test_idempotent(self) -> None:
+        # A second call must not double-tag.
+        note = _make_invalid_note()
+        once = tombstone_tags(note)
+        # Replace the note's tag list with the first-pass output and
+        # re-run.  Exactly one tombstone tag in the result.
+        note_after = dict(note)
+        note_after["tags"] = once
+        twice = tombstone_tags(note_after)
+        assert twice.count(TOMBSTONE_TAG) == 1
+
+    def test_does_not_mutate_input_note(self) -> None:
+        note = _make_invalid_note()
+        original_tags = list(note["tags"])  # type: ignore[arg-type]
+        tombstone_tags(note)
+        assert note["tags"] == original_tags
+
+
+# ── Report formatting ─────────────────────────────────────────────────
+
+
+class TestFormatAuditReport:
+    """``format_audit_report`` produces an operator-friendly summary."""
+
+    def test_empty_input_returns_no_op_line(self) -> None:
+        report = format_audit_report([])
+        assert "No notes carry" in report
+        assert INVALID_SOURCE_TAG in report
+
+    def test_includes_per_note_action_label(self) -> None:
+        findings = [
+            AuditFinding(
+                note_id="recoverable-id",
+                title="Recoverable Note",
+                path="papers/arxiv/2026/04",
+                source_url="https://arxiv.org/abs/2601.12345",
+                existing_source_tag="",
+                inferred_source="arxiv",
+                tags=(INVALID_SOURCE_TAG,),
+            ),
+            AuditFinding(
+                note_id="lost-id",
+                title="Lost Note",
+                path="",
+                source_url="",
+                existing_source_tag="",
+                inferred_source=None,
+                tags=(INVALID_SOURCE_TAG,),
+            ),
+        ]
+        report = format_audit_report(findings)
+
+        assert "[RECONSTRUCT] recoverable-id" in report
+        assert "[TOMBSTONE] lost-id" in report
+        assert "1 recoverable, 1 unrecoverable" in report
+        # Hint preview surfaces the inferred source for the recoverable
+        # note and the "no fallback" note for the unrecoverable one.
+        assert "source:arxiv" in report
+        assert "no fallback" in report.lower() or "(none" in report
+
+    def test_concise_when_metadata_missing(self) -> None:
+        # An unrecoverable note with empty path/source_url should not
+        # produce stray ``None`` or ``''`` in the report.
+        findings = [
+            AuditFinding(
+                note_id="x",
+                title="",
+                path="",
+                source_url="",
+                existing_source_tag="",
+                inferred_source=None,
+                tags=(INVALID_SOURCE_TAG,),
+            ),
+        ]
+        report = format_audit_report(findings)
+        # Render uses ``(empty)`` for missing path so the column lines
+        # up; ``source_url`` is omitted entirely when empty.
+        assert "(empty)" in report
+        assert "source_url" not in report
+
+
+# ── Audit + apply round-trip ──────────────────────────────────────────
+
+
+class TestAuditAndApplyRoundTrip:
+    """Audit findings drive the right action without operator override.
+
+    Pins the operator workflow contract: the audit classifies, the
+    apply step uses the classification's recommended action.  A
+    re-audit of the post-apply state shows the cleanup landed.
+    """
+
+    def test_recoverable_note_becomes_dispatchable_after_reconstruct(self) -> None:
+        note = _make_invalid_note(source_url="https://arxiv.org/abs/2601.12345")
+        finding = audit_one_note(note)
+        assert finding.recommended_action == "reconstruct"
+        assert finding.inferred_source == "arxiv"
+
+        new_tags = reconstruct_tags(note, inferred_source=finding.inferred_source)
+
+        # Simulate the rewrite by swapping in the new tag list.
+        note_after = dict(note)
+        note_after["tags"] = new_tags
+
+        # Re-audit: the note is no longer invalid + no longer terminal.
+        finding_after = audit_one_note(note_after)
+        assert INVALID_SOURCE_TAG not in finding_after.tags
+        assert TEXT_TERMINAL_TAG not in finding_after.tags
+        assert REPAIR_NEEDED_TAG in finding_after.tags
+        assert finding_after.existing_source_tag == "arxiv"
+
+    def test_unrecoverable_note_carries_tombstone_after_apply(self) -> None:
+        note = _make_invalid_note()
+        finding = audit_one_note(note)
+        assert finding.recommended_action == "tombstone"
+
+        new_tags = tombstone_tags(note)
+        note_after = dict(note)
+        note_after["tags"] = new_tags
+
+        # Tombstone tag present, repair-needed gone, in-band terminal
+        # state preserved for audit history.
+        assert TOMBSTONE_TAG in new_tags
+        assert REPAIR_NEEDED_TAG not in new_tags
+        assert INVALID_SOURCE_TAG in new_tags
+        assert TEXT_TERMINAL_TAG in new_tags

--- a/tests/unit/test_audit_invalid_source.py
+++ b/tests/unit/test_audit_invalid_source.py
@@ -169,6 +169,19 @@ class TestReconstructTags:
         reconstruct_tags(note, inferred_source="arxiv")
         assert note["tags"] == original_tags
 
+    def test_drops_existing_tombstone_tag(self) -> None:
+        # PR #170 Copilot review: a previously-tombstoned note that
+        # becomes recoverable (e.g. because inference paths expanded)
+        # must shed the tombstone tag during reconstruct — otherwise
+        # the note would still be filtered out by "operator-cleaned"
+        # dashboards / sweep selectors despite being re-armed for
+        # processing.
+        note = _make_invalid_note(extra_tags=[TOMBSTONE_TAG])
+        result = reconstruct_tags(note, inferred_source="arxiv")
+        assert TOMBSTONE_TAG not in result
+        # And the reconstruct still re-arms the note.
+        assert REPAIR_NEEDED_TAG in result
+
 
 class TestTombstoneTags:
     """``tombstone_tags`` adds the tombstone marker and drops repair-needed."""

--- a/tests/unit/test_diagnose_invalid_source.py
+++ b/tests/unit/test_diagnose_invalid_source.py
@@ -1,0 +1,388 @@
+"""Unit tests for the ``influx-diagnose invalid-source`` subcommand (#162).
+
+Covers the CLI plumbing that wraps :mod:`influx.audit_invalid_source`:
+
+* The audit / apply orchestration in ``cmd_invalid_source``.
+* The async ``_fetch_invalid_source_notes`` helper resolves the
+  candidate set via ``lithos_list`` (or skips it when ``--id`` is
+  supplied).
+* The async ``_apply_invalid_source_action`` helper rewrites a note
+  with the new tag list, short-circuits when the target tag set
+  matches the existing set, and surfaces unexpected write statuses
+  as "refused".
+
+The pure classification + tag-rewrite logic is exercised by
+``test_audit_invalid_source.py`` — this file only pins the wiring.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _load_script() -> Any:
+    """Load ``scripts/influx-diagnose.py`` as a module for direct testing."""
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "influx_diagnose_invalid_source",
+        repo_root / "scripts" / "influx-diagnose.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_DIAGNOSE = _load_script()
+
+
+# ── Shared fixtures ───────────────────────────────────────────────────
+
+
+def _invalid_note(
+    *,
+    note_id: str,
+    source_url: str = "",
+    path: str = "",
+    title: str = "Title",
+) -> dict[str, Any]:
+    return {
+        "id": note_id,
+        "title": title,
+        "path": path,
+        "source_url": source_url,
+        "content": "## Summary\nfoo\n",
+        "tags": [
+            "profile:retro-computing",
+            "text:abstract-only",
+            "influx:text-terminal",
+            "influx:source-invalid",
+        ],
+        "confidence": 0.5,
+        "note_type": "summary",
+        "namespace": "influx",
+    }
+
+
+def _make_client(notes: list[dict[str, Any]]) -> MagicMock:
+    """Build a mock ``LithosClient`` that returns *notes* for list+read."""
+    client = MagicMock()
+    client.list_notes_body = AsyncMock(
+        return_value={"items": [{"id": n["id"]} for n in notes]}
+    )
+    by_id = {n["id"]: n for n in notes}
+
+    async def _read(*, note_id: str) -> dict[str, Any]:
+        return by_id[note_id]
+
+    client.read_note = AsyncMock(side_effect=_read)
+
+    write_result = MagicMock()
+    write_result.status = "updated"
+    client.write_note = AsyncMock(return_value=write_result)
+    client.close = AsyncMock()
+    return client
+
+
+# ── _fetch_invalid_source_notes ───────────────────────────────────────
+
+
+class TestFetchInvalidSourceNotes:
+    """The fetch helper uses lithos_list by default and lithos_read per id."""
+
+    def test_list_scan_returns_full_notes(self) -> None:
+        notes = [_invalid_note(note_id="a"), _invalid_note(note_id="b")]
+        client = _make_client(notes)
+
+        with patch.object(_DIAGNOSE, "_make_lithos_client", return_value=client):
+            result = asyncio.run(
+                _DIAGNOSE._fetch_invalid_source_notes(
+                    lithos_url="http://example/sse",
+                )
+            )
+
+        # lithos_list was queried with the invalid-source tag.
+        client.list_notes_body.assert_awaited_once()
+        kwargs = client.list_notes_body.await_args.kwargs
+        assert kwargs["tags"] == ["influx:source-invalid"]
+
+        # Each listed id was read for the full body.
+        assert client.read_note.await_count == 2
+        assert [n["id"] for n in result] == ["a", "b"]
+
+    def test_id_list_bypasses_list_scan(self) -> None:
+        notes = [_invalid_note(note_id="a")]
+        client = _make_client(notes)
+
+        with patch.object(_DIAGNOSE, "_make_lithos_client", return_value=client):
+            result = asyncio.run(
+                _DIAGNOSE._fetch_invalid_source_notes(
+                    lithos_url="http://example/sse",
+                    note_ids=["a"],
+                )
+            )
+
+        # list_notes is NOT called when ids are passed explicitly.
+        client.list_notes_body.assert_not_awaited()
+        # Read was still called for the explicit id.
+        client.read_note.assert_awaited_once_with(note_id="a")
+        assert [n["id"] for n in result] == ["a"]
+
+    def test_read_failure_is_skipped_with_warning(self, capsys: Any) -> None:
+        notes = [_invalid_note(note_id="ok")]
+        client = _make_client(notes)
+
+        async def _read(*, note_id: str) -> dict[str, Any]:
+            if note_id == "missing":
+                raise RuntimeError("doc not found")
+            return notes[0]
+
+        client.read_note = AsyncMock(side_effect=_read)
+
+        with patch.object(_DIAGNOSE, "_make_lithos_client", return_value=client):
+            result = asyncio.run(
+                _DIAGNOSE._fetch_invalid_source_notes(
+                    lithos_url="http://example/sse",
+                    note_ids=["missing", "ok"],
+                )
+            )
+
+        # Only the readable note made it through.
+        assert [n["id"] for n in result] == ["ok"]
+        captured = capsys.readouterr()
+        assert "warning: read failed for missing" in captured.err
+
+
+# ── _apply_invalid_source_action ──────────────────────────────────────
+
+
+class TestApplyInvalidSourceAction:
+    """The apply helper rewrites notes and surfaces unexpected outcomes."""
+
+    def test_writes_with_new_tag_set(self) -> None:
+        note = _invalid_note(note_id="a", source_url="https://arxiv.org/abs/1.2")
+        client = _make_client([note])
+
+        new_tags = list(note["tags"]) + ["source:arxiv"]
+
+        with patch.object(_DIAGNOSE, "_make_lithos_client", return_value=client):
+            outcome, reason = asyncio.run(
+                _DIAGNOSE._apply_invalid_source_action(
+                    lithos_url="http://example/sse",
+                    note=note,
+                    new_tags=new_tags,
+                    agent="influx-diagnose",
+                )
+            )
+
+        assert outcome == "applied"
+        assert reason == "updated"
+        client.write_note.assert_awaited_once()
+        call_kwargs = client.write_note.await_args.kwargs
+        assert call_kwargs["tags"] == new_tags
+        assert call_kwargs["agent"] == "influx-diagnose"
+        # Confidence / note_type / namespace round-trip from the read note.
+        assert call_kwargs["confidence"] == 0.5
+        assert call_kwargs["note_type"] == "summary"
+
+    def test_already_clean_skips_write(self) -> None:
+        note = _invalid_note(note_id="a")
+        client = _make_client([note])
+
+        # New tag set is identical to the existing one (order irrelevant).
+        new_tags = list(reversed(note["tags"]))
+
+        with patch.object(_DIAGNOSE, "_make_lithos_client", return_value=client):
+            outcome, reason = asyncio.run(
+                _DIAGNOSE._apply_invalid_source_action(
+                    lithos_url="http://example/sse",
+                    note=note,
+                    new_tags=new_tags,
+                    agent="influx-diagnose",
+                )
+            )
+
+        assert outcome == "already_clean"
+        client.write_note.assert_not_awaited()
+
+    def test_unexpected_status_is_refused(self) -> None:
+        note = _invalid_note(note_id="a")
+        client = _make_client([note])
+
+        bad_result = MagicMock()
+        bad_result.status = "invalid_input"
+        client.write_note = AsyncMock(return_value=bad_result)
+
+        with patch.object(_DIAGNOSE, "_make_lithos_client", return_value=client):
+            outcome, reason = asyncio.run(
+                _DIAGNOSE._apply_invalid_source_action(
+                    lithos_url="http://example/sse",
+                    note=note,
+                    new_tags=list(note["tags"]) + ["foo"],
+                    agent="influx-diagnose",
+                )
+            )
+
+        assert outcome == "refused"
+        assert "invalid_input" in reason
+
+
+# ── cmd_invalid_source — end-to-end orchestration ─────────────────────
+
+
+def _build_args(**overrides: Any) -> argparse.Namespace:
+    base = {
+        "env": "staging",
+        "id": None,
+        "limit": None,
+        "apply": False,
+        "yes": None,
+        "yes_to_all": False,
+        "agent": "influx-diagnose",
+        "lithos_url": "http://example/sse",
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+class TestCmdInvalidSourceReadOnly:
+    """Default mode prints the audit report and never calls write_note."""
+
+    def test_reports_and_does_not_write(self, capsys: Any) -> None:
+        notes = [
+            _invalid_note(note_id="recoverable", source_url="https://arxiv.org/abs/1"),
+            _invalid_note(note_id="unrecoverable"),
+        ]
+        client = _make_client(notes)
+
+        with (
+            patch.object(_DIAGNOSE, "_make_lithos_client", return_value=client),
+            patch.object(_DIAGNOSE, "_load_env", return_value={}),
+            patch.object(_DIAGNOSE, "_read_lithos_url", return_value="http://x/sse"),
+            patch.object(_DIAGNOSE, "_ensure_project_runtime_or_reexec"),
+        ):
+            rc = _DIAGNOSE.cmd_invalid_source(_build_args())
+
+        assert rc == 0
+        client.write_note.assert_not_awaited()
+
+        out = capsys.readouterr().out
+        assert "[RECONSTRUCT] recoverable" in out
+        assert "[TOMBSTONE] unrecoverable" in out
+        assert "1 recoverable, 1 unrecoverable" in out
+        # The footer prompts the operator to add --apply.
+        assert "--apply" in out
+
+
+class TestCmdInvalidSourceApply:
+    """``--apply`` paths rewrite notes per the audit's recommendation."""
+
+    def test_apply_yes_to_all_writes_each_note_with_recommended_tags(
+        self, capsys: Any
+    ) -> None:
+        notes = [
+            _invalid_note(note_id="r", source_url="https://arxiv.org/abs/1"),
+            _invalid_note(note_id="u"),
+        ]
+        client = _make_client(notes)
+
+        with (
+            patch.object(_DIAGNOSE, "_make_lithos_client", return_value=client),
+            patch.object(_DIAGNOSE, "_load_env", return_value={}),
+            patch.object(_DIAGNOSE, "_read_lithos_url", return_value="http://x/sse"),
+            patch.object(_DIAGNOSE, "_ensure_project_runtime_or_reexec"),
+        ):
+            rc = _DIAGNOSE.cmd_invalid_source(_build_args(apply=True, yes_to_all=True))
+
+        assert rc == 0
+        # Two write_note calls: one reconstruct, one tombstone.
+        assert client.write_note.await_count == 2
+
+        # Look at the tag sets passed to write_note.
+        writes_by_id: dict[str, list[str]] = {}
+        for call in client.write_note.await_args_list:
+            kwargs = call.kwargs
+            writes_by_id[kwargs["source_url"] or kwargs["path"] or "u"] = list(
+                kwargs["tags"]
+            )
+
+        # The reconstruct candidate (source_url set) gets the
+        # backfilled source tag and the repair-needed tag.
+        recon_tags = writes_by_id["https://arxiv.org/abs/1"]
+        assert "source:arxiv" in recon_tags
+        assert "influx:repair-needed" in recon_tags
+        assert "influx:source-invalid" not in recon_tags
+        assert "influx:text-terminal" not in recon_tags
+
+        # The tombstone candidate gets the tombstone tag without
+        # losing its in-band terminal state.
+        tomb_tags = writes_by_id["u"]
+        assert "influx:tombstone" in tomb_tags
+        assert "influx:source-invalid" in tomb_tags
+        assert "influx:text-terminal" in tomb_tags
+
+        out = capsys.readouterr().out
+        assert "RECONSTRUCT" in out
+        assert "TOMBSTONE" in out
+        assert "applied=2" in out
+
+    def test_apply_without_confirmation_aborts(self) -> None:
+        notes = [_invalid_note(note_id="r", source_url="https://arxiv.org/abs/1")]
+        client = _make_client(notes)
+
+        with (
+            patch.object(_DIAGNOSE, "_make_lithos_client", return_value=client),
+            patch.object(_DIAGNOSE, "_load_env", return_value={}),
+            patch.object(_DIAGNOSE, "_read_lithos_url", return_value="http://x/sse"),
+            patch.object(_DIAGNOSE, "_ensure_project_runtime_or_reexec"),
+        ):
+            try:
+                _DIAGNOSE.cmd_invalid_source(_build_args(apply=True))
+            except SystemExit as exc:
+                # ``sys.exit`` is invoked with an error message.
+                assert "--apply requires" in str(exc.code)
+            else:
+                raise AssertionError("expected SystemExit when --apply has no confirm")
+
+    def test_apply_yes_per_id_only_writes_named_note(self, capsys: Any) -> None:
+        notes = [
+            _invalid_note(note_id="r", source_url="https://arxiv.org/abs/1"),
+            _invalid_note(note_id="other", source_url="https://arxiv.org/abs/2"),
+        ]
+        client = _make_client(notes)
+
+        with (
+            patch.object(_DIAGNOSE, "_make_lithos_client", return_value=client),
+            patch.object(_DIAGNOSE, "_load_env", return_value={}),
+            patch.object(_DIAGNOSE, "_read_lithos_url", return_value="http://x/sse"),
+            patch.object(_DIAGNOSE, "_ensure_project_runtime_or_reexec"),
+        ):
+            rc = _DIAGNOSE.cmd_invalid_source(_build_args(apply=True, yes=["r"]))
+
+        assert rc == 0
+        # Only one write — the one named via --yes r.
+        assert client.write_note.await_count == 1
+        call_kwargs = client.write_note.await_args_list[0].kwargs
+        assert "source:arxiv" in call_kwargs["tags"]
+
+    def test_apply_id_only_writes_that_note_no_list_scan(self) -> None:
+        notes = [_invalid_note(note_id="r", source_url="https://arxiv.org/abs/1")]
+        client = _make_client(notes)
+
+        with (
+            patch.object(_DIAGNOSE, "_make_lithos_client", return_value=client),
+            patch.object(_DIAGNOSE, "_load_env", return_value={}),
+            patch.object(_DIAGNOSE, "_read_lithos_url", return_value="http://x/sse"),
+            patch.object(_DIAGNOSE, "_ensure_project_runtime_or_reexec"),
+        ):
+            rc = _DIAGNOSE.cmd_invalid_source(_build_args(apply=True, id=["r"]))
+
+        assert rc == 0
+        # No list scan when --id is used.
+        client.list_notes_body.assert_not_awaited()
+        client.write_note.assert_awaited_once()

--- a/tests/unit/test_diagnose_invalid_source.py
+++ b/tests/unit/test_diagnose_invalid_source.py
@@ -210,6 +210,44 @@ class TestApplyInvalidSourceAction:
         assert outcome == "already_clean"
         client.write_note.assert_not_awaited()
 
+    def test_refuses_note_without_source_invalid_tag(self) -> None:
+        # PR #170 review safety check: ``--id`` skips the tag-filtered
+        # ``lithos_list`` scan, so an operator could name a healthy
+        # note by id and have it rewritten.  The apply helper MUST
+        # refuse any note whose tags do not include
+        # ``influx:source-invalid`` — regardless of how it was fetched.
+        healthy_note = {
+            "id": "healthy",
+            "title": "Healthy Note",
+            "path": "papers/arxiv/2026/04",
+            "source_url": "https://arxiv.org/abs/2601.12345",
+            "content": "## Summary\nfoo\n",
+            "tags": [
+                "profile:retro-computing",
+                "source:arxiv",
+                "ingested-by:influx",
+            ],
+            "confidence": 0.5,
+            "note_type": "summary",
+            "namespace": "influx",
+        }
+        client = _make_client([healthy_note])
+
+        with patch.object(_DIAGNOSE, "_make_lithos_client", return_value=client):
+            outcome, reason = asyncio.run(
+                _DIAGNOSE._apply_invalid_source_action(
+                    lithos_url="http://example/sse",
+                    note=healthy_note,
+                    new_tags=list(healthy_note["tags"]) + ["influx:tombstone"],
+                    agent="influx-diagnose",
+                )
+            )
+
+        assert outcome == "refused"
+        assert "not tagged influx:source-invalid" in reason
+        # And no write was attempted.
+        client.write_note.assert_not_awaited()
+
     def test_unexpected_status_is_refused(self) -> None:
         note = _invalid_note(note_id="a")
         client = _make_client([note])
@@ -369,6 +407,52 @@ class TestCmdInvalidSourceApply:
         assert client.write_note.await_count == 1
         call_kwargs = client.write_note.await_args_list[0].kwargs
         assert "source:arxiv" in call_kwargs["tags"]
+
+    def test_apply_id_pointing_at_healthy_note_is_refused(self, capsys: Any) -> None:
+        # PR #170 review: even when an operator names a healthy note
+        # via ``--id``, the apply path must refuse to rewrite it.
+        # End-to-end check that the safety boundary in
+        # ``_apply_invalid_source_action`` fires from the CLI path.
+        healthy_note = {
+            "id": "healthy",
+            "title": "Healthy Note",
+            "path": "papers/arxiv/2026/04",
+            "source_url": "https://arxiv.org/abs/1",
+            "content": "## Summary\nfoo\n",
+            "tags": [
+                "profile:retro-computing",
+                "source:arxiv",
+                "ingested-by:influx",
+            ],
+            "confidence": 0.5,
+            "note_type": "summary",
+            "namespace": "influx",
+        }
+        client = _make_client([healthy_note])
+
+        with (
+            patch.object(_DIAGNOSE, "_make_lithos_client", return_value=client),
+            patch.object(_DIAGNOSE, "_load_env", return_value={}),
+            patch.object(_DIAGNOSE, "_read_lithos_url", return_value="http://x/sse"),
+            patch.object(_DIAGNOSE, "_ensure_project_runtime_or_reexec"),
+        ):
+            rc = _DIAGNOSE.cmd_invalid_source(_build_args(apply=True, id=["healthy"]))
+
+        # Exit non-zero because the apply was refused.
+        assert rc == 1
+        client.write_note.assert_not_awaited()
+
+        out = capsys.readouterr().out
+        # The ineligible-warning fires up-front so the operator sees
+        # the issue before the per-id REFUSED line.
+        assert "INELIGIBLE" in out
+        assert "healthy" in out
+        # And the apply path also prints a REFUSED line with the
+        # specific safety reason.
+        assert "REFUSED" in out
+        assert "not tagged influx:source-invalid" in out
+        # Summary reflects the refusal.
+        assert "refused=1" in out
 
     def test_apply_id_only_writes_that_note_no_list_scan(self) -> None:
         notes = [_invalid_note(note_id="r", source_url="https://arxiv.org/abs/1")]


### PR DESCRIPTION
## Summary

In-band repair (#150) stopped the retry loop for mid-flight ``invalid_source_metadata`` failures but historical bad-state notes still carried ``influx:source-invalid`` with no operator-facing cleanup path. Adds both the audit logic and a CLI entry point so staging / production can clean leftover state after a repair incident.

**New module ``influx.audit_invalid_source``** (pure, no MCP / IO):

- ``AuditFinding`` — per-note classification with a ``recoverable`` property and a ``recommended_action`` (``"reconstruct"`` | ``"tombstone"``) derived from :func:`influx.repair_hooks.infer_note_source`.
- ``audit_one_note`` / ``audit_notes`` — pure classification.
- ``reconstruct_tags`` — backfills ``source:*``, drops ``influx:source-invalid`` + ``influx:text-terminal`` + any ``text:*`` tag, re-arms ``influx:repair-needed`` so the next sweep retries text extraction with valid metadata.
- ``tombstone_tags`` — layers ``influx:tombstone`` on top of the existing terminal state; drops ``influx:repair-needed``. In-band terminal tags are preserved for audit history. Idempotent.
- ``format_audit_report`` — line-oriented report with per-note action label, hint preview, and recoverable totals.

**New CLI subcommand ``./scripts/influx-diagnose.py invalid-source``:**

- Read-only by default: ``lithos_list`` scan + ``lithos_read`` per id → audit report.
- ``--apply`` requires ``--yes <doc-id>`` / ``--yes-to-all`` / ``--id`` to confirm. Applies the per-note recommended action via ``lithos_write``.
- Mirrors the existing ``squatters`` subcommand's confirmation discipline.
- Logged with ``agent=influx-diagnose`` for the Lithos audit trail.

**Documentation:** new "8b. Cleaning up invalid-source-metadata notes" section in ``docs/operations/staging-runbook.md`` explains when to run the workflow, the action semantics, and the safety properties.

Closes #162.

## Test plan

- [x] ``test_audit_invalid_source.py`` (21 tests):
  - Classification: unrecoverable when no metadata, recoverable from ``source_url`` / note path / id prefix, existing non-empty source preserved.
  - ``reconstruct_tags``: backfills source, clears terminal flags, drops empty/garbled source, drops ``text:*``, preserves unrelated tags, no mutation.
  - ``tombstone_tags``: adds tombstone, preserves in-band terminal state, drops ``repair-needed``, idempotent, no mutation.
  - ``format_audit_report``: per-note action labels, totals header, concise rendering when metadata is missing.
  - Round-trip: re-auditing a reconstructed note shows the in-band tags cleared; tombstone state correctly preserves audit history.
- [x] ``test_diagnose_invalid_source.py`` (11 tests):
  - ``_fetch_invalid_source_notes`` uses ``lithos_list`` by default; ``--id`` skips the scan; read failures are skipped with a warning.
  - ``_apply_invalid_source_action`` writes with the new tag set; short-circuits when tags already match; surfaces unexpected statuses as ``refused``.
  - ``cmd_invalid_source`` read-only mode prints the report without writes; ``--apply --yes-to-all`` writes each note with the recommended tag set; ``--apply`` without confirmation aborts; ``--yes <id>`` only writes the named note; ``--apply --id <id>`` skips the list scan.
- [x] Full suite green: **2209 passed**.