### PR TITLE
feat: promotion gate based on degraded-run severity classes (#165)

### DIFF
--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -460,9 +460,12 @@ Policy:
   scorer failures).  The acceptance criterion is "fail immediately"
   — even one such run trips the gate.
 - **Soft fail** when the fraction of `expected_lossy` runs in the
-  window exceeds `--max-lossy-ratio` (default `0.5`, inclusive at
-  the boundary).  Tolerated upstream noise is fine in small doses
-  but becomes a quality signal if it dominates.
+  window is **strictly greater than** `--max-lossy-ratio` (default
+  `0.5`).  A ratio exactly equal to the threshold passes — only
+  ratios above it fail — so an operator setting `0.5` does not see
+  the gate flap on a clean 50/50 split.  Tolerated upstream noise
+  is fine in small doses but becomes a quality signal if it
+  dominates.
 - **Insufficient runs** when fewer than `--min-runs` (default 5)
   scheduled completed runs are present — prevents spurious
   PASS/FAIL on a freshly-started deployment.

--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -443,6 +443,62 @@ Safety properties:
 - The subcommand never deletes notes — use the `squatters` subcommand
   when actual removal is required.
 
+## 8c. Promotion gate (issue #165)
+
+A configurable gate that consumes the `degradation_severity` split
+from #164 and produces a single PASS/FAIL verdict suitable for a
+staging-promotion CI step.
+
+```bash
+./scripts/influx-diagnose.py promotion-gate [--window N] [--max-lossy-ratio R] [--min-runs M]
+```
+
+Policy:
+
+- **Hard fail** on any `degradation_severity=unexpected_failure`
+  run in the window (write-time data integrity, stall ratchets,
+  scorer failures).  The acceptance criterion is "fail immediately"
+  — even one such run trips the gate.
+- **Soft fail** when the fraction of `expected_lossy` runs in the
+  window exceeds `--max-lossy-ratio` (default `0.5`, inclusive at
+  the boundary).  Tolerated upstream noise is fine in small doses
+  but becomes a quality signal if it dominates.
+- **Insufficient runs** when fewer than `--min-runs` (default 5)
+  scheduled completed runs are present — prevents spurious
+  PASS/FAIL on a freshly-started deployment.
+- **PASS** otherwise.
+
+Output is a stable, line-oriented summary with:
+- the verdict + machine-readable `reason` code
+- runs evaluated vs. configured window/min
+- severity bucket counts
+- the expected-lossy ratio vs. threshold
+- top driver reasons / profiles (top 5 each)
+- on hard-fail, the specific failing `run_id`s with their reasons
+
+Exit codes: `0` on PASS, `1` on FAIL (any reason).  Suitable for
+direct use in a CI step:
+
+```bash
+./scripts/influx-diagnose.py --env staging promotion-gate \
+    --window 24 --max-lossy-ratio 0.4 \
+    || { echo "Staging quality gate failed"; exit 1; }
+```
+
+Tuning the knobs:
+
+- `--window`: roughly aligned with your scheduled cadence.  At one
+  run per hour, `24` = last day.  Higher values trade
+  responsiveness (a recent regression takes longer to clear) for
+  stability (one bad run does not dominate the verdict).
+- `--max-lossy-ratio`: depends on upstream noise floor.  Start
+  near `0.5` and tighten as you trust the steady-state.
+- `--min-runs`: bump to your usual daily run count if you only run
+  the gate after a 24h window has filled.
+
+The gate is read-only: no Lithos connection, no docker exec, no
+ledger writes.  It only reads `${INFLUX_STATE_PATH}/runs.jsonl`.
+
 ## 9. Scheduling stagger (issue #87)
 
 Profiles share a single global `[schedule].cron` expression. Within

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -27,6 +27,10 @@ Subcommands
                     ``influx:source-invalid`` (issue #162); default
                     read-only, ``--apply`` reconstructs recoverable
                     notes or tombstones unrecoverable ones
+    promotion-gate  Evaluate recent scheduled-run health against a
+                    configurable severity policy (issue #165); exits
+                    0 on PASS / 1 on FAIL so a CI promotion step can
+                    consume it directly
     cancel          Print the curl line for cancelling an in-flight run
                     (this script never sends destructive HTTP itself)
 
@@ -1386,6 +1390,38 @@ def cmd_invalid_source(args: argparse.Namespace) -> int:
     return 0 if refused == 0 else 1
 
 
+def cmd_promotion_gate(args: argparse.Namespace) -> int:
+    """Evaluate the promotion gate against recent ledger entries (issue #165).
+
+    Pure read of ``runs.jsonl`` plus the pure :mod:`influx.promotion_gate`
+    classifier — no Lithos connection, no docker logs, no admin HTTP.
+    Exits ``0`` on PASS, ``1`` on FAIL so the subcommand can drive a
+    staging-promotion CI step directly.
+    """
+    _ensure_project_runtime_or_reexec()
+    from influx.promotion_gate import (
+        PromotionGateConfig,
+        evaluate_promotion_gate,
+        format_gate_summary,
+    )
+
+    env = _load_env(args.env)
+    state = _state_dir(env)
+    runs = _read_runs_jsonl(state)
+    # ``_read_runs_jsonl`` returns oldest-first; the gate's window
+    # semantics need newest-first.
+    runs.reverse()
+
+    config = PromotionGateConfig(
+        window_runs=int(args.window),
+        max_expected_lossy_ratio=float(args.max_lossy_ratio),
+        min_runs_required=int(args.min_runs),
+    )
+    result = evaluate_promotion_gate(runs, config)
+    print(format_gate_summary(result, config))
+    return 0 if result.passed else 1
+
+
 def cmd_cancel(args: argparse.Namespace) -> int:
     env = _load_env(args.env)
     host = env.get("INFLUX_ADMIN_BIND_HOST", "127.0.0.1")
@@ -1634,6 +1670,41 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     p_invalid.set_defaults(func=cmd_invalid_source)
+
+    p_gate = sub.add_parser(
+        "promotion-gate",
+        help=(
+            "evaluate recent runs against a configurable severity policy "
+            "(issue #165); exits 0 on PASS, 1 on FAIL"
+        ),
+    )
+    p_gate.add_argument(
+        "--window",
+        type=int,
+        default=20,
+        help=("number of recent scheduled completed runs to evaluate (default: 20)"),
+    )
+    p_gate.add_argument(
+        "--max-lossy-ratio",
+        type=float,
+        default=0.5,
+        help=(
+            "fail the gate when the fraction of expected_lossy runs in "
+            "the window exceeds this value (inclusive at the boundary; "
+            "default: 0.5)"
+        ),
+    )
+    p_gate.add_argument(
+        "--min-runs",
+        type=int,
+        default=5,
+        help=(
+            "minimum scheduled completed runs required in the window to "
+            "evaluate at all (default: 5).  Below this the gate reports "
+            "'insufficient_runs' rather than a spurious pass / fail."
+        ),
+    )
+    p_gate.set_defaults(func=cmd_promotion_gate)
 
     p_cancel = sub.add_parser(
         "cancel",

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -1690,8 +1690,8 @@ def _build_parser() -> argparse.ArgumentParser:
         default=0.5,
         help=(
             "fail the gate when the fraction of expected_lossy runs in "
-            "the window exceeds this value (inclusive at the boundary; "
-            "default: 0.5)"
+            "the window is strictly greater than this value.  A ratio "
+            "exactly equal to the threshold passes (default: 0.5)."
         ),
     )
     p_gate.add_argument(

--- a/src/influx/promotion_gate.py
+++ b/src/influx/promotion_gate.py
@@ -47,10 +47,13 @@ class PromotionGateConfig:
         20 — a roughly-day-long window at the typical hourly cadence.
     max_expected_lossy_ratio:
         Hard ceiling on the ratio of ``expected_lossy`` runs in the
-        window.  Above this the gate fails with reason
-        ``"expected_lossy_above_threshold"`` even when every run is
-        below ``unexpected_failure``.  Defaults to 0.5 (half the
-        window).  Set to 1.0 to disable the ratio check entirely.
+        window.  The gate fails with reason
+        ``"expected_lossy_above_threshold"`` when the observed ratio
+        is **strictly greater than** this value; a ratio exactly
+        equal to the threshold passes (so an operator setting ``0.5``
+        does not see the gate flap on a clean 50/50 split).  Defaults
+        to 0.5 (half the window).  Set to 1.0 to disable the ratio
+        check entirely (no observable ratio can exceed 1.0).
     min_runs_required:
         Refuse to evaluate when fewer than this many scheduled
         completed runs are present in the window.  Prevents
@@ -61,6 +64,28 @@ class PromotionGateConfig:
     window_runs: int = 20
     max_expected_lossy_ratio: float = 0.5
     min_runs_required: int = 5
+
+    def __post_init__(self) -> None:
+        """Validate config values at construction time (Copilot review on PR #172).
+
+        Reject obviously-bogus values up front so a CI misconfiguration
+        (e.g. ``min_runs_required = 0`` making the insufficient-runs
+        check unreachable, or a negative ratio that no real run can
+        satisfy) cannot silently promote.  Raised as ``ValueError`` so
+        the operator sees the specific bad knob rather than a vague
+        downstream failure.
+        """
+        if self.window_runs < 1:
+            raise ValueError(f"window_runs must be >= 1, got {self.window_runs}")
+        if self.min_runs_required < 1:
+            raise ValueError(
+                f"min_runs_required must be >= 1, got {self.min_runs_required}"
+            )
+        if not 0.0 <= self.max_expected_lossy_ratio <= 1.0:
+            raise ValueError(
+                "max_expected_lossy_ratio must be in [0.0, 1.0], got "
+                f"{self.max_expected_lossy_ratio}"
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -273,4 +298,7 @@ def format_gate_summary(
             reasons_str = ",".join(str(r) for r in reasons_list) or "<none>"
             lines.append(f"  run_id={run_id} profile={profile} reasons={reasons_str}")
 
-    return "\n".join(lines) + "\n"
+    # No trailing newline — caller decides how to emit (Copilot review
+    # on PR #172: wrapping in ``print(...)`` previously added a second
+    # newline and produced extra blank lines in CI logs).
+    return "\n".join(lines)

--- a/src/influx/promotion_gate.py
+++ b/src/influx/promotion_gate.py
@@ -1,0 +1,276 @@
+"""Promotion gate evaluating recent run health (issue #165).
+
+Builds on the :func:`influx.run_ledger.classify_degradation_severity`
+split from #164 to produce a single pass/fail signal a promotion
+script can consume:
+
+* **Hard fail** on any ``unexpected_failure`` run in the recent
+  window — write-time data integrity, scorer execution failures,
+  stall ratchets, etc.  These are always actionable regressions.
+* **Soft fail** when the ratio of ``expected_lossy`` runs in the
+  window exceeds a configured threshold — tolerated upstream noise
+  is fine in small doses but becomes a quality signal if it
+  dominates.
+* **Pass** otherwise, with a human-readable summary listing the
+  severity breakdown and the top driver reasons / domains so the
+  operator sees *why* the gate landed where it did even on success.
+
+Pure module — no IO, no Lithos client.  The CLI subcommand in
+``scripts/influx-diagnose.py`` reads ``runs.jsonl`` and passes the
+entries in; tests pass synthetic entries directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from influx.run_ledger import classify_degradation_severity
+
+__all__ = [
+    "PromotionGateConfig",
+    "PromotionGateResult",
+    "evaluate_promotion_gate",
+    "format_gate_summary",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PromotionGateConfig:
+    """Tunables for :func:`evaluate_promotion_gate`.
+
+    Attributes
+    ----------
+    window_runs:
+        Maximum number of recent scheduled completed runs to
+        evaluate.  Runs older than this are ignored.  Defaults to
+        20 — a roughly-day-long window at the typical hourly cadence.
+    max_expected_lossy_ratio:
+        Hard ceiling on the ratio of ``expected_lossy`` runs in the
+        window.  Above this the gate fails with reason
+        ``"expected_lossy_above_threshold"`` even when every run is
+        below ``unexpected_failure``.  Defaults to 0.5 (half the
+        window).  Set to 1.0 to disable the ratio check entirely.
+    min_runs_required:
+        Refuse to evaluate when fewer than this many scheduled
+        completed runs are present in the window.  Prevents
+        spurious pass / fail on a freshly-started deployment.
+        Defaults to 5.
+    """
+
+    window_runs: int = 20
+    max_expected_lossy_ratio: float = 0.5
+    min_runs_required: int = 5
+
+
+@dataclass(frozen=True, slots=True)
+class PromotionGateResult:
+    """Outcome of :func:`evaluate_promotion_gate`.
+
+    Attributes
+    ----------
+    passed:
+        Overall verdict — ``True`` only when no unexpected failures
+        landed in the window AND the expected-lossy ratio is at or
+        below the configured threshold.
+    reason:
+        Stable machine-readable code: ``"ok"``,
+        ``"insufficient_runs"``, ``"unexpected_failure_present"``,
+        ``"expected_lossy_above_threshold"``.  Callers can branch
+        on this without parsing the human-readable summary.
+    runs_evaluated:
+        How many scheduled completed runs the gate actually
+        inspected (clamped to ``config.window_runs``).
+    severity_counts:
+        ``{"success": N, "expected_lossy": N, "unexpected_failure": N}``
+        — exhaustive bucket counts for the inspected runs.
+    expected_lossy_ratio:
+        ``expected_lossy_count / runs_evaluated`` — ``0.0`` when
+        ``runs_evaluated == 0``.
+    unexpected_failure_runs:
+        The actual ledger entries that triggered the hard fail (or
+        empty when ``"unexpected_failure" not in reason``).  Surfaced
+        so the operator can drill into the offending run_ids without
+        a second ledger fetch.
+    top_drivers:
+        ``{"reasons": {reason: count}, "profiles": {profile: count}}``
+        breakdown across all evaluated runs.  Helps the operator
+        spot whether a single profile / a single reason dominates.
+    """
+
+    passed: bool
+    reason: str
+    runs_evaluated: int
+    severity_counts: dict[str, int]
+    expected_lossy_ratio: float
+    unexpected_failure_runs: list[dict[str, Any]] = field(default_factory=list)
+    top_drivers: dict[str, dict[str, int]] = field(default_factory=dict)
+
+
+def evaluate_promotion_gate(
+    entries: list[dict[str, Any]],
+    config: PromotionGateConfig | None = None,
+) -> PromotionGateResult:
+    """Evaluate the promotion gate against *entries* (newest first).
+
+    *entries* is the raw shape returned by
+    :meth:`influx.run_ledger.RunLedger.recent` — the gate filters
+    to ``status=="completed"`` AND ``kind=="scheduled"`` runs only
+    (skipped / failed / manual / backfill runs are excluded because
+    their semantics don't fit the steady-state quality signal we are
+    gating on).
+
+    Pure function — order-sensitive on the inspected window (the
+    "recent" semantics come from the caller passing entries
+    newest-first), otherwise stateless.
+    """
+    cfg = config if config is not None else PromotionGateConfig()
+    severity_counts = {
+        "success": 0,
+        "expected_lossy": 0,
+        "unexpected_failure": 0,
+    }
+    inspected: list[dict[str, Any]] = []
+    unexpected: list[dict[str, Any]] = []
+    reason_counts: dict[str, int] = {}
+    profile_counts: dict[str, int] = {}
+
+    for entry in entries:
+        if len(inspected) >= cfg.window_runs:
+            break
+        if entry.get("status") != "completed":
+            continue
+        if entry.get("kind") != "scheduled":
+            continue
+        inspected.append(entry)
+        # Prefer the persisted severity field (issue #164); fall
+        # back to recomputing from the reason list for entries
+        # written before #164 landed.
+        severity = entry.get("degradation_severity")
+        if severity not in severity_counts:
+            severity = classify_degradation_severity(
+                [
+                    str(r)
+                    for r in (entry.get("degraded_reasons") or [])
+                    if isinstance(r, str)
+                ]
+            )
+        severity_counts[severity] += 1
+        if severity == "unexpected_failure":
+            unexpected.append(entry)
+        profile = entry.get("profile")
+        if isinstance(profile, str) and profile:
+            profile_counts[profile] = profile_counts.get(profile, 0) + 1
+        for reason in entry.get("degraded_reasons") or []:
+            if isinstance(reason, str):
+                reason_counts[reason] = reason_counts.get(reason, 0) + 1
+
+    runs_evaluated = len(inspected)
+    expected_lossy_ratio = (
+        severity_counts["expected_lossy"] / runs_evaluated
+        if runs_evaluated > 0
+        else 0.0
+    )
+    top_drivers = {
+        "reasons": reason_counts,
+        "profiles": profile_counts,
+    }
+
+    if runs_evaluated < cfg.min_runs_required:
+        return PromotionGateResult(
+            passed=False,
+            reason="insufficient_runs",
+            runs_evaluated=runs_evaluated,
+            severity_counts=severity_counts,
+            expected_lossy_ratio=expected_lossy_ratio,
+            top_drivers=top_drivers,
+        )
+
+    if unexpected:
+        return PromotionGateResult(
+            passed=False,
+            reason="unexpected_failure_present",
+            runs_evaluated=runs_evaluated,
+            severity_counts=severity_counts,
+            expected_lossy_ratio=expected_lossy_ratio,
+            unexpected_failure_runs=unexpected,
+            top_drivers=top_drivers,
+        )
+
+    if expected_lossy_ratio > cfg.max_expected_lossy_ratio:
+        return PromotionGateResult(
+            passed=False,
+            reason="expected_lossy_above_threshold",
+            runs_evaluated=runs_evaluated,
+            severity_counts=severity_counts,
+            expected_lossy_ratio=expected_lossy_ratio,
+            top_drivers=top_drivers,
+        )
+
+    return PromotionGateResult(
+        passed=True,
+        reason="ok",
+        runs_evaluated=runs_evaluated,
+        severity_counts=severity_counts,
+        expected_lossy_ratio=expected_lossy_ratio,
+        top_drivers=top_drivers,
+    )
+
+
+def format_gate_summary(
+    result: PromotionGateResult,
+    config: PromotionGateConfig | None = None,
+) -> str:
+    """Render a human-readable promotion-gate summary.
+
+    Stable, line-oriented so operators can ``grep`` / ``less``.
+    Includes the verdict, the severity counts, the expected-lossy
+    ratio (relative to the configured threshold), the top driver
+    reasons / profiles, and — on a hard fail — the specific failing
+    run_ids so the operator has a direct drill-in target.
+    """
+    cfg = config if config is not None else PromotionGateConfig()
+    verdict = "PASS" if result.passed else "FAIL"
+    lines: list[str] = []
+    lines.append(f"Promotion gate: {verdict}")
+    lines.append(f"  reason          : {result.reason}")
+    lines.append(
+        f"  runs_evaluated  : {result.runs_evaluated} "
+        f"(window={cfg.window_runs}, min_required={cfg.min_runs_required})"
+    )
+    counts = result.severity_counts
+    lines.append(
+        "  severity_counts : "
+        f"success={counts.get('success', 0)} "
+        f"expected_lossy={counts.get('expected_lossy', 0)} "
+        f"unexpected_failure={counts.get('unexpected_failure', 0)}"
+    )
+    lines.append(
+        "  expected_lossy  : "
+        f"ratio={result.expected_lossy_ratio:.2f} "
+        f"(max={cfg.max_expected_lossy_ratio:.2f})"
+    )
+
+    reasons = result.top_drivers.get("reasons") or {}
+    if reasons:
+        ranked = sorted(reasons.items(), key=lambda kv: (-kv[1], kv[0]))
+        formatted = " ".join(f"{r}={c}" for r, c in ranked[:5])
+        lines.append(f"  top reasons     : {formatted}")
+
+    profiles = result.top_drivers.get("profiles") or {}
+    if profiles:
+        ranked = sorted(profiles.items(), key=lambda kv: (-kv[1], kv[0]))
+        formatted = " ".join(f"{p}={c}" for p, c in ranked[:5])
+        lines.append(f"  profiles        : {formatted}")
+
+    if result.unexpected_failure_runs:
+        lines.append("")
+        lines.append("Unexpected-failure runs (most recent first):")
+        for entry in result.unexpected_failure_runs:
+            run_id = entry.get("run_id", "?")
+            profile = entry.get("profile", "?")
+            reasons_list = entry.get("degraded_reasons") or []
+            reasons_str = ",".join(str(r) for r in reasons_list) or "<none>"
+            lines.append(f"  run_id={run_id} profile={profile} reasons={reasons_str}")
+
+    return "\n".join(lines) + "\n"

--- a/tests/unit/test_diagnose_promotion_gate.py
+++ b/tests/unit/test_diagnose_promotion_gate.py
@@ -1,0 +1,167 @@
+"""Unit tests for the ``influx-diagnose promotion-gate`` subcommand (#165).
+
+The CLI thin-wraps :mod:`influx.promotion_gate` over the local
+``runs.jsonl`` ledger.  These tests pin the wiring:
+
+* The subcommand reads the ledger, reverses to newest-first, and
+  feeds the entries to the gate.
+* Exit code is ``0`` on PASS and ``1`` on FAIL so a CI step can
+  consume the verdict directly.
+* The summary text is written to stdout (operator log surface).
+
+Gate behaviour is covered by ``test_promotion_gate.py``; here we
+only check the script glue.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+
+def _load_script() -> Any:
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "influx_diagnose_promotion_gate",
+        repo_root / "scripts" / "influx-diagnose.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_DIAGNOSE = _load_script()
+
+
+def _write_ledger(tmp_path: Path, entries: list[dict[str, Any]]) -> Path:
+    """Write ledger entries as JSONL (one per line, oldest first).
+
+    ``_read_runs_jsonl`` returns them in file order, and
+    ``cmd_promotion_gate`` reverses to newest-first before passing
+    them to the gate.
+    """
+    state = tmp_path / "state"
+    state.mkdir()
+    runs = state / "runs.jsonl"
+    runs.write_text("\n".join(json.dumps(e) for e in entries))
+    return state
+
+
+def _scheduled_entry(
+    run_id: str,
+    *,
+    severity: str = "success",
+    reasons: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "run_id": run_id,
+        "profile": "alpha",
+        "kind": "scheduled",
+        "status": "completed",
+        "degraded_reasons": list(reasons or []),
+        "degradation_severity": severity,
+    }
+
+
+def _args(**overrides: Any) -> argparse.Namespace:
+    base = {
+        "env": "staging",
+        "window": 20,
+        "max_lossy_ratio": 0.5,
+        "min_runs": 5,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+class TestCmdPromotionGate:
+    """The subcommand wires the ledger into the gate and exits 0/1."""
+
+    def test_pass_returns_zero_and_prints_pass(
+        self, tmp_path: Path, capsys: Any
+    ) -> None:
+        state = _write_ledger(tmp_path, [_scheduled_entry(f"r-{i}") for i in range(6)])
+        env = {"INFLUX_STATE_PATH": str(state)}
+
+        with (
+            patch.object(_DIAGNOSE, "_load_env", return_value=env),
+            patch.object(_DIAGNOSE, "_ensure_project_runtime_or_reexec"),
+        ):
+            rc = _DIAGNOSE.cmd_promotion_gate(_args(min_runs=5))
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Promotion gate: PASS" in out
+        assert "reason          : ok" in out
+
+    def test_unexpected_failure_returns_one(self, tmp_path: Path, capsys: Any) -> None:
+        entries = [
+            _scheduled_entry(
+                "bad",
+                severity="unexpected_failure",
+                reasons=["invalid_note_state"],
+            ),
+        ] + [_scheduled_entry(f"ok-{i}") for i in range(5)]
+        state = _write_ledger(tmp_path, entries)
+        env = {"INFLUX_STATE_PATH": str(state)}
+
+        with (
+            patch.object(_DIAGNOSE, "_load_env", return_value=env),
+            patch.object(_DIAGNOSE, "_ensure_project_runtime_or_reexec"),
+        ):
+            rc = _DIAGNOSE.cmd_promotion_gate(_args())
+
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "Promotion gate: FAIL" in out
+        assert "unexpected_failure_present" in out
+        # The offending run_id appears in the summary so the operator
+        # has a direct drill-in target.
+        assert "run_id=bad" in out
+
+    def test_lossy_above_ratio_returns_one(self, tmp_path: Path, capsys: Any) -> None:
+        # 7 lossy + 3 success = 0.7 ratio; threshold default is 0.5.
+        entries = [
+            _scheduled_entry(
+                f"lossy-{i}",
+                severity="expected_lossy",
+                reasons=["archive_acquisition"],
+            )
+            for i in range(7)
+        ] + [_scheduled_entry(f"ok-{i}") for i in range(3)]
+        state = _write_ledger(tmp_path, entries)
+        env = {"INFLUX_STATE_PATH": str(state)}
+
+        with (
+            patch.object(_DIAGNOSE, "_load_env", return_value=env),
+            patch.object(_DIAGNOSE, "_ensure_project_runtime_or_reexec"),
+        ):
+            rc = _DIAGNOSE.cmd_promotion_gate(_args())
+
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "expected_lossy_above_threshold" in out
+        assert "ratio=0.70" in out
+
+    def test_missing_ledger_file_falls_through_to_insufficient_runs(
+        self, tmp_path: Path, capsys: Any
+    ) -> None:
+        # No runs.jsonl in the state dir: empty entries → insufficient.
+        state = tmp_path / "state"
+        state.mkdir()
+        env = {"INFLUX_STATE_PATH": str(state)}
+
+        with (
+            patch.object(_DIAGNOSE, "_load_env", return_value=env),
+            patch.object(_DIAGNOSE, "_ensure_project_runtime_or_reexec"),
+        ):
+            rc = _DIAGNOSE.cmd_promotion_gate(_args())
+
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "insufficient_runs" in out

--- a/tests/unit/test_promotion_gate.py
+++ b/tests/unit/test_promotion_gate.py
@@ -1,0 +1,292 @@
+"""Unit tests for the promotion gate (issue #165).
+
+The gate consumes ledger-shaped entries and produces a pass/fail
+verdict for a staging-promotion script.  Tests pin:
+
+* Filtering: only ``status="completed"`` AND ``kind="scheduled"``
+  runs count.
+* The three failure modes — ``insufficient_runs``,
+  ``unexpected_failure_present``, ``expected_lossy_above_threshold``.
+* The success mode (``"ok"``) and that the ratio threshold is
+  inclusive (a ratio exactly equal to the configured max passes).
+* The top-driver / unexpected-failure summary surfaces.
+* Backward-compat: entries written before #164 land in the ledger
+  without ``degradation_severity``; the gate falls back to
+  recomputing from ``degraded_reasons``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from influx.promotion_gate import (
+    PromotionGateConfig,
+    evaluate_promotion_gate,
+    format_gate_summary,
+)
+
+
+def _entry(
+    *,
+    run_id: str,
+    severity: str | None = "success",
+    reasons: list[str] | None = None,
+    profile: str = "alpha",
+    kind: str = "scheduled",
+    status: str = "completed",
+) -> dict[str, Any]:
+    """Build a ledger-shaped entry suitable for the gate."""
+    entry: dict[str, Any] = {
+        "run_id": run_id,
+        "profile": profile,
+        "kind": kind,
+        "status": status,
+        "degraded_reasons": list(reasons or []),
+    }
+    # ``severity=None`` means "simulate a legacy entry written before
+    # issue #164 landed" — the gate must fall back to recomputing.
+    if severity is not None:
+        entry["degradation_severity"] = severity
+    return entry
+
+
+# ── Filtering ─────────────────────────────────────────────────────────
+
+
+class TestEntryFiltering:
+    """The gate only inspects scheduled completed runs."""
+
+    def test_skipped_and_failed_entries_are_ignored(self) -> None:
+        entries = [
+            _entry(run_id="ok-1"),
+            _entry(run_id="ok-2"),
+            _entry(run_id="ok-3"),
+            _entry(run_id="ok-4"),
+            _entry(run_id="ok-5"),
+            _entry(run_id="abandoned", status="abandoned"),
+            _entry(run_id="failed", status="failed"),
+            _entry(run_id="skipped", status="skipped"),
+        ]
+        result = evaluate_promotion_gate(
+            entries, PromotionGateConfig(min_runs_required=1)
+        )
+        assert result.runs_evaluated == 5
+        assert result.passed is True
+        assert result.reason == "ok"
+
+    def test_manual_and_backfill_runs_are_ignored(self) -> None:
+        entries = [
+            _entry(run_id="manual", kind="manual"),
+            _entry(run_id="backfill", kind="backfill"),
+        ] + [_entry(run_id=f"s-{i}") for i in range(5)]
+        result = evaluate_promotion_gate(
+            entries, PromotionGateConfig(min_runs_required=1)
+        )
+        # Only the 5 scheduled runs are inspected.
+        assert result.runs_evaluated == 5
+
+    def test_window_clamps_inspected_runs(self) -> None:
+        entries = [_entry(run_id=f"r-{i}") for i in range(30)]
+        result = evaluate_promotion_gate(
+            entries, PromotionGateConfig(window_runs=10, min_runs_required=1)
+        )
+        assert result.runs_evaluated == 10
+
+
+# ── Pass / fail outcomes ──────────────────────────────────────────────
+
+
+class TestPromotionGateOutcomes:
+    """The three failure modes plus the success mode."""
+
+    def test_insufficient_runs_fails_gate(self) -> None:
+        entries = [_entry(run_id="r-1"), _entry(run_id="r-2")]
+        result = evaluate_promotion_gate(
+            entries, PromotionGateConfig(min_runs_required=5)
+        )
+        assert result.passed is False
+        assert result.reason == "insufficient_runs"
+        assert result.runs_evaluated == 2
+
+    def test_all_success_passes(self) -> None:
+        entries = [_entry(run_id=f"r-{i}") for i in range(5)]
+        result = evaluate_promotion_gate(
+            entries, PromotionGateConfig(min_runs_required=5)
+        )
+        assert result.passed is True
+        assert result.reason == "ok"
+
+    def test_single_unexpected_failure_fails_gate(self) -> None:
+        # Even one unexpected failure in the window is an immediate
+        # fail — the acceptance criterion says: "gate fails on
+        # unexpected-failure even when the raw degraded ratio is low".
+        entries = [
+            _entry(
+                run_id="bad",
+                severity="unexpected_failure",
+                reasons=["invalid_note_state"],
+            ),
+        ] + [_entry(run_id=f"ok-{i}") for i in range(10)]
+        result = evaluate_promotion_gate(entries, PromotionGateConfig())
+        assert result.passed is False
+        assert result.reason == "unexpected_failure_present"
+        assert len(result.unexpected_failure_runs) == 1
+        assert result.unexpected_failure_runs[0]["run_id"] == "bad"
+
+    def test_unexpected_failure_beats_high_lossy_ratio_in_reason(self) -> None:
+        # If both conditions would trip, ``unexpected_failure_present``
+        # wins because it's the more actionable signal.
+        entries = [
+            _entry(
+                run_id="bad",
+                severity="unexpected_failure",
+                reasons=["invalid_note_state"],
+            ),
+        ] + [
+            _entry(
+                run_id=f"lossy-{i}",
+                severity="expected_lossy",
+                reasons=["archive_acquisition"],
+            )
+            for i in range(9)
+        ]
+        result = evaluate_promotion_gate(entries, PromotionGateConfig())
+        assert result.reason == "unexpected_failure_present"
+
+    def test_expected_lossy_under_threshold_passes(self) -> None:
+        # 4 lossy + 6 success = 0.4 ratio; threshold is 0.5 → passes.
+        entries = [
+            _entry(
+                run_id=f"lossy-{i}",
+                severity="expected_lossy",
+                reasons=["archive_acquisition"],
+            )
+            for i in range(4)
+        ] + [_entry(run_id=f"ok-{i}") for i in range(6)]
+        result = evaluate_promotion_gate(
+            entries, PromotionGateConfig(max_expected_lossy_ratio=0.5)
+        )
+        assert result.passed is True
+        assert result.reason == "ok"
+        assert result.expected_lossy_ratio == 0.4
+
+    def test_ratio_exactly_at_threshold_passes(self) -> None:
+        # 5 lossy + 5 success = exactly 0.5 → inclusive at the
+        # boundary so an operator setting ``max=0.5`` does not see
+        # gate flap from a 50/50 split.
+        entries = [
+            _entry(
+                run_id=f"lossy-{i}",
+                severity="expected_lossy",
+                reasons=["archive_acquisition"],
+            )
+            for i in range(5)
+        ] + [_entry(run_id=f"ok-{i}") for i in range(5)]
+        result = evaluate_promotion_gate(
+            entries, PromotionGateConfig(max_expected_lossy_ratio=0.5)
+        )
+        assert result.passed is True
+
+    def test_expected_lossy_above_threshold_fails_gate(self) -> None:
+        # 7 lossy + 3 success = 0.7 ratio; threshold is 0.5 → fail.
+        entries = [
+            _entry(
+                run_id=f"lossy-{i}",
+                severity="expected_lossy",
+                reasons=["archive_acquisition"],
+            )
+            for i in range(7)
+        ] + [_entry(run_id=f"ok-{i}") for i in range(3)]
+        result = evaluate_promotion_gate(
+            entries, PromotionGateConfig(max_expected_lossy_ratio=0.5)
+        )
+        assert result.passed is False
+        assert result.reason == "expected_lossy_above_threshold"
+        assert result.expected_lossy_ratio == 0.7
+
+
+# ── Severity fallback ─────────────────────────────────────────────────
+
+
+class TestLegacyEntryFallback:
+    """Entries written before #164 lack ``degradation_severity``."""
+
+    def test_legacy_entry_uses_classify_from_reasons(self) -> None:
+        # Legacy entry: no degradation_severity field, but reasons
+        # list contains an unexpected-failure reason — gate must
+        # still classify it as unexpected_failure and hard-fail.
+        entries = [
+            _entry(
+                run_id="legacy",
+                severity=None,  # simulate missing field
+                reasons=["invalid_note_state"],
+            ),
+        ] + [_entry(run_id=f"ok-{i}") for i in range(5)]
+        result = evaluate_promotion_gate(entries, PromotionGateConfig())
+        assert result.reason == "unexpected_failure_present"
+
+    def test_legacy_clean_entry_classified_as_success(self) -> None:
+        entries = [
+            _entry(run_id="legacy", severity=None, reasons=[]),
+        ] + [_entry(run_id=f"ok-{i}") for i in range(5)]
+        result = evaluate_promotion_gate(entries, PromotionGateConfig())
+        assert result.passed is True
+        assert result.severity_counts["success"] == 6
+
+
+# ── Summary rendering ─────────────────────────────────────────────────
+
+
+class TestFormatGateSummary:
+    """The CLI summary surfaces the verdict + supporting numbers."""
+
+    def test_pass_summary_lists_verdict_and_counts(self) -> None:
+        entries = [_entry(run_id=f"r-{i}") for i in range(5)]
+        result = evaluate_promotion_gate(
+            entries, PromotionGateConfig(min_runs_required=1)
+        )
+        text = format_gate_summary(result, PromotionGateConfig(min_runs_required=1))
+        assert "PASS" in text
+        assert "reason          : ok" in text
+        assert "runs_evaluated  : 5" in text
+        assert "success=5" in text
+
+    def test_fail_summary_includes_offending_run_ids(self) -> None:
+        entries = [
+            _entry(
+                run_id="bad-run-1",
+                severity="unexpected_failure",
+                reasons=["invalid_note_state", "archive_acquisition"],
+                profile="ai-agents",
+            ),
+        ] + [_entry(run_id=f"ok-{i}") for i in range(5)]
+        result = evaluate_promotion_gate(entries, PromotionGateConfig())
+        text = format_gate_summary(result, PromotionGateConfig())
+        assert "FAIL" in text
+        assert "unexpected_failure_present" in text
+        # The offending run is listed by id + profile + reasons.
+        assert "bad-run-1" in text
+        assert "ai-agents" in text
+        assert "invalid_note_state" in text
+
+    def test_top_reasons_block_appears(self) -> None:
+        entries = [
+            _entry(
+                run_id=f"r-{i}",
+                severity="expected_lossy",
+                reasons=["archive_acquisition", "source_acquisition"],
+            )
+            for i in range(5)
+        ]
+        result = evaluate_promotion_gate(entries, PromotionGateConfig())
+        text = format_gate_summary(result, PromotionGateConfig())
+        assert "top reasons" in text
+        assert "archive_acquisition=5" in text
+        assert "source_acquisition=5" in text
+
+    def test_empty_window_summary_is_safe(self) -> None:
+        result = evaluate_promotion_gate([], PromotionGateConfig(min_runs_required=5))
+        text = format_gate_summary(result, PromotionGateConfig())
+        assert "FAIL" in text
+        assert "insufficient_runs" in text
+        assert "runs_evaluated  : 0" in text

--- a/tests/unit/test_promotion_gate.py
+++ b/tests/unit/test_promotion_gate.py
@@ -7,8 +7,9 @@ verdict for a staging-promotion script.  Tests pin:
   runs count.
 * The three failure modes — ``insufficient_runs``,
   ``unexpected_failure_present``, ``expected_lossy_above_threshold``.
-* The success mode (``"ok"``) and that the ratio threshold is
-  inclusive (a ratio exactly equal to the configured max passes).
+* The success mode (``"ok"``) and that the ratio comparison is
+  strict ``>`` rather than ``>=`` — a ratio exactly equal to the
+  configured max passes; only ratios strictly above it fail.
 * The top-driver / unexpected-failure summary surfaces.
 * Backward-compat: entries written before #164 land in the ledger
   without ``degradation_severity``; the gate falls back to
@@ -19,11 +20,87 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from influx.promotion_gate import (
     PromotionGateConfig,
     evaluate_promotion_gate,
     format_gate_summary,
 )
+
+# ── Config validation (Copilot review on PR #172) ─────────────────────
+
+
+class TestPromotionGateConfigValidation:
+    """``PromotionGateConfig.__post_init__`` rejects bogus knob values.
+
+    Without validation, a CI misconfiguration like ``min_runs_required=0``
+    silently makes the insufficient-runs check unreachable and the gate
+    can pass on an empty window.  Pinning the contract here keeps the
+    knobs from drifting back into the wild west.
+    """
+
+    def test_window_runs_below_one_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="window_runs"):
+            PromotionGateConfig(window_runs=0)
+        with pytest.raises(ValueError, match="window_runs"):
+            PromotionGateConfig(window_runs=-1)
+
+    def test_min_runs_required_below_one_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="min_runs_required"):
+            PromotionGateConfig(min_runs_required=0)
+        with pytest.raises(ValueError, match="min_runs_required"):
+            PromotionGateConfig(min_runs_required=-1)
+
+    def test_max_expected_lossy_ratio_out_of_range_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="max_expected_lossy_ratio"):
+            PromotionGateConfig(max_expected_lossy_ratio=-0.01)
+        with pytest.raises(ValueError, match="max_expected_lossy_ratio"):
+            PromotionGateConfig(max_expected_lossy_ratio=1.01)
+
+    def test_ratio_at_zero_and_one_are_accepted(self) -> None:
+        # 0.0 = "any expected_lossy fails" — a tightening operator may
+        # want this.  1.0 = "no observable ratio can exceed 1.0", so
+        # the lossy-ratio check is effectively disabled.
+        PromotionGateConfig(max_expected_lossy_ratio=0.0)
+        PromotionGateConfig(max_expected_lossy_ratio=1.0)
+
+
+# ── Formatter contract: no trailing newline ───────────────────────────
+
+
+class TestFormatGateSummaryNewlines:
+    """``format_gate_summary`` returns text WITHOUT a trailing newline.
+
+    Caller decides how to emit (default ``print(...)`` adds the single
+    final newline).  Copilot review on PR #172: a function-side
+    trailing newline plus ``print`` produced extra blank lines in CI
+    logs.
+    """
+
+    def test_no_trailing_newline(self) -> None:
+        entries = [
+            {
+                "run_id": "r-1",
+                "profile": "alpha",
+                "kind": "scheduled",
+                "status": "completed",
+                "degraded_reasons": [],
+                "degradation_severity": "success",
+            }
+        ]
+        result = evaluate_promotion_gate(
+            entries, PromotionGateConfig(min_runs_required=1)
+        )
+        text = format_gate_summary(result, PromotionGateConfig(min_runs_required=1))
+        assert not text.endswith("\n"), (
+            "format_gate_summary must not return a trailing newline; the "
+            "caller decides how to emit"
+        )
+        # Still ends with the substantive last line.
+        assert text.endswith("success=1 expected_lossy=0 unexpected_failure=0") or (
+            "success=1" in text
+        )
 
 
 def _entry(
@@ -171,9 +248,10 @@ class TestPromotionGateOutcomes:
         assert result.expected_lossy_ratio == 0.4
 
     def test_ratio_exactly_at_threshold_passes(self) -> None:
-        # 5 lossy + 5 success = exactly 0.5 → inclusive at the
-        # boundary so an operator setting ``max=0.5`` does not see
-        # gate flap from a 50/50 split.
+        # 5 lossy + 5 success = exactly 0.5 → passes because the
+        # comparison is strict ``>`` (only ratios strictly above the
+        # threshold fail), so an operator setting ``max=0.5`` does
+        # not see gate flap from a clean 50/50 split.
         entries = [
             _entry(
                 run_id=f"lossy-{i}",


### PR DESCRIPTION
## Summary

Builds on the ``degradation_severity`` split from #164 to produce a single PASS/FAIL verdict a staging-promotion CI step can consume. Today an operator has to eyeball the recent ledger and decide; the gate codifies the policy.

**Policy:**

- **Hard fail** on any ``unexpected_failure`` run in the window (write-time data integrity, stall ratchets, scorer failures). Even one trips the gate — acceptance criterion: "fail immediately".
- **Soft fail** when ``expected_lossy`` ratio exceeds ``--max-lossy-ratio`` (default 0.5, inclusive at the boundary).
- **Insufficient runs** when fewer than ``--min-runs`` (default 5) scheduled completed runs are in the window — prevents spurious PASS/FAIL on freshly-started deployments.
- **PASS** otherwise.

**Surfaces:**

- New pure module ``influx.promotion_gate`` (``PromotionGateConfig``, ``PromotionGateResult``, ``evaluate_promotion_gate``, ``format_gate_summary``).
- New CLI subcommand ``./scripts/influx-diagnose.py promotion-gate`` with ``--window`` / ``--max-lossy-ratio`` / ``--min-runs`` flags. Exits ``0`` on PASS, ``1`` on FAIL.
- Runbook section "8c. Promotion gate" with example CI usage.

**Backward compat:** entries written before #164 lack ``degradation_severity``; the gate falls back to recomputing via ``classify_degradation_severity``.

Closes #165.

## Test plan

- [x] ``test_promotion_gate.py`` (16 tests):
  - Filtering: only ``status=completed`` + ``kind=scheduled``; window clamps; manual / backfill excluded.
  - All four reasons: ``ok`` / ``insufficient_runs`` / ``unexpected_failure_present`` / ``expected_lossy_above_threshold``.
  - Boundary inclusiveness — a 50/50 split exactly at ``max=0.5`` passes.
  - Reason precedence — ``unexpected_failure_present`` wins over ``expected_lossy_above_threshold`` when both would fire.
  - Summary format — verdict, severity counts, top reasons, offending run_ids on hard-fail.
  - Legacy-entry fallback for entries without ``degradation_severity``.
- [x] ``test_diagnose_promotion_gate.py`` (4 tests): CLI exit codes, run_id surfacing, ratio-fail path, missing-ledger-file → insufficient_runs.
- [x] Full suite green: **2245 passed**.