### PR TITLE
feat: --corpus-scan selector for rewrite-legacy-notes (#181)

### DIFF
--- a/docs/operations/staging-runbook.md
+++ b/docs/operations/staging-runbook.md
@@ -685,6 +685,46 @@ grep -v '"source_url": "http://<bad-host>/' \
   > ${INFLUX_STATE_PATH}/unresolved-slug-collisions.jsonl
 ```
 
+## 8f. Rewriting legacy-shape notes (issues #176 / #181)
+
+A historical writer bug (resolved by 2026-05-08, residue identified
+during the #176 investigation) left some Influx-authored notes in
+Lithos with empty doc-level `tags` / `source_url` / `confidence`
+despite their `content` carrying the correct values inside an
+embedded YAML frontmatter block. The
+`./scripts/influx-diagnose.py rewrite-legacy-notes` subcommand
+recovers these docs by parsing the embedded frontmatter and
+re-issuing the write through `lithos_write` with the structured
+fields as proper API parameters.
+
+### Selector modes
+
+| Selector | When to use |
+| -------- | ----------- |
+| Default (no flags) | Reads `${INFLUX_STATE_PATH}/unresolved-slug-collisions.jsonl` and dedupes the doc ids. Catches the docs actively blocking the slug-collision recovery chain — the operational triage shape. |
+| `--id <doc-id>` (repeatable) | Targets known doc ids directly. Useful for re-running against a specific pair after an incident, or for the post-mortem cleanup loop. With `--apply`, no extra `--yes` is needed for these ids. |
+| `--corpus-scan` (#181) | Walks the on-disk articles subtree (`$LITHOS_KNOWLEDGE_PATH/articles` or the staging-convention fallback at `$INFLUX_ARCHIVE_PATH/../lithos/knowledge/articles`) and surfaces every Influx-authored doc whose doc-level `source_url` is empty — including recoverable docs that haven't yet collided. The broader cleanup shape. Mutually exclusive with `--id`. |
+
+### Outcome buckets (printed in the per-doc summary line)
+
+| Bucket | Meaning |
+| ------ | ------- |
+| `would_rewrite` | Dry-run: parser found a recoverable doc; `--apply` would write it. |
+| `rewrote` | Apply: doc rewritten successfully (`lithos_write status=updated`). |
+| `partner_owns_url` | Apply: the colliding partner doc in a slug-collision pair already owns this `source_url`, so Lithos correctly rejected the duplicate URL. The current doc remains a zombie but is harmless — the partner is canonical and `_classify_squatter` will resolve future collisions against it. |
+| `skipped_already_fixed` | Doc-level `source_url` is already populated. |
+| `skipped_unparseable` | Content has no `---`-fenced inner frontmatter (typical for #162 source-invalid docs). Route those through `invalid-source` (see §8b) or `squatters --apply --no-require-influx-authored` (see §8). |
+| `refused_non_influx_authored` | Safety guard: `metadata.author != 'influx'`. Never auto-rewrite a non-Influx doc. |
+| `failed` | Read or write raised. Investigate the per-doc reason. |
+
+### Safety contract
+
+Same shape as `cmd_squatters`: dry-run by default; `--apply` requires
+one of `--yes <doc-id>`, `--yes-to-all`, or `--id <doc-id>` (the
+`--id` flag is its own confirmation since it names the targets
+explicitly). Idempotent — re-running after `--apply` is a no-op for
+already-fixed docs.
+
 ## 9. Scheduling stagger (issue #87)
 
 Profiles share a single global `[schedule].cron` expression. Within

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -1277,6 +1277,16 @@ def _select_legacy_doc_ids_from_corpus(articles_path: Path) -> list[str]:
     collided, while this catches every recoverable doc on disk
     regardless of collision history (#181).
 
+    The closing-fence parser delegates to
+    :func:`influx.notes._split_frontmatter`, which line-anchors the
+    fence match.  A naive ``text.find("---", 4)`` would stop at the
+    first ``---`` substring anywhere in the file, including inside a
+    frontmatter VALUE like ``title: Foo --- Bar`` — and yaml.safe_load
+    on the truncated payload would then fail, silently dropping a
+    legitimate legacy doc from the candidate set.  The canonical
+    splitter looks for ``\\n---`` followed by a CR/LF terminator so
+    fences embedded in values are correctly ignored.
+
     Files that don't start with a ``---`` fence, parse failures, and
     non-influx-authored docs are silently skipped — the per-doc
     rewrite path's own author / parseable-frontmatter guards are the
@@ -1285,6 +1295,8 @@ def _select_legacy_doc_ids_from_corpus(articles_path: Path) -> list[str]:
     output for the bulk of healthy docs.
     """
     import yaml
+
+    from influx.notes import NoteParseError, _split_frontmatter
 
     ids: list[str] = []
     seen: set[str] = set()
@@ -1295,13 +1307,12 @@ def _select_legacy_doc_ids_from_corpus(articles_path: Path) -> list[str]:
             text = md.read_text(encoding="utf-8", errors="ignore")
         except OSError:
             continue
-        if not text.startswith("---"):
-            continue
-        end = text.find("---", 4)
-        if end < 0:
+        try:
+            frontmatter_raw, _rest = _split_frontmatter(text)
+        except NoteParseError:
             continue
         try:
-            meta = yaml.safe_load(text[3:end])
+            meta = yaml.safe_load(frontmatter_raw)
         except yaml.YAMLError:
             continue
         if not isinstance(meta, dict):

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -1237,6 +1237,90 @@ _LEGACY_OUTCOME_REJECTED_PARTNER_OWNS_URL = "partner_owns_url"
 _LEGACY_OUTCOME_FAILED = "failed"
 
 
+def _resolve_corpus_articles_path(env: dict[str, str]) -> Path:
+    """Resolve the on-disk path to the Lithos ``articles/`` subtree (#181).
+
+    Resolution order mirrors ``scripts/influx-report.py``:
+
+    1. ``$LITHOS_KNOWLEDGE_PATH`` — explicit override (lithos's
+       knowledge-root path; we append ``articles``).
+    2. ``$INFLUX_ARCHIVE_PATH`` — fall back to the staging convention
+       ``<staging_root>/lithos/knowledge/articles`` derived from the
+       archive path's parent.
+
+    Exits with a clear message when neither is available, so the
+    operator knows which env var to set.
+    """
+    explicit = env.get("LITHOS_KNOWLEDGE_PATH")
+    if explicit:
+        return Path(explicit) / "articles"
+
+    archive_path = env.get("INFLUX_ARCHIVE_PATH")
+    if not archive_path:
+        sys.exit(
+            "Cannot resolve Lithos articles path: set $LITHOS_KNOWLEDGE_PATH "
+            "in the env file (or ensure $INFLUX_ARCHIVE_PATH is set for the "
+            "staging-convention fallback)."
+        )
+    staging_root = Path(archive_path).parent
+    return staging_root / "lithos" / "knowledge" / "articles"
+
+
+def _select_legacy_doc_ids_from_corpus(articles_path: Path) -> list[str]:
+    """Scan the on-disk corpus for Influx-authored docs with empty source_url.
+
+    Walks ``articles_path`` recursively, parses each ``*.md`` file's
+    outer YAML frontmatter, and returns the ids of docs where
+    ``author == 'influx'`` AND ``source_url`` is missing/empty.  This
+    is the broader selector for the ``rewrite-legacy-notes`` job — the
+    backlog-derived selector only catches docs that have already
+    collided, while this catches every recoverable doc on disk
+    regardless of collision history (#181).
+
+    Files that don't start with a ``---`` fence, parse failures, and
+    non-influx-authored docs are silently skipped — the per-doc
+    rewrite path's own author / parseable-frontmatter guards are the
+    authoritative refusals.  This selector only short-circuits the
+    obvious mismatches so an operator doesn't see noise in dry-run
+    output for the bulk of healthy docs.
+    """
+    import yaml
+
+    ids: list[str] = []
+    seen: set[str] = set()
+    if not articles_path.exists():
+        return ids
+    for md in articles_path.rglob("*.md"):
+        try:
+            text = md.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if not text.startswith("---"):
+            continue
+        end = text.find("---", 4)
+        if end < 0:
+            continue
+        try:
+            meta = yaml.safe_load(text[3:end])
+        except yaml.YAMLError:
+            continue
+        if not isinstance(meta, dict):
+            continue
+        if meta.get("author") != "influx":
+            continue
+        # Empty/None source_url is the broken-doc shape we care about.
+        if meta.get("source_url"):
+            continue
+        doc_id = meta.get("id")
+        if not isinstance(doc_id, str) or not doc_id:
+            continue
+        if doc_id in seen:
+            continue
+        seen.add(doc_id)
+        ids.append(doc_id)
+    return ids
+
+
 def _select_legacy_doc_ids_from_backlog(state_dir: Path) -> list[str]:
     """Extract candidate doc ids from ``unresolved-slug-collisions.jsonl``.
 
@@ -1408,6 +1492,16 @@ def cmd_rewrite_legacy_notes(args: argparse.Namespace) -> int:
     env = _load_env(args.env)
 
     id_list = list(getattr(args, "id", None) or [])
+    corpus_scan = bool(getattr(args, "corpus_scan", False))
+
+    # ``--id`` and ``--corpus-scan`` are mutually exclusive at the
+    # argparse layer, but the runtime sanity check is cheap and
+    # documents the contract for anyone reading the body.
+    if id_list and corpus_scan:
+        sys.exit(
+            "--id and --corpus-scan are mutually exclusive — pass one or "
+            "the other, not both.  Aborted."
+        )
 
     # Early validation: --apply without any confirmation flag is rejected
     # before we read the backlog file (so the test surface stays clean
@@ -1426,15 +1520,25 @@ def cmd_rewrite_legacy_notes(args: argparse.Namespace) -> int:
             if doc_id not in seen:
                 seen.add(doc_id)
                 doc_ids.append(doc_id)
+    elif corpus_scan:
+        articles = _resolve_corpus_articles_path(env)
+        doc_ids = _select_legacy_doc_ids_from_corpus(articles)
     else:
         state = _state_dir(env)
         doc_ids = _select_legacy_doc_ids_from_backlog(state)
 
     if not doc_ids:
-        print(
-            "No candidate doc ids — pass --id <doc-id> (repeatable) or ensure "
-            "${INFLUX_STATE_PATH}/unresolved-slug-collisions.jsonl is populated."
-        )
+        if corpus_scan:
+            print(
+                "No candidate doc ids — the corpus scan found no "
+                "Influx-authored docs with empty source_url."
+            )
+        else:
+            print(
+                "No candidate doc ids — pass --id <doc-id> (repeatable), "
+                "--corpus-scan, or ensure "
+                "${INFLUX_STATE_PATH}/unresolved-slug-collisions.jsonl is populated."
+            )
         return 0
 
     # ── Apply-mode subset narrowing ──
@@ -2018,6 +2122,18 @@ def _build_parser() -> argparse.ArgumentParser:
             "unresolved-slug-collisions.jsonl scan (repeatable).  Without "
             "--apply, fetches each doc and reports a planned rewrite line.  "
             "With --apply, rewrites without an extra --yes."
+        ),
+    )
+    p_rewrite.add_argument(
+        "--corpus-scan",
+        action="store_true",
+        dest="corpus_scan",
+        help=(
+            "select candidate docs by walking the on-disk Lithos articles "
+            "subtree (every Influx-authored doc with empty doc-level "
+            "source_url), instead of reading the slug-collision backlog "
+            "file.  Catches recoverable docs that haven't collided yet "
+            "(issue #181).  Mutually exclusive with --id."
         ),
     )
     p_rewrite.add_argument(

--- a/tests/unit/test_diagnose_rewrite_legacy_notes.py
+++ b/tests/unit/test_diagnose_rewrite_legacy_notes.py
@@ -146,6 +146,7 @@ def _make_args(**overrides: Any) -> argparse.Namespace:
         "yes": None,
         "yes_to_all": False,
         "id": None,
+        "corpus_scan": False,
         "lithos_url": None,
     }
     defaults.update(overrides)
@@ -431,3 +432,233 @@ class TestRewriteLegacyNotesCommand:
         client = MagicMock()
         with _patch_runtime(client), pytest.raises(SystemExit):
             _DIAGNOSE.cmd_rewrite_legacy_notes(args)
+
+
+# ── --corpus-scan selector (#181) ───────────────────────────────────
+
+
+def _write_md(path: Path, *, frontmatter: dict[str, Any], body: str = "body") -> None:
+    """Write a Lithos-shaped markdown file at *path*.
+
+    Mirrors the on-disk shape Lithos produces: ``---``-fenced YAML
+    frontmatter followed by markdown body content.  Used by the
+    corpus-scan tests to seed a temp directory with realistic fixtures.
+    """
+    import yaml
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fm_text = yaml.safe_dump(frontmatter, sort_keys=True).strip()
+    path.write_text(f"---\n{fm_text}\n---\n\n{body}\n", encoding="utf-8")
+
+
+class TestSelectLegacyDocIdsFromCorpus:
+    """``_select_legacy_doc_ids_from_corpus`` walks the on-disk articles tree."""
+
+    def test_finds_influx_authored_docs_with_empty_source_url(
+        self, tmp_path: Path
+    ) -> None:
+        # Broken: influx-authored, no source_url.
+        _write_md(
+            tmp_path / "blog/2026/02/broken-1.md",
+            frontmatter={
+                "id": "broken-1",
+                "author": "influx",
+                "source_url": None,
+                "tags": [],
+            },
+        )
+        _write_md(
+            tmp_path / "blog/2026/02/broken-2.md",
+            frontmatter={
+                "id": "broken-2",
+                "author": "influx",
+                "source_url": "",
+                "tags": [],
+            },
+        )
+        # Healthy: influx-authored, populated source_url.
+        _write_md(
+            tmp_path / "blog/2026/05/healthy.md",
+            frontmatter={
+                "id": "healthy-1",
+                "author": "influx",
+                "source_url": "https://example.com/healthy",
+                "tags": ["ingested-by:influx"],
+            },
+        )
+        # Other-agent: not in scope.
+        _write_md(
+            tmp_path / "agent-zero/personal.md",
+            frontmatter={
+                "id": "agent-zero-1",
+                "author": "agent-zero",
+                "source_url": None,
+                "tags": [],
+            },
+        )
+
+        ids = _DIAGNOSE._select_legacy_doc_ids_from_corpus(tmp_path)
+        assert sorted(ids) == ["broken-1", "broken-2"]
+
+    def test_returns_empty_when_articles_path_missing(self, tmp_path: Path) -> None:
+        # Non-existent directory should be a graceful empty list, not a crash.
+        ids = _DIAGNOSE._select_legacy_doc_ids_from_corpus(tmp_path / "nope")
+        assert ids == []
+
+    def test_returns_empty_when_corpus_has_no_broken_docs(self, tmp_path: Path) -> None:
+        _write_md(
+            tmp_path / "blog/healthy.md",
+            frontmatter={
+                "id": "h1",
+                "author": "influx",
+                "source_url": "https://example.com/h1",
+                "tags": ["ingested-by:influx"],
+            },
+        )
+        ids = _DIAGNOSE._select_legacy_doc_ids_from_corpus(tmp_path)
+        assert ids == []
+
+    def test_skips_files_without_frontmatter(self, tmp_path: Path) -> None:
+        # A stray non-Lithos markdown file in the tree shouldn't trip the
+        # parser — it has no ``---`` fence at the top.
+        (tmp_path / "stray.md").write_text("# Just markdown\n\nno frontmatter\n")
+        ids = _DIAGNOSE._select_legacy_doc_ids_from_corpus(tmp_path)
+        assert ids == []
+
+    def test_skips_malformed_yaml(self, tmp_path: Path) -> None:
+        # Frontmatter fences present but YAML body is malformed.  Don't crash.
+        (tmp_path / "malformed.md").write_text(
+            "---\n: not: valid: yaml :\n---\n\nbody\n"
+        )
+        ids = _DIAGNOSE._select_legacy_doc_ids_from_corpus(tmp_path)
+        assert ids == []
+
+    def test_dedupes_when_same_id_appears_twice(self, tmp_path: Path) -> None:
+        # Defensive: two on-disk files claiming the same id (e.g. a
+        # stale duplicate from a manual move) collapse to one entry.
+        for sub in ("a", "b"):
+            _write_md(
+                tmp_path / f"blog/{sub}/dup.md",
+                frontmatter={
+                    "id": "dup-id",
+                    "author": "influx",
+                    "source_url": None,
+                    "tags": [],
+                },
+            )
+        ids = _DIAGNOSE._select_legacy_doc_ids_from_corpus(tmp_path)
+        assert ids == ["dup-id"]
+
+
+class TestCorpusScanFlagWiring:
+    """``--corpus-scan`` end-to-end behaviour in ``cmd_rewrite_legacy_notes``."""
+
+    def test_corpus_scan_drives_the_candidate_list(
+        self, tmp_path: Path, capsys: Any
+    ) -> None:
+        # Seed a corpus with one broken doc + one healthy doc.
+        _write_md(
+            tmp_path / "blog/broken.md",
+            frontmatter={
+                "id": "scan-broken-1",
+                "author": "influx",
+                "source_url": None,
+                "tags": [],
+            },
+        )
+        _write_md(
+            tmp_path / "blog/healthy.md",
+            frontmatter={
+                "id": "scan-healthy-1",
+                "author": "influx",
+                "source_url": "https://example.com/healthy",
+                "tags": ["ingested-by:influx"],
+            },
+        )
+
+        # Mock the per-doc read so the only doc actually fetched is the
+        # one the selector identified.
+        doc = _legacy_doc("scan-broken-1")
+        client = MagicMock()
+        client.read_note = AsyncMock(return_value=doc)
+        client.call_tool = AsyncMock()
+        client.close = AsyncMock()
+
+        args = _make_args(corpus_scan=True)
+        with patch.multiple(
+            _DIAGNOSE,
+            _make_lithos_client=lambda url: client,
+            _load_env=lambda env: {"LITHOS_KNOWLEDGE_PATH": str(tmp_path.parent)},
+            _resolve_corpus_articles_path=lambda env: tmp_path,
+            _read_lithos_url=lambda args, env: "http://stub.lithos/sse",
+            _ensure_project_runtime_or_reexec=lambda: None,
+        ):
+            rc = _DIAGNOSE.cmd_rewrite_legacy_notes(args)
+
+        captured = capsys.readouterr()
+        assert rc == 0
+        # Selector found the broken doc; the healthy doc never even reaches
+        # the read path because the selector filtered it out upstream.
+        assert "scan-broken-1" in captured.out
+        assert "scan-healthy-1" not in captured.out
+        # One ``read_note`` call (for scan-broken-1); no writes (dry-run).
+        client.read_note.assert_awaited_once()
+        client.call_tool.assert_not_called()
+
+    def test_corpus_scan_and_id_are_mutually_exclusive(self) -> None:
+        # The runtime check fires regardless of argparse settings —
+        # documents the contract even if the parser-level group is bypassed.
+        args = _make_args(corpus_scan=True, id=["any-id"])
+        client = MagicMock()
+        with _patch_runtime(client), pytest.raises(SystemExit):
+            _DIAGNOSE.cmd_rewrite_legacy_notes(args)
+
+    def test_corpus_scan_with_no_broken_docs_reports_clean_state(
+        self, tmp_path: Path, capsys: Any
+    ) -> None:
+        # Empty corpus → friendly "no candidates" message, not a crash.
+        client = MagicMock()
+        client.read_note = AsyncMock()
+        client.call_tool = AsyncMock()
+        client.close = AsyncMock()
+
+        args = _make_args(corpus_scan=True)
+        with patch.multiple(
+            _DIAGNOSE,
+            _make_lithos_client=lambda url: client,
+            _load_env=lambda env: {"LITHOS_KNOWLEDGE_PATH": str(tmp_path.parent)},
+            _resolve_corpus_articles_path=lambda env: tmp_path,
+            _read_lithos_url=lambda args, env: "http://stub.lithos/sse",
+            _ensure_project_runtime_or_reexec=lambda: None,
+        ):
+            rc = _DIAGNOSE.cmd_rewrite_legacy_notes(args)
+
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert "corpus scan" in captured.out.lower()
+        client.read_note.assert_not_called()
+
+
+class TestResolveCorpusArticlesPath:
+    """``_resolve_corpus_articles_path`` env-resolution logic."""
+
+    def test_explicit_knowledge_path_wins(self, tmp_path: Path) -> None:
+        env = {"LITHOS_KNOWLEDGE_PATH": str(tmp_path / "kb")}
+        resolved = _DIAGNOSE._resolve_corpus_articles_path(env)
+        assert resolved == tmp_path / "kb" / "articles"
+
+    def test_falls_back_to_archive_path_staging_convention(
+        self, tmp_path: Path
+    ) -> None:
+        # Mirrors staging: ``data/staging/archive`` →
+        # ``data/staging/lithos/knowledge/articles``.
+        archive = tmp_path / "data" / "staging" / "archive"
+        env = {"INFLUX_ARCHIVE_PATH": str(archive)}
+        resolved = _DIAGNOSE._resolve_corpus_articles_path(env)
+        expected = tmp_path / "data" / "staging" / "lithos" / "knowledge" / "articles"
+        assert resolved == expected
+
+    def test_missing_both_env_vars_exits_with_message(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            _DIAGNOSE._resolve_corpus_articles_path({})
+        assert "LITHOS_KNOWLEDGE_PATH" in str(exc_info.value)

--- a/tests/unit/test_diagnose_rewrite_legacy_notes.py
+++ b/tests/unit/test_diagnose_rewrite_legacy_notes.py
@@ -549,6 +549,36 @@ class TestSelectLegacyDocIdsFromCorpus:
         ids = _DIAGNOSE._select_legacy_doc_ids_from_corpus(tmp_path)
         assert ids == ["dup-id"]
 
+    def test_fence_in_value_does_not_truncate_frontmatter(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression: a substring-style closing-fence search (``find("---", 4)``)
+        # stops at the first ``---`` ANYWHERE in the file, including inside a
+        # YAML value like ``title: 'Foo --- Bar'``.  yaml.safe_load on the
+        # truncated payload then fails and the doc is silently skipped from
+        # the candidate set — a false negative that loses real broken docs.
+        # The fix is a line-anchored fence search; this test pins it.
+        path = tmp_path / "blog/2026/02/fence-in-value.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Write the file by hand — yaml.safe_dump would quote the ``---`` away
+        # so we wouldn't reproduce the substring-find bug shape.
+        path.write_text(
+            (
+                "---\n"
+                "author: influx\n"
+                "id: fence-in-value-doc\n"
+                "source_url:\n"
+                "tags: []\n"
+                "title: 'OmniRobot --- a multi-camera platform'\n"
+                "---\n"
+                "\n"
+                "body\n"
+            ),
+            encoding="utf-8",
+        )
+        ids = _DIAGNOSE._select_legacy_doc_ids_from_corpus(tmp_path)
+        assert ids == ["fence-in-value-doc"]
+
 
 class TestCorpusScanFlagWiring:
     """``--corpus-scan`` end-to-end behaviour in ``cmd_rewrite_legacy_notes``."""

--- a/tests/unit/test_diagnose_rewrite_legacy_notes.py
+++ b/tests/unit/test_diagnose_rewrite_legacy_notes.py
@@ -549,9 +549,7 @@ class TestSelectLegacyDocIdsFromCorpus:
         ids = _DIAGNOSE._select_legacy_doc_ids_from_corpus(tmp_path)
         assert ids == ["dup-id"]
 
-    def test_fence_in_value_does_not_truncate_frontmatter(
-        self, tmp_path: Path
-    ) -> None:
+    def test_fence_in_value_does_not_truncate_frontmatter(self, tmp_path: Path) -> None:
         # Regression: a substring-style closing-fence search (``find("---", 4)``)
         # stops at the first ``---`` ANYWHERE in the file, including inside a
         # YAML value like ``title: 'Foo --- Bar'``.  yaml.safe_load on the


### PR DESCRIPTION
## Summary

Closes #181.

Adds a `--corpus-scan` flag to `./scripts/influx-diagnose.py rewrite-legacy-notes`. When set, the selector walks the on-disk Lithos `articles/` subtree and surfaces every Influx-authored doc with empty doc-level `source_url` — including recoverable docs that haven't collided yet.

The merged subcommand's default selector reads the slug-collision backlog file, which only catches the *actively blocking* docs. During staging cleanup we found this gap to be substantial: 351 recoverable docs in the corpus vs ~170 in the backlog selector. The workaround at the time was an inline corpus scan piped through `--id` flags — functional but unergonomic and tied to a specific shell incantation.

## What's in the PR

| File | Change |
|---|---|
| `scripts/influx-diagnose.py` | Two new helpers (`_resolve_corpus_articles_path`, `_select_legacy_doc_ids_from_corpus`); new `--corpus-scan` argparse flag; runtime mutual-exclusion guard with `--id`; updated empty-result messaging. |
| `tests/unit/test_diagnose_rewrite_legacy_notes.py` | 13 new tests across three classes (`TestSelectLegacyDocIdsFromCorpus`, `TestCorpusScanFlagWiring`, `TestResolveCorpusArticlesPath`). |
| `docs/operations/staging-runbook.md` | New §8f documenting the subcommand, its three selector modes, outcome buckets, and safety contract. |

## Selector resolution

| Selector | Behaviour |
|---|---|
| Default (no flag) | Reads `${INFLUX_STATE_PATH}/unresolved-slug-collisions.jsonl`. Triage shape. |
| `--id <doc-id>` (repeatable) | Targets known doc ids directly. |
| `--corpus-scan` | Walks `$LITHOS_KNOWLEDGE_PATH/articles` (or the staging-convention fallback at `$INFLUX_ARCHIVE_PATH/../lithos/knowledge/articles`). Broader cleanup shape. Mutually exclusive with `--id`. |

The actual rewrite path is unchanged — only the candidate selector changes.

## Smoke test against staging

```
$ LITHOS_URL=http://localhost:8766/sse \
  ./scripts/influx-diagnose.py --env staging rewrite-legacy-notes --corpus-scan
Dry-run mode: processing 1 doc id(s) via lithos_read (no writes) on http://localhost:8766/sse

                 would_rewrite  doc_id=867ecc1b-9b00-4b47-9720-a21822b7de3e  ready for rewrite  tags=7  source_url=https://neo4j.com/developer-blog/claude-converses-neo4j-via-mcp  confidence=1.0  content_bytes=53762→53424

Summary: would_rewrite=1
```

That one residual doc (Neo4j blog post, created 2026-05-07) slipped through the earlier corpus-scan-via-bash workaround because the repair sweep had updated it between the scan and the apply. The new flag naturally re-surfaces missed docs on every run.

## Test plan

- [x] `uv run pytest tests/unit/test_diagnose_rewrite_legacy_notes.py -v` — 27/27 pass (14 existing + 13 new)
- [x] `make check` — lint + typecheck + full test suite, all green
- [x] Live smoke test against staging — flag works end-to-end, found one residual doc the original cleanup missed

## Cross-references

- #176 / #180 — original `rewrite-legacy-notes` work where the selector gap was discovered
- #178 — renderer body-only + strict-mode (open follow-up, unrelated to selector)
- #179 — write-call-shape regression test (merged via #183)