### PR TITLE
feat: invalid_url_rejections burst signal + URL validation runbook (#177)

### DIFF
--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -95,7 +95,7 @@ Three quick signals, all read-only:
   | Severity | Triggers | Operator action |
   |----------|----------|-----------------|
   | `success` | `degraded_reasons` empty | None |
-  | `expected_lossy` | only `source_acquisition`, `source_cooldown_skip`, `archive_acquisition` present | Glance; investigate only if frequency spikes. These are tolerated upstream / policy-driven outcomes. |
+  | `expected_lossy` | only `source_acquisition`, `source_cooldown_skip`, `archive_acquisition`, `invalid_url_rejections` present | Glance; investigate only if frequency spikes. These are tolerated upstream / policy-driven outcomes. |
   | `unexpected_failure` | any of `invalid_note_state`, `invalid_url_stall`, `ingestion_stall`, `fetch_stall`, `filter_stall`, `filter_error` present | Triage — actionable regression signal. |
   | `not_applicable` | `outcome=skipped` (circuit breaker fired) or `outcome=failure` (body raised before reasons were computed) | Read the existing `outcome` label — `severity` is set to a constant so the metric series shape stays uniform across all completions. |
 
@@ -613,6 +613,77 @@ unaffected.
 - **No repair-sweep re-evaluation.**  The thin-summary rule fires
   at write-time only.  A note tagged `influx:archive-missing` before
   #166 landed is not retroactively dropped on a later sweep.
+
+## 8e. URL validation rules (issues #131 / #177)
+
+Influx validates every article URL pre-acquire so a misbehaving feed
+cannot persist garbage URLs into Lithos. The check happens in
+`classify_article_url` (`src/influx/urls.py`) and runs against every
+`<link>` parsed out of an RSS entry. Rejected entries are counted
+toward the run's `invalid_url_rejections_total` and never reach the
+LLM filter or the write path.
+
+### What gets rejected
+
+| Reason            | Examples that trip it                                          |
+| ----------------- | -------------------------------------------------------------- |
+| `malformed`       | unparseable URL string, missing scheme                         |
+| `scheme`          | non-`http(s)` schemes (`file://`, `javascript:`, `data:`, …)   |
+| `no_host`         | URL with empty host part                                       |
+| `loopback`        | `localhost`, `127.0.0.0/8`, `::1` (the Sourcegraph 5174 case)  |
+| `link_local`      | `169.254.0.0/16`, `fe80::/10`                                  |
+| `private`         | RFC1918 (`10/8`, `172.16/12`, `192.168/16`) and IPv6 equivalents |
+| `multicast`       | `224.0.0.0/4` and IPv6 equivalents                             |
+
+Each rejection logs a WARNING with `profile`, `feed`, `url`, `reason`,
+and `title` so operators can drill via:
+
+```
+./scripts/influx-diagnose.py warnings --contains "rss item rejected pre-acquire"
+```
+
+### Operator-facing severity
+
+Two degraded reasons surface URL-validation activity at the run level
+(see §2 degradation-severity table for placement):
+
+- **`invalid_url_stall`** (unexpected_failure, single-run) — every
+  fetched item was URL-rejected, so nothing reached the filter.
+  Single bad-feed shape: typically a feed-shape regression upstream.
+- **`invalid_url_rejections`** (expected_lossy, single-run, #177) —
+  rejection count meets or exceeds the burst threshold (currently
+  `10`, see `_INVALID_URL_REJECTIONS_BURST_THRESHOLD` in
+  `run_ledger.py`) while some good items still reached the filter.
+  Canonical incident: the Sourcegraph blog feed shipped
+  `http://localhost:5174/...` links for 5 days in May 2026, rejecting
+  ~30 URLs/run silently. The burst signal fires immediately so the
+  next operator review surfaces it.
+
+### Cleaning up after a leak
+
+If bad URLs slipped into Lithos before the validation was tightened
+(or before the burst signal was added), use the recipe from §8 plus
+the `--no-require-influx-authored` flag — the bad-URL squatters may
+have lost their `ingested-by:influx` tag through the repair sweep:
+
+```
+# Enumerate by host, e.g. localhost:5174:
+LITHOS_URL=...
+./scripts/influx-diagnose.py --env staging squatters --apply \
+  --no-require-influx-authored \
+  --id <doc-id-1> --id <doc-id-2> ...
+```
+
+Then drop the stale backlog entries (defensive backup first):
+
+```
+cp ${INFLUX_STATE_PATH}/unresolved-slug-collisions.jsonl \
+   ${INFLUX_STATE_PATH}/unresolved-slug-collisions.jsonl.bak.$(date +%s)
+# Filter out the bad host:
+grep -v '"source_url": "http://<bad-host>/' \
+  ${INFLUX_STATE_PATH}/unresolved-slug-collisions.jsonl.bak.* \
+  > ${INFLUX_STATE_PATH}/unresolved-slug-collisions.jsonl
+```
 
 ## 9. Scheduling stagger (issue #87)
 

--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -97,8 +97,31 @@ _EXPECTED_LOSSY_REASONS: frozenset[str] = frozenset(
         "source_acquisition",
         "source_cooldown_skip",
         "archive_acquisition",
+        # Issue #177: ``invalid_url_rejections`` fires when an upstream
+        # feed is shipping many bad URLs (loopback / private / scheme
+        # / malformed) per run but at least some good ones still
+        # reach the filter — distinct from ``invalid_url_stall``,
+        # which requires that EVERY URL be rejected.  The Sourcegraph
+        # 5174 leak (2026-05-09 → 2026-05-10) is the canonical
+        # incident: 30 URLs/run rejected silently for five days
+        # because the stall variant never tripped.  Classed as
+        # expected_lossy because the validator is doing its job; the
+        # signal is "go look at this feed" rather than a data
+        # integrity regression.
+        "invalid_url_rejections",
     }
 )
+
+
+# Issue #177: ``invalid_url_rejections`` burst threshold — fires when
+# ``invalid_url_rejections_total`` for a single run meets or exceeds
+# this value AND ``invalid_url_stall`` is not already firing (the
+# stall variant is the all-bad case; this is the many-bad case).  Set
+# above the noise floor of occasional typo'd entries in an otherwise
+# healthy feed (~1–3) and well below the Sourcegraph incident shape
+# (~30/run).  Operator tunable in a follow-up if the default rate
+# of false positives proves wrong.
+_INVALID_URL_REJECTIONS_BURST_THRESHOLD: int = 10
 
 
 # Union of the two classified sets.  Used by the meta-test only;
@@ -639,6 +662,17 @@ class RunLedger:
           disallowed-scheme), so nothing reached the LLM filter.
           Single-run signal — like ``filter_error`` — because URL
           malformation is an immediately actionable upstream bug.
+        - ``"invalid_url_rejections"`` (issue #177) — the feed
+          shipped many bad URLs per run but at least some good ones
+          still reached the filter.  Distinct from
+          ``invalid_url_stall``: this is the partial-bad case.
+          Fires when ``invalid_url_rejections_total`` meets or
+          exceeds :data:`_INVALID_URL_REJECTIONS_BURST_THRESHOLD`
+          (currently ``10``).  Slotted into ``expected_lossy``
+          because the validator is doing its job — the signal is
+          "operator should look at this feed" rather than a data
+          integrity regression.  Suppressed when
+          ``invalid_url_stall`` already fires.
         - ``"invalid_note_state"`` (issue #152 review) — at least one
           write-time outcome landed in the materially-failed set
           (``invalid_input``, ``version_conflict``, ``slug_collision``,
@@ -734,6 +768,21 @@ class RunLedger:
         )
         if has_invalid_url_stall:
             reasons.append("invalid_url_stall")
+
+        # Issue #177: ``invalid_url_rejections`` (burst).  Fires when
+        # a run's URL-rejection count meets or exceeds
+        # :data:`_INVALID_URL_REJECTIONS_BURST_THRESHOLD` while at
+        # least some items still reached the filter — the partial-bad
+        # case that the stall variant above misses.  Suppressed when
+        # ``invalid_url_stall`` already fires (the stall is the
+        # more-specific signal for the all-bad case).
+        has_invalid_url_burst = (
+            not has_invalid_url_stall
+            and isinstance(invalid_url_rejections_total, int)
+            and invalid_url_rejections_total >= _INVALID_URL_REJECTIONS_BURST_THRESHOLD
+        )
+        if has_invalid_url_burst:
+            reasons.append("invalid_url_rejections")
 
         # Resolve profile + kind once for the stall checks.  All three
         # stall flags only apply to scheduled runs (backfills

--- a/tests/unit/test_run_ledger.py
+++ b/tests/unit/test_run_ledger.py
@@ -1623,6 +1623,62 @@ def test_invalid_url_stall_fires_on_first_run(tmp_path: Path) -> None:
     assert "invalid_url_stall" in reasons
 
 
+# ── #177: invalid_url_rejections (burst) detection ──────────────────
+
+
+def test_invalid_url_rejections_burst_at_threshold_fires(tmp_path: Path) -> None:
+    """When rejections meet the threshold AND some items reach filter,
+    fire ``invalid_url_rejections`` (the Sourcegraph 5174 shape — #177)."""
+    ledger = RunLedger(tmp_path / "state")
+    # 30 fetched, 10 rejected (threshold), 20 reached the filter and at
+    # least one was ingested → not a stall.
+    reasons = _start_complete(
+        ledger,
+        run_id="r-burst",
+        profile="p",
+        sources_checked=20,
+        ingested=2,
+        fetched_total=30,
+        invalid_url_rejections_total=10,
+    )
+    assert "invalid_url_rejections" in reasons
+    assert "invalid_url_stall" not in reasons
+
+
+def test_invalid_url_rejections_below_threshold_does_not_fire(
+    tmp_path: Path,
+) -> None:
+    """A handful of bad URLs is noise, not a degraded reason."""
+    ledger = RunLedger(tmp_path / "state")
+    reasons = _start_complete(
+        ledger,
+        run_id="r-noise",
+        profile="p",
+        sources_checked=30,
+        ingested=5,
+        fetched_total=33,
+        invalid_url_rejections_total=3,
+    )
+    assert "invalid_url_rejections" not in reasons
+
+
+def test_invalid_url_rejections_suppressed_by_url_stall(tmp_path: Path) -> None:
+    """When the stall variant fires (every URL bad), don't double-flag
+    with the burst variant — the stall is the more-specific signal."""
+    ledger = RunLedger(tmp_path / "state")
+    reasons = _start_complete(
+        ledger,
+        run_id="r-stall",
+        profile="p",
+        sources_checked=0,
+        ingested=0,
+        fetched_total=15,
+        invalid_url_rejections_total=15,
+    )
+    assert "invalid_url_stall" in reasons
+    assert "invalid_url_rejections" not in reasons
+
+
 # ── #152: degradation summary ────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Closes #177.

Addresses the two outstanding actions from #177 after this session's data cleanup (A and A.5 — see [this comment](https://github.com/agent-lore/influx/issues/177#issuecomment-4529971616) — already deleted the 10 residual `localhost:5174` docs and pruned 62 stale backlog entries):

- **B. Visibility for `invalid_url_rejections`**: adds a new degraded reason that fires on a configurable burst threshold, slotted into the `expected_lossy` severity bucket. The validator already logged WARNINGs per rejection (`rss.py:276`), but there was no run-level signal — so a feed leaking 30 bad URLs/run for 5 days could go unnoticed unless every URL was rejected (the existing `invalid_url_stall`). The new signal catches the partial-bad case.
- **C. Runbook documentation**: new §8e in `docs/operations/staging-runbook.md` documents the rule set enforced by `classify_article_url` (loopback / private / link-local / multicast / malformed / scheme / no-host), the operator-facing severity behaviour, and the cleanup recipe used in this session.

## What's in the PR

| File | Change |
|---|---|
| `src/influx/run_ledger.py` | Add `invalid_url_rejections` to `_EXPECTED_LOSSY_REASONS`. Add `_INVALID_URL_REJECTIONS_BURST_THRESHOLD = 10` constant. Add detection logic in `complete()` right after the existing `has_invalid_url_stall` check, suppressed when the stall variant already fires. Add docstring entry. |
| `tests/unit/test_run_ledger.py` | Three new tests (`_at_threshold_fires`, `_below_threshold_does_not_fire`, `_suppressed_by_url_stall`). |
| `docs/operations/staging-runbook.md` | Update the §2 expected_lossy row to include the new reason. New §8e *URL validation rules* documenting the rule set, log shape, severity buckets, and operator cleanup recipe. |

## Severity model fit

`_EXPECTED_LOSSY_REASONS` already contains `source_acquisition`, `source_cooldown_skip`, `archive_acquisition` — outcomes where the pipeline is healthy but upstream is being weird. URL-rejection bursts fit the same pattern: the validator is doing its job, the operator should investigate the feed, but data integrity isn't at risk. Promotion gate's `unexpected_failure_present` reason is unaffected; the burst surfaces in `failures` / `recent` and as `severity=expected_lossy` on the metric labels.

## Why threshold = 10

| Shape | Per-run rejections | Threshold catches? |
|---|---|---|
| Healthy feed with occasional typo | 0–3 | No (correctly: noise) |
| Sourcegraph 5174 incident (2026-05) | ~30 | Yes |
| Feed-wide shape regression | feed-size | Yes (and likely also `invalid_url_stall`) |

10 puts the floor well above noise and well below the canonical incident shape. Operator-tunable in a follow-up if the false-positive rate ever proves wrong.

## Test plan

- [x] `uv run pytest tests/unit/test_run_ledger.py -v` — full suite passes, 3 new tests green
- [x] `make check` — lint + typecheck + test, all green
- [x] Existing `invalid_url_stall` tests confirm the stall path is unchanged
- [x] Documentation rendered locally — §8e references existing diagnose commands accurately

## Cross-references

- #131 — the existing `classify_article_url` validation work this builds on
- #176 / #180 — tonight's writer-bug residue cleanup that left #177 with only B + C remaining
- #181 — the corpus-scan selector for rewrite-legacy-notes (independent follow-up)