### PR TITLE
feat: split run degradation severity into expected_lossy vs unexpected_failure (#164)

### DIFF
--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -81,6 +81,27 @@ Three quick signals, all read-only:
   `filter_stall`) are mutually exclusive on any single run.
   `filter_error` is mutually exclusive with `filter_stall` (same
   shape, different cause) but orthogonal to the rest.
+
+  ### Degradation severity (issue #164)
+
+  On top of the flat `degraded_reasons` list, every completed run
+  carries a `degradation_severity` bucket so dashboards / paging /
+  triage can separate release-noise from real breakage without
+  parsing the reason list. The bucket also appears as `severity=` in
+  the `run completed` log line and as the `severity` label on the
+  `run_completions` metric.
+
+  | Severity | Triggers | Operator action |
+  |----------|----------|-----------------|
+  | `success` | `degraded_reasons` empty | None |
+  | `expected_lossy` | only `source_acquisition`, `source_cooldown_skip`, `archive_acquisition` present | Glance; investigate only if frequency spikes. These are tolerated upstream / policy-driven outcomes. |
+  | `unexpected_failure` | any of `invalid_note_state`, `invalid_url_stall`, `ingestion_stall`, `fetch_stall`, `filter_stall`, `filter_error` present | Triage — actionable regression signal. |
+
+  When unexpected and lossy reasons co-occur on the same run (the
+  staging shape `reasons=archive_acquisition,invalid_note_state`),
+  the run escalates to `unexpected_failure`. The flat
+  `degraded_reasons` list still carries both entries so operators see
+  the full picture; only the severity bucket is single-valued.
   A `skipped` run (#40) means the Lithos circuit breaker fired:
   ProbeLoop saw 3+ consecutive `degraded` Lithos probes, so the
   scheduler short-circuited to avoid burning LLM tokens against a

--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -89,13 +89,15 @@ Three quick signals, all read-only:
   triage can separate release-noise from real breakage without
   parsing the reason list. The bucket also appears as `severity=` in
   the `run completed` log line and as the `severity` label on the
-  `run_completions` metric.
+  `run_completions` metric (always present, including on `skipped`
+  and `failure` outcomes — see below).
 
   | Severity | Triggers | Operator action |
   |----------|----------|-----------------|
   | `success` | `degraded_reasons` empty | None |
   | `expected_lossy` | only `source_acquisition`, `source_cooldown_skip`, `archive_acquisition` present | Glance; investigate only if frequency spikes. These are tolerated upstream / policy-driven outcomes. |
   | `unexpected_failure` | any of `invalid_note_state`, `invalid_url_stall`, `ingestion_stall`, `fetch_stall`, `filter_stall`, `filter_error` present | Triage — actionable regression signal. |
+  | `not_applicable` | `outcome=skipped` (circuit breaker fired) or `outcome=failure` (body raised before reasons were computed) | Read the existing `outcome` label — `severity` is set to a constant so the metric series shape stays uniform across all completions. |
 
   When unexpected and lossy reasons co-occur on the same run (the
   staging shape `reasons=archive_acquisition,invalid_note_state`),

--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -14,7 +14,7 @@ import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +39,79 @@ _STALL_HISTORY_LIMIT = 20
 # ``/runs/recent`` payload.  Tied to a constant so the bound is
 # discoverable from one place.
 _DEGRADATION_SUMMARY_TOP_N = 5
+
+
+# Issue #164: severity classification of degraded reasons.  Splits the
+# existing flat ``degraded_reasons`` list into two operational
+# severities so dashboards / paging / triage can separate
+# release-noise (tolerated upstream lossiness) from real breakage
+# (data integrity / pipeline regressions).
+#
+# Reasons listed here ALWAYS escalate the run to
+# ``unexpected_failure`` even when expected-lossy reasons co-occur.
+# This matches the issue's acceptance criterion ("Invalid note state
+# or malformed persisted metadata is always treated as unexpected
+# failure").
+#
+# Reasons NOT in this set are classified as ``expected_lossy`` when
+# they are the only reasons present:
+#
+# * ``source_acquisition`` — transient upstream errors that the
+#   in-fetch retry loop already absorbed; the swallowed-error list
+#   is surfaced for operator awareness but does not warrant paging.
+# * ``source_cooldown_skip`` — we intentionally backed off; the
+#   operator's policy decision firing as designed.
+# * ``archive_acquisition`` — archive download failed for items that
+#   were still ingested (summary text / abstract preserved).  Policy
+#   modes (``unsupported`` / ``blocked``) are explicitly tolerated
+#   per #149 / #161; generic transient failures are also acceptable
+#   noise.
+#
+# Stalls and ``invalid_*`` shapes are unexpected because they
+# represent actionable regressions — a 2-run streak of "nothing
+# fetched / ingested / passed the filter" or an upstream feed
+# emitting only broken URLs.  ``filter_error`` is unexpected because
+# the in-fetch scorer execution failed (provider config / model
+# availability / response schema bug) — not a soft rate-limit.
+_UNEXPECTED_FAILURE_REASONS: frozenset[str] = frozenset(
+    {
+        "invalid_note_state",
+        "invalid_url_stall",
+        "ingestion_stall",
+        "fetch_stall",
+        "filter_stall",
+        "filter_error",
+    }
+)
+
+
+# Severity literal — surfaced on the ledger entry as
+# ``degradation_severity`` and as the ``severity`` label on the
+# ``run_completions`` metric.  Mutually exclusive across a single
+# run; a run with mixed reasons is escalated to the higher severity
+# (``unexpected_failure`` beats ``expected_lossy``).
+_SeverityLiteral = Literal["success", "expected_lossy", "unexpected_failure"]
+
+
+def classify_degradation_severity(degraded_reasons: list[str]) -> _SeverityLiteral:
+    """Return the severity classification for *degraded_reasons*.
+
+    * ``"success"`` when no reasons fired.
+    * ``"unexpected_failure"`` when any reason in
+      :data:`_UNEXPECTED_FAILURE_REASONS` is present.
+    * ``"expected_lossy"`` otherwise (only tolerated reasons fired).
+
+    Public — exposed for callers (run service, admin HTTP) that need
+    to surface severity without re-implementing the mapping.  The
+    classification is stable for a given reason list and does not
+    consult any ambient state.
+    """
+    if not degraded_reasons:
+        return "success"
+    for reason in degraded_reasons:
+        if reason in _UNEXPECTED_FAILURE_REASONS:
+            return "unexpected_failure"
+    return "expected_lossy"
 
 
 def _top_n_by_count(counts: dict[str, int], *, n: int) -> list[dict[str, Any]]:
@@ -425,6 +498,11 @@ class RunLedger:
             "error": None,
             "degraded": False,
             "degraded_reasons": [],
+            # Issue #164: severity bucket on top of the flat
+            # ``degraded_reasons`` list.  Starts at ``"success"`` while
+            # the run is in flight; finalised by ``_finish`` once
+            # ``degraded_reasons`` is known.
+            "degradation_severity": "success",
             "source_acquisition_errors": [],
             # Issue #146: cooldown skips are surfaced in the entry
             # alongside ``source_acquisition_errors`` so the active
@@ -1018,6 +1096,14 @@ class RunLedger:
                         "error": reason,
                         "degraded": entry.get("degraded", False),
                         "degraded_reasons": list(entry.get("degraded_reasons") or []),
+                        # Issue #164: preserve the in-flight severity
+                        # on abandon — typically ``"success"`` since
+                        # the field is only finalised by ``_finish``,
+                        # but a restart hand-off should not silently
+                        # downgrade an already-set value.
+                        "degradation_severity": entry.get(
+                            "degradation_severity", "success"
+                        ),
                         "source_acquisition_errors": list(
                             entry.get("source_acquisition_errors") or []
                         ),
@@ -1134,6 +1220,16 @@ class RunLedger:
                     "error": error,
                     "degraded": degraded,
                     "degraded_reasons": list(degraded_reasons or []),
+                    # Issue #164: precompute the severity bucket from
+                    # the reason list so downstream consumers
+                    # (``/runs/recent``, dashboards, paging) read a
+                    # stable classification without reimplementing the
+                    # mapping.  ``"unexpected_failure"`` wins when any
+                    # unexpected reason co-occurs with expected-lossy
+                    # ones.
+                    "degradation_severity": classify_degradation_severity(
+                        list(degraded_reasons or [])
+                    ),
                     "source_acquisition_errors": list(source_acquisition_errors or []),
                     # Issue #146: persist cooldown skips alongside
                     # ``source_acquisition_errors`` so the same JSONL

--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -85,6 +85,29 @@ _UNEXPECTED_FAILURE_REASONS: frozenset[str] = frozenset(
 )
 
 
+# Issue #164 review: the complement set of expected-lossy reasons.
+# Together with :data:`_UNEXPECTED_FAILURE_REASONS` this is the
+# exhaustive list of degraded reasons :meth:`RunLedger.complete` may
+# append.  A meta-test in ``tests/unit/test_run_ledger.py`` scans the
+# source of ``complete`` and asserts every ``reasons.append("…")``
+# literal lands in :data:`_KNOWN_DEGRADED_REASONS`, so a new reason
+# cannot be added without an explicit severity classification.
+_EXPECTED_LOSSY_REASONS: frozenset[str] = frozenset(
+    {
+        "source_acquisition",
+        "source_cooldown_skip",
+        "archive_acquisition",
+    }
+)
+
+
+# Union of the two classified sets.  Used by the meta-test only;
+# production callers consult the individual sets.
+_KNOWN_DEGRADED_REASONS: frozenset[str] = (
+    _UNEXPECTED_FAILURE_REASONS | _EXPECTED_LOSSY_REASONS
+)
+
+
 # Severity literal — surfaced on the ledger entry as
 # ``degradation_severity`` and as the ``severity`` label on the
 # ``run_completions`` metric.  Mutually exclusive across a single

--- a/src/influx/run_service.py
+++ b/src/influx/run_service.py
@@ -265,7 +265,18 @@ async def ledger_lifecycle(
                 1, {"profile": profile, "reason": session.skip_reason}
             )
             metrics.run_duration().record(elapsed, metric_attrs)
-            metrics.run_completions().add(1, {**metric_attrs, "outcome": "skipped"})
+            # Issue #164 review: every ``run_completions`` series carries
+            # the ``severity`` label so dashboard queries can filter
+            # uniformly.  ``skipped`` runs never ran the body and have
+            # no degraded-reasons list, so the value is ``not_applicable``.
+            metrics.run_completions().add(
+                1,
+                {
+                    **metric_attrs,
+                    "outcome": "skipped",
+                    "severity": "not_applicable",
+                },
+            )
             logger.warning(
                 "run skipped profile=%s kind=%s run_id=%s reason=%s",
                 profile,
@@ -644,7 +655,19 @@ async def ledger_lifecycle(
             error=f"{type(exc).__name__}: {exc}" if exc is not None else "unknown",
         )
         metrics.run_duration().record(elapsed, metric_attrs)
-        metrics.run_completions().add(1, {**metric_attrs, "outcome": "failure"})
+        # Issue #164 review: failure path also carries the ``severity``
+        # label so the ``run_completions`` series shape is uniform
+        # across outcomes.  ``failure`` runs raised before
+        # ``degraded_reasons`` was computed, so the value is
+        # ``not_applicable``.
+        metrics.run_completions().add(
+            1,
+            {
+                **metric_attrs,
+                "outcome": "failure",
+                "severity": "not_applicable",
+            },
+        )
         raise
     finally:
         metrics.active_runs().add(-1, {"profile": profile})

--- a/src/influx/run_service.py
+++ b/src/influx/run_service.py
@@ -567,8 +567,20 @@ async def ledger_lifecycle(
                 archive_unsupported_total,
             )
 
+        # Issue #164: classify the degraded reasons into the
+        # ``severity`` bucket the ledger entry stores so the metric
+        # label and the run-completed log line agree on the
+        # ``"expected_lossy"`` / ``"unexpected_failure"`` split.  The
+        # ledger has the authoritative computation; we mirror it
+        # here for the metric attribute.
+        from influx.run_ledger import classify_degradation_severity
+
+        severity = classify_degradation_severity(list(degraded_reasons))
+
         metrics.run_duration().record(elapsed, metric_attrs)
-        metrics.run_completions().add(1, {**metric_attrs, "outcome": run_outcome})
+        metrics.run_completions().add(
+            1, {**metric_attrs, "outcome": run_outcome, "severity": severity}
+        )
 
         if outcome is not None:
             # #79: tie ``degraded`` to ``run_outcome`` (the same source of
@@ -583,6 +595,11 @@ async def ledger_lifecycle(
             # broken?" without requiring a ledger fetch.  Computed in
             # one shot via :func:`build_degradation_summary` so the log
             # tail and the persisted summary stay in lockstep.
+            #
+            # #164: emit ``severity=...`` alongside ``degraded=...``
+            # so operators can immediately distinguish expected
+            # upstream lossiness from real pipeline regressions
+            # without re-deriving the bucket from the reason list.
             top_drivers = _format_top_drivers_tail(
                 archive_failures=archive_failures,
                 source_acquisition_errors=source_errors,
@@ -590,7 +607,8 @@ async def ledger_lifecycle(
             )
             logger.info(
                 "run completed profile=%s kind=%s run_id=%s duration=%.1fs "
-                "sources_checked=%d ingested=%d degraded=%s reasons=%s%s",
+                "sources_checked=%d ingested=%d degraded=%s severity=%s "
+                "reasons=%s%s",
                 profile,
                 plan.kind.value,
                 run_id,
@@ -598,6 +616,7 @@ async def ledger_lifecycle(
                 outcome.sources_checked,
                 outcome.ingested,
                 run_outcome == "degraded",
+                severity,
                 ",".join(degraded_reasons) if degraded_reasons else "",
                 f" top_drivers={top_drivers}" if top_drivers else "",
             )

--- a/tests/unit/test_run_ledger.py
+++ b/tests/unit/test_run_ledger.py
@@ -5,7 +5,143 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from influx.run_ledger import RunLedger
+from influx.run_ledger import RunLedger, classify_degradation_severity
+
+# ── Issue #164: degradation severity classification ──────────────────
+
+
+class TestClassifyDegradationSeverity:
+    """``classify_degradation_severity`` separates lossy noise from real breakage.
+
+    Pinning the contract here keeps the mapping authoritative — every
+    new degraded reason added to ``RunLedger.complete`` MUST be
+    classified explicitly (either listed in
+    ``_UNEXPECTED_FAILURE_REASONS`` or accepted as expected-lossy).
+    """
+
+    def test_no_reasons_is_success(self) -> None:
+        assert classify_degradation_severity([]) == "success"
+
+    def test_lossy_only_reasons_are_expected_lossy(self) -> None:
+        # source_acquisition + cooldown + archive_acquisition are all
+        # tolerated upstream noise; their presence alone keeps the
+        # severity at expected_lossy.
+        for reason in (
+            "source_acquisition",
+            "source_cooldown_skip",
+            "archive_acquisition",
+        ):
+            assert classify_degradation_severity([reason]) == "expected_lossy"
+        assert (
+            classify_degradation_severity(["source_acquisition", "archive_acquisition"])
+            == "expected_lossy"
+        )
+
+    def test_invalid_note_state_is_always_unexpected(self) -> None:
+        # Issue acceptance criterion: "Invalid note state or malformed
+        # persisted metadata is always treated as unexpected failure."
+        assert (
+            classify_degradation_severity(["invalid_note_state"])
+            == "unexpected_failure"
+        )
+
+    def test_invalid_note_state_escalates_when_mixed_with_lossy(self) -> None:
+        # The staging-evidence shape:
+        # ``reasons=archive_acquisition,invalid_note_state``.  Must
+        # escalate to unexpected_failure even though archive_acquisition
+        # is expected-lossy on its own.
+        assert (
+            classify_degradation_severity(["archive_acquisition", "invalid_note_state"])
+            == "unexpected_failure"
+        )
+
+    def test_stall_reasons_are_unexpected_failures(self) -> None:
+        # Stalls fire on a 2-run streak — by then the signal is
+        # operationally actionable, not noisy.
+        for reason in (
+            "ingestion_stall",
+            "fetch_stall",
+            "filter_stall",
+            "invalid_url_stall",
+        ):
+            assert classify_degradation_severity([reason]) == "unexpected_failure", (
+                reason
+            )
+
+    def test_filter_error_is_unexpected(self) -> None:
+        # filter_error fires on scorer execution failure — a config /
+        # availability / response-schema bug, not a soft rate limit.
+        assert classify_degradation_severity(["filter_error"]) == "unexpected_failure"
+
+
+class TestLedgerEntrySeverityField:
+    """Completed ledger entries carry ``degradation_severity``."""
+
+    @staticmethod
+    def _complete(
+        ledger: RunLedger,
+        *,
+        run_id: str = "r-1",
+        profile: str = "p",
+        kind: str = "scheduled",
+        sources_checked: int = 5,
+        ingested: int = 2,
+        fetched_total: int | None = None,
+        archive_failures_total: int | None = None,
+        write_outcomes: dict[tuple[str, str], int] | None = None,
+    ) -> list[str]:
+        ledger.start(run_id=run_id, profile=profile, kind=kind, run_range=None)
+        return ledger.complete(
+            run_id=run_id,
+            sources_checked=sources_checked,
+            ingested=ingested,
+            fetched_total=fetched_total
+            if fetched_total is not None
+            else sources_checked,
+            archive_failures_total=archive_failures_total,
+            write_outcomes=write_outcomes,
+        )
+
+    def test_clean_run_carries_success_severity(self, tmp_path: Path) -> None:
+        ledger = RunLedger(tmp_path / "state")
+        self._complete(ledger, sources_checked=5, ingested=3)
+        entry = ledger.recent()[0]
+        assert entry["degradation_severity"] == "success"
+
+    def test_expected_lossy_run_carries_expected_lossy_severity(
+        self, tmp_path: Path
+    ) -> None:
+        ledger = RunLedger(tmp_path / "state")
+        self._complete(ledger, archive_failures_total=1)
+        entry = ledger.recent()[0]
+        assert entry["degraded_reasons"] == ["archive_acquisition"]
+        assert entry["degradation_severity"] == "expected_lossy"
+
+    def test_invalid_note_state_run_is_unexpected_failure(self, tmp_path: Path) -> None:
+        # Drive the ledger with the write-outcomes shape that produces
+        # invalid_note_state.
+        ledger = RunLedger(tmp_path / "state")
+        reasons = self._complete(
+            ledger,
+            write_outcomes={("invalid_input", "arxiv"): 1},
+        )
+        assert "invalid_note_state" in reasons
+        entry = ledger.recent()[0]
+        assert entry["degradation_severity"] == "unexpected_failure"
+
+    def test_mixed_reasons_escalate_to_unexpected_failure(self, tmp_path: Path) -> None:
+        # Staging evidence verbatim:
+        # reasons=archive_acquisition,invalid_note_state must collapse
+        # to unexpected_failure.
+        ledger = RunLedger(tmp_path / "state")
+        reasons = self._complete(
+            ledger,
+            archive_failures_total=1,
+            write_outcomes={("invalid_input", "arxiv"): 1},
+        )
+        assert set(reasons) >= {"archive_acquisition", "invalid_note_state"}
+        entry = ledger.recent()[0]
+        assert entry["degradation_severity"] == "unexpected_failure"
 
 
 def test_run_ledger_records_completed_run(tmp_path: Path) -> None:

--- a/tests/unit/test_run_ledger.py
+++ b/tests/unit/test_run_ledger.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import inspect
+import re
 from pathlib import Path
 from typing import Any
 
-from influx.run_ledger import RunLedger, classify_degradation_severity
+from influx.run_ledger import (
+    _KNOWN_DEGRADED_REASONS,
+    RunLedger,
+    classify_degradation_severity,
+)
 
 # ── Issue #164: degradation severity classification ──────────────────
 
@@ -13,10 +19,12 @@ from influx.run_ledger import RunLedger, classify_degradation_severity
 class TestClassifyDegradationSeverity:
     """``classify_degradation_severity`` separates lossy noise from real breakage.
 
-    Pinning the contract here keeps the mapping authoritative — every
-    new degraded reason added to ``RunLedger.complete`` MUST be
-    classified explicitly (either listed in
-    ``_UNEXPECTED_FAILURE_REASONS`` or accepted as expected-lossy).
+    Pinning the contract here keeps the mapping authoritative.  A
+    sibling meta-test (:class:`TestKnownDegradedReasonsCoverage`)
+    scans the source of ``RunLedger.complete`` and refuses to let a
+    new ``reasons.append("…")`` literal land without an explicit
+    severity classification, so the contract is enforced rather than
+    aspirational.
     """
 
     def test_no_reasons_is_success(self) -> None:
@@ -72,6 +80,35 @@ class TestClassifyDegradationSeverity:
         # filter_error fires on scorer execution failure — a config /
         # availability / response-schema bug, not a soft rate limit.
         assert classify_degradation_severity(["filter_error"]) == "unexpected_failure"
+
+
+class TestKnownDegradedReasonsCoverage:
+    """Every reason ``RunLedger.complete`` appends must be classified.
+
+    Scans the source of ``RunLedger.complete`` for the
+    ``reasons.append("…")`` literals and asserts each value lands in
+    :data:`_KNOWN_DEGRADED_REASONS`.  Catches the case where a new
+    degraded reason is added without simultaneously updating the
+    expected/unexpected mapping — the classifier would otherwise
+    silently default the unknown reason and the runbook contract
+    would silently drift.
+    """
+
+    _APPEND_RE = re.compile(r'reasons\.append\(\s*"([^"]+)"\s*\)')
+
+    def test_complete_only_appends_classified_reasons(self) -> None:
+        source = inspect.getsource(RunLedger.complete)
+        appended = set(self._APPEND_RE.findall(source))
+        # Sanity: the test would be a no-op if the regex caught nothing.
+        assert appended, "expected to find at least one reasons.append() literal"
+        unknown = appended - _KNOWN_DEGRADED_REASONS
+        assert not unknown, (
+            "RunLedger.complete appends degraded reasons that are not in "
+            "_KNOWN_DEGRADED_REASONS: "
+            + ", ".join(sorted(unknown))
+            + ".  Add each to either _UNEXPECTED_FAILURE_REASONS or "
+            "_EXPECTED_LOSSY_REASONS in src/influx/run_ledger.py."
+        )
 
 
 class TestLedgerEntrySeverityField:

--- a/tests/unit/test_run_service.py
+++ b/tests/unit/test_run_service.py
@@ -621,6 +621,130 @@ async def test_run_completed_log_degraded_false_for_clean_run(
 
     record = _extract_run_completed_record(caplog)
     assert "degraded=False" in record.message
+    # Issue #164: clean runs carry the ``severity=success`` bucket so
+    # operator log greps can filter for non-trivial outcomes uniformly.
+    assert "severity=success" in record.message
+
+
+async def test_run_completed_log_carries_expected_lossy_severity(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Issue #164: archive_acquisition alone → ``severity=expected_lossy``.
+
+    Tolerated upstream lossiness (the openai.com / lesswrong.com
+    staging shape) gets the ``expected_lossy`` bucket so dashboards
+    can separate release-noise from real breakage without parsing
+    the reason list.
+    """
+    from influx.notifications import HighlightItem, ProfileRunResult, RunStats
+
+    config = _make_config()
+    ledger = RunLedger(tmp_path)
+    service = RunService(config=config, ledger=ledger)
+
+    body_outcome = RunOutcome(
+        sources_checked=2,
+        ingested=1,
+        profile_run_result=ProfileRunResult(
+            run_date="2026-05-08",
+            profile="alpha",
+            stats=RunStats(sources_checked=2, ingested=1),
+            items=[
+                HighlightItem(
+                    id="note-1",
+                    title="Archive failed",
+                    score=8,
+                    tags=["profile:alpha", "influx:archive-missing"],
+                    reason="archive fetch failed",
+                    url="https://www.lesswrong.com/posts/x",
+                    related_in_lithos=[],
+                )
+            ],
+        ),
+    )
+    with (
+        caplog.at_level(logging.INFO, logger="influx.run_service"),
+        patch(
+            "influx.run.Run.execute",
+            new_callable=AsyncMock,
+            return_value=body_outcome,
+        ),
+    ):
+        await service.execute(_scheduled_plan())
+
+    record = _extract_run_completed_record(caplog)
+    assert "degraded=True" in record.message
+    assert "severity=expected_lossy" in record.message
+
+    entry = next(e for e in ledger.recent() if e["status"] == "completed")
+    assert entry["degradation_severity"] == "expected_lossy"
+
+
+async def test_run_completed_log_carries_unexpected_failure_severity(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Issue #164: invalid_note_state escalates to ``unexpected_failure``.
+
+    Reproduces the staging shape
+    ``reasons=archive_acquisition,invalid_note_state`` — even though
+    archive_acquisition is expected-lossy on its own, the
+    invalid_note_state co-occurrence escalates the whole run.
+    """
+    from influx.notifications import HighlightItem, ProfileRunResult, RunStats
+    from influx.telemetry import current_write_outcomes
+
+    config = _make_config()
+    ledger = RunLedger(tmp_path)
+    service = RunService(config=config, ledger=ledger)
+
+    async def body_with_invalid_input(self: Any) -> RunOutcome:
+        # Stamp an ``invalid_input`` write outcome so the run-service
+        # surfaces ``invalid_note_state`` to the ledger.
+        counter = current_write_outcomes.get()
+        assert counter is not None
+        counter[("invalid_input", "arxiv")] = (
+            counter.get(("invalid_input", "arxiv"), 0) + 1
+        )
+        return RunOutcome(
+            sources_checked=2,
+            ingested=1,
+            profile_run_result=ProfileRunResult(
+                run_date="2026-05-08",
+                profile="alpha",
+                stats=RunStats(sources_checked=2, ingested=1),
+                items=[
+                    HighlightItem(
+                        id="note-1",
+                        title="Archive failed",
+                        score=8,
+                        tags=["profile:alpha", "influx:archive-missing"],
+                        reason="archive fetch failed",
+                        url="https://openai.com/index/x",
+                        related_in_lithos=[],
+                    )
+                ],
+            ),
+        )
+
+    with (
+        caplog.at_level(logging.INFO, logger="influx.run_service"),
+        patch("influx.run.Run.execute", new=body_with_invalid_input),
+    ):
+        await service.execute(_scheduled_plan())
+
+    record = _extract_run_completed_record(caplog)
+    assert "degraded=True" in record.message
+    assert "severity=unexpected_failure" in record.message
+    assert "invalid_note_state" in record.message
+
+    entry = next(e for e in ledger.recent() if e["status"] == "completed")
+    assert entry["degradation_severity"] == "unexpected_failure"
+    assert "invalid_note_state" in entry["degraded_reasons"]
+    # archive_acquisition is still present in the list — the
+    # severity bucket escalated, but the reason list preserves both.
+    assert "archive_acquisition" in entry["degraded_reasons"]
 
 
 async def test_archive_acquisition_degrades_run_and_logs_warning(


### PR DESCRIPTION
## Summary

Today every degraded run lands in the same bucket regardless of whether the degradation is tolerated upstream lossiness or a real pipeline regression. Staging evidence:

```
reasons=archive_acquisition,invalid_note_state           ← real bug
reasons=archive_acquisition,source_acquisition           ← tolerated
reasons=source_acquisition (rss/timeout=1)               ← tolerated
```

Adds a new ``degradation_severity`` field on every ledger entry, computed from the existing ``degraded_reasons`` list:

| Severity | Triggers |
|----------|----------|
| ``success`` | no degraded reasons |
| ``expected_lossy`` | only ``source_acquisition`` / ``source_cooldown_skip`` / ``archive_acquisition`` |
| ``unexpected_failure`` | any of ``invalid_note_state``, ``invalid_url_stall``, ``ingestion_stall``, ``fetch_stall``, ``filter_stall``, ``filter_error`` |

Mixing reasons escalates to ``unexpected_failure``. The flat ``degraded_reasons`` list is unchanged; severity is a new single-valued bucket layered on top.

**Wiring:**

- ``RunLedger._finish`` writes the field on every completed entry.
- ``RunService`` mirrors it in the ``run completed`` log line as ``severity=...`` and on the ``run_completions`` metric as a ``severity`` label.
- ``/runs/recent`` carries the field automatically (it serialises the entry as-is).
- New runbook section 2 explains the severity model and the recommended operator action per bucket.

Closes #164.

## Test plan

- [x] ``test_run_ledger.py::TestClassifyDegradationSeverity`` (7 tests) — pins the mapping for every existing reason and the escalation contract (``invalid_note_state + archive_acquisition`` → ``unexpected_failure``).
- [x] ``test_run_ledger.py::TestLedgerEntrySeverityField`` (4 tests) — pins the persisted field for clean / lossy / unexpected / mixed-reasons runs.
- [x] ``test_run_service.py``:
  - ``test_run_completed_log_degraded_false_for_clean_run`` now also asserts ``severity=success``.
  - New ``test_run_completed_log_carries_expected_lossy_severity`` — archive-missing alone → ``severity=expected_lossy``.
  - New ``test_run_completed_log_carries_unexpected_failure_severity`` — the staging shape (``invalid_note_state`` + ``archive_acquisition``) → ``severity=unexpected_failure`` in both log and ledger.
- [x] Full suite green: **2224 passed**.