### PR TITLE
docs: fix influx-report.py invocation in staging runbook

### DIFF
--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -30,8 +30,8 @@ values, so substituting environments is `--env dev` / `--env staging`.
 Three quick signals, all read-only:
 
 ```
-./scripts/influx-diagnose.py recent --limit 5
-./scripts/influx-diagnose.py failures
+./scripts/influx-diagnose.py --env staging recent --limit 5
+./scripts/influx-diagnose.py --env staging failures
 ./scripts/influx-report.py --env staging
 ```
 

--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -32,7 +32,7 @@ Three quick signals, all read-only:
 ```
 ./scripts/influx-diagnose.py recent --limit 5
 ./scripts/influx-diagnose.py failures
-./scripts/influx-report.py staging
+./scripts/influx-report.py --env staging
 ```
 
 - **`recent`** lists the last terminal runs with status, profile, kind,


### PR DESCRIPTION
## Summary
- Runbook §2 lists three read-only signals; the third (`./scripts/influx-report.py staging`) fails because the script takes `--env` as a named flag, not a positional argument (`unrecognized arguments: staging`).
- One-line fix to match the diagnose-script invocation style used elsewhere in the runbook (`--env staging`).

Surfaced while walking the runbook end-to-end against staging on 2026-05-24.

## Test plan
- [x] Verified `./scripts/influx-report.py --env staging` produces the expected status snapshot (profile table + recent runs).
- [x] Confirmed `./scripts/influx-report.py staging` exits with `usage: …unrecognized arguments: staging` pre-fix.