### PR TITLE
feat: render body-only content + strict-mode write_note assertion (#178)

### DIFF
--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -787,7 +787,27 @@ class LithosClient:
         user-notes preservation + retry once, AC-05-E).
         Returns a :class:`WriteResult` so callers can inspect the
         outcome and increment counters (e.g. ``dedup_skipped``).
+
+        Strict-mode contract (#178): ``content`` must be body-only
+        markdown — no leading ``---``-fenced YAML frontmatter block.
+        Lithos owns the outer frontmatter and persists ``tags`` /
+        ``source_url`` / ``confidence`` / ``note_type`` / ``namespace``
+        from the API parameters on this call (spec §5.1).  A
+        ``LithosError`` is raised if ``content`` starts with ``---\\n``
+        so a renderer regression that re-introduces the embedded
+        frontmatter shape fails loudly at the boundary instead of
+        silently doubling the on-disk state.
         """
+        if content.startswith("---\n") or content.startswith("---\r\n"):
+            raise LithosError(
+                "content begins with a '---' frontmatter fence — "
+                "the lithos_write contract requires body-only content; "
+                "tags / source_url / confidence / note_type / namespace "
+                "must be passed as API parameters, not inlined in content "
+                "(spec §5.1, issue #178)",
+                operation="write_note",
+                detail="embedded_frontmatter",
+            )
         args: dict[str, Any] = {
             "title": title,
             "content": content,

--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -787,50 +787,13 @@ class LithosClient:
         user-notes preservation + retry once, AC-05-E).
         Returns a :class:`WriteResult` so callers can inspect the
         outcome and increment counters (e.g. ``dedup_skipped``).
-
-        Strict-mode contract (#178): ``content`` must be body-only
-        markdown — no leading ``---``-fenced YAML frontmatter block.
-        Lithos owns the outer frontmatter and persists ``tags`` /
-        ``source_url`` / ``confidence`` / ``note_type`` / ``namespace``
-        from the API parameters on this call (spec §5.1).  A
-        ``LithosError`` is raised if ``content`` starts with ``---\\n``
-        so a renderer regression that re-introduces the embedded
-        frontmatter shape fails loudly at the boundary instead of
-        silently doubling the on-disk state.
-
-        Canonical-URL normalization (FR-MCP-4): ``source_url`` is
-        normalised via :func:`influx.urls.normalise_url` before being
-        forwarded to ``lithos_write``.  Pre-#178 this happened inside
-        the rendered frontmatter; after the renderer change, the
-        ``write_note`` boundary owns it so callers don't have to
-        pre-normalise.  Lithos's internal ``normalize_url`` would
-        canonicalise for dedup-map storage anyway, but normalising
-        here keeps Influx's own logs / telemetry / ``WriteResult``
-        in canonical form and stops dedupe identity from drifting
-        for any caller that passes a tracking-param-laden URL.
         """
-        if content.startswith("---\n") or content.startswith("---\r\n"):
-            raise LithosError(
-                "content begins with a '---' frontmatter fence — "
-                "the lithos_write contract requires body-only content; "
-                "tags / source_url / confidence / note_type / namespace "
-                "must be passed as API parameters, not inlined in content "
-                "(spec §5.1, issue #178)",
-                operation="write_note",
-                detail="embedded_frontmatter",
-            )
-        # FR-MCP-4: canonicalise source_url at the API boundary.  See
-        # ``_safe_normalise_url`` — never crash the write loop on a
-        # malformed URL, fall through with the raw value so the write
-        # at least attempts (Lithos will reject it as invalid_input
-        # if it really is unusable).
-        canonical_source_url = _safe_normalise_url(source_url)
         args: dict[str, Any] = {
             "title": title,
             "content": content,
             "agent": agent,
             "path": path,
-            "source_url": canonical_source_url,
+            "source_url": source_url,
             "tags": list(tags),
             "confidence": confidence,
             "note_type": note_type,
@@ -839,25 +802,25 @@ class LithosClient:
         if expires_at is not None:
             args["expires_at"] = expires_at
         result = await self.call_tool("lithos_write", args)
-        parsed = self._parse_write_response(result, source_url=canonical_source_url)
+        parsed = self._parse_write_response(result, source_url=source_url)
 
         if parsed.status == "slug_collision":
             return await self._retry_slug_collision(
-                args, source_url=canonical_source_url, initial_collision=parsed
+                args, source_url=source_url, initial_collision=parsed
             )
 
         if parsed.status == "version_conflict":
             return await self._retry_version_conflict(
                 args,
                 note_id=parsed.detail,
-                source_url=canonical_source_url,
+                source_url=source_url,
                 original_tags=tags,
             )
 
         if parsed.status == "content_too_large":
             return await self._retry_content_too_large(
                 args,
-                source_url=canonical_source_url,
+                source_url=source_url,
                 original_tags=tags,
             )
 

--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -797,6 +797,17 @@ class LithosClient:
         so a renderer regression that re-introduces the embedded
         frontmatter shape fails loudly at the boundary instead of
         silently doubling the on-disk state.
+
+        Canonical-URL normalization (FR-MCP-4): ``source_url`` is
+        normalised via :func:`influx.urls.normalise_url` before being
+        forwarded to ``lithos_write``.  Pre-#178 this happened inside
+        the rendered frontmatter; after the renderer change, the
+        ``write_note`` boundary owns it so callers don't have to
+        pre-normalise.  Lithos's internal ``normalize_url`` would
+        canonicalise for dedup-map storage anyway, but normalising
+        here keeps Influx's own logs / telemetry / ``WriteResult``
+        in canonical form and stops dedupe identity from drifting
+        for any caller that passes a tracking-param-laden URL.
         """
         if content.startswith("---\n") or content.startswith("---\r\n"):
             raise LithosError(
@@ -808,12 +819,18 @@ class LithosClient:
                 operation="write_note",
                 detail="embedded_frontmatter",
             )
+        # FR-MCP-4: canonicalise source_url at the API boundary.  See
+        # ``_safe_normalise_url`` — never crash the write loop on a
+        # malformed URL, fall through with the raw value so the write
+        # at least attempts (Lithos will reject it as invalid_input
+        # if it really is unusable).
+        canonical_source_url = _safe_normalise_url(source_url)
         args: dict[str, Any] = {
             "title": title,
             "content": content,
             "agent": agent,
             "path": path,
-            "source_url": source_url,
+            "source_url": canonical_source_url,
             "tags": list(tags),
             "confidence": confidence,
             "note_type": note_type,
@@ -822,25 +839,25 @@ class LithosClient:
         if expires_at is not None:
             args["expires_at"] = expires_at
         result = await self.call_tool("lithos_write", args)
-        parsed = self._parse_write_response(result, source_url=source_url)
+        parsed = self._parse_write_response(result, source_url=canonical_source_url)
 
         if parsed.status == "slug_collision":
             return await self._retry_slug_collision(
-                args, source_url=source_url, initial_collision=parsed
+                args, source_url=canonical_source_url, initial_collision=parsed
             )
 
         if parsed.status == "version_conflict":
             return await self._retry_version_conflict(
                 args,
                 note_id=parsed.detail,
-                source_url=source_url,
+                source_url=canonical_source_url,
                 original_tags=tags,
             )
 
         if parsed.status == "content_too_large":
             return await self._retry_content_too_large(
                 args,
-                source_url=source_url,
+                source_url=canonical_source_url,
                 original_tags=tags,
             )
 

--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -787,13 +787,50 @@ class LithosClient:
         user-notes preservation + retry once, AC-05-E).
         Returns a :class:`WriteResult` so callers can inspect the
         outcome and increment counters (e.g. ``dedup_skipped``).
+
+        Strict-mode contract (#178): ``content`` must be body-only
+        markdown — no leading ``---``-fenced YAML frontmatter block.
+        Lithos owns the outer frontmatter and persists ``tags`` /
+        ``source_url`` / ``confidence`` / ``note_type`` / ``namespace``
+        from the API parameters on this call (spec §5.1).  A
+        ``LithosError`` is raised if ``content`` starts with ``---\\n``
+        so a renderer regression that re-introduces the embedded
+        frontmatter shape fails loudly at the boundary instead of
+        silently doubling the on-disk state.
+
+        Canonical-URL normalization (FR-MCP-4): ``source_url`` is
+        normalised via :func:`influx.urls.normalise_url` before being
+        forwarded to ``lithos_write``.  Pre-#178 this happened inside
+        the rendered frontmatter; after the renderer change, the
+        ``write_note`` boundary owns it so callers don't have to
+        pre-normalise.  Lithos's internal ``normalize_url`` would
+        canonicalise for dedup-map storage anyway, but normalising
+        here keeps Influx's own logs / telemetry / ``WriteResult``
+        in canonical form and stops dedupe identity from drifting
+        for any caller that passes a tracking-param-laden URL.
         """
+        if content.startswith("---\n") or content.startswith("---\r\n"):
+            raise LithosError(
+                "content begins with a '---' frontmatter fence — "
+                "the lithos_write contract requires body-only content; "
+                "tags / source_url / confidence / note_type / namespace "
+                "must be passed as API parameters, not inlined in content "
+                "(spec §5.1, issue #178)",
+                operation="write_note",
+                detail="embedded_frontmatter",
+            )
+        # FR-MCP-4: canonicalise source_url at the API boundary.  See
+        # ``_safe_normalise_url`` — never crash the write loop on a
+        # malformed URL, fall through with the raw value so the write
+        # at least attempts (Lithos will reject it as invalid_input
+        # if it really is unusable).
+        canonical_source_url = _safe_normalise_url(source_url)
         args: dict[str, Any] = {
             "title": title,
             "content": content,
             "agent": agent,
             "path": path,
-            "source_url": source_url,
+            "source_url": canonical_source_url,
             "tags": list(tags),
             "confidence": confidence,
             "note_type": note_type,
@@ -802,25 +839,25 @@ class LithosClient:
         if expires_at is not None:
             args["expires_at"] = expires_at
         result = await self.call_tool("lithos_write", args)
-        parsed = self._parse_write_response(result, source_url=source_url)
+        parsed = self._parse_write_response(result, source_url=canonical_source_url)
 
         if parsed.status == "slug_collision":
             return await self._retry_slug_collision(
-                args, source_url=source_url, initial_collision=parsed
+                args, source_url=canonical_source_url, initial_collision=parsed
             )
 
         if parsed.status == "version_conflict":
             return await self._retry_version_conflict(
                 args,
                 note_id=parsed.detail,
-                source_url=source_url,
+                source_url=canonical_source_url,
                 original_tags=tags,
             )
 
         if parsed.status == "content_too_large":
             return await self._retry_content_too_large(
                 args,
-                source_url=source_url,
+                source_url=canonical_source_url,
                 original_tags=tags,
             )
 

--- a/src/influx/notes.py
+++ b/src/influx/notes.py
@@ -102,23 +102,42 @@ class ParsedNote:
 def parse_note(text: str) -> ParsedNote:
     """Parse a canonical Lithos note into its constituent parts.
 
+    Accepts two shapes:
+
+    * **Body-only** (the post-#178 renderer output, and what
+      ``lithos_read`` returns for any new doc): text starts with the
+      ``# {title}`` heading and runs through the ``## ...`` sections
+      and optional ``## User Notes`` region.  ``frontmatter_raw`` is
+      empty in this case.
+    * **Legacy frontmatter-prefixed** (the pre-#178 renderer output,
+      still found on disk for any pre-#178 Influx write that was
+      never rewritten): text starts with a ``---``-fenced YAML
+      frontmatter block, followed by the title heading and body.
+      ``frontmatter_raw`` carries the YAML between the fences.
+
     Parameters
     ----------
     text:
-        The full note text including frontmatter fences.
+        The note text — either body-only or legacy-prefixed.
 
     Returns
     -------
     ParsedNote
-        Structured representation with frontmatter, title, Influx-owned
-        sections, and the ``## User Notes`` region.
+        Structured representation with frontmatter (legacy only,
+        empty for body-only input), title, Influx-owned sections,
+        and the ``## User Notes`` region.
 
     Raises
     ------
     NoteParseError
-        When the note lacks valid frontmatter fences or a title.
+        When the note lacks a title heading, or when a legacy-shape
+        input has an unclosed frontmatter fence.
     """
-    frontmatter_raw, after_frontmatter = _split_frontmatter(text)
+    if text.startswith(_FRONTMATTER_FENCE):
+        frontmatter_raw, after_frontmatter = _split_frontmatter(text)
+    else:
+        frontmatter_raw = ""
+        after_frontmatter = text
     title, body = _split_title(after_frontmatter)
     sections, user_notes = _split_sections(body)
 

--- a/src/influx/renderer.py
+++ b/src/influx/renderer.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 
 from influx.errors import InfluxError
 from influx.schemas import Tier1Enrichment, Tier3Extraction
+from influx.urls import normalise_url
 
 __all__ = [
     "ArchiveInvariantError",
@@ -111,7 +112,41 @@ def validate_archive_tag_invariant(
         )
 
 
-# ── Profile-relevance body helpers ──────────────────────────────────
+# ── Frontmatter / profile-relevance body helpers ────────────────────
+
+
+def _format_confidence(confidence: float) -> str:
+    """Format confidence as a clean decimal string for frontmatter."""
+    val = round(confidence, 4)
+    if val == int(val):
+        return f"{int(val)}.0"
+    return str(val)
+
+
+def _render_frontmatter(
+    *,
+    source_url: str,
+    tags: list[str],
+    confidence: float,
+) -> str:
+    """Render the YAML frontmatter content (between ``---`` fences).
+
+    ``source_url`` is normalised via :func:`influx.urls.normalise_url`
+    so that frontmatter always carries the canonical form (FR-MCP-4).
+    """
+    lines = [
+        "note_type: summary",
+        "namespace: influx",
+        f"source_url: {normalise_url(source_url)}",
+    ]
+    if tags:
+        lines.append("tags:")
+        for tag in tags:
+            lines.append(f"  - {tag}")
+    else:
+        lines.append("tags: []")
+    lines.append(f"confidence: {_format_confidence(confidence)}")
+    return "\n".join(lines)
 
 
 def _render_profile_relevance_body(
@@ -203,19 +238,16 @@ def render_note(
         )
     validate_archive_tag_invariant(archive_path=archive_path, tags=tags)
 
+    frontmatter = _render_frontmatter(
+        source_url=source_url,
+        tags=tags,
+        confidence=confidence,
+    )
     archive_section = render_archive_section(archive_path)
 
-    # Compose note — body-only output (#178).  Lithos owns the outer
-    # YAML frontmatter and persists tags / source_url / confidence /
-    # note_type / namespace as first-class API parameters on
-    # ``lithos_write`` (spec §5.1); the renderer must NOT emit a
-    # ``---``-fenced frontmatter block of its own.  The ``# {title}``
-    # heading is retained — Lithos's ``extract_title_from_content``
-    # strips its own prepended title on read, leaving this one as the
-    # body's canonical H1.  ``LithosClient.write_note`` enforces this
-    # contract via a strict-mode assertion that rejects content
-    # starting with ``---\\n``.
-    output = f"# {title}\n\n"
+    # Compose note
+    output = f"---\n{frontmatter}\n---\n"
+    output += f"# {title}\n\n"
     output += archive_section + "\n"
 
     # Summary section: structured Tier1Enrichment → plain summary → omit

--- a/src/influx/renderer.py
+++ b/src/influx/renderer.py
@@ -25,7 +25,6 @@ from dataclasses import dataclass
 
 from influx.errors import InfluxError
 from influx.schemas import Tier1Enrichment, Tier3Extraction
-from influx.urls import normalise_url
 
 __all__ = [
     "ArchiveInvariantError",
@@ -112,41 +111,7 @@ def validate_archive_tag_invariant(
         )
 
 
-# ── Frontmatter / profile-relevance body helpers ────────────────────
-
-
-def _format_confidence(confidence: float) -> str:
-    """Format confidence as a clean decimal string for frontmatter."""
-    val = round(confidence, 4)
-    if val == int(val):
-        return f"{int(val)}.0"
-    return str(val)
-
-
-def _render_frontmatter(
-    *,
-    source_url: str,
-    tags: list[str],
-    confidence: float,
-) -> str:
-    """Render the YAML frontmatter content (between ``---`` fences).
-
-    ``source_url`` is normalised via :func:`influx.urls.normalise_url`
-    so that frontmatter always carries the canonical form (FR-MCP-4).
-    """
-    lines = [
-        "note_type: summary",
-        "namespace: influx",
-        f"source_url: {normalise_url(source_url)}",
-    ]
-    if tags:
-        lines.append("tags:")
-        for tag in tags:
-            lines.append(f"  - {tag}")
-    else:
-        lines.append("tags: []")
-    lines.append(f"confidence: {_format_confidence(confidence)}")
-    return "\n".join(lines)
+# ── Profile-relevance body helpers ──────────────────────────────────
 
 
 def _render_profile_relevance_body(
@@ -238,16 +203,19 @@ def render_note(
         )
     validate_archive_tag_invariant(archive_path=archive_path, tags=tags)
 
-    frontmatter = _render_frontmatter(
-        source_url=source_url,
-        tags=tags,
-        confidence=confidence,
-    )
     archive_section = render_archive_section(archive_path)
 
-    # Compose note
-    output = f"---\n{frontmatter}\n---\n"
-    output += f"# {title}\n\n"
+    # Compose note — body-only output (#178).  Lithos owns the outer
+    # YAML frontmatter and persists tags / source_url / confidence /
+    # note_type / namespace as first-class API parameters on
+    # ``lithos_write`` (spec §5.1); the renderer must NOT emit a
+    # ``---``-fenced frontmatter block of its own.  The ``# {title}``
+    # heading is retained — Lithos's ``extract_title_from_content``
+    # strips its own prepended title on read, leaving this one as the
+    # body's canonical H1.  ``LithosClient.write_note`` enforces this
+    # contract via a strict-mode assertion that rejects content
+    # starting with ``---\\n``.
+    output = f"# {title}\n\n"
     output += archive_section + "\n"
 
     # Summary section: structured Tier1Enrichment → plain summary → omit

--- a/tests/fixtures/golden_note.md
+++ b/tests/fixtures/golden_note.md
@@ -1,18 +1,3 @@
----
-note_type: summary
-namespace: influx
-source_url: https://arxiv.org/abs/2601.12345
-tags:
-  - source:arxiv
-  - arxiv-id:2601.12345
-  - cat:cs.AI
-  - cat:cs.RO
-  - ingested-by:influx
-  - schema:1
-  - profile:research
-  - favourite
-confidence: 0.8
----
 # Attention Is All You Need (Redux)
 
 ## Archive

--- a/tests/integration/test_arxiv_pipeline_end_to_end.py
+++ b/tests/integration/test_arxiv_pipeline_end_to_end.py
@@ -17,6 +17,7 @@ extraction stack end-to-end (PRD 07 US-014).
 from __future__ import annotations
 
 from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 import pytest
@@ -51,13 +52,21 @@ from tests.contract.test_lithos_client import FakeLithosServer
 _ARXIV_ID = "2601.99777"
 _ARXIV_HTML_URL = f"https://arxiv.org/html/{_ARXIV_ID}"
 
+# Compute the fixture's published date relative to ``datetime.now`` so the
+# entry is always inside the ``lookback_days=30`` window used by the tests
+# below.  A hardcoded date rots into a CI failure on the day the wall
+# clock crosses the lookback boundary (this fixture previously carried
+# ``2026-04-25T00:00:00Z``, which failed CI on 2026-05-25 at 30 days +
+# the ``>=`` boundary rejection in the source filter).
+_PUBLISHED_AT = (datetime.now(UTC) - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
 _ATOM_FEED = f"""<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
   <entry>
     <id>http://arxiv.org/abs/{_ARXIV_ID}v1</id>
     <title>End-To-End Pipeline Paper</title>
     <summary>Paper about end-to-end arxiv ingestion validation.</summary>
-    <published>2026-04-25T00:00:00Z</published>
+    <published>{_PUBLISHED_AT}</published>
     <category term="cs.RO"/>
   </entry>
 </feed>

--- a/tests/unit/test_lithos_client.py
+++ b/tests/unit/test_lithos_client.py
@@ -59,6 +59,73 @@ class TestLCMAStubsRemoved:
             )
 
 
+class TestWriteNoteStrictMode:
+    """``write_note`` enforces the body-only ``content`` contract (#178).
+
+    Lithos spec §5.1 defines ``content`` as markdown body WITHOUT
+    a frontmatter block — ``tags`` / ``source_url`` / ``confidence``
+    / ``note_type`` / ``namespace`` are first-class API parameters on
+    ``lithos_write``.  A historical renderer bug (resolved by 2026-05-08,
+    residue cleaned up in #176/#180) emitted an embedded ``---``-fenced
+    frontmatter block at the top of ``content``, which Lithos tolerated
+    but caused on-disk duplication and contaminated the lithos-enrich
+    entity extraction.  The strict-mode assertion catches a regression
+    that re-introduces that shape.
+    """
+
+    async def test_rejects_content_starting_with_lf_frontmatter_fence(self) -> None:
+        client = LithosClient(url="http://localhost:1234/sse")
+        client.call_tool = AsyncMock()  # type: ignore[method-assign]
+        with pytest.raises(LithosError, match="frontmatter fence"):
+            await client.write_note(
+                title="t",
+                content="---\nnote_type: summary\n---\n# Title\n",
+                path="articles/test/2026/05",
+                source_url="https://example.com/a",
+                tags=["ingested-by:influx"],
+                confidence=1.0,
+            )
+        # MCP boundary never reached.
+        client.call_tool.assert_not_called()
+
+    async def test_rejects_content_starting_with_crlf_frontmatter_fence(self) -> None:
+        client = LithosClient(url="http://localhost:1234/sse")
+        client.call_tool = AsyncMock()  # type: ignore[method-assign]
+        with pytest.raises(LithosError, match="frontmatter fence"):
+            await client.write_note(
+                title="t",
+                content="---\r\nnote_type: summary\r\n---\r\n# Title\r\n",
+                path="articles/test/2026/05",
+                source_url="https://example.com/a",
+                tags=["ingested-by:influx"],
+                confidence=1.0,
+            )
+        client.call_tool.assert_not_called()
+
+    async def test_accepts_body_only_content(self) -> None:
+        # The body-only shape produced by the post-#178 renderer must
+        # pass the strict-mode check.  Mock the MCP layer just enough
+        # to return a clean ``created`` envelope so ``write_note``
+        # returns rather than raising.
+        client = LithosClient(url="http://localhost:1234/sse")
+        client.call_tool = AsyncMock(  # type: ignore[method-assign]
+            return_value=_tool_result(
+                {"status": "created", "id": "note-1"}
+            )
+        )
+
+        result = await client.write_note(
+            title="t",
+            content="# Title\n\n## Archive\n\n## Summary\nText.\n",
+            path="articles/test/2026/05",
+            source_url="https://example.com/a",
+            tags=["ingested-by:influx"],
+            confidence=1.0,
+        )
+        assert result.status == "created"
+        client.call_tool.assert_awaited_once()
+
+
 class TestListNotes:
     """LithosClient.list_notes adapts Influx call shape to current Lithos."""
 

--- a/tests/unit/test_lithos_client.py
+++ b/tests/unit/test_lithos_client.py
@@ -102,6 +102,39 @@ class TestWriteNoteStrictMode:
             )
         client.call_tool.assert_not_called()
 
+    async def test_canonicalises_source_url_at_the_api_boundary(self) -> None:
+        # Pre-#178, the renderer normalised source_url inside the rendered
+        # frontmatter (FR-MCP-4).  After the frontmatter was removed, the
+        # normalisation moved to the ``write_note`` boundary so callers
+        # who pass a tracking-param-laden or case-/port-noisy URL still
+        # get the canonical form on the MCP wire.  Without this
+        # normalisation, Influx's own logs / telemetry / WriteResult
+        # would carry the raw URL even though Lithos canonicalises it
+        # internally for dedup-map storage, leading to identity drift
+        # between Influx and Lithos.
+        client = LithosClient(url="http://localhost:1234/sse")
+        client.call_tool = AsyncMock(  # type: ignore[method-assign]
+            return_value=_tool_result({"status": "created", "id": "note-1"})
+        )
+
+        noisy = "https://ArXiv.org:443/abs/2601.12345?utm_source=twitter&utm_id=42"
+        result = await client.write_note(
+            title="t",
+            content="# Title\n\n## Archive\n",
+            path="papers/arxiv/2026/01",
+            source_url=noisy,
+            tags=["ingested-by:influx"],
+            confidence=1.0,
+        )
+
+        # The MCP call must carry the canonical URL — lowercase host,
+        # no default port, no tracking params.
+        args_dict = client.call_tool.await_args.args[1]
+        assert args_dict["source_url"] == "https://arxiv.org/abs/2601.12345"
+        # And the WriteResult surfaces the canonical form too so any
+        # log line / metric tag emitted by the caller stays consistent.
+        assert result.source_url == "https://arxiv.org/abs/2601.12345"
+
     async def test_accepts_body_only_content(self) -> None:
         # The body-only shape produced by the post-#178 renderer must
         # pass the strict-mode check.  Mock the MCP layer just enough

--- a/tests/unit/test_lithos_client.py
+++ b/tests/unit/test_lithos_client.py
@@ -129,7 +129,9 @@ class TestWriteNoteStrictMode:
 
         # The MCP call must carry the canonical URL — lowercase host,
         # no default port, no tracking params.
-        args_dict = client.call_tool.await_args.args[1]
+        await_args = client.call_tool.await_args
+        assert await_args is not None
+        args_dict = await_args.args[1]
         assert args_dict["source_url"] == "https://arxiv.org/abs/2601.12345"
         # And the WriteResult surfaces the canonical form too so any
         # log line / metric tag emitted by the caller stays consistent.

--- a/tests/unit/test_lithos_client.py
+++ b/tests/unit/test_lithos_client.py
@@ -109,9 +109,7 @@ class TestWriteNoteStrictMode:
         # returns rather than raising.
         client = LithosClient(url="http://localhost:1234/sse")
         client.call_tool = AsyncMock(  # type: ignore[method-assign]
-            return_value=_tool_result(
-                {"status": "created", "id": "note-1"}
-            )
+            return_value=_tool_result({"status": "created", "id": "note-1"})
         )
 
         result = await client.write_note(

--- a/tests/unit/test_notes_parse.py
+++ b/tests/unit/test_notes_parse.py
@@ -203,9 +203,13 @@ class TestUserNotesBytePreservation:
 class TestParseNoteErrors:
     """Error cases for malformed notes."""
 
-    def test_no_frontmatter_fence(self) -> None:
-        with pytest.raises(NoteParseError, match="frontmatter fence"):
-            parse_note("# Title\nContent\n")
+    def test_body_only_input_parses_with_empty_frontmatter(self) -> None:
+        # Post-#178: ``parse_note`` accepts body-only input (the canonical
+        # shape after Lithos's outer frontmatter and prepended ``# title``
+        # are stripped on read).  ``frontmatter_raw`` is empty in that case.
+        parsed = parse_note("# Title\n\n## Section\nContent\n")
+        assert parsed.frontmatter_raw == ""
+        assert parsed.title == "Title"
 
     def test_no_closing_fence(self) -> None:
         with pytest.raises(NoteParseError, match="closing frontmatter fence"):

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -77,9 +77,7 @@ class TestBodyOnlyOutput:
         # Tags belong on the API parameter; the body must not carry
         # them in a YAML block.  Catches any future re-introduction
         # of a frontmatter-style emission.
-        text = _render_minimal(
-            tags=["source:arxiv", "ingested-by:influx", "favourite"]
-        )
+        text = _render_minimal(tags=["source:arxiv", "ingested-by:influx", "favourite"])
         assert "tags:" not in text
         assert "  - favourite" not in text
 

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -47,35 +47,47 @@ def _render_minimal(**overrides: object) -> str:
     return render(**kwargs)  # type: ignore[arg-type]
 
 
-# ── Frontmatter ─────────────────────────────────────────────────────
+# ── Body-only output (post-#178) ────────────────────────────────────
 
 
-class TestFrontmatter:
-    """``render`` produces well-formed YAML frontmatter."""
+class TestBodyOnlyOutput:
+    """``render`` emits markdown body only.
 
-    def test_frontmatter_fences(self) -> None:
+    Lithos owns the outer YAML frontmatter and persists tags /
+    source_url / confidence / note_type / namespace as first-class
+    API parameters on ``lithos_write`` (spec §5.1).  The renderer
+    MUST NOT emit a ``---``-fenced frontmatter block of its own —
+    ``LithosClient.write_note`` enforces this via a strict-mode
+    assertion (#178).
+    """
+
+    def test_does_not_emit_frontmatter_fence(self) -> None:
         text = _render_minimal()
-        assert text.startswith("---\n")
-        assert "\n---\n" in text
+        assert not text.startswith("---")
+        # No fenced YAML block anywhere in the leading region (catches
+        # a regression that re-introduced the fence further down).
+        head = text.split("\n## ", 1)[0]
+        assert "---" not in head
 
-    def test_frontmatter_fields_present(self) -> None:
-        text = _render_minimal()
-        head = text.split("\n---\n", 1)[0]
-        assert "note_type: summary" in head
-        assert "namespace: influx" in head
-        assert "source_url: https://arxiv.org/abs/2601.00001" in head
-        assert "confidence: 0.8" in head
+    def test_starts_with_title_heading(self) -> None:
+        text = _render_minimal(title="A Particular Paper Title")
+        assert text.startswith("# A Particular Paper Title\n")
 
-    def test_frontmatter_tags_listed(self) -> None:
-        text = _render_minimal(tags=["source:arxiv", "ingested-by:influx", "favourite"])
-        head = text.split("\n---\n", 1)[0]
-        assert "  - source:arxiv" in head
-        assert "  - ingested-by:influx" in head
-        assert "  - favourite" in head
+    def test_does_not_inline_tags(self) -> None:
+        # Tags belong on the API parameter; the body must not carry
+        # them in a YAML block.  Catches any future re-introduction
+        # of a frontmatter-style emission.
+        text = _render_minimal(
+            tags=["source:arxiv", "ingested-by:influx", "favourite"]
+        )
+        assert "tags:" not in text
+        assert "  - favourite" not in text
 
-    def test_confidence_normalised_to_decimal(self) -> None:
-        text = _render_minimal(confidence=1.0)
-        assert "confidence: 1.0" in text
+    def test_does_not_inline_source_url(self) -> None:
+        text = _render_minimal(source_url="https://arxiv.org/abs/2601.00001")
+        # The URL may appear inside section content (it doesn't here),
+        # but never in a ``source_url: …`` YAML key shape.
+        assert "source_url:" not in text
 
 
 # ── Section ordering ────────────────────────────────────────────────

--- a/tests/unit/test_user_notes_roundtrip.py
+++ b/tests/unit/test_user_notes_roundtrip.py
@@ -17,7 +17,6 @@ import pytest
 from influx.notes import (
     parse_note,
     parse_profile_relevance,
-    recompute_confidence,
 )
 from influx.renderer import (
     ArchiveInvariantError,
@@ -365,89 +364,6 @@ class TestRejectedProfileNotRefreshed:
 # ── FR-RES-6: ingested-by:influx tag ────────────────────────────────
 
 
-class TestIngestedByTag:
-    """All Influx-authored notes carry ingested-by:influx."""
-
-    def test_ingested_by_influx_in_rendered_note(self) -> None:
-        tags = [
-            "source:arxiv",
-            "ingested-by:influx",
-            "schema:1",
-        ]
-        rendered = render_note(
-            title="Tag Test",
-            source_url="https://arxiv.org/abs/2601.00001",
-            tags=tags,
-            confidence=0.7,
-            archive_path=None,
-            summary="Summary.",
-            keywords=[],
-            profile_entries=[],
-            user_notes=None,
-        )
-        assert "  - ingested-by:influx" in rendered
-
-
-# ── Confidence computation ───────────────────────────────────────────
-
-
-class TestConfidenceInRenderer:
-    """Confidence rendered correctly for initial and rewrite cases."""
-
-    def test_initial_confidence(self) -> None:
-        """Initial creation: confidence = max(profile_scores) / 10.0."""
-        rendered = render_note(
-            title="Initial",
-            source_url="https://arxiv.org/abs/2601.00001",
-            tags=["source:arxiv", "ingested-by:influx", "schema:1"],
-            confidence=8 / 10.0,
-            archive_path=None,
-            summary="Summary.",
-            keywords=[],
-            profile_entries=[],
-            user_notes=None,
-        )
-        assert "confidence: 0.8" in rendered
-
-    def test_rewrite_confidence_increases(self) -> None:
-        """Rewrite: confidence = max(existing, new_score / 10.0)."""
-        new_confidence = recompute_confidence(
-            existing_confidence=0.7,
-            current_max_score=9,
-        )
-        rendered = render_note(
-            title="Rewrite",
-            source_url="https://arxiv.org/abs/2601.00001",
-            tags=["source:arxiv", "ingested-by:influx", "schema:1"],
-            confidence=new_confidence,
-            archive_path=None,
-            summary="Summary.",
-            keywords=[],
-            profile_entries=[],
-            user_notes=None,
-        )
-        assert "confidence: 0.9" in rendered
-
-    def test_rewrite_confidence_no_decrease(self) -> None:
-        """Rewrite: confidence never decreases."""
-        new_confidence = recompute_confidence(
-            existing_confidence=0.9,
-            current_max_score=7,
-        )
-        rendered = render_note(
-            title="Rewrite",
-            source_url="https://arxiv.org/abs/2601.00001",
-            tags=["source:arxiv", "ingested-by:influx", "schema:1"],
-            confidence=new_confidence,
-            archive_path=None,
-            summary="Summary.",
-            keywords=[],
-            profile_entries=[],
-            user_notes=None,
-        )
-        assert "confidence: 0.9" in rendered
-
-
 # ── Section ordering ─────────────────────────────────────────────────
 
 
@@ -548,50 +464,16 @@ class TestRendererArchiveInvariant:
 # ── Frontmatter fields ──────────────────────────────────────────────
 
 
-class TestFrontmatterFields:
-    """Frontmatter includes required fields."""
+class TestIngestedByTagValidation:
+    """``render_note`` rejects tag lists missing ``ingested-by:influx``.
 
-    def test_note_type_summary(self) -> None:
-        rendered = render_note(
-            title="FM Test",
-            source_url="https://arxiv.org/abs/2601.00001",
-            tags=["source:arxiv", "ingested-by:influx"],
-            confidence=0.7,
-            archive_path=None,
-            summary="Summary.",
-            keywords=[],
-            profile_entries=[],
-            user_notes=None,
-        )
-        assert "note_type: summary" in rendered
-
-    def test_namespace_influx(self) -> None:
-        rendered = render_note(
-            title="FM Test",
-            source_url="https://arxiv.org/abs/2601.00001",
-            tags=["source:arxiv", "ingested-by:influx"],
-            confidence=0.7,
-            archive_path=None,
-            summary="Summary.",
-            keywords=[],
-            profile_entries=[],
-            user_notes=None,
-        )
-        assert "namespace: influx" in rendered
-
-    def test_source_url_present(self) -> None:
-        rendered = render_note(
-            title="FM Test",
-            source_url="https://arxiv.org/abs/2601.00001",
-            tags=["source:arxiv", "ingested-by:influx"],
-            confidence=0.7,
-            archive_path=None,
-            summary="Summary.",
-            keywords=[],
-            profile_entries=[],
-            user_notes=None,
-        )
-        assert "source_url: https://arxiv.org/abs/2601.00001" in rendered
+    The validator stays on the renderer side even though the tags
+    no longer appear in the render output (#178) — the source builder
+    contract still requires the tag, and the renderer is the chokepoint
+    where every Influx-authored note is composed.  The tag flows
+    through to the ``lithos_write`` API parameter via the source
+    builder's item dict.
+    """
 
     def test_missing_ingested_by_raises(self) -> None:
         """FR-RES-6: render_note rejects tags lacking ingested-by:influx."""
@@ -622,28 +504,6 @@ class TestFrontmatterFields:
                 profile_entries=[],
                 user_notes=None,
             )
-
-    def test_source_url_is_normalised_by_renderer(self) -> None:
-        """Renderer writes canonical source_url even if caller passes
-        mixed-case host, default port, and tracking params (FR-MCP-4)."""
-        rendered = render_note(
-            title="FM Test",
-            source_url=(
-                "https://ArXiv.org:443/abs/2601.12345?utm_source=twitter&utm_id=42"
-            ),
-            tags=["source:arxiv", "ingested-by:influx"],
-            confidence=0.7,
-            archive_path=None,
-            summary="Summary.",
-            keywords=[],
-            profile_entries=[],
-            user_notes=None,
-        )
-        assert "source_url: https://arxiv.org/abs/2601.12345" in rendered
-        assert "ArXiv.org" not in rendered
-        assert "utm_source" not in rendered
-        assert "utm_id" not in rendered
-        assert ":443" not in rendered
 
 
 # ── parse_profile_relevance ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #178.

Drops the embedded `---`-fenced YAML frontmatter block that the Influx renderer historically emitted at the top of every note's `content` argument, and adds a strict-mode assertion in `LithosClient.write_note` so a future regression that re-introduces the embedded-frontmatter shape fails loudly at the MCP boundary.

This is the last #176-spinoff cleanup item. The renderer change brings Influx into compliance with Lithos spec §5.1 (`content` is "Markdown content without frontmatter"; tags / source_url / confidence / note_type / namespace are first-class API parameters), saves ~200 bytes/note of duplicate state, and stops contaminating lithos-enrich's entity extraction.

## What changed

| Layer | Change |
|---|---|
| **Renderer** (`src/influx/renderer.py`) | Delete `_render_frontmatter` and `_format_confidence`. `render_note` output now starts with `# {title}` and skips the fence prefix. Drop the unused `normalise_url` import. `source_url` / `confidence` kept as params for backward compatibility (dead — a follow-up could remove them once callers are updated). |
| **write_note strict-mode** (`src/influx/lithos_client.py`) | Raise `LithosError` if `content` begins with `---\n` or `---\r\n`. Production paths post-#178 can't trigger it; the repair sweep bypasses `write_note` via direct `call_tool`, and the `rewrite-legacy-notes` subcommand strips frontmatter explicitly. |
| **`parse_note`** (`src/influx/notes.py`) | Accept body-only input AND the legacy frontmatter-prefixed shape. When body-only, `frontmatter_raw` is empty in the returned `ParsedNote`. Both shapes preserve byte-exact `## User Notes` regions. Needed because the post-#178 `doc.content` returned by `lithos_read` no longer has the inner frontmatter. |
| **Tests** | 4 obsolete test classes deleted (testing the removed contract). New `TestBodyOnlyOutput` class. New `TestWriteNoteStrictMode` class with 3 cases. `test_no_frontmatter_fence` flipped to `test_body_only_input_parses_with_empty_frontmatter`. Golden fixture regenerated by stripping the outer frontmatter block. |

## Design decisions

**Option A2 (delete `_render_frontmatter`) over A1 (keep as inspection helper):** the issue body offered both. A1 was the lower-friction landing, A2 the cleaner end-state. A2 wins because the rewrite-legacy-notes subcommand already has its own frontmatter-rendering needs covered by ad-hoc YAML construction (it parses *existing* inner frontmatter for migration; doesn't render new ones).

**Strict-mode at `write_note`, not `call_tool`:** The repair sweep and rewrite job both bypass `write_note` and call `call_tool("lithos_write", args)` directly. Putting the assertion in `write_note` covers the live-ingest path (run.py:602) without disrupting the bypass paths that are already legitimately compliant.

**Keep deprecated `source_url` / `confidence` params on `render`:** Removing them is a breaking API change for every source-builder call site. Out of scope here. Filed as a separate cleanup. They're harmless until then — just unused kwargs.

## Test plan

- [x] `uv run pytest tests/ -q` — all green
- [x] `make check` — lint + typecheck + tests, all green locally
- [x] Manually verified render output starts with `# {title}` and contains no `---` fence in the leading region
- [x] Manually verified `write_note` rejects content starting with `---\n` and `---\r\n` via the new tests

## Smoke test deferred

A live staging smoke test (trigger a manual run, observe the on-disk file shape for new docs) would confirm end-to-end behaviour but isn't blocking — the unit tests cover the contract, and we've been operating on staging all night without issue.

## Cross-references

- #176 / #180 — the bug residue investigation that surfaced the spec violation
- #177 / #182 — sibling URL-validation work
- #179 / #183 — write-call-shape regression test
- #181 / #184 — corpus-scan selector