### PR TITLE
feat: suppress summary-only notes when archive fetch fails

### DIFF
--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -502,6 +502,118 @@ Tuning the knobs:
 The gate is read-only: no Lithos connection, no docker exec, no
 ledger writes.  It only reads `${INFLUX_STATE_PATH}/runs.jsonl`.
 
+## 8d. Thin-summary suppression (issue #166)
+
+When an RSS or arXiv archive fetch fails for any reason, Influx
+previously wrote a Lithos note built from the feed-provided
+`<summary>` / arXiv `<abstract>` plus the title.  Many of those
+summary-only notes are operationally garbage — Hacker News pointers
+(`Discussion (47 points)`), title repetitions, generic teasers
+(`Read the full article at example.com…`) — accumulating in Lithos
+with no recovery path.
+
+Issue #166 adds a forward-only **thin-summary suppression** rule.
+When the archive fetch did not deliver a body **and** the feed
+summary is "thin" by a structural test, the source adapter drops the
+item entirely — no Lithos note, no `influx:archive-missing` tag, no
+repair-sweep entry.  Existing notes already in Lithos are not
+touched; only new items are affected.
+
+The rule fires on `not archive_result.ok` for **any** failure kind —
+including `non_html_source` (#160) and `unsupported` (#161) — so the
+trigger scope is broader than the `archive_missing` flag alone.
+
+### The rule (any-of)
+
+| Rule | Fires when |
+| ---- | ---------- |
+| `length` | The trimmed summary is shorter than `min_summary_chars` (default 80).  Setting `min_summary_chars = 0` disables this rule only. |
+| `title_equality` | The summary equals the title after normalisation (lowercase, strip Unicode punctuation, collapse whitespace). |
+| `boilerplate` | The trimmed summary matches one of the patterns below. |
+
+Order matters — the cheapest rule is evaluated first.  The rule that
+fires is logged so an operator can decide which knob to tune.
+
+### Boilerplate patterns
+
+The pattern list ships in
+`src/influx/thin_summary.py::BOILERPLATE_PATTERNS` as a single
+module-level constant of `(regex, rationale)` pairs.  Current entries:
+
+| Pattern | Rationale |
+| ------- | --------- |
+| `^Discussion \(\d+ points?\)$` (case-insensitive) | Hacker News pointer summary — the feed surfaces only the comment-thread points count, not the article body. |
+| `^Comments(\.|\s|$)` (case-insensitive) | HN / Reddit pointer summary — the feed item is just a link to the comment thread. |
+| `^Read (the |this )?(full |entire )?(article|post|story|entry) (at|on|via)\s` (case-insensitive) | Generic teaser — the feed publisher truncates the body to a "read the full article at…" pointer with no real content. |
+| `^Continue reading\b` (case-insensitive) | WordPress / Substack-style truncation marker with no extra content beyond the title. |
+| `^Read more\b` (case-insensitive) | Generic "Read more" truncation marker — the feed body is effectively empty. |
+| `^[…\.\s\[\]]*$` | Empty-ish marker — the summary is only ellipsis / bracket characters / whitespace, no real text at all. |
+
+To propose a new pattern: confirm the boilerplate shape on a real feed
+sample, add the regex + rationale to the tuple, write a parametrised
+case in `tests/unit/test_thin_summary.py::TestBoilerplateRule`, and
+open a PR.  Patterns are deliberately anchored to the *start* of the
+trimmed summary so an article that mentions "continue reading"
+mid-body is not affected — only summaries that *are* the boilerplate.
+
+### Tuning
+
+Set in `influx.toml`:
+
+```toml
+[extraction]
+min_summary_chars = 80   # default; raise to suppress more aggressively
+```
+
+Reasonable values:
+
+- **0** — disables the length rule only.  Title-equality and
+  boilerplate-match continue to fire.  Use this when an operator
+  has audited a specific feed and wants to keep its terse-but-real
+  summaries; tag-shape and pointer-style drops are still on.
+- **80** (default) — drops the obvious pointer-shape garbage without
+  affecting realistic feed summaries.
+- **200+** — aggressive; will drop many feeds whose summaries are
+  genuine first-sentence teasers.  Only tighten when an operator has
+  measured the suppression impact on the run logs (see telemetry
+  below).
+
+### Telemetry
+
+| Surface | Where | Notes |
+| ------- | ----- | ----- |
+| Per-drop INFO log | `influx.sources.rss` / `influx.sources.arxiv` | One line per dropped item: `thin-summary drop source=… profile=… url=… failure_kind=… rule=…`.  `rule` names the first rule that fired (`length` / `title_equality` / `boilerplate`). |
+| Per-run INFO summary | `influx.run_service` | `run summary_thin_drops profile=… kind=… run_id=… dropped_items=N` when N > 0.  Distinct from the unsupported-policy summary above it. |
+| OTel counter | `influx_summary_thin_drops_total` | Labels: `profile`, `source`, `failure_kind`, `rule`.  Distinct from `influx_archive_missing_total` and `influx_archive_policy_failures_total` so dashboards can pivot the suppression rate independently. |
+| Ledger entry field | `summary_thin_drops_total` on each `runs.jsonl` entry | Per-run total; `None` on legacy entries written before #166 landed. |
+
+The drop is deliberately **excluded** from:
+
+- `archive_failures_total` (the item never received `influx:archive-missing`).
+- The `archive_acquisition` degraded reason.
+- `source_acquisition_errors`.
+- The `degradation_severity` classification (a drop is a quality
+  choice, not a degradation).
+
+So a run whose only "issue" is thin-summary suppression remains
+classified `success` with no degraded reasons, even if `dropped_items`
+is large.  An operator sees the suppression in the dedicated INFO
+line and the dedicated counter; the run-completion verdict is
+unaffected.
+
+### Out of scope
+
+- **No retrospective pruning.**  Existing summary-only notes already
+  in Lithos keep their current state.  A separate cleanup pass
+  against Lithos would be needed to remove them and is intentionally
+  out of scope here.
+- **No per-profile threshold.**  A single global `min_summary_chars`
+  applies to every profile; per-profile overrides can be added later
+  if operator need emerges.
+- **No repair-sweep re-evaluation.**  The thin-summary rule fires
+  at write-time only.  A note tagged `influx:archive-missing` before
+  #166 landed is not retroactively dropped on a later sweep.
+
 ## 9. Scheduling stagger (issue #87)
 
 Profiles share a single global `[schedule].cron` expression. Within

--- a/src/influx/config.py
+++ b/src/influx/config.py
@@ -520,6 +520,13 @@ class ExtractionConfig(BaseModel):
 
     min_html_chars: int = 1000
     min_web_chars: int = 500
+    # Issue #166: thin-summary suppression threshold.  When an item's
+    # archive fetch fails AND the (post-extraction-fallback) summary
+    # is shorter than this value, the source adapter drops the item
+    # entirely rather than writing a summary-only note.  Setting this
+    # to ``0`` disables the length rule only — title-equality and
+    # boilerplate-pattern suppression continue to fire.
+    min_summary_chars: int = 80
     strip_tags: list[str] = Field(
         default_factory=lambda: [
             "script",

--- a/src/influx/metrics.py
+++ b/src/influx/metrics.py
@@ -260,6 +260,12 @@ def tier3_fallbacks() -> Any:
 def archive_missing() -> Any:
     """Counter of items tagged ``influx:archive-missing`` during a run.
 
+    Bumped by the source adapters *after* the issue #166 thin-summary
+    suppression check returns the item — items that the suppression
+    rule drops never reach the write loop and so never receive the
+    tag, and are accounted for separately by
+    :func:`summary_thin_drops`.
+
     Labels: ``profile``, ``source``.
     """
     return get_meter().counter(
@@ -280,16 +286,34 @@ def summary_thin_drops() -> Any:
     :func:`archive_policy_failures` so dashboards can pivot
     suppressions independently of archive-failure counts — the dropped
     items never reach the Lithos write loop and so never receive an
-    ``influx:archive-missing`` tag, and they are deliberately excluded
-    from ``archive_failures_total`` / ``source_acquisition_errors`` /
-    ``archive_acquisition`` degraded reasons.
+    ``influx:archive-missing`` tag.  Per the issue #166 review,
+    ``archive_missing`` / ``archive_policy_failures`` are deferred past
+    the suppression decision in the source adapters so they only count
+    items that actually got written with the corresponding tag; this
+    counter and the archive-failure counters therefore partition the
+    set of archive-not-OK items rather than double-counting them.
+    Also deliberately excluded from ``archive_failures_total`` /
+    ``source_acquisition_errors`` / ``archive_acquisition`` degraded
+    reasons in the run ledger.
 
-    Labels: ``profile``, ``source`` (``rss`` / ``arxiv`` / …),
-    ``failure_kind`` (the archive failure_kind that triggered the
-    suppression — ``http_404`` / ``timeout`` / ``blocked`` /
-    ``non_html_source`` / ``unsupported`` / …), ``rule``
-    (``length`` | ``title_equality`` | ``boilerplate``) — the
-    thin-summary rule that fired first.
+    Labels:
+
+    - ``profile`` — profile name.
+    - ``source`` — the source-adapter identity, matching the existing
+      convention used by :func:`archive_policy_failures`: for arXiv
+      this is the literal ``"arxiv"``; for RSS this is the per-feed
+      ``source_tag`` configured under ``[[profiles.sources.rss]]``,
+      which defaults to ``"rss"`` but operators may override to
+      e.g. ``"blog"`` / ``"tech-news"`` for cardinality-friendly
+      per-feed-class dashboards.
+    - ``failure_kind`` — the archive failure_kind that triggered the
+      suppression: ``http_404`` / ``timeout`` / ``http_5xx`` /
+      ``blocked`` / ``rate_limited`` / ``missing_by_policy`` /
+      ``non_html_source`` / ``unsupported`` / ``oversize`` /
+      ``content_type_mismatch`` / ``write`` / ``ssrf`` / ``dns`` /
+      ``network`` / ``terminal`` (arXiv terminal-flipped) / ``unknown``.
+    - ``rule`` — ``length`` | ``title_equality`` | ``boilerplate``,
+      the thin-summary rule that fired first.
     """
     return get_meter().counter(
         "influx_summary_thin_drops_total",
@@ -311,6 +335,12 @@ def archive_policy_failures() -> Any:
     reserved for the (large, expected) baseline of unclassified
     failures so dashboards can compute the ratio without subtracting
     series.
+
+    Per the issue #166 review this counter is deferred past the
+    thin-summary suppression check (the source adapters bump it only
+    for items that actually get written with the policy tag), keeping
+    it in lock-step with :func:`archive_missing`.  Items dropped by the
+    suppression rule are accounted for by :func:`summary_thin_drops`.
 
     Labels: ``profile``, ``source``, ``kind``
     (``"blocked"`` | ``"rate_limited"`` | ``"missing_by_policy"`` |

--- a/src/influx/metrics.py
+++ b/src/influx/metrics.py
@@ -56,6 +56,7 @@ __all__ = [
     "slug_collision_url_recovery",
     "source_acquisition_errors",
     "source_cooldown_skips",
+    "summary_thin_drops",
     "tier3_fallbacks",
 ]
 
@@ -264,6 +265,39 @@ def archive_missing() -> Any:
     return get_meter().counter(
         "influx_archive_missing_total",
         description="Items tagged influx:archive-missing during a run.",
+    )
+
+
+def summary_thin_drops() -> Any:
+    """Counter of items suppressed by the thin-summary rule (#166).
+
+    Increments once per item the source adapter drops because the
+    archive fetch did not produce a body AND the feed-provided
+    summary (after extraction fallback) was thin per
+    :func:`influx.thin_summary.is_thin_summary`.
+
+    Distinct from :func:`archive_missing` and
+    :func:`archive_policy_failures` so dashboards can pivot
+    suppressions independently of archive-failure counts — the dropped
+    items never reach the Lithos write loop and so never receive an
+    ``influx:archive-missing`` tag, and they are deliberately excluded
+    from ``archive_failures_total`` / ``source_acquisition_errors`` /
+    ``archive_acquisition`` degraded reasons.
+
+    Labels: ``profile``, ``source`` (``rss`` / ``arxiv`` / …),
+    ``failure_kind`` (the archive failure_kind that triggered the
+    suppression — ``http_404`` / ``timeout`` / ``blocked`` /
+    ``non_html_source`` / ``unsupported`` / …), ``rule``
+    (``length`` | ``title_equality`` | ``boilerplate``) — the
+    thin-summary rule that fired first.
+    """
+    return get_meter().counter(
+        "influx_summary_thin_drops_total",
+        description=(
+            "Items suppressed by the thin-summary rule because their "
+            "archive fetch failed and the feed-provided summary was "
+            "too thin to keep (issue #166)."
+        ),
     )
 
 

--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -518,6 +518,13 @@ class RunLedger:
             "filter_errors_total": None,
             "invalid_url_rejections_total": None,
             "archive_failures_total": None,
+            # Issue #166: per-run total of items the source adapters
+            # suppressed via the thin-summary rule.  Distinct from
+            # ``archive_failures_total`` — these items never reached the
+            # write loop and so never received ``influx:archive-missing``.
+            # Stays ``None`` while the run is in flight; populated from
+            # the per-run contextvar at ``complete`` time.
+            "summary_thin_drops_total": None,
             "error": None,
             "degraded": False,
             "degraded_reasons": [],
@@ -570,6 +577,7 @@ class RunLedger:
         filter_errors_total: int | None = None,
         invalid_url_rejections_total: int | None = None,
         archive_failures_total: int | None = None,
+        summary_thin_drops_total: int | None = None,
         source_acquisition_errors: list[dict[str, str]] | None = None,
         source_cooldown_skips: list[dict[str, str]] | None = None,
         source_retry_counts: dict[str, dict[str, int]] | None = None,
@@ -846,6 +854,7 @@ class RunLedger:
             filter_errors_total=filter_errors_total,
             invalid_url_rejections_total=invalid_url_rejections_total,
             archive_failures_total=archive_failures_total,
+            summary_thin_drops_total=summary_thin_drops_total,
             error=None,
             degraded=bool(reasons),
             source_acquisition_errors=errors,
@@ -1203,6 +1212,7 @@ class RunLedger:
         filter_errors_total: int | None = None,
         invalid_url_rejections_total: int | None = None,
         archive_failures_total: int | None = None,
+        summary_thin_drops_total: int | None = None,
         degraded: bool = False,
         source_acquisition_errors: list[dict[str, str]] | None = None,
         source_cooldown_skips: list[dict[str, str]] | None = None,
@@ -1240,6 +1250,10 @@ class RunLedger:
                     "filter_errors_total": filter_errors_total,
                     "invalid_url_rejections_total": invalid_url_rejections_total,
                     "archive_failures_total": archive_failures_total,
+                    # Issue #166: persist per-run total of thin-summary
+                    # suppressions so operators can see how many items
+                    # the rule is dropping without scraping logs.
+                    "summary_thin_drops_total": summary_thin_drops_total,
                     "error": error,
                     "degraded": degraded,
                     "degraded_reasons": list(degraded_reasons or []),

--- a/src/influx/run_service.py
+++ b/src/influx/run_service.py
@@ -53,6 +53,7 @@ from influx.telemetry import (
     current_source_acquisition_errors,
     current_source_cooldown_skips,
     current_source_retry_counts,
+    current_summary_thin_drops,
     current_tier3_fallback_counts,
     current_write_outcomes,
     get_tracer,
@@ -186,6 +187,16 @@ async def ledger_lifecycle(
     invalid_url_rejections_counter: list[int] = [0]
     invalid_url_rejections_token = current_invalid_url_rejections.set(
         invalid_url_rejections_counter
+    )
+    # #166: per-run count of items dropped by the thin-summary rule.
+    # Source adapters increment via :func:`record_summary_thin_drop`
+    # when the archive fetch failed and the feed summary was thin.
+    # Surfaced on the run-ledger entry as ``summary_thin_drops_total``
+    # so an operator can see "we suppressed N summary-only notes this
+    # run" distinct from archive failures and URL rejections.
+    summary_thin_drops_counter: list[int] = [0]
+    summary_thin_drops_token = current_summary_thin_drops.set(
+        summary_thin_drops_counter
     )
     # #129: per-run counter of recovered source-fetch retries (i.e.
     # retries followed by another attempt, distinct from the swallowed
@@ -334,6 +345,11 @@ async def ledger_lifecycle(
         filter_errors_total = filter_errors_counter[0]
         # #131: total per-run pre-acquire URL rejections.
         invalid_url_rejections_total = invalid_url_rejections_counter[0]
+        # #166: total per-run thin-summary suppressions (items dropped
+        # because archive fetch failed AND the feed summary was thin).
+        # Deliberately distinct from archive_failures_total — these
+        # items never reached the write loop.
+        summary_thin_drops_total = summary_thin_drops_counter[0]
         # #152: total cache hits this run, surfaced under the
         # degradation summary's ``totals.cache_hits``.
         cache_hits_total = cache_hits_counter[0]
@@ -345,6 +361,7 @@ async def ledger_lifecycle(
             filter_errors_total=filter_errors_total,
             invalid_url_rejections_total=invalid_url_rejections_total,
             archive_failures_total=archive_failures_total,
+            summary_thin_drops_total=summary_thin_drops_total,
             source_acquisition_errors=source_errors,
             # Issue #146: cooldown skips are run-level state distinct
             # from swallowed acquisition errors — the ledger fires the
@@ -577,6 +594,24 @@ async def ledger_lifecycle(
                 run_id,
                 archive_unsupported_total,
             )
+        # Issue #166: surface per-run thin-summary suppression total at
+        # INFO so an operator sees "we dropped N summary-only notes
+        # this run" alongside the unsupported total.  Distinct from
+        # ``archive_acquisition`` — these items never received the
+        # ``influx:archive-missing`` tag because they were dropped
+        # before the write loop.
+        if summary_thin_drops_total > 0:
+            logger.info(
+                "run summary_thin_drops profile=%s kind=%s run_id=%s "
+                "dropped_items=%d "
+                "(items suppressed by the thin-summary rule — archive "
+                "fetch failed AND feed summary was thin; not counted "
+                "toward archive_failures_total or archive_acquisition)",
+                profile,
+                plan.kind.value,
+                run_id,
+                summary_thin_drops_total,
+            )
 
         # Issue #164: classify the degraded reasons into the
         # ``severity`` bucket the ledger entry stores so the metric
@@ -677,6 +712,7 @@ async def ledger_lifecycle(
         current_fetched_total.reset(fetched_total_token)
         current_filter_errors.reset(filter_errors_token)
         current_invalid_url_rejections.reset(invalid_url_rejections_token)
+        current_summary_thin_drops.reset(summary_thin_drops_token)
         current_source_retry_counts.reset(source_retry_counts_token)
         current_tier3_fallback_counts.reset(tier3_fallback_counts_token)
         current_cache_hits.reset(cache_hits_token)

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -63,7 +63,9 @@ from influx.telemetry import (
     record_source_acquisition_error,
     record_source_cooldown_skip,
     record_source_retry,
+    record_summary_thin_drop,
 )
+from influx.thin_summary import is_thin_summary
 
 if TYPE_CHECKING:
     from influx.sources import FetchCache
@@ -1031,7 +1033,7 @@ def build_arxiv_note_item(
     config: AppConfig,
     thresholds: ProfileThresholds | None = None,
     filter_tags: Iterable[str] | None = None,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     """Build a complete ``ProfileItem`` dict for the scheduler.
 
     Runs the HTML → PDF → abstract-only extraction cascade when the
@@ -1059,9 +1061,11 @@ def build_arxiv_note_item(
 
     Returns
     -------
-    dict[str, Any]
-        Ready-to-yield ``ProfileItem`` dict (title, source_url,
-        content, tags, score, confidence, path, abstract_or_summary).
+    dict[str, Any] | None
+        Ready-to-yield ``ProfileItem`` dict, or ``None`` when the
+        thin-summary rule (#166) suppressed this item.  ``None`` is
+        the orchestrator's signal to skip the item (see
+        :mod:`influx.run` line 451).
     """
     profile_cfg = next((p for p in config.profiles if p.name == profile_name), None)
     if thresholds is None:
@@ -1082,12 +1086,18 @@ def build_arxiv_note_item(
     pdf_url = f"https://arxiv.org/pdf/{item.arxiv_id}.pdf"
     tracer = get_tracer()
 
+    # Issue #166: label of the failure that caused the archive to NOT
+    # deliver a body — used by the thin-summary suppression check
+    # below.  ``None`` when the archive succeeded; a string like
+    # ``"terminal"`` / ``"http_404"`` / ``"unsupported"`` otherwise.
+    _archive_failure_kind_label: str | None = None
     if is_archive_terminal:
         # Issue #14: this paper's archive download has been terminal-flipped
         # by an earlier repair sweep (or hand-set by an operator).  Skip the
         # download attempt entirely; the existing Lithos note's tags will
         # be preserved by the canonical merge_tags path on rewrite.
         archive_missing = True
+        _archive_failure_kind_label = "terminal"
         metrics.archive_missing().add(1, {"profile": profile_name, "source": "arxiv"})
         _log.info(
             "archive download skipped (terminal) profile=%s arxiv_id=%s",
@@ -1135,6 +1145,11 @@ def build_arxiv_note_item(
             # policy fired.
             archive_unsupported = archive_result.failure_kind == "unsupported"
             archive_missing = not archive_unsupported
+            # Issue #166: capture the failure_kind label for the
+            # thin-summary suppression check below.  Includes
+            # ``unsupported`` because the user-decided trigger scope is
+            # broader than ``archive_missing == True``.
+            _archive_failure_kind_label = archive_result.failure_kind or "unknown"
             archive_policy_tag = _tag_for_archive_failure_kind(
                 # ArchiveFailureKind is a Literal; mypy needs a cast.
                 archive_result.failure_kind  # type: ignore[arg-type]
@@ -1156,6 +1171,43 @@ def build_arxiv_note_item(
                         "kind": archive_result.failure_kind or "unknown",
                     },
                 )
+
+    # Issue #166: thin-summary suppression.  When the archive fetch did
+    # NOT deliver a body (any failure kind: terminal / http_404 /
+    # timeout / blocked / unsupported / …) AND the feed-provided
+    # abstract is thin per :mod:`influx.thin_summary`, drop the item
+    # entirely rather than writing a low-value abstract-only note.
+    # arXiv abstracts are typically several hundred characters of real
+    # content so the default 80-char threshold rarely fires; the rule
+    # is here for uniformity with the RSS adapter (PR description
+    # acceptance criterion: "per-source consistency").
+    if _archive_failure_kind_label is not None:
+        thin, thin_rule = is_thin_summary(
+            summary=item.abstract,
+            title=item.title,
+            min_chars=config.extraction.min_summary_chars,
+        )
+        if thin:
+            metrics.summary_thin_drops().add(
+                1,
+                {
+                    "profile": profile_name,
+                    "source": "arxiv",
+                    "failure_kind": _archive_failure_kind_label,
+                    "rule": thin_rule or "unknown",
+                },
+            )
+            record_summary_thin_drop()
+            _log.info(
+                "thin-summary drop source=arxiv profile=%s arxiv_id=%s "
+                "url=%s failure_kind=%s rule=%s",
+                profile_name,
+                item.arxiv_id,
+                source_url,
+                _archive_failure_kind_label,
+                thin_rule,
+            )
+            return None
 
     acquired = Acquired(
         item_id=item.arxiv_id,
@@ -1454,12 +1506,15 @@ class ArxivSource:
         *,
         profile_cfg: ProfileConfig,
         config: AppConfig,
-    ) -> dict[str, Any]:
+    ) -> dict[str, Any] | None:
         """Acquire stage: download archive + run cascade + render note.
 
         Delegates to :func:`build_arxiv_note_item`.  The legacy module
         binding is preserved so existing tests that patch
         ``influx.sources.arxiv.build_arxiv_note_item`` continue to work.
+
+        Returns ``None`` when the thin-summary rule (#166) suppressed
+        the item — the orchestrator skips ``None`` results.
         """
         item = scored.candidate.payload
         if not isinstance(item, ArxivItem):

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -1064,8 +1064,9 @@ def build_arxiv_note_item(
     dict[str, Any] | None
         Ready-to-yield ``ProfileItem`` dict, or ``None`` when the
         thin-summary rule (#166) suppressed this item.  ``None`` is
-        the orchestrator's signal to skip the item (see
-        :mod:`influx.run` line 451).
+        the orchestrator's signal to skip the item; the consumer in
+        :mod:`influx.run` calls ``continue`` on ``None`` rather than
+        appending to the acquired-items list.
     """
     profile_cfg = next((p for p in config.profiles if p.name == profile_name), None)
     if thresholds is None:
@@ -1091,6 +1092,14 @@ def build_arxiv_note_item(
     # below.  ``None`` when the archive succeeded; a string like
     # ``"terminal"`` / ``"http_404"`` / ``"unsupported"`` otherwise.
     _archive_failure_kind_label: str | None = None
+    # Issue #166 review: deferred metric bumps so
+    # ``influx_archive_missing_total`` /
+    # ``influx_archive_policy_failures_total`` only increment for items
+    # that survive the thin-summary suppression check (i.e. items that
+    # actually get written with the corresponding tags).  The bumps
+    # happen in a single block below, after the suppression decision.
+    _archive_missing_bump_pending = False
+    _archive_policy_failure_kind: str | None = None
     if is_archive_terminal:
         # Issue #14: this paper's archive download has been terminal-flipped
         # by an earlier repair sweep (or hand-set by an operator).  Skip the
@@ -1098,7 +1107,7 @@ def build_arxiv_note_item(
         # be preserved by the canonical merge_tags path on rewrite.
         archive_missing = True
         _archive_failure_kind_label = "terminal"
-        metrics.archive_missing().add(1, {"profile": profile_name, "source": "arxiv"})
+        _archive_missing_bump_pending = True
         _log.info(
             "archive download skipped (terminal) profile=%s arxiv_id=%s",
             profile_name,
@@ -1155,22 +1164,11 @@ def build_arxiv_note_item(
                 archive_result.failure_kind  # type: ignore[arg-type]
             )
             if archive_missing:
-                metrics.archive_missing().add(
-                    1, {"profile": profile_name, "source": "arxiv"}
-                )
-                # Issue #149: reclassify the failure into a policy tag
-                # when the failure_kind is one of blocked / rate_limited /
-                # missing_by_policy.  Generic failures (http_404, oversize,
-                # timeout, …) keep the default ``influx:archive-missing``
-                # shape so repair-sweep behaviour is unchanged for them.
-                metrics.archive_policy_failures().add(
-                    1,
-                    {
-                        "profile": profile_name,
-                        "source": "arxiv",
-                        "kind": archive_result.failure_kind or "unknown",
-                    },
-                )
+                # Issue #166 review: deferred until after the thin-summary
+                # suppression check below so the metrics stay consistent
+                # with the tags actually applied to a written note.
+                _archive_missing_bump_pending = True
+                _archive_policy_failure_kind = archive_result.failure_kind or "unknown"
 
     # Issue #166: thin-summary suppression.  When the archive fetch did
     # NOT deliver a body (any failure kind: terminal / http_404 /
@@ -1208,6 +1206,28 @@ def build_arxiv_note_item(
                 thin_rule,
             )
             return None
+
+    # Issue #166 review: the item survived the thin-summary suppression
+    # check and will be written below.  Bump the archive-missing-side
+    # counters now so they stay consistent with the
+    # ``influx:archive-missing`` tag and the policy tag applied by the
+    # tag-composition block.  Deferred from the eager bumps that lived
+    # inside the if/else above before this review.
+    if _archive_missing_bump_pending:
+        metrics.archive_missing().add(1, {"profile": profile_name, "source": "arxiv"})
+        if _archive_policy_failure_kind is not None:
+            # Issue #149 + #166 review: the policy_failures counter is
+            # documented as "Increments alongside archive_missing" so
+            # the two move in lock-step — including when thin-summary
+            # suppression defers both.
+            metrics.archive_policy_failures().add(
+                1,
+                {
+                    "profile": profile_name,
+                    "source": "arxiv",
+                    "kind": _archive_policy_failure_kind,
+                },
+            )
 
     acquired = Acquired(
         item_id=item.arxiv_id,

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -377,8 +377,9 @@ def build_rss_note_item(
     dict[str, Any] | None
         Ready-to-yield ``ProfileItem`` dict, or ``None`` when the
         thin-summary rule (#166) suppressed this item.  ``None`` is
-        the orchestrator's signal to skip the item — see
-        :mod:`influx.run` line 451 for the consumer.
+        the orchestrator's signal to skip the item; the consumer in
+        :mod:`influx.run` calls ``continue`` on ``None`` rather than
+        appending to the acquired-items list.
     """
     feed_slug = slugify_feed_name(item.feed_name)
     hash_val = url_hash(item.url)
@@ -460,15 +461,16 @@ def build_rss_note_item(
         if archive_missing or archive_skipped_no_failure
         else None
     )
+    # Issue #166 review: deferred until after the thin-summary
+    # suppression check below so the metric stays consistent with the
+    # ``influx:archive-*`` tag actually applied to a written note.
+    # ``archive_policy_failures()`` is documented as "Increments
+    # alongside archive_missing" so it moves in lock-step with the
+    # archive-missing tag.  Eager bump here pollutes the counter for
+    # items the suppression rule drops.
+    _archive_policy_failure_kind: str | None = None
     if archive_missing:
-        metrics.archive_policy_failures().add(
-            1,
-            {
-                "profile": profile_name,
-                "source": item.source_tag,
-                "kind": archive_result.failure_kind or "unknown",
-            },
-        )
+        _archive_policy_failure_kind = archive_result.failure_kind or "unknown"
 
     # Article text extraction with summary fallback (FR-ENR-3): try web
     # article extraction; fall back to the feed item's ``<summary>``
@@ -538,6 +540,22 @@ def build_rss_note_item(
                 thin_rule,
             )
             return None
+
+    # Issue #166 review: the item survived the thin-summary suppression
+    # check and will be written below.  Bump the deferred
+    # ``archive_policy_failures`` counter now so it stays consistent
+    # with the archive-failure tag actually applied to the rendered
+    # note.  No bump on the suppression path above — the dropped item
+    # never produced a tag.
+    if _archive_policy_failure_kind is not None:
+        metrics.archive_policy_failures().add(
+            1,
+            {
+                "profile": profile_name,
+                "source": item.source_tag,
+                "kind": _archive_policy_failure_kind,
+            },
+        )
 
     acquired = Acquired(
         item_id=item_id,

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -58,7 +58,9 @@ from influx.telemetry import (
     record_invalid_url_rejection,
     record_source_acquisition_error,
     record_source_cooldown_skip,
+    record_summary_thin_drop,
 )
+from influx.thin_summary import is_thin_summary
 from influx.urls import classify_article_url, normalise_url, url_hash
 
 if TYPE_CHECKING:
@@ -353,7 +355,7 @@ def build_rss_note_item(
     confidence: float = 0.0,
     reason: str = "",
     filter_tags: Iterable[str] | None = None,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     """Build a complete ``ProfileItem`` dict for an RSS feed item.
 
     Downloads the article HTML via the guarded HTTP client (FR-SRC-5),
@@ -372,8 +374,11 @@ def build_rss_note_item(
 
     Returns
     -------
-    dict[str, Any]
-        Ready-to-yield ``ProfileItem`` dict.
+    dict[str, Any] | None
+        Ready-to-yield ``ProfileItem`` dict, or ``None`` when the
+        thin-summary rule (#166) suppressed this item.  ``None`` is
+        the orchestrator's signal to skip the item — see
+        :mod:`influx.run` line 451 for the consumer.
     """
     feed_slug = slugify_feed_name(item.feed_name)
     hash_val = url_hash(item.url)
@@ -492,6 +497,47 @@ def build_rss_note_item(
 
     source_url = normalise_url(item.url)
     profile_cfg = next((p for p in config.profiles if p.name == profile_name), None)
+
+    # Issue #166: thin-summary suppression.  When the archive fetch did
+    # NOT deliver a body (any failure kind — http_404 / timeout /
+    # blocked / non_html_source / unsupported / …) AND the
+    # post-extraction-fallback summary is "thin" by the structural test
+    # in :mod:`influx.thin_summary`, drop the item entirely rather than
+    # writing a low-value summary-only note.  The check runs
+    # post-extraction so a successful ``extract_article`` that filled
+    # ``summary`` with real body text bypasses the suppression — only
+    # genuinely-no-body items end up here.  Deliberately broader than
+    # the ``archive_missing`` flag so ``non_html_source`` /
+    # ``unsupported`` short-circuits also benefit (a thin summary + a
+    # URL that never pointed at HTML is still a low-value note).
+    if not archive_result.ok:
+        thin, thin_rule = is_thin_summary(
+            summary=summary,
+            title=item.title,
+            min_chars=config.extraction.min_summary_chars,
+        )
+        if thin:
+            failure_kind_label = archive_result.failure_kind or "unknown"
+            metrics.summary_thin_drops().add(
+                1,
+                {
+                    "profile": profile_name,
+                    "source": item.source_tag,
+                    "failure_kind": failure_kind_label,
+                    "rule": thin_rule or "unknown",
+                },
+            )
+            record_summary_thin_drop()
+            _log.info(
+                "thin-summary drop source=rss profile=%s feed-slug=%s "
+                "url=%s failure_kind=%s rule=%s",
+                profile_name,
+                feed_slug,
+                source_url,
+                failure_kind_label,
+                thin_rule,
+            )
+            return None
 
     acquired = Acquired(
         item_id=item_id,
@@ -790,8 +836,12 @@ class RssSource:
         *,
         profile_cfg: ProfileConfig,
         config: AppConfig,
-    ) -> dict[str, Any]:
-        """Acquire stage: download archive + run cascade + render note."""
+    ) -> dict[str, Any] | None:
+        """Acquire stage: download archive + run cascade + render note.
+
+        Returns ``None`` when the thin-summary rule (#166) suppressed
+        the item — the orchestrator skips ``None`` results.
+        """
         item = scored.candidate.payload
         if not isinstance(item, RssFeedItem):
             raise TypeError(

--- a/src/influx/telemetry.py
+++ b/src/influx/telemetry.py
@@ -43,6 +43,7 @@ __all__ = [
     "current_source_acquisition_errors",
     "current_source_cooldown_skips",
     "current_source_retry_counts",
+    "current_summary_thin_drops",
     "current_tier3_fallback_counts",
     "current_write_outcomes",
     "get_meter",
@@ -54,6 +55,7 @@ __all__ = [
     "record_source_acquisition_error",
     "record_source_cooldown_skip",
     "record_source_retry",
+    "record_summary_thin_drop",
     "record_tier3_fallback",
     "record_write_outcome",
 ]
@@ -299,6 +301,44 @@ def record_invalid_url_rejection(count: int = 1) -> None:
     if count <= 0:
         return
     counter = current_invalid_url_rejections.get()
+    if counter is None:
+        return
+    counter[0] += count
+
+
+# Per-run counter of items suppressed by the thin-summary rule (#166).
+# Set to ``[0]`` at run start by ``run_service.ledger_lifecycle``; source
+# adapters increment via :func:`record_summary_thin_drop` when the
+# archive fetch failed and the feed-provided summary was thin per
+# :func:`influx.thin_summary.is_thin_summary`.
+#
+# Surfaced on the run-ledger entry as ``summary_thin_drops_total`` so
+# operators can see "we suppressed N summary-only notes this run"
+# distinct from archive failures and from upstream URL rejections.
+# Deliberately does NOT contribute to ``archive_failures_total``,
+# ``source_acquisition_errors``, or the ``archive_acquisition``
+# degraded reason — a thin-summary drop is a quality choice, not a
+# pipeline failure.
+current_summary_thin_drops: ContextVar[list[int] | None] = ContextVar(
+    "current_summary_thin_drops",
+    default=None,
+)
+
+
+def record_summary_thin_drop(count: int = 1) -> None:
+    """Add *count* to the current run's ``summary_thin_drops_total`` (#166).
+
+    Safe to call outside a run context — silently no-ops when
+    :data:`current_summary_thin_drops` is unset.  Source adapters call
+    this once per dropped item, alongside the per-drop INFO log line
+    and the ``influx_summary_thin_drops_total`` metric bump, so the
+    ledger entry can carry the per-run total without re-scanning
+    written notes (the suppression deliberately means the item never
+    reaches the write loop).
+    """
+    if count <= 0:
+        return
+    counter = current_summary_thin_drops.get()
     if counter is None:
         return
     counter[0] += count

--- a/src/influx/thin_summary.py
+++ b/src/influx/thin_summary.py
@@ -51,11 +51,20 @@ ThinSummaryRule = Literal["length", "title_equality", "boilerplate"]
 
 
 # Module-level constant of (compiled-regex, operator-facing rationale)
-# pairs.  Listed in the staging runbook verbatim so operators can decide
-# whether to propose additions.  Each pattern is anchored / shaped to
-# fire on the *whole* summary string after whitespace trimming, so a
-# legitimate article body that happens to mention "continue reading"
-# inline is not affected — only summaries that *are* the boilerplate.
+# pairs.  Listed in the staging runbook verbatim so operators can
+# decide whether to propose additions.  Patterns are evaluated with
+# :meth:`re.Pattern.match`, which anchors at the *start* of the
+# trimmed summary; a few patterns also include an explicit end-anchor
+# (``$`` or terminating character class) for shapes that need
+# whole-string matching ("Discussion (47 points)" — strict), while
+# others ("Continue reading", "Read more", "Read … article at") are
+# deliberately prefix-anchored so they also catch the common case of a
+# pointer-boilerplate prefix followed by trailing URL / "on Medium…"
+# noise.  Real article bodies that happen to mention "continue
+# reading" *mid-sentence* are unaffected because of the start anchor;
+# a body that *starts* with one of these prefixes is rare in practice
+# but would trip the rule — operators can either rewrite the offending
+# pattern to add ``$`` or raise the issue for review.
 _BOILERPLATE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (
         re.compile(r"^Discussion \(\d+ points?\)$", re.IGNORECASE),

--- a/src/influx/thin_summary.py
+++ b/src/influx/thin_summary.py
@@ -1,0 +1,164 @@
+"""Thin-summary suppression helper (issue #166).
+
+When an item's archive fetch fails for any reason, Influx today still
+writes a Lithos note built from the feed-provided ``<summary>`` / arXiv
+``<abstract>`` plus the title.  In practice many of those summaries are
+operationally garbage — pointer-style strings like ``"Discussion (47
+points)"``, single-line title repetitions, or generic "read the full
+article at…" teasers — that accumulate in Lithos with no recovery path.
+
+This module provides a pure structural test the source adapters call
+*before* constructing a summary-only note.  If the rule fires the
+adapter drops the item entirely (no note, no ``influx:archive-missing``
+tag, no repair-sweep entry); the drop is surfaced via dedicated
+telemetry so the suppression is visible to operators without polluting
+the existing archive-failure counters.
+
+The rule is **any-of** across three checks:
+
+* **Length** — the trimmed summary is shorter than ``min_chars``.
+  Skipped entirely when ``min_chars == 0`` so an operator can disable
+  the length test (but title-equality / boilerplate remain on).
+* **Title-equality** — the summary, after a normalisation pass
+  (lowercase, strip Unicode punctuation, collapse whitespace), equals
+  the title under the same normalisation.  Catches feeds that mirror
+  the title field into the summary with no extra content.
+* **Boilerplate match** — the trimmed summary matches one of a small
+  built-in set of regex patterns covering common RSS pointers /
+  teasers / ellipsis markers.  See :data:`_BOILERPLATE_PATTERNS`; the
+  staging runbook documents each entry's rationale so operators can
+  propose additions.
+
+Pure module — no IO, no global state, no Lithos client.  All run-time
+data flows through the function arguments so tests pass synthetic
+strings directly.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Literal
+
+__all__ = [
+    "BOILERPLATE_PATTERNS",
+    "ThinSummaryRule",
+    "is_thin_summary",
+]
+
+
+ThinSummaryRule = Literal["length", "title_equality", "boilerplate"]
+
+
+# Module-level constant of (compiled-regex, operator-facing rationale)
+# pairs.  Listed in the staging runbook verbatim so operators can decide
+# whether to propose additions.  Each pattern is anchored / shaped to
+# fire on the *whole* summary string after whitespace trimming, so a
+# legitimate article body that happens to mention "continue reading"
+# inline is not affected — only summaries that *are* the boilerplate.
+_BOILERPLATE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"^Discussion \(\d+ points?\)$", re.IGNORECASE),
+        "Hacker News pointer summary — the feed surfaces only the "
+        "comment-thread points count, not the article body.",
+    ),
+    (
+        re.compile(r"^Comments(\.|\s|$)", re.IGNORECASE),
+        "HN / Reddit pointer summary — the feed item is just a link to "
+        "the comment thread.",
+    ),
+    (
+        re.compile(
+            r"^Read (the |this )?(full |entire )?(article|post|story|entry) "
+            r"(at|on|via)\s",
+            re.IGNORECASE,
+        ),
+        "Generic teaser — the feed publisher truncates the body to a "
+        "'read the full article at…' pointer with no real content.",
+    ),
+    (
+        re.compile(r"^Continue reading\b", re.IGNORECASE),
+        "WordPress / Substack-style truncation marker with no extra "
+        "content beyond the title.",
+    ),
+    (
+        re.compile(r"^Read more\b", re.IGNORECASE),
+        "Generic 'Read more' truncation marker — the feed body is effectively empty.",
+    ),
+    (
+        re.compile(r"^[…\.\s\[\]]*$"),
+        "Empty-ish marker — the summary is only ellipsis / bracket "
+        "characters / whitespace, no real text at all.",
+    ),
+)
+
+
+# Public re-export so callers / tests can introspect the pattern list
+# without reaching into a private name.  The list is intentionally
+# small; new entries should land alongside a runbook update.
+BOILERPLATE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = _BOILERPLATE_PATTERNS
+
+
+def _normalize_for_equality(text: str) -> str:
+    """Normalise *text* for the title-equality check.
+
+    Lowercases, strips characters with Unicode general-category starting
+    with ``P`` (all punctuation classes — ``Pc``, ``Pd``, ``Pe``, ``Pf``,
+    ``Pi``, ``Po``, ``Ps``), collapses internal whitespace to single
+    spaces, and trims leading / trailing whitespace.  Two strings that
+    differ only in punctuation / casing / whitespace compare equal
+    under this transform.
+    """
+    stripped_chars = (ch for ch in text if not unicodedata.category(ch).startswith("P"))
+    no_punct = "".join(stripped_chars).lower()
+    return " ".join(no_punct.split())
+
+
+def is_thin_summary(
+    *, summary: str, title: str, min_chars: int
+) -> tuple[bool, ThinSummaryRule | None]:
+    """Decide whether *summary* is "thin" relative to *title* / *min_chars*.
+
+    Returns ``(True, rule_name)`` on first match, where ``rule_name`` is
+    the rule that fired (``"length"`` / ``"title_equality"`` /
+    ``"boilerplate"``).  Returns ``(False, None)`` when the summary
+    passes all three checks.
+
+    Parameters
+    ----------
+    summary:
+        The (post-extraction-fallback) summary that would otherwise be
+        used to build the Lithos note.  Pass the *final* string — if
+        the source adapter has already replaced the feed summary with
+        extracted body text, pass the extracted text; the rule then
+        only fires when the extraction also produced a thin string.
+    title:
+        The item title.  Used only by the title-equality check.
+    min_chars:
+        Length-rule threshold.  When ``0`` the length check is skipped
+        entirely; title-equality / boilerplate continue to fire.  Must
+        be non-negative — negative values are treated as ``0`` so a
+        misconfigured override cannot raise inside the source adapter.
+
+    Notes
+    -----
+    Order matters: length is checked first (cheapest), then
+    title-equality (one normalisation pass), then the boilerplate
+    pattern list (regex sweep).  The returned ``rule_name`` reflects
+    the *first* match so the INFO log line a caller emits points the
+    operator at the actionable rule.
+    """
+    trimmed = summary.strip()
+    safe_min_chars = max(min_chars, 0)
+
+    if safe_min_chars > 0 and len(trimmed) < safe_min_chars:
+        return True, "length"
+
+    if _normalize_for_equality(trimmed) == _normalize_for_equality(title):
+        return True, "title_equality"
+
+    for pattern, _rationale in _BOILERPLATE_PATTERNS:
+        if pattern.match(trimmed):
+            return True, "boilerplate"
+
+    return False, None

--- a/tests/integration/test_arxiv_html_to_full_text.py
+++ b/tests/integration/test_arxiv_html_to_full_text.py
@@ -182,6 +182,7 @@ class TestArxivHTMLToFullText:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "text:html" in result["tags"]
 
@@ -199,6 +200,7 @@ class TestArxivHTMLToFullText:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "full-text" in result["tags"]
 
@@ -216,6 +218,7 @@ class TestArxivHTMLToFullText:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "## Full Text" in result["content"]
         # The extracted text should contain recognisable content from the
@@ -237,6 +240,7 @@ class TestArxivHTMLToFullText:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         # Find the full-text section body.
         content = result["content"]
@@ -267,6 +271,7 @@ class TestArxivHTMLToFullText:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         # The full-text section should contain no HTML tags.
         content = result["content"]
@@ -297,6 +302,7 @@ class TestArxivHTMLToFullText:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "influx:repair-needed" not in result["tags"]
 

--- a/tests/integration/test_arxiv_pdf_fallback.py
+++ b/tests/integration/test_arxiv_pdf_fallback.py
@@ -168,6 +168,7 @@ class TestArxivPDFFallback:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "text:pdf" in result["tags"]
 
@@ -189,6 +190,7 @@ class TestArxivPDFFallback:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "full-text" in result["tags"]
 
@@ -208,6 +210,7 @@ class TestArxivPDFFallback:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "text:html" not in result["tags"]
 
@@ -229,6 +232,7 @@ class TestArxivPDFFallback:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "## Full Text" in result["content"]
         # The PDF fixture contains recognisable content about extraction testing.
@@ -277,5 +281,6 @@ class TestArxivPDFFallback:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "influx:repair-needed" not in result["tags"]

--- a/tests/integration/test_backfill_arxiv.py
+++ b/tests/integration/test_backfill_arxiv.py
@@ -57,18 +57,31 @@ from tests.contract.test_lithos_client import FakeLithosServer
 
 PROFILE = "ai-robotics"
 
+# Abstract lengths comfortably clear the issue #166 thin-summary
+# threshold so the suppression rule does not interfere with the
+# backfill ingest assertions.
 _FIXTURE_ARXIV_ITEMS = [
     ArxivItem(
         arxiv_id="2601.00010",
         title="Backfill Paper Alpha",
-        abstract="A historical paper about attention mechanisms.",
+        abstract=(
+            "A historical paper about attention mechanisms, with an "
+            "abstract long enough to clear the default thin-summary "
+            "threshold so the backfill ingest assertions are not "
+            "affected by the suppression rule."
+        ),
         published=datetime(2026, 4, 20, tzinfo=UTC),
         categories=["cs.AI"],
     ),
     ArxivItem(
         arxiv_id="2601.00011",
         title="Backfill Paper Beta",
-        abstract="A second historical paper about transformers.",
+        abstract=(
+            "A second historical paper about transformers, with an "
+            "abstract long enough to clear the default thin-summary "
+            "threshold so the backfill ingest assertions are not "
+            "affected by the suppression rule."
+        ),
         published=datetime(2026, 4, 21, tzinfo=UTC),
         categories=["cs.AI"],
     ),

--- a/tests/integration/test_fetch_dedup.py
+++ b/tests/integration/test_fetch_dedup.py
@@ -56,11 +56,19 @@ PROFILE_A = "ai-robotics"
 PROFILE_B = "web-tech"
 
 # Fixture arXiv item (cs.AI category, shared by both profiles).
+# Abstract length comfortably clears the issue #166 thin-summary
+# threshold so the suppression rule does not interfere with the
+# dedup assertion.
 _FIXTURE_ARXIV_ITEMS = [
     ArxivItem(
         arxiv_id="2601.00001",
         title="Shared cs.AI Paper",
-        abstract="This paper covers attention mechanisms relevant to both profiles.",
+        abstract=(
+            "This paper covers attention mechanisms relevant to both "
+            "profiles, with a deliberately long abstract so the issue "
+            "#166 thin-summary rule does not interfere with the dedup "
+            "assertion."
+        ),
         published=datetime(2026, 4, 25, tzinfo=UTC),
         categories=["cs.AI"],
     ),
@@ -424,7 +432,9 @@ class TestRssFetchDedup:
         fetch_cache = FetchCache()
         http_fetch_count = 0
 
-        # Minimal RSS 2.0 feed fixture.
+        # Minimal RSS 2.0 feed fixture.  Description is long enough to
+        # clear the issue #166 thin-summary threshold so the suppression
+        # rule does not interfere with the dedup assertion.
         rss_xml = (
             '<?xml version="1.0" encoding="UTF-8"?>'
             '<rss version="2.0"><channel>'
@@ -432,7 +442,9 @@ class TestRssFetchDedup:
             "<item>"
             "<title>Shared Blog Post</title>"
             "<link>https://shared-blog.example/post-1</link>"
-            "<description>A shared blog post.</description>"
+            "<description>A shared blog post with a substantive "
+            "description that comfortably exceeds the default "
+            "thin-summary threshold for this dedup test.</description>"
             "<pubDate>Sat, 25 Apr 2026 00:00:00 GMT</pubDate>"
             "</item>"
             "</channel></rss>"

--- a/tests/integration/test_otel_metrics.py
+++ b/tests/integration/test_otel_metrics.py
@@ -168,7 +168,12 @@ async def _run_arxiv_scenario(meter: InfluxMeter, config: Any) -> None:
         ArxivItem(
             arxiv_id="2601.12345",
             title="Test Paper",
-            abstract="Abstract text",
+            # Long enough to clear the issue #166 thin-summary threshold.
+            abstract=(
+                "Abstract text that comfortably exceeds the default "
+                "thin-summary threshold so this metrics test runs the "
+                "full ingest pipeline."
+            ),
             published=datetime(2026, 4, 25, tzinfo=UTC),
             categories=["cs.AI"],
         ),
@@ -346,7 +351,12 @@ class TestOtelDisabledZeroMetrics:
             ArxivItem(
                 arxiv_id="2601.12345",
                 title="Test Paper",
-                abstract="Abstract text",
+                # Long enough to clear the issue #166 thin-summary threshold.
+                abstract=(
+                    "Abstract text that comfortably exceeds the default "
+                    "thin-summary threshold so this metrics test runs "
+                    "the full ingest pipeline."
+                ),
                 published=datetime(2026, 4, 25, tzinfo=UTC),
                 categories=["cs.AI"],
             ),

--- a/tests/integration/test_otel_spans.py
+++ b/tests/integration/test_otel_spans.py
@@ -196,7 +196,12 @@ async def _run_arxiv_scenario(
         ArxivItem(
             arxiv_id="2601.12345",
             title="Test Paper",
-            abstract="Abstract text",
+            # Long enough to clear the issue #166 thin-summary threshold.
+            abstract=(
+                "Abstract text that comfortably exceeds the default "
+                "thin-summary threshold so this span test runs the "
+                "full ingest pipeline."
+            ),
             published=datetime(2026, 4, 25, tzinfo=UTC),
             categories=["cs.AI"],
         ),
@@ -281,7 +286,12 @@ async def _run_rss_scenario(
             title="Blog Post",
             url="https://example.com/post-1",
             published=datetime(2026, 4, 25, tzinfo=UTC),
-            summary="Post summary",
+            # Long enough to clear the issue #166 thin-summary threshold.
+            summary=(
+                "Post summary that comfortably exceeds the default "
+                "thin-summary threshold so this span test runs the "
+                "full ingest pipeline."
+            ),
             source_tag="blog",
             feed_name="Test Blog",
         ),
@@ -418,7 +428,12 @@ class TestOtelDisabledZeroSpans:
             ArxivItem(
                 arxiv_id="2601.12345",
                 title="Test Paper",
-                abstract="Abstract text",
+                # Long enough to clear the issue #166 thin-summary threshold.
+                abstract=(
+                    "Abstract text that comfortably exceeds the default "
+                    "thin-summary threshold so this span test runs the "
+                    "full ingest pipeline."
+                ),
                 published=datetime(2026, 4, 25, tzinfo=UTC),
                 categories=["cs.AI"],
             ),

--- a/tests/integration/test_rss_to_lithos.py
+++ b/tests/integration/test_rss_to_lithos.py
@@ -176,7 +176,15 @@ def _make_item(
     title: str = "Test Article",
     url: str,
     published_iso: str = "2026-04-23T10:00:00+00:00",
-    summary: str = "Test summary.",
+    # Long enough by default to clear the issue #166 thin-summary
+    # threshold so generic fixtures don't trip the rule.  Tests that
+    # specifically exercise short-summary behaviour pass a shorter
+    # string explicitly.
+    summary: str = (
+        "A substantive test summary that comfortably exceeds the "
+        "default thin-summary threshold so end-to-end tests are not "
+        "accidentally affected by the suppression rule."
+    ),
     source_tag: Literal["rss", "blog"] = "rss",
     feed_name: str = "AI Research Blog",
 ) -> RssFeedItem:

--- a/tests/integration/test_rss_to_lithos.py
+++ b/tests/integration/test_rss_to_lithos.py
@@ -400,6 +400,7 @@ class TestArchiveNotePathAgreement:
             profile_name="test-profile",
             config=config,
         )
+        assert result is not None
 
         # Tag agreement
         assert "source:rss" in result["tags"]
@@ -440,6 +441,7 @@ class TestArchiveNotePathAgreement:
             profile_name="test-profile",
             config=config,
         )
+        assert result is not None
 
         assert "source:blog" in result["tags"]
         assert result["path"] == "articles/blog/2026/04"
@@ -465,6 +467,7 @@ class TestArchiveNotePathAgreement:
             profile_name="test-profile",
             config=config,
         )
+        assert result is not None
 
         # File on disk
         archive_files = list(archive_dir.rglob("*.html"))
@@ -527,11 +530,13 @@ class TestCollision:
             profile_name="test-profile",
             config=config,
         )
+        assert result_a is not None
         result_b = build_rss_note_item(
             item=item_b,
             profile_name="test-profile",
             config=config,
         )
+        assert result_b is not None
 
         # Both archive files exist on disk
         archive_files = sorted(archive_dir.rglob("*.html"))
@@ -591,6 +596,7 @@ class TestCollision:
                 profile_name="test-profile",
                 config=config,
             )
+            assert result is not None
             results.append(result)
 
         # Two distinct archive files on disk
@@ -642,6 +648,7 @@ class TestDeterminism:
             profile_name="test-profile",
             config=config,
         )
+        assert result1 is not None
 
         # Verify single file
         files_after_first = list(archive_dir.rglob("*.html"))
@@ -654,6 +661,7 @@ class TestDeterminism:
             profile_name="test-profile",
             config=config,
         )
+        assert result2 is not None
 
         files_after_second = list(archive_dir.rglob("*.html"))
         assert len(files_after_second) == 1
@@ -714,6 +722,7 @@ class TestEndToEndFixtureFeed:
                 profile_name="test-profile",
                 config=config,
             )
+            assert result is not None
             results.append(result)
 
         # Two archive files on disk
@@ -764,6 +773,7 @@ class TestEndToEndFixtureFeed:
                 profile_name="test-profile",
                 config=config,
             )
+            assert result is not None
             results.append(result)
 
         archive_files = list(archive_dir.rglob("*.html"))
@@ -797,6 +807,7 @@ class TestEndToEndFixtureFeed:
             profile_name="test-profile",
             config=config,
         )
+        assert result is not None
         assert "influx:archive-missing" not in result["tags"]
 
         # Now test that without allow_private_ips the download fails
@@ -818,6 +829,7 @@ class TestEndToEndFixtureFeed:
             profile_name="test-profile",
             config=strict_config,
         )
+        assert result_strict is not None
         # Archive download failed due to SSRF guard
         assert "influx:archive-missing" in result_strict["tags"]
 
@@ -923,6 +935,7 @@ class TestExtractionFallbackToSummary:
             profile_name="test-profile",
             config=config,
         )
+        assert result is not None
 
         # Feed summary should be used, not the short extracted text
         assert result["abstract_or_summary"] == feed_summary
@@ -947,6 +960,7 @@ class TestExtractionFallbackToSummary:
             profile_name="test-profile",
             config=config,
         )
+        assert result is not None
 
         # Extracted text should be used, not the feed summary
         assert result["abstract_or_summary"] != feed_summary

--- a/tests/unit/test_archive_policy_source_tags.py
+++ b/tests/unit/test_archive_policy_source_tags.py
@@ -127,6 +127,7 @@ class TestRssArchivePolicyTags:
         result = build_rss_note_item(
             item=item, profile_name="ai-robotics", config=config
         )
+        assert result is not None
 
         tags = cast(list[str], result["tags"])
         assert "influx:archive-skipped-by-policy" in tags
@@ -151,6 +152,7 @@ class TestRssArchivePolicyTags:
         result = build_rss_note_item(
             item=item, profile_name="ai-robotics", config=config
         )
+        assert result is not None
 
         tags = cast(list[str], result["tags"])
         assert "influx:archive-blocked" in tags
@@ -173,6 +175,7 @@ class TestRssArchivePolicyTags:
         result = build_rss_note_item(
             item=item, profile_name="ai-robotics", config=config
         )
+        assert result is not None
 
         tags = cast(list[str], result["tags"])
         assert "influx:archive-rate-limited" in tags
@@ -196,6 +199,7 @@ class TestRssArchivePolicyTags:
         result = build_rss_note_item(
             item=item, profile_name="ai-robotics", config=config
         )
+        assert result is not None
 
         tags = cast(list[str], result["tags"])
         assert "influx:archive-missing" in tags
@@ -227,6 +231,7 @@ class TestRssArchivePolicyTags:
         result = build_rss_note_item(
             item=item, profile_name="ai-robotics", config=config
         )
+        assert result is not None
 
         tags = cast(list[str], result["tags"])
         assert "influx:archive-unsupported" in tags
@@ -255,6 +260,7 @@ class TestRssArchivePolicyTags:
         result = build_rss_note_item(
             item=item, profile_name="ai-robotics", config=config
         )
+        assert result is not None
 
         tags = cast(list[str], result["tags"])
         assert "influx:archive-non-html-source" in tags
@@ -278,6 +284,7 @@ class TestRssArchivePolicyTags:
         result = build_rss_note_item(
             item=item, profile_name="ai-robotics", config=config
         )
+        assert result is not None
 
         tags = cast(list[str], result["tags"])
         assert "influx:archive-missing" not in tags
@@ -336,6 +343,7 @@ class TestArxivArchivePolicyTags:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         tags = cast(list[str], result["tags"])
         assert "influx:archive-blocked" in tags
@@ -364,6 +372,7 @@ class TestArxivArchivePolicyTags:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         tags = cast(list[str], result["tags"])
         assert "influx:archive-rate-limited" in tags
@@ -393,6 +402,7 @@ class TestArxivArchivePolicyTags:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         tags = cast(list[str], result["tags"])
         assert "influx:archive-missing" in tags
@@ -486,6 +496,7 @@ class TestPolicyModeTagCrossProduct:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
         tags = cast(list[str], result["tags"])
 
         assert expected_tag in tags

--- a/tests/unit/test_archive_policy_source_tags.py
+++ b/tests/unit/test_archive_policy_source_tags.py
@@ -93,7 +93,14 @@ def _make_rss_item(url: str = "https://example.com/article") -> RssFeedItem:
         title="Test Article",
         url=url,
         published=datetime(2026, 4, 25, tzinfo=UTC),
-        summary="A summary of the article.",
+        # Long enough to clear the issue #166 thin-summary threshold so
+        # these archive-policy-tag tests exercise their intended path
+        # rather than the suppression drop.
+        summary=(
+            "A substantive summary that comfortably exceeds the default "
+            "thin-summary threshold so this test focuses on archive "
+            "policy tags rather than suppression."
+        ),
         source_tag="rss",
         feed_name="example-feed",
     )
@@ -286,7 +293,13 @@ def _make_arxiv_item() -> ArxivItem:
     return ArxivItem(
         arxiv_id="2601.12345",
         title="Test Paper",
-        abstract="An abstract.",
+        # Long enough to clear the issue #166 thin-summary threshold so
+        # these archive-policy-tag tests exercise their intended path.
+        abstract=(
+            "A substantive abstract that comfortably exceeds the "
+            "default thin-summary threshold so this test focuses on "
+            "archive policy tags rather than suppression."
+        ),
         published=datetime(2026, 4, 25, tzinfo=UTC),
         categories=["cs.AI"],
     )

--- a/tests/unit/test_arxiv_thin_summary_drop.py
+++ b/tests/unit/test_arxiv_thin_summary_drop.py
@@ -1,0 +1,244 @@
+"""Tests for the thin-summary suppression on the arXiv adapter (issue #166).
+
+arXiv abstracts are typically several hundred characters of real
+content so the default 80-char threshold rarely fires in the wild.
+These tests force the conditions where the rule must / must not fire
+so the per-source behaviour is provably consistent with the RSS path.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+
+from influx.config import (
+    AppConfig,
+    ExtractionConfig,
+    LithosConfig,
+    ProfileConfig,
+    ProfileThresholds,
+    PromptEntryConfig,
+    PromptsConfig,
+    ScheduleConfig,
+    SecurityConfig,
+)
+from influx.sources.arxiv import ArxivItem, build_arxiv_note_item
+from influx.storage import ArchiveResult
+from influx.telemetry import current_summary_thin_drops
+
+# A realistic ~250-char arXiv abstract: comfortably above 80 chars,
+# matches no boilerplate, distinct from any title we synthesise here.
+_REAL_ABSTRACT = (
+    "We present a novel architecture for self-supervised learning on "
+    "graph-structured data that improves downstream node classification "
+    "accuracy by 4.7% on benchmark datasets while reducing training "
+    "time by an order of magnitude over prior work."
+)
+
+
+def _make_config(*, min_summary_chars: int = 80) -> AppConfig:
+    return AppConfig(
+        lithos=LithosConfig(url="http://localhost:0/sse"),
+        schedule=ScheduleConfig(),
+        profiles=[
+            ProfileConfig(
+                name="ai-robotics",
+                description="AI and robotics research",
+                thresholds=ProfileThresholds(
+                    relevance=7, full_text=100, deep_extract=100
+                ),
+            )
+        ],
+        providers={},
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="x"),
+            tier1_enrich=PromptEntryConfig(text="x"),
+            tier3_extract=PromptEntryConfig(text="x"),
+        ),
+        security=SecurityConfig(allow_private_ips=True),
+        extraction=ExtractionConfig(min_summary_chars=min_summary_chars),
+    )
+
+
+def _make_item(
+    *,
+    abstract: str = _REAL_ABSTRACT,
+    title: str = "Self-Supervised Graph Learning",
+    arxiv_id: str = "2604.12345",
+) -> ArxivItem:
+    return ArxivItem(
+        arxiv_id=arxiv_id,
+        title=title,
+        abstract=abstract,
+        published=datetime(2026, 4, 25, tzinfo=UTC),
+        categories=["cs.AI"],
+    )
+
+
+def _failed_archive(failure_kind: str = "http_404") -> ArchiveResult:
+    return ArchiveResult(
+        ok=False,
+        rel_posix_path=None,
+        error=f"forced ({failure_kind})",
+        failure_kind=failure_kind,  # type: ignore[arg-type]
+    )
+
+
+def _ok_archive() -> ArchiveResult:
+    return ArchiveResult(
+        ok=True,
+        rel_posix_path="arxiv/2026/04/2604.12345.pdf",
+        error="",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_counter() -> object:
+    bucket: list[int] = [0]
+    token = current_summary_thin_drops.set(bucket)
+    try:
+        yield bucket
+    finally:
+        current_summary_thin_drops.reset(token)
+
+
+class TestArxivThinSummaryDrop:
+    """Thin abstract + failed PDF archive → drop with telemetry."""
+
+    @patch("influx.sources.arxiv.download_archive")
+    def test_pointer_abstract_drops_item(
+        self,
+        mock_dl: object,
+        _isolate_counter: list[int],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        mock_dl.return_value = _failed_archive("http_404")  # type: ignore[attr-defined]
+        item = _make_item(abstract="Comments")
+
+        with caplog.at_level(logging.INFO, logger="influx.sources.arxiv"):
+            result = build_arxiv_note_item(
+                item=item,
+                score=8,
+                confidence=0.8,
+                reason="R",
+                profile_name="ai-robotics",
+                config=_make_config(min_summary_chars=0),
+            )
+
+        assert result is None
+        assert _isolate_counter[0] == 1
+        assert any(
+            "thin-summary drop source=arxiv" in record.message
+            and "rule=boilerplate" in record.message
+            and "failure_kind=http_404" in record.message
+            for record in caplog.records
+        )
+
+    @patch("influx.sources.arxiv.download_archive")
+    def test_short_abstract_drops_at_default_threshold(
+        self,
+        mock_dl: object,
+        _isolate_counter: list[int],
+    ) -> None:
+        mock_dl.return_value = _failed_archive("timeout")  # type: ignore[attr-defined]
+        # 30-char abstract — below default 80-char threshold.
+        item = _make_item(abstract="Short stub abstract for paper.")
+
+        result = build_arxiv_note_item(
+            item=item,
+            score=8,
+            confidence=0.8,
+            reason="R",
+            profile_name="ai-robotics",
+            config=_make_config(),
+        )
+
+        assert result is None
+        assert _isolate_counter[0] == 1
+
+
+class TestArxivThinSummaryNoDrop:
+    """Realistic abstracts pass; archive success bypasses the rule entirely."""
+
+    @patch("influx.sources.arxiv.download_archive")
+    def test_real_abstract_with_failed_archive_writes_note(
+        self,
+        mock_dl: object,
+        _isolate_counter: list[int],
+    ) -> None:
+        mock_dl.return_value = _failed_archive("http_404")  # type: ignore[attr-defined]
+        item = _make_item(abstract=_REAL_ABSTRACT)
+
+        with patch(
+            "influx.sources.arxiv.extract_arxiv_text",
+            side_effect=Exception("extraction not the focus"),
+        ):
+            result = build_arxiv_note_item(
+                item=item,
+                score=4,  # below full_text threshold so extraction is skipped
+                confidence=0.4,
+                reason="R",
+                profile_name="ai-robotics",
+                config=_make_config(),
+            )
+
+        assert result is not None
+        assert "influx:archive-missing" in result["tags"]
+        assert _isolate_counter[0] == 0
+
+    @patch("influx.sources.arxiv.download_archive")
+    def test_thin_abstract_with_archive_success_writes_note(
+        self,
+        mock_dl: object,
+        _isolate_counter: list[int],
+    ) -> None:
+        # Archive OK — the suppression check never runs even with a
+        # pointer-shaped abstract.
+        mock_dl.return_value = _ok_archive()  # type: ignore[attr-defined]
+        item = _make_item(abstract="Comments")
+
+        result = build_arxiv_note_item(
+            item=item,
+            score=4,
+            confidence=0.4,
+            reason="R",
+            profile_name="ai-robotics",
+            config=_make_config(min_summary_chars=0),
+        )
+
+        assert result is not None
+        assert "influx:archive-missing" not in result["tags"]
+        assert _isolate_counter[0] == 0
+
+
+class TestArxivUnsupportedScope:
+    """The broader trigger scope decision also applies to arXiv."""
+
+    @patch("influx.sources.arxiv.download_archive")
+    def test_unsupported_with_thin_abstract_drops(
+        self,
+        mock_dl: object,
+        _isolate_counter: list[int],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        mock_dl.return_value = _failed_archive("unsupported")  # type: ignore[attr-defined]
+        item = _make_item(abstract="...")
+
+        with caplog.at_level(logging.INFO, logger="influx.sources.arxiv"):
+            result = build_arxiv_note_item(
+                item=item,
+                score=4,
+                confidence=0.4,
+                reason="R",
+                profile_name="ai-robotics",
+                config=_make_config(min_summary_chars=0),
+            )
+
+        assert result is None
+        assert _isolate_counter[0] == 1
+        assert any(
+            "failure_kind=unsupported" in record.message for record in caplog.records
+        )

--- a/tests/unit/test_arxiv_thin_summary_drop.py
+++ b/tests/unit/test_arxiv_thin_summary_drop.py
@@ -214,6 +214,115 @@ class TestArxivThinSummaryNoDrop:
         assert _isolate_counter[0] == 0
 
 
+class TestMetricsDeferralPastSuppression:
+    """Issue #166 review: archive_missing / archive_policy_failures must
+    NOT bump for items the thin-summary rule drops, since those items
+    never receive the corresponding tags on a written note.
+    """
+
+    @patch("influx.sources.arxiv.metrics.archive_policy_failures")
+    @patch("influx.sources.arxiv.metrics.archive_missing")
+    @patch("influx.sources.arxiv.download_archive")
+    def test_thin_summary_drop_skips_archive_missing_bump_on_terminal(
+        self,
+        mock_dl: object,
+        mock_am: object,
+        mock_apf: object,
+        _isolate_counter: list[int],
+    ) -> None:
+        # Terminal-flipped path: archive_missing would have bumped
+        # eagerly under the original wiring.  Drop must skip the bump.
+        from influx.telemetry import current_archive_terminal_arxiv_ids
+
+        item = _make_item(abstract="Comments")
+        token = current_archive_terminal_arxiv_ids.set(frozenset({item.arxiv_id}))
+        try:
+            result = build_arxiv_note_item(
+                item=item,
+                score=4,
+                confidence=0.4,
+                reason="R",
+                profile_name="ai-robotics",
+                config=_make_config(min_summary_chars=0),
+            )
+        finally:
+            current_archive_terminal_arxiv_ids.reset(token)
+
+        assert result is None
+        assert _isolate_counter[0] == 1
+        # ``mock_am``/``mock_apf`` are the helper-getter mocks; their
+        # ``.return_value`` is the per-call counter mock — assert no
+        # ``.add`` invocation happened.
+        mock_am.return_value.add.assert_not_called()  # type: ignore[attr-defined]
+        mock_apf.return_value.add.assert_not_called()  # type: ignore[attr-defined]
+        # Sanity: download_archive was NOT called because terminal
+        # short-circuits download.
+        mock_dl.assert_not_called()  # type: ignore[attr-defined]
+
+    @patch("influx.sources.arxiv.metrics.archive_policy_failures")
+    @patch("influx.sources.arxiv.metrics.archive_missing")
+    @patch("influx.sources.arxiv.download_archive")
+    def test_thin_summary_drop_skips_archive_metrics_on_generic_failure(
+        self,
+        mock_dl: object,
+        mock_am: object,
+        mock_apf: object,
+        _isolate_counter: list[int],
+    ) -> None:
+        # Generic 404 path: both archive_missing AND
+        # archive_policy_failures would have bumped eagerly.  Drop must
+        # skip both.
+        mock_dl.return_value = _failed_archive("http_404")  # type: ignore[attr-defined]
+        item = _make_item(abstract="...")
+
+        result = build_arxiv_note_item(
+            item=item,
+            score=4,
+            confidence=0.4,
+            reason="R",
+            profile_name="ai-robotics",
+            config=_make_config(min_summary_chars=0),
+        )
+
+        assert result is None
+        assert _isolate_counter[0] == 1
+        mock_am.return_value.add.assert_not_called()  # type: ignore[attr-defined]
+        mock_apf.return_value.add.assert_not_called()  # type: ignore[attr-defined]
+
+    @patch("influx.sources.arxiv.metrics.archive_policy_failures")
+    @patch("influx.sources.arxiv.metrics.archive_missing")
+    @patch("influx.sources.arxiv.download_archive")
+    def test_non_thin_summary_still_bumps_archive_metrics(
+        self,
+        mock_dl: object,
+        mock_am: object,
+        mock_apf: object,
+        _isolate_counter: list[int],
+    ) -> None:
+        # Non-thin abstract + failed archive: item is written, so both
+        # counters must bump (deferred but still hit).
+        mock_dl.return_value = _failed_archive("http_404")  # type: ignore[attr-defined]
+        item = _make_item(abstract=_REAL_ABSTRACT)
+
+        with patch(
+            "influx.sources.arxiv.extract_arxiv_text",
+            side_effect=Exception("extraction not the focus"),
+        ):
+            result = build_arxiv_note_item(
+                item=item,
+                score=4,
+                confidence=0.4,
+                reason="R",
+                profile_name="ai-robotics",
+                config=_make_config(),
+            )
+
+        assert result is not None
+        assert _isolate_counter[0] == 0
+        mock_am.return_value.add.assert_called_once()  # type: ignore[attr-defined]
+        mock_apf.return_value.add.assert_called_once()  # type: ignore[attr-defined]
+
+
 class TestArxivUnsupportedScope:
     """The broader trigger scope decision also applies to arXiv."""
 

--- a/tests/unit/test_build_arxiv_note_item.py
+++ b/tests/unit/test_build_arxiv_note_item.py
@@ -113,6 +113,7 @@ class TestHTMLSuccess:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "text:html" in result["tags"]
 
@@ -132,6 +133,7 @@ class TestHTMLSuccess:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "full-text" in result["tags"]
 
@@ -151,6 +153,7 @@ class TestHTMLSuccess:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "## Full Text" in result["content"]
         assert "The full extracted article text" in result["content"]
@@ -171,6 +174,7 @@ class TestHTMLSuccess:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "influx:repair-needed" not in result["tags"]
 
@@ -196,6 +200,7 @@ class TestPDFFallback:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "text:pdf" in result["tags"]
         assert "full-text" in result["tags"]
@@ -223,6 +228,7 @@ class TestBothFail:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "text:abstract-only" in result["tags"]
 
@@ -241,6 +247,7 @@ class TestBothFail:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "influx:repair-needed" in result["tags"]
 
@@ -259,6 +266,7 @@ class TestBothFail:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "## Full Text" not in result["content"]
         assert "full-text" not in result["tags"]
@@ -279,6 +287,7 @@ class TestBothFail:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "influx:text-terminal" not in result["tags"]
 
@@ -303,6 +312,7 @@ class TestBelowThreshold:
                 profile_name="ai-robotics",
                 config=config,
             )
+            assert result is not None
             mock_extract.assert_not_called()  # type: ignore[union-attr]
 
         assert "text:abstract-only" in result["tags"]
@@ -321,6 +331,7 @@ class TestBelowThreshold:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "## Full Text" not in result["content"]
 
@@ -343,6 +354,7 @@ class TestItemShape:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert result["title"] == "Test Paper Title"
         assert result["source_url"] == "https://arxiv.org/abs/2601.99999"
@@ -363,6 +375,7 @@ class TestItemShape:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "profile:ai-robotics" in result["tags"]
         assert "arxiv-id:2601.12345" in result["tags"]
@@ -382,6 +395,7 @@ class TestItemShape:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "cat:cs.AI" in result["tags"]
         assert "cat:cs.RO" in result["tags"]
@@ -398,6 +412,7 @@ class TestItemShape:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert result["path"] == "papers/arxiv/2026/04"
 
@@ -413,6 +428,7 @@ class TestItemShape:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "# Test Paper Title" in result["content"]
 
@@ -427,6 +443,7 @@ class TestItemShape:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "## Profile Relevance" in result["content"]
         assert "ai-robotics" in result["content"]
@@ -447,6 +464,7 @@ class TestItemShape:
                 config=config,
                 thresholds=custom_thresholds,
             )
+            assert result is not None
             mock_extract.assert_not_called()  # type: ignore[union-attr]
 
         # Score 9 < threshold 100, so no extraction
@@ -502,6 +520,7 @@ class TestTier1EnrichmentSuccess:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "## Summary" in result["content"]
         assert "### Contributions" in result["content"]
@@ -545,6 +564,7 @@ class TestTier1EnrichmentSuccess:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "influx:repair-needed" not in result["tags"]
 
@@ -575,6 +595,7 @@ class TestTier1EnrichmentSuccess:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "## Summary" in result["content"]
         assert "This is the abstract of the test paper" in result["content"]
@@ -602,6 +623,7 @@ class TestTier1EnrichmentFailure:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "## Summary" not in result["content"]
 
@@ -620,6 +642,7 @@ class TestTier1EnrichmentFailure:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "influx:repair-needed" in result["tags"]
 
@@ -639,6 +662,7 @@ class TestTier1EnrichmentFailure:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         # No summary placeholder, abstract not rendered as summary
         assert "## Summary" not in result["content"]
@@ -672,6 +696,7 @@ class TestTier3ExtractionSuccess:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "## Claims" in result["content"]
         assert "## Datasets & Benchmarks" in result["content"]
@@ -699,6 +724,7 @@ class TestTier3ExtractionSuccess:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "influx:deep-extracted" in result["tags"]
 
@@ -723,6 +749,7 @@ class TestTier3ExtractionSuccess:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "influx:repair-needed" not in result["tags"]
 
@@ -803,6 +830,7 @@ class TestTier3ExtractionFailure:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "## Claims" not in result["content"]
         assert "## Datasets & Benchmarks" not in result["content"]
@@ -832,6 +860,7 @@ class TestTier3ExtractionFailure:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "influx:deep-extracted" not in result["tags"]
 
@@ -858,6 +887,7 @@ class TestTier3ExtractionFailure:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "influx:repair-needed" in result["tags"]
 
@@ -890,6 +920,7 @@ class TestTier3ExtractionFailure:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "influx:repair-needed" in result["tags"]
         assert "influx:deep-extracted" not in result["tags"]
@@ -917,6 +948,7 @@ class TestTier3ExtractionFailure:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "influx:repair-needed" in result["tags"]
         assert "## Summary" not in result["content"]
@@ -952,6 +984,7 @@ class TestPerTierFailureIndependence:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         # Tier 1 succeeded → ## Summary present
         assert "## Summary" in result["content"]
@@ -986,6 +1019,7 @@ class TestPerTierFailureIndependence:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         # Tier 1 failed → no ## Summary
         assert "## Summary" not in result["content"]
@@ -1016,6 +1050,7 @@ class TestPerTierFailureIndependence:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         # Tier 1 succeeded
         assert "## Summary" in result["content"]
@@ -1057,6 +1092,7 @@ class TestTagDerivationInvariants:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         has_section = "## Full Text" in result["content"]
         has_tag = "full-text" in result["tags"]
@@ -1084,6 +1120,7 @@ class TestTagDerivationInvariants:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         has_sections = all(
             h in result["content"]
@@ -1118,6 +1155,7 @@ class TestTagDerivationInvariants:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert "influx:deep-extracted" not in result["tags"]
         assert "## Claims" not in result["content"]
@@ -1144,6 +1182,7 @@ class TestTagDerivationInvariants:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
 
         assert result["tags"].count("influx:repair-needed") == 1
 
@@ -1172,6 +1211,7 @@ class TestFilterTagsPropagation:
             config=config,
             filter_tags=["topic:robotics", "topic:ai"],
         )
+        assert result is not None
 
         assert result["filter_tags"] == ["topic:robotics", "topic:ai"]
         # Filter-result tags are not mixed into persisted note tags.
@@ -1187,6 +1227,7 @@ class TestFilterTagsPropagation:
             profile_name="ai-robotics",
             config=config,
         )
+        assert result is not None
         assert result["filter_tags"] == []
 
 
@@ -1216,6 +1257,7 @@ class TestInspectorArchiveTerminalSkip:
                 profile_name="ai-robotics",
                 config=config,
             )
+            assert result is not None
         finally:
             current_archive_terminal_arxiv_ids.reset(token)
 

--- a/tests/unit/test_build_arxiv_note_item.py
+++ b/tests/unit/test_build_arxiv_note_item.py
@@ -80,7 +80,12 @@ def _make_item(arxiv_id: str = "2601.12345") -> ArxivItem:
     return ArxivItem(
         arxiv_id=arxiv_id,
         title="Test Paper Title",
-        abstract="This is the abstract of the test paper.",
+        abstract=(
+            "This is the abstract of the test paper, deliberately long "
+            "enough to clear the issue #166 thin-summary threshold so "
+            "this fixture exercises the note-builder rather than the "
+            "suppression drop."
+        ),
         published=datetime(2026, 4, 25, tzinfo=UTC),
         categories=["cs.AI", "cs.RO"],
     )
@@ -522,7 +527,9 @@ class TestTier1EnrichmentSuccess:
         mock_t1.assert_called_once()  # type: ignore[union-attr]
         call_kwargs = mock_t1.call_args.kwargs  # type: ignore[union-attr]
         assert call_kwargs["title"] == "Test Paper Title"
-        assert call_kwargs["abstract"] == "This is the abstract of the test paper."
+        assert call_kwargs["abstract"].startswith(
+            "This is the abstract of the test paper"
+        )
         assert call_kwargs["profile_summary"] == "AI and robotics research"
 
     @patch("influx.cascade.tier1_enrich")
@@ -570,7 +577,7 @@ class TestTier1EnrichmentSuccess:
         )
 
         assert "## Summary" in result["content"]
-        assert "This is the abstract of the test paper." in result["content"]
+        assert "This is the abstract of the test paper" in result["content"]
 
 
 # ── Tier 1 enrichment failure ────────────────────────────────────

--- a/tests/unit/test_metrics_module.py
+++ b/tests/unit/test_metrics_module.py
@@ -60,6 +60,7 @@ HELPERS: dict[str, str] = {
     "llm_validation_failures": "influx_llm_validation_failures_total",
     "tier3_fallbacks": "influx_tier3_fallbacks_total",
     "archive_missing": "influx_archive_missing_total",
+    "summary_thin_drops": "influx_summary_thin_drops_total",
     "source_acquisition_errors": "influx_source_acquisition_errors_total",
     "slug_collision_url_recovery": "influx_slug_collision_url_recovery_total",
 }

--- a/tests/unit/test_rss_thin_summary_drop.py
+++ b/tests/unit/test_rss_thin_summary_drop.py
@@ -1,0 +1,408 @@
+"""Tests for the thin-summary suppression on the RSS adapter (issue #166).
+
+Verifies the wiring from :func:`influx.sources.rss.build_rss_note_item`
+into :func:`influx.thin_summary.is_thin_summary` and the per-drop
+telemetry:
+
+* Thin summary + failed archive  → ``build_rss_note_item`` returns
+  ``None``; the contextvar counter / OTel metric / INFO log all fire.
+* Thin summary + successful archive → note is still written (the rule
+  only fires when no body arrived).
+* Non-thin summary + failed archive → note is written as today (with
+  the existing ``influx:archive-missing`` tag).
+* ``non_html_source`` / ``unsupported`` failures with a thin summary
+  → dropped (the user picked the broader scope so these short-circuits
+  benefit too).
+* ``min_summary_chars = 0`` override disables length-rule suppression
+  but title-equality + boilerplate continue to fire.
+
+``extract_article`` is patched to raise ``NetworkError`` in every test
+so the feed summary is the value the rule actually sees — no real
+network IO, no implicit extraction-fallback noise.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+
+from influx.config import (
+    AppConfig,
+    ArchivePolicyConfig,
+    ExtractionConfig,
+    LithosConfig,
+    ProfileConfig,
+    ProfileThresholds,
+    PromptEntryConfig,
+    PromptsConfig,
+    ScheduleConfig,
+    SecurityConfig,
+    StorageConfig,
+)
+from influx.errors import NetworkError
+from influx.sources.rss import RssFeedItem, build_rss_note_item
+from influx.storage import ArchiveResult
+from influx.telemetry import current_summary_thin_drops
+
+# A meaningful summary well above the default 80-char threshold so any
+# test that wants a "non-thin" baseline can re-use it.
+_LONG_SUMMARY = (
+    "This is a substantial article body discussing the subject in "
+    "enough detail that no structural thin-summary rule should ever "
+    "trip on it under default configuration."
+)
+
+
+def _make_config(
+    *,
+    min_summary_chars: int = 80,
+    archive_dir: str = "/archive",
+) -> AppConfig:
+    """Build a minimal AppConfig with a tunable thin-summary threshold."""
+    return AppConfig(
+        lithos=LithosConfig(url="http://localhost:0/sse"),
+        schedule=ScheduleConfig(),
+        storage=StorageConfig(
+            archive_dir=archive_dir,
+            archive_policy=ArchivePolicyConfig(include_defaults=False),
+        ),
+        profiles=[
+            ProfileConfig(
+                name="ai-robotics",
+                description="AI and robotics research",
+                thresholds=ProfileThresholds(
+                    relevance=7, full_text=100, deep_extract=100
+                ),
+            )
+        ],
+        providers={},
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="x"),
+            tier1_enrich=PromptEntryConfig(text="x"),
+            tier3_extract=PromptEntryConfig(text="x"),
+        ),
+        security=SecurityConfig(allow_private_ips=True),
+        extraction=ExtractionConfig(min_summary_chars=min_summary_chars),
+    )
+
+
+def _make_item(
+    *,
+    summary: str = "A summary of the article.",
+    title: str = "Test Article",
+    url: str = "https://example.com/article",
+) -> RssFeedItem:
+    return RssFeedItem(
+        title=title,
+        url=url,
+        published=datetime(2026, 4, 25, tzinfo=UTC),
+        summary=summary,
+        source_tag="rss",
+        feed_name="example-feed",
+    )
+
+
+def _failed_archive(
+    *,
+    failure_kind: str = "http_404",
+) -> ArchiveResult:
+    return ArchiveResult(
+        ok=False,
+        rel_posix_path=None,
+        error=f"HTTP 404 for url ({failure_kind})",
+        failure_kind=cast(  # type: ignore[arg-type]
+            "str",
+            failure_kind,
+        ),
+    )
+
+
+def _ok_archive() -> ArchiveResult:
+    return ArchiveResult(
+        ok=True,
+        rel_posix_path="rss/example-feed/2026/04/abcd1234.html",
+        error="",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_counter() -> object:
+    """Each test gets its own ``current_summary_thin_drops`` bucket."""
+    bucket: list[int] = [0]
+    token = current_summary_thin_drops.set(bucket)
+    try:
+        yield bucket
+    finally:
+        current_summary_thin_drops.reset(token)
+
+
+@pytest.fixture(autouse=True)
+def _force_extraction_failure() -> object:
+    """Force ``extract_article`` to raise so the test sees the feed summary verbatim."""
+    with patch(
+        "influx.sources.rss.extract_article",
+        side_effect=NetworkError(
+            "test forced",
+            url="https://example.com/article",
+            kind="timeout",
+        ),
+    ) as patched:
+        yield patched
+
+
+class TestThinSummaryDrop:
+    """Thin summary + failed archive → drop with metric + counter + INFO log."""
+
+    @patch("influx.sources.rss.download_archive")
+    def test_pointer_summary_drops_item(
+        self,
+        mock_dl: object,
+        _isolate_counter: list[int],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # "Discussion (47 points)" is 22 chars — well under the default
+        # 80-char threshold, so the length rule fires first.
+        mock_dl.return_value = _failed_archive(failure_kind="http_404")  # type: ignore[attr-defined]
+        item = _make_item(summary="Discussion (47 points)")
+
+        with caplog.at_level(logging.INFO, logger="influx.sources.rss"):
+            result = build_rss_note_item(
+                item=item,
+                profile_name="ai-robotics",
+                config=_make_config(),
+            )
+
+        assert result is None
+        assert _isolate_counter[0] == 1
+        assert any(
+            "thin-summary drop source=rss" in record.message
+            and "rule=length" in record.message
+            and "failure_kind=http_404" in record.message
+            for record in caplog.records
+        )
+
+    @patch("influx.sources.rss.download_archive")
+    def test_title_equality_drops_item_at_min_chars_zero(
+        self,
+        mock_dl: object,
+        _isolate_counter: list[int],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # min_summary_chars=0 disables the length rule, so this proves
+        # the title-equality check fires independently.
+        mock_dl.return_value = _failed_archive(failure_kind="timeout")  # type: ignore[attr-defined]
+        item = _make_item(
+            title="The Title Verbatim",
+            summary="THE TITLE VERBATIM!",
+        )
+
+        with caplog.at_level(logging.INFO, logger="influx.sources.rss"):
+            result = build_rss_note_item(
+                item=item,
+                profile_name="ai-robotics",
+                config=_make_config(min_summary_chars=0),
+            )
+
+        assert result is None
+        assert _isolate_counter[0] == 1
+        assert any(
+            "rule=title_equality" in record.message
+            and "failure_kind=timeout" in record.message
+            for record in caplog.records
+        )
+
+    @patch("influx.sources.rss.download_archive")
+    def test_boilerplate_summary_drops_item_at_min_chars_zero(
+        self,
+        mock_dl: object,
+        _isolate_counter: list[int],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        mock_dl.return_value = _failed_archive(failure_kind="http_5xx")  # type: ignore[attr-defined]
+        item = _make_item(summary="Read more at example.com")
+
+        with caplog.at_level(logging.INFO, logger="influx.sources.rss"):
+            result = build_rss_note_item(
+                item=item,
+                profile_name="ai-robotics",
+                config=_make_config(min_summary_chars=0),
+            )
+
+        assert result is None
+        assert _isolate_counter[0] == 1
+        assert any("rule=boilerplate" in record.message for record in caplog.records)
+
+
+class TestThinSummaryNoDrop:
+    """The rule must NOT fire outside its trigger scope."""
+
+    @patch("influx.sources.rss.download_archive")
+    def test_long_summary_still_writes_note(
+        self,
+        mock_dl: object,
+        _isolate_counter: list[int],
+    ) -> None:
+        mock_dl.return_value = _failed_archive(failure_kind="http_404")  # type: ignore[attr-defined]
+        item = _make_item(summary=_LONG_SUMMARY)
+
+        result = build_rss_note_item(
+            item=item,
+            profile_name="ai-robotics",
+            config=_make_config(),
+        )
+
+        assert result is not None
+        # Existing behaviour preserved: archive failure still produces the
+        # archive-missing tag on the rendered note.
+        tags = cast(list[str], result["tags"])
+        assert "influx:archive-missing" in tags
+        assert _isolate_counter[0] == 0
+
+    @patch("influx.sources.rss.download_archive")
+    def test_thin_summary_with_archive_success_writes_note(
+        self,
+        mock_dl: object,
+        _isolate_counter: list[int],
+    ) -> None:
+        # Archive succeeded → suppression check does not even run.
+        mock_dl.return_value = _ok_archive()  # type: ignore[attr-defined]
+        item = _make_item(summary="Discussion (47 points)")
+
+        result = build_rss_note_item(
+            item=item,
+            profile_name="ai-robotics",
+            config=_make_config(),
+        )
+
+        assert result is not None
+        tags = cast(list[str], result["tags"])
+        assert "influx:archive-missing" not in tags
+        assert _isolate_counter[0] == 0
+
+
+class TestThinSummaryScopeBroaderFailureKinds:
+    """User decision: also fire on ``non_html_source`` / ``unsupported``."""
+
+    @patch("influx.sources.rss.download_archive")
+    def test_non_html_source_with_thin_summary_drops(
+        self,
+        mock_dl: object,
+        _isolate_counter: list[int],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # ``non_html_source`` (issue #160) short-circuits the download.
+        # Today it writes a note WITHOUT archive-missing; with #166
+        # the thin-summary rule extends to this case too.
+        mock_dl.return_value = _failed_archive(failure_kind="non_html_source")  # type: ignore[attr-defined]
+        item = _make_item(summary="Comments")
+
+        with caplog.at_level(logging.INFO, logger="influx.sources.rss"):
+            result = build_rss_note_item(
+                item=item,
+                profile_name="ai-robotics",
+                config=_make_config(min_summary_chars=0),
+            )
+
+        assert result is None
+        assert _isolate_counter[0] == 1
+        assert any(
+            "failure_kind=non_html_source" in record.message
+            for record in caplog.records
+        )
+
+    @patch("influx.sources.rss.download_archive")
+    def test_unsupported_with_thin_summary_drops(
+        self,
+        mock_dl: object,
+        _isolate_counter: list[int],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # ``unsupported`` (issue #161) — domain policy says no archive.
+        mock_dl.return_value = _failed_archive(failure_kind="unsupported")  # type: ignore[attr-defined]
+        item = _make_item(summary="Continue reading")
+
+        with caplog.at_level(logging.INFO, logger="influx.sources.rss"):
+            result = build_rss_note_item(
+                item=item,
+                profile_name="ai-robotics",
+                config=_make_config(min_summary_chars=0),
+            )
+
+        assert result is None
+        assert _isolate_counter[0] == 1
+        assert any(
+            "failure_kind=unsupported" in record.message for record in caplog.records
+        )
+
+    @patch("influx.sources.rss.download_archive")
+    def test_non_html_source_with_long_summary_writes_note(
+        self,
+        mock_dl: object,
+        _isolate_counter: list[int],
+    ) -> None:
+        # A non-thin summary on a non_html_source URL keeps today's
+        # behaviour: note written with the dedicated tag.  This pins
+        # the rule's *narrowness* — it does NOT broaden to "drop every
+        # non_html_source / unsupported outcome".
+        mock_dl.return_value = _failed_archive(failure_kind="non_html_source")  # type: ignore[attr-defined]
+        item = _make_item(summary=_LONG_SUMMARY)
+
+        result = build_rss_note_item(
+            item=item,
+            profile_name="ai-robotics",
+            config=_make_config(),
+        )
+
+        assert result is not None
+        tags = cast(list[str], result["tags"])
+        assert "influx:archive-non-html-source" in tags
+        assert _isolate_counter[0] == 0
+
+
+class TestConfigOverride:
+    """``min_summary_chars`` propagates from the config."""
+
+    @patch("influx.sources.rss.download_archive")
+    def test_zero_threshold_disables_length_rule_only(
+        self,
+        mock_dl: object,
+        _isolate_counter: list[int],
+    ) -> None:
+        # 30-char summary that doesn't match boilerplate / title-equality.
+        # With min_summary_chars=0 the length rule is off, so the item
+        # passes and a note is written.
+        mock_dl.return_value = _failed_archive(failure_kind="http_404")  # type: ignore[attr-defined]
+        item = _make_item(summary="Just a brief but real summary.")  # 30 chars
+
+        result = build_rss_note_item(
+            item=item,
+            profile_name="ai-robotics",
+            config=_make_config(min_summary_chars=0),
+        )
+
+        assert result is not None
+        assert _isolate_counter[0] == 0
+
+    @patch("influx.sources.rss.download_archive")
+    def test_high_threshold_drops_medium_summaries(
+        self,
+        mock_dl: object,
+        _isolate_counter: list[int],
+    ) -> None:
+        # A 30-char summary that is fine at the default threshold is
+        # dropped when an operator raises the bar to 200 chars.
+        mock_dl.return_value = _failed_archive(failure_kind="http_404")  # type: ignore[attr-defined]
+        item = _make_item(summary="A short factual summary string.")
+
+        result = build_rss_note_item(
+            item=item,
+            profile_name="ai-robotics",
+            config=_make_config(min_summary_chars=200),
+        )
+
+        assert result is None
+        assert _isolate_counter[0] == 1

--- a/tests/unit/test_rss_thin_summary_drop.py
+++ b/tests/unit/test_rss_thin_summary_drop.py
@@ -363,6 +363,60 @@ class TestThinSummaryScopeBroaderFailureKinds:
         assert _isolate_counter[0] == 0
 
 
+class TestMetricsDeferralPastSuppression:
+    """Issue #166 review: ``archive_policy_failures`` must NOT bump for
+    items the thin-summary rule drops, since those items never receive
+    the archive-failure tag on a written note (the counter is
+    documented as moving in lock-step with ``archive_missing``).
+    """
+
+    @patch("influx.sources.rss.metrics.archive_policy_failures")
+    @patch("influx.sources.rss.download_archive")
+    def test_thin_summary_drop_skips_policy_failures_bump(
+        self,
+        mock_dl: object,
+        mock_apf: object,
+        _isolate_counter: list[int],
+    ) -> None:
+        mock_dl.return_value = _failed_archive(failure_kind="blocked")  # type: ignore[attr-defined]
+        item = _make_item(summary="Discussion (47 points)")
+
+        result = build_rss_note_item(
+            item=item,
+            profile_name="ai-robotics",
+            config=_make_config(),
+        )
+
+        assert result is None
+        assert _isolate_counter[0] == 1
+        # Helper-getter mock; ``.return_value.add`` is the per-call
+        # instrument mock that should never have been invoked.
+        mock_apf.return_value.add.assert_not_called()  # type: ignore[attr-defined]
+
+    @patch("influx.sources.rss.metrics.archive_policy_failures")
+    @patch("influx.sources.rss.download_archive")
+    def test_non_thin_summary_still_bumps_policy_failures(
+        self,
+        mock_dl: object,
+        mock_apf: object,
+        _isolate_counter: list[int],
+    ) -> None:
+        # Non-thin summary + failed archive: item is written so the
+        # counter bumps (deferred but still hit).
+        mock_dl.return_value = _failed_archive(failure_kind="blocked")  # type: ignore[attr-defined]
+        item = _make_item(summary=_LONG_SUMMARY)
+
+        result = build_rss_note_item(
+            item=item,
+            profile_name="ai-robotics",
+            config=_make_config(),
+        )
+
+        assert result is not None
+        assert _isolate_counter[0] == 0
+        mock_apf.return_value.add.assert_called_once()  # type: ignore[attr-defined]
+
+
 class TestConfigOverride:
     """``min_summary_chars`` propagates from the config."""
 

--- a/tests/unit/test_run_ledger.py
+++ b/tests/unit/test_run_ledger.py
@@ -2109,6 +2109,76 @@ def test_degradation_summary_invalid_note_state_drives_degradation(
     assert by_source == {"arxiv": 2, "rss": 2}
 
 
+def test_summary_thin_drops_total_persists_on_ledger_entry(tmp_path: Path) -> None:
+    """Issue #166: ``summary_thin_drops_total`` round-trips through the ledger.
+
+    Confirms the new kwarg is plumbed through ``complete`` → ``_finish``
+    and surfaces on the persisted entry shape so downstream consumers
+    (``/runs/recent``, dashboards) can read it without scraping logs.
+    """
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(run_id="r-1", profile="p", kind="scheduled", run_range=None)
+    ledger.complete(
+        run_id="r-1",
+        sources_checked=3,
+        ingested=3,
+        fetched_total=10,
+        summary_thin_drops_total=7,
+    )
+    entry = ledger.recent()[0]
+    assert entry["summary_thin_drops_total"] == 7
+    # Distinct field — must NOT be conflated with the archive-failure
+    # total even when archive_failures_total is unset.
+    assert entry["archive_failures_total"] is None
+
+
+def test_summary_thin_drops_total_does_not_trigger_archive_acquisition(
+    tmp_path: Path,
+) -> None:
+    """Issue #166: thin-summary drops are deliberately NOT degraded reasons.
+
+    A run with 50 thin-summary drops and zero archive failures must not
+    surface the ``archive_acquisition`` reason — these items never
+    became ``influx:archive-missing`` notes; they were dropped before
+    the write loop.
+    """
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(run_id="r-1", profile="p", kind="scheduled", run_range=None)
+    reasons = ledger.complete(
+        run_id="r-1",
+        sources_checked=3,
+        ingested=3,
+        fetched_total=53,
+        archive_failures_total=None,
+        summary_thin_drops_total=50,
+    )
+    assert reasons == []
+    entry = ledger.recent()[0]
+    assert entry["degraded"] is False
+    assert entry["degraded_reasons"] == []
+    assert entry["degradation_severity"] == "success"
+    assert entry["summary_thin_drops_total"] == 50
+
+
+def test_summary_thin_drops_total_defaults_to_none(tmp_path: Path) -> None:
+    """A run that doesn't pass the kwarg gets ``None`` on the entry.
+
+    Backwards-compatibility canary: existing callers that don't pass
+    the new kwarg still produce valid entries (just with the field set
+    to ``None`` rather than ``0``).
+    """
+    ledger = RunLedger(tmp_path / "state")
+    ledger.start(run_id="r-1", profile="p", kind="scheduled", run_range=None)
+    ledger.complete(
+        run_id="r-1",
+        sources_checked=1,
+        ingested=1,
+        fetched_total=1,
+    )
+    entry = ledger.recent()[0]
+    assert entry["summary_thin_drops_total"] is None
+
+
 def test_build_degradation_summary_accepts_no_write_outcomes(tmp_path: Path) -> None:
     """``write_outcomes=None`` produces a zero-shaped writes /
     invalid_note_state block so legacy callers (and the ``fail`` /

--- a/tests/unit/test_telemetry_wiring.py
+++ b/tests/unit/test_telemetry_wiring.py
@@ -1123,6 +1123,7 @@ class TestEnrichSpansDisabled:
                 profile_name="ai-robotics",
                 config=config,
             )
+            assert result is not None
 
         # Enrichment still runs — just no spans
         mock_tier1.assert_called_once()

--- a/tests/unit/test_telemetry_wiring.py
+++ b/tests/unit/test_telemetry_wiring.py
@@ -841,7 +841,13 @@ def _make_test_arxiv_item() -> Any:
     return ArxivItem(
         arxiv_id="2601.12345",
         title="Test Paper Title",
-        abstract="This is the abstract.",
+        # Long enough to clear the issue #166 thin-summary threshold so
+        # these enrichment-span tests exercise the full build path.
+        abstract=(
+            "This is the abstract for the test paper, deliberately "
+            "long enough to clear the default thin-summary threshold "
+            "so the enrichment-span tests run their intended path."
+        ),
         published=datetime(2026, 4, 25, tzinfo=UTC),
         categories=["cs.AI"],
     )

--- a/tests/unit/test_thin_summary.py
+++ b/tests/unit/test_thin_summary.py
@@ -1,0 +1,370 @@
+"""Unit tests for :mod:`influx.thin_summary` (issue #166).
+
+The module is pure (no IO, no global state) so every test passes
+synthetic strings directly.  The goal is to pin the precise contract
+between the source adapters and the structural rule so an accidental
+broadening / narrowing is loud.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from influx.thin_summary import (
+    BOILERPLATE_PATTERNS,
+    _normalize_for_equality,
+    is_thin_summary,
+)
+
+# Sentinel non-thin string used whenever a test wants to isolate one
+# rule by feeding the others a known-passing input.  Padded with real
+# words so the length / boilerplate / title-equality checks all see
+# something distinct.
+_NON_THIN_SUMMARY = (
+    "A meaningful summary of roughly two hundred characters describing "
+    "the article body in enough detail that no structural thin-summary "
+    "rule would ever fire on it under default configuration."
+)
+
+
+class TestNormalizeForEquality:
+    """``_normalize_for_equality`` strips punctuation, casing, and folds whitespace."""
+
+    def test_lowercases(self) -> None:
+        assert _normalize_for_equality("Hello") == "hello"
+
+    def test_collapses_internal_whitespace(self) -> None:
+        assert _normalize_for_equality("hello   world\t\n  here") == "hello world here"
+
+    def test_strips_leading_and_trailing_whitespace(self) -> None:
+        assert _normalize_for_equality("   hello world   ") == "hello world"
+
+    def test_strips_ascii_punctuation(self) -> None:
+        assert _normalize_for_equality("Hello, world!") == "hello world"
+
+    def test_strips_unicode_punctuation(self) -> None:
+        # Curly quotes (Unicode Pi / Pf) and an em dash (Pd) all strip.
+        assert _normalize_for_equality("“Hello” — world") == "hello world"
+
+    def test_empty_string_round_trips(self) -> None:
+        assert _normalize_for_equality("") == ""
+
+
+class TestLengthRule:
+    """The length rule fires first; below ``min_chars`` => thin."""
+
+    def test_below_min_chars_is_thin(self) -> None:
+        thin, rule = is_thin_summary(
+            summary="short string",  # 12 chars
+            title="completely unrelated title",
+            min_chars=80,
+        )
+        assert thin is True
+        assert rule == "length"
+
+    def test_above_min_chars_passes_length_rule(self) -> None:
+        thin, rule = is_thin_summary(
+            summary=_NON_THIN_SUMMARY,
+            title="completely unrelated title",
+            min_chars=80,
+        )
+        assert thin is False
+        assert rule is None
+
+    def test_at_min_chars_passes(self) -> None:
+        # Strict ``<`` boundary: exactly ``min_chars`` characters is OK.
+        summary = "a" * 80
+        thin, rule = is_thin_summary(
+            summary=summary,
+            title="completely unrelated title",
+            min_chars=80,
+        )
+        # 80 chars passes the length rule; the rest of the rules also pass.
+        assert thin is False
+        assert rule is None
+
+    def test_min_chars_zero_disables_length_rule(self) -> None:
+        # 5-char summary is well below any positive threshold.  With
+        # ``min_chars=0`` the length rule is off; title-equality and
+        # boilerplate still get a chance — pass both.
+        thin, rule = is_thin_summary(
+            summary="short",
+            title="completely unrelated title",
+            min_chars=0,
+        )
+        assert thin is False
+        assert rule is None
+
+    def test_negative_min_chars_treated_as_zero(self) -> None:
+        # Defensive: a misconfigured override should not raise inside
+        # the source adapter.  Negative is clamped to zero, so a short
+        # non-boilerplate summary passes.
+        thin, rule = is_thin_summary(
+            summary="short but real",
+            title="completely unrelated title",
+            min_chars=-5,
+        )
+        assert thin is False
+        assert rule is None
+
+    def test_whitespace_only_summary_counts_as_zero_length(self) -> None:
+        # ``len(trimmed)`` is what the rule checks, so a summary that
+        # is just whitespace fires the length rule even though the raw
+        # string is technically long.
+        thin, rule = is_thin_summary(
+            summary="   \n\t   ",
+            title="completely unrelated title",
+            min_chars=10,
+        )
+        assert thin is True
+        assert rule == "length"
+
+
+class TestTitleEqualityRule:
+    """Summary equals title under the normalisation transform."""
+
+    def test_exact_match_fires(self) -> None:
+        thin, rule = is_thin_summary(
+            summary="The Foo Bar",
+            title="The Foo Bar",
+            min_chars=0,
+        )
+        assert thin is True
+        assert rule == "title_equality"
+
+    def test_punctuation_difference_still_matches(self) -> None:
+        thin, rule = is_thin_summary(
+            summary="The Foo: Bar!",
+            title="The Foo, Bar",
+            min_chars=0,
+        )
+        assert thin is True
+        assert rule == "title_equality"
+
+    def test_casing_difference_still_matches(self) -> None:
+        thin, rule = is_thin_summary(
+            summary="THE FOO BAR",
+            title="the foo bar",
+            min_chars=0,
+        )
+        assert thin is True
+        assert rule == "title_equality"
+
+    def test_whitespace_difference_still_matches(self) -> None:
+        thin, rule = is_thin_summary(
+            summary="The  Foo\tBar",
+            title="The Foo Bar",
+            min_chars=0,
+        )
+        assert thin is True
+        assert rule == "title_equality"
+
+    def test_extra_content_in_summary_is_not_equality(self) -> None:
+        # Same title prefix plus extra real content => not title-equal.
+        # min_chars=0 disables length so we isolate the equality rule.
+        thin, rule = is_thin_summary(
+            summary="The Foo Bar by Author Name on Publisher (2026)",
+            title="The Foo Bar",
+            min_chars=0,
+        )
+        # Doesn't match equality and doesn't match boilerplate either.
+        assert thin is False
+        assert rule is None
+
+
+class TestBoilerplateRule:
+    """Each :data:`BOILERPLATE_PATTERNS` entry fires on a representative string."""
+
+    @pytest.mark.parametrize(
+        ("summary",),
+        [
+            ("Discussion (47 points)",),
+            ("Discussion (1 point)",),
+            ("DISCUSSION (47 POINTS)",),  # case-insensitive
+        ],
+    )
+    def test_hn_points_pointer(self, summary: str) -> None:
+        thin, rule = is_thin_summary(
+            summary=summary,
+            title="completely unrelated title",
+            min_chars=0,
+        )
+        assert thin is True
+        assert rule == "boilerplate"
+
+    @pytest.mark.parametrize(
+        ("summary",),
+        [
+            ("Comments",),
+            ("Comments.",),
+            ("Comments ",),
+        ],
+    )
+    def test_comments_pointer(self, summary: str) -> None:
+        thin, rule = is_thin_summary(
+            summary=summary,
+            title="completely unrelated title",
+            min_chars=0,
+        )
+        assert thin is True
+        assert rule == "boilerplate"
+
+    @pytest.mark.parametrize(
+        ("summary",),
+        [
+            ("Read the full article at example.com tomorrow",),
+            ("Read this full post on Medium",),
+            ("Read the entire story at the publisher",),
+            ("Read the article via the syndication feed",),
+        ],
+    )
+    def test_generic_teaser_pointer(self, summary: str) -> None:
+        thin, rule = is_thin_summary(
+            summary=summary,
+            title="completely unrelated title",
+            min_chars=0,
+        )
+        assert thin is True
+        assert rule == "boilerplate"
+
+    @pytest.mark.parametrize(
+        ("summary",),
+        [
+            ("Continue reading",),
+            ("Continue reading at the source",),
+            ("CONTINUE READING",),
+        ],
+    )
+    def test_continue_reading_truncation(self, summary: str) -> None:
+        thin, rule = is_thin_summary(
+            summary=summary,
+            title="completely unrelated title",
+            min_chars=0,
+        )
+        assert thin is True
+        assert rule == "boilerplate"
+
+    @pytest.mark.parametrize(
+        ("summary",),
+        [
+            ("Read more",),
+            ("Read more.",),
+            ("Read more at example.com",),
+        ],
+    )
+    def test_read_more_truncation(self, summary: str) -> None:
+        thin, rule = is_thin_summary(
+            summary=summary,
+            title="completely unrelated title",
+            min_chars=0,
+        )
+        assert thin is True
+        assert rule == "boilerplate"
+
+    @pytest.mark.parametrize(
+        ("summary",),
+        [
+            ("...",),
+            ("…",),
+            ("[…]",),
+            ("[ ]",),
+            (".....",),
+        ],
+    )
+    def test_empty_ish_markers(self, summary: str) -> None:
+        thin, rule = is_thin_summary(
+            summary=summary,
+            title="completely unrelated title",
+            min_chars=0,
+        )
+        assert thin is True
+        assert rule == "boilerplate"
+
+    def test_legitimate_body_with_continue_reading_inline_passes(self) -> None:
+        # The pattern is anchored at the start of the *trimmed* summary,
+        # so an inline "continue reading" inside real body text does not
+        # trip the rule.
+        summary = (
+            "This is a legitimate article body discussing the topic in "
+            "depth.  Authors continue reading the literature throughout."
+        )
+        thin, rule = is_thin_summary(
+            summary=summary,
+            title="A long descriptive title",
+            min_chars=0,
+        )
+        assert thin is False
+        assert rule is None
+
+
+class TestRulePrecedence:
+    """When multiple rules would fire, the first match wins (length → equality → bp)."""
+
+    def test_short_boilerplate_reports_length(self) -> None:
+        # "Read more" is also boilerplate but length fires first.
+        thin, rule = is_thin_summary(
+            summary="Read more",
+            title="completely unrelated title",
+            min_chars=80,
+        )
+        assert thin is True
+        # Length is evaluated before boilerplate, so the rule label
+        # surfaces the cheapest-actionable signal.
+        assert rule == "length"
+
+    def test_title_equality_reports_equality_over_boilerplate(self) -> None:
+        # A summary that equals the title (after normalisation) AND
+        # would also match boilerplate — equality is reported first.
+        thin, rule = is_thin_summary(
+            summary="Read more",
+            title="read more",
+            min_chars=0,
+        )
+        assert thin is True
+        assert rule == "title_equality"
+
+
+class TestNonThinPasses:
+    """The default 80-char threshold lets meaningful summaries through."""
+
+    def test_substantive_summary_passes_default_threshold(self) -> None:
+        thin, rule = is_thin_summary(
+            summary=_NON_THIN_SUMMARY,
+            title="A long descriptive title that does not match the summary",
+            min_chars=80,
+        )
+        assert thin is False
+        assert rule is None
+
+    def test_realistic_arxiv_abstract_passes(self) -> None:
+        # ~ 250-character snippet typical of arXiv abstracts.
+        abstract = (
+            "We present a novel architecture for self-supervised learning "
+            "on graph-structured data that improves downstream node "
+            "classification accuracy by 4.7% on benchmark datasets while "
+            "reducing training time by an order of magnitude over prior work."
+        )
+        thin, rule = is_thin_summary(
+            summary=abstract,
+            title="Self-Supervised Graph Learning",
+            min_chars=80,
+        )
+        assert thin is False
+        assert rule is None
+
+
+class TestBoilerplatePatternsExposed:
+    """The pattern list is part of the public contract (operators read it)."""
+
+    def test_each_pattern_has_a_rationale(self) -> None:
+        # Module-level constant ships ``(regex, rationale)`` pairs.  An
+        # empty rationale would defeat the purpose of the registry.
+        for pattern, rationale in BOILERPLATE_PATTERNS:
+            assert pattern.pattern, "pattern must be non-empty"
+            assert rationale.strip(), f"pattern {pattern.pattern!r} missing rationale"
+
+    def test_pattern_count_is_at_least_six(self) -> None:
+        # Six patterns ship today; future additions should never reduce
+        # the set without an explicit migration.  This is a low-stakes
+        # canary that catches accidental deletions.
+        assert len(BOILERPLATE_PATTERNS) >= 6


### PR DESCRIPTION
## Summary

Closes #166.

- **Forward-only thin-summary suppression**: when an item's archive fetch did not deliver a body AND the (post-extraction-fallback) feed summary is "thin" by a structural test, the source adapter drops the item — no Lithos note, no `influx:archive-missing` tag, no repair-sweep entry.
- **Trigger scope broader than the brief's literal "archive-missing" reading** (per planning-time user decision): the rule also fires on `non_html_source` (#160) and `unsupported` (#161) short-circuits, so thin summaries on non-article URLs / declared-unsupported domains are dropped too.
- **Three-rule any-of test** in a new pure module `src/influx/thin_summary.py`:
  - `length` — trimmed summary < `min_summary_chars` (default 80; set to 0 to disable just this rule)
  - `title_equality` — summary equals title after Unicode-aware normalisation (lowercase + strip Pc/Pd/Pe/Pf/Pi/Po/Ps + collapse whitespace)
  - `boilerplate` — matches one of six initial patterns documented in the runbook
- **Distinct telemetry** so suppression is visible to operators without polluting existing failure counters:
  - OTel counter `influx_summary_thin_drops_total` (labels: `profile`, `source`, `failure_kind`, `rule`)
  - Per-drop INFO log
  - Per-run INFO summary line in `run_service`
  - `summary_thin_drops_total` field on each `runs.jsonl` ledger entry
- **Deliberately excluded** from `archive_failures_total`, `source_acquisition_errors`, the `archive_acquisition` degraded reason, and `degradation_severity` — a drop is a quality choice, not a pipeline failure. A run whose only "issue" is N thin-summary drops still classifies `success`.
- **Forward-only**: existing summary-only notes already in Lithos are not touched.

### Deviation from the brief

The brief specifies `profile / source / failure_kind` labels on the metric.  This PR adds `rule` as a fourth label because the rule name already flows into the INFO log line, and the metric is the natural pivot for "how many of our drops are length vs boilerplate vs title-equality" at no extra cost.  Happy to drop the label if reviewers prefer the brief verbatim.

### Files

- `src/influx/thin_summary.py` (new) — pure helper + pattern constant
- `src/influx/config.py` — `ExtractionConfig.min_summary_chars: int = 80`
- `src/influx/metrics.py` — `summary_thin_drops()` counter
- `src/influx/telemetry.py` — `current_summary_thin_drops` contextvar + `record_summary_thin_drop()` helper
- `src/influx/run_service.py` — counter wiring + per-run INFO summary
- `src/influx/run_ledger.py` — `summary_thin_drops_total` kwarg + persisted field
- `src/influx/sources/rss.py` / `src/influx/sources/arxiv.py` — suppression check; widened return type to `dict | None`
- `docs/operations/staging-runbook.md` — new section 8d
- Tests: new `test_thin_summary.py` (45), `test_rss_thin_summary_drop.py` (10), `test_arxiv_thin_summary_drop.py` (5); extended `test_run_ledger.py` + `test_metrics_module.py`
- Existing test fixtures across 9 files widened their summary/abstract strings so they no longer accidentally trip the new rule

### Test plan

- [x] `uv run pytest tests/unit/test_thin_summary.py -v` — 45 passed
- [x] `uv run pytest tests/unit/test_rss_thin_summary_drop.py tests/unit/test_arxiv_thin_summary_drop.py -v` — 15 passed
- [x] `uv run pytest tests/unit/test_run_ledger.py -v` — extended cases pass; new ledger field round-trips
- [x] `uv run pytest tests/meta/test_v1_gate.py` — pure-module coverage gate unchanged (followed PR #172 precedent of not adding new pure modules to `_PURE_MODULE_TESTS`)
- [x] `uv run pytest -q` — full suite: **2313 passed, 0 failed**
- [x] `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/` — clean
- [ ] Manual staging soak — observe `influx_summary_thin_drops_total` on a real RSS feed with thin-summary items; confirm the suppression total and the per-run INFO line land as documented