### PR TITLE
fix: normalise lithos_read envelope so the repair sweep stops stripping source metadata (#187)

### DIFF
--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -193,6 +193,11 @@ def _doc_tags(doc: dict[str, Any]) -> list[str]:
     Tags live under ``metadata`` in the canonical envelope but some
     code paths (and the diagnose-script preview) read them at the top
     level — be tolerant of both shapes.
+
+    Note: docs obtained via :meth:`LithosClient.read_note` are already
+    flattened by :func:`_normalise_read_envelope` (#187), so for those the
+    top-level branch hits first.  The ``metadata`` fallback here still
+    guards any direct caller that passes a raw, un-normalised envelope.
     """
     direct = doc.get("tags")
     if isinstance(direct, list):
@@ -216,6 +221,59 @@ def _doc_source_url(doc: dict[str, Any]) -> str | None:
         if isinstance(nested, str) and nested:
             return nested
     return None
+
+
+# Structured fields that Lithos returns nested under ``metadata`` in a
+# ``lithos_read`` response but that Influx reads at the top level — most
+# importantly the repair sweep (``influx.repair``), which builds its
+# rewrite args from ``note.get("source_url")`` / ``note.get("path")`` /
+# ``note.get("tags")``.  Issue #187: when these stayed nested, each sweep
+# pass rewrote a repair-needed note with empty source_url / path / tags,
+# progressively stripping it into an ``influx:source-invalid`` zombie.
+#
+# Each entry maps the field to its expected JSON type — a schema-violating
+# nested value (e.g. ``metadata.tags`` as a string) is NOT hoisted, mirroring
+# the ``isinstance`` guards in ``_doc_tags`` / ``_doc_source_url`` so callers
+# that apply ``list(...)`` to a hoisted value can never iterate a stray
+# string into character-garbage tags.
+_READ_ENVELOPE_FIELD_TYPES: dict[str, type | tuple[type, ...]] = {
+    "tags": list,
+    "source_url": str,
+    "path": str,
+    "confidence": (int, float),
+    "note_type": str,
+    "namespace": str,
+    "version": int,
+    "author": str,
+}
+
+
+def _normalise_read_envelope(doc: dict[str, Any]) -> dict[str, Any]:
+    """Hoist nested ``metadata.*`` fields to the top level of a read doc (#187).
+
+    For each allow-listed field, copy ``metadata[field]`` to the top
+    level **only when the top-level value is missing or empty AND the
+    nested value has the expected type** — a present, non-empty top-level
+    value always wins, so this never clobbers real data and is a no-op on
+    already-flat docs.  "Empty" means ``None`` / ``""`` / ``[]`` only, so a
+    legitimate ``confidence: 0.0`` or ``version: 0`` is preserved, while an
+    empty ``tags: []`` or ``source_url: ""`` is correctly replaced from
+    ``metadata``.  List values are copied so the hoisted top-level field
+    does not alias ``metadata[field]``.  Mutates and returns *doc* for
+    caller convenience.
+    """
+    meta = doc.get("metadata")
+    if not isinstance(meta, dict):
+        return doc
+    for field, expected in _READ_ENVELOPE_FIELD_TYPES.items():
+        if doc.get(field) not in (None, "", []):
+            continue  # a present, non-empty top-level value always wins
+        value = meta.get(field)
+        if field not in meta or not isinstance(value, expected):
+            continue  # absent, or schema-violating nested type — skip
+        # Copy lists so the hoisted value doesn't alias metadata[field].
+        doc[field] = list(value) if isinstance(value, list) else value
+    return doc
 
 
 @dataclasses.dataclass(frozen=True)
@@ -760,9 +818,18 @@ class LithosClient:
         )
 
     async def read_note(self, *, note_id: str) -> dict[str, Any]:
-        """Read a note by ID (used for version_conflict re-reads)."""
+        """Read a note by ID (used for version_conflict re-reads).
+
+        The returned dict is envelope-normalised (#187): structured
+        fields Lithos nests under ``metadata`` are hoisted to the top
+        level so downstream top-level ``note.get(...)`` reads — notably
+        the repair sweep's rewrite-arg construction — see the correct
+        values instead of empties.
+        """
         result = await self.call_tool("lithos_read", {"id": note_id})
-        return self._result_json_dict(result, operation="read_note")
+        return _normalise_read_envelope(
+            self._result_json_dict(result, operation="read_note")
+        )
 
     async def write_note(
         self,

--- a/tests/unit/test_lithos_client.py
+++ b/tests/unit/test_lithos_client.py
@@ -468,3 +468,198 @@ class TestUnresolvedDetailFormat:
         )
         assert "first_existing_id=<missing>" in out
         assert "retry_existing_id=doc-b" in out
+
+
+class TestReadNoteEnvelopeNormalisation:
+    """``read_note`` hoists nested ``metadata.*`` fields to the top level (#187).
+
+    Regression guard for the repair-sweep zombie bug: Lithos returns
+    structured fields nested under ``metadata``, but the sweep reads them
+    at the top level via ``note.get(...)``.  Without normalisation the
+    sweep rewrote notes with empty source_url / path / tags and
+    terminalised them as ``influx:source-invalid``.
+    """
+
+    def _read_result(self, payload: dict[str, object]) -> MagicMock:
+        return _tool_result(payload)
+
+    async def test_hoists_nested_source_url_path_tags(self) -> None:
+        """The canonical Lithos shape (fields under ``metadata``) is flattened."""
+        client = LithosClient(url="http://localhost:1234/sse")
+        client.call_tool = AsyncMock(  # type: ignore[method-assign]
+            return_value=self._read_result(
+                {
+                    "id": "11111111-2222-3333-4444-555555555555",
+                    "title": "Retrying vs Resampling in AI Control",
+                    "content": "## Summary\n\nBody.\n",
+                    "metadata": {
+                        "tags": [
+                            "profile:ai-foundations",
+                            "source:rss",
+                            "feed-slug:alignmentforum",
+                            "ingested-by:influx",
+                            "influx:repair-needed",
+                        ],
+                        "source_url": "https://www.alignmentforum.org/posts/x/retrying",
+                        "path": "articles/rss/2026/05",
+                        "confidence": 0.4,
+                        "version": 3,
+                    },
+                }
+            )
+        )
+
+        note = await client.read_note(note_id="11111111-2222-3333-4444-555555555555")
+
+        # Top-level reads (what the repair sweep performs) now resolve.
+        assert note["source_url"] == "https://www.alignmentforum.org/posts/x/retrying"
+        assert note["path"] == "articles/rss/2026/05"
+        assert "source:rss" in note["tags"]
+        assert "profile:ai-foundations" in note["tags"]
+        assert note["confidence"] == 0.4
+        assert note["version"] == 3
+
+    async def test_present_top_level_value_is_not_clobbered(self) -> None:
+        """A non-empty top-level field always wins over the nested copy."""
+        client = LithosClient(url="http://localhost:1234/sse")
+        client.call_tool = AsyncMock(  # type: ignore[method-assign]
+            return_value=self._read_result(
+                {
+                    "id": "n1",
+                    "source_url": "https://top.example/canonical",
+                    "tags": ["source:rss"],
+                    "metadata": {
+                        "source_url": "https://nested.example/stale",
+                        "tags": ["source:stale"],
+                    },
+                }
+            )
+        )
+
+        note = await client.read_note(note_id="n1")
+
+        assert note["source_url"] == "https://top.example/canonical"
+        assert note["tags"] == ["source:rss"]
+
+    async def test_empty_top_level_is_filled_from_metadata(self) -> None:
+        """Empty ``""`` / ``[]`` top-level values are treated as missing."""
+        client = LithosClient(url="http://localhost:1234/sse")
+        client.call_tool = AsyncMock(  # type: ignore[method-assign]
+            return_value=self._read_result(
+                {
+                    "id": "n1",
+                    "source_url": "",
+                    "tags": [],
+                    "metadata": {
+                        "source_url": "https://nested.example/real",
+                        "tags": ["source:rss"],
+                    },
+                }
+            )
+        )
+
+        note = await client.read_note(note_id="n1")
+
+        assert note["source_url"] == "https://nested.example/real"
+        assert note["tags"] == ["source:rss"]
+
+    async def test_already_flat_doc_is_unchanged(self) -> None:
+        """A response with no ``metadata`` object passes through untouched."""
+        client = LithosClient(url="http://localhost:1234/sse")
+        client.call_tool = AsyncMock(  # type: ignore[method-assign]
+            return_value=self._read_result(
+                {
+                    "id": "n1",
+                    "source_url": "https://example.com/a",
+                    "path": "articles/rss/2026/05",
+                    "tags": ["source:rss"],
+                    "confidence": 0.9,
+                }
+            )
+        )
+
+        note = await client.read_note(note_id="n1")
+
+        assert note["source_url"] == "https://example.com/a"
+        assert note["path"] == "articles/rss/2026/05"
+        assert note["tags"] == ["source:rss"]
+        assert note["confidence"] == 0.9
+
+    async def test_zero_confidence_top_level_preserved(self) -> None:
+        """A legitimate ``confidence: 0.0`` is not treated as empty."""
+        client = LithosClient(url="http://localhost:1234/sse")
+        client.call_tool = AsyncMock(  # type: ignore[method-assign]
+            return_value=self._read_result(
+                {
+                    "id": "n1",
+                    "confidence": 0.0,
+                    "metadata": {"confidence": 0.7},
+                }
+            )
+        )
+
+        note = await client.read_note(note_id="n1")
+
+        assert note["confidence"] == 0.0
+
+    async def test_zero_confidence_hoisted_from_metadata(self) -> None:
+        """A nested ``confidence: 0.0`` IS hoisted when top-level is absent."""
+        client = LithosClient(url="http://localhost:1234/sse")
+        client.call_tool = AsyncMock(  # type: ignore[method-assign]
+            return_value=self._read_result(
+                {"id": "n1", "metadata": {"confidence": 0.0}}
+            )
+        )
+
+        note = await client.read_note(note_id="n1")
+
+        assert note["confidence"] == 0.0
+
+    async def test_metadata_not_a_dict_is_noop(self) -> None:
+        """A non-dict ``metadata`` value is ignored (no crash, no hoist)."""
+        client = LithosClient(url="http://localhost:1234/sse")
+        client.call_tool = AsyncMock(  # type: ignore[method-assign]
+            return_value=self._read_result(
+                {"id": "n1", "source_url": "https://example.com/a", "metadata": None}
+            )
+        )
+
+        note = await client.read_note(note_id="n1")
+
+        assert note["source_url"] == "https://example.com/a"
+
+    async def test_schema_violating_nested_type_not_hoisted(self) -> None:
+        """A nested value of the wrong type is NOT hoisted (mirrors the
+        isinstance guards in _doc_tags/_doc_source_url) — prevents a stray
+        ``metadata.tags`` string being list()'d into character-garbage.
+        """
+        client = LithosClient(url="http://localhost:1234/sse")
+        client.call_tool = AsyncMock(  # type: ignore[method-assign]
+            return_value=self._read_result(
+                {
+                    "id": "n1",
+                    "tags": [],
+                    "metadata": {"tags": "not-a-list", "source_url": 12345},
+                }
+            )
+        )
+
+        note = await client.read_note(note_id="n1")
+
+        # Wrong-typed nested values are skipped; top-level stays empty/absent.
+        assert note["tags"] == []
+        assert note.get("source_url") in (None, "")
+
+    async def test_hoisted_tags_do_not_alias_metadata(self) -> None:
+        """The hoisted top-level ``tags`` is a copy, not the metadata list."""
+        client = LithosClient(url="http://localhost:1234/sse")
+        client.call_tool = AsyncMock(  # type: ignore[method-assign]
+            return_value=self._read_result(
+                {"id": "n1", "metadata": {"tags": ["source:rss"]}}
+            )
+        )
+
+        note = await client.read_note(note_id="n1")
+        note["tags"].append("mutated")
+
+        assert note["metadata"]["tags"] == ["source:rss"]

--- a/tests/unit/test_repair_sweep.py
+++ b/tests/unit/test_repair_sweep.py
@@ -1496,3 +1496,90 @@ class TestSweepTextExtractionRetry:
         rewritten = self._last_write_args(client)
         assert "source:arxiv" in rewritten["tags"]
         assert "text:html" in rewritten["tags"]
+
+
+def _payload_result(payload: dict[str, Any]) -> MagicMock:
+    """Build a fake ``CallToolResult`` whose body is *payload*."""
+    text_content = MagicMock()
+    text_content.text = json.dumps(payload)
+    result = MagicMock()
+    result.content = [text_content]
+    result.isError = False
+    return result
+
+
+class TestSweepEnvelopeNormalisation:
+    """#187 end-to-end: a repair-needed RSS note whose structured fields
+    arrive nested under ``metadata`` (the real ``lithos_read`` shape) must
+    be rewritten with source_url / path / source-tag intact, not stripped
+    into an ``influx:source-invalid`` zombie.
+
+    Unlike the other sweep tests this drives a *real* ``LithosClient`` with
+    only the transport (``call_tool``) mocked, so the read goes through the
+    real ``read_note`` envelope-normalisation (the fix site).
+    """
+
+    async def test_metadata_nested_source_survives_sweep_rewrite(self) -> None:
+        from influx.lithos_client import LithosClient
+        from influx.repair_hooks import infer_note_source
+
+        note_id = "11111111-2222-3333-4444-555555555555"  # Lithos UUID id
+        source_url = "https://www.alignmentforum.org/posts/x/retrying-vs-resampling"
+        nested_read = {
+            "id": note_id,
+            "title": "Retrying vs Resampling in AI Control",
+            "content": "# Retrying vs Resampling\n\n## Archive\n\n## Summary\nBody.\n",
+            # Real Lithos shape: structured fields under ``metadata`` only.
+            "metadata": {
+                "tags": [
+                    "profile:ai-foundations",
+                    "source:rss",
+                    "feed-slug:alignmentforum",
+                    "ingested-by:influx",
+                    "influx:repair-needed",
+                ],
+                "source_url": source_url,
+                "path": "articles/rss/2026/05",
+                "confidence": 0.4,
+                "version": 3,
+            },
+        }
+
+        def _dispatch(tool: str, args: dict[str, Any]) -> MagicMock:
+            if tool == "lithos_list":
+                return _payload_result({"items": [{"id": note_id}]})
+            if tool == "lithos_read":
+                return _payload_result(nested_read)
+            if tool == "lithos_write":
+                return _payload_result({"status": "updated"})
+            return _payload_result({"status": "ok"})
+
+        client = LithosClient(url="http://localhost:1234/sse")
+        client.call_tool = AsyncMock(side_effect=_dispatch)  # type: ignore[method-assign]
+
+        await sweep(
+            "ai-foundations", client=client, config=_make_config(), hooks=SweepHooks()
+        )
+
+        write_calls = [
+            c for c in client.call_tool.call_args_list if c.args[0] == "lithos_write"
+        ]
+        assert write_calls, "expected a lithos_write rewrite"
+        args = cast("dict[str, Any]", write_calls[0].args[1])
+
+        # The nested-only fields must reach the rewrite — not be blanked.
+        assert args["source_url"] == source_url
+        assert args["path"] == "articles/rss/2026/05"
+        assert "source:rss" in args["tags"]
+        assert "profile:ai-foundations" in args["tags"]
+
+        # Causal chain: the rewritten note is still source-recoverable, so a
+        # subsequent sweep would NOT terminalise it as influx:source-invalid.
+        rewritten = {
+            "id": note_id,
+            "tags": args["tags"],
+            "source_url": args["source_url"],
+            "path": args["path"],
+            "content": args["content"],
+        }
+        assert infer_note_source(rewritten) == "rss"


### PR DESCRIPTION
## Problem
RSS notes were being terminalised into `influx:source-invalid` abstract-only "zombie" notes that squat slugs, drive the `invalid_note_state` degraded reason, and fail the staging promotion gate. The affected notes were **real articles with working links** (e.g. alignmentforum posts), so the metadata was being lost *after* ingest — not at fetch time.

## Root cause
Lithos nests structured fields (`tags`, `source_url`, `path`, …) under `metadata` in the `lithos_read` response — the `_doc_tags` / `_doc_source_url` helpers exist precisely for this shape. But the repair sweep reads them at the **top level** via `note.get(...)` (`repair.py::_rewrite_note_via_lithos` and the stage code). Each sweep pass on a repair-needed note therefore rewrote it with **empty** `source_url` / `path` / `tags`, progressively stripping the note until `infer_note_source` had nothing left to recover — the Lithos **UUID doc id** also defeats the id-prefix fallback — and it was terminalised as a `source-invalid` zombie.

## Fix
Normalise the envelope **once** at the `LithosClient.read_note` boundary: hoist an allow-list of `metadata.*` fields to the top level, filling **only missing/empty** top-level values, with per-field **type guards** (mirroring `_doc_tags` / `_doc_source_url`) and **list copies** to avoid aliasing. The repair sweep code is unchanged — its top-level reads now resolve correctly. Chosen over scattering accessor calls across the sweep so the entire bug class disappears.

## Tests
- 9 `read_note` boundary cases: flatten nested fields, don't clobber present top-level values, fill empty `""`/`[]`, no-op on flat docs, preserve **and** hoist `confidence: 0.0`, non-dict `metadata` no-op, wrong-type nested value skipped, hoisted list not aliased.
- 1 end-to-end sweep test driving the **real** `read_note`: a metadata-nested, repair-needed RSS note survives the rewrite with `source_url`/`path`/`source:rss` intact and stays source-recoverable (`infer_note_source` → `"rss"`).

## Verification
`make check` green locally: ruff + pyright (0 errors) + **2356 tests passed**. Reviewed by the `code-reviewer` and `python-reviewer` agents (both approve; their type-guard and list-aliasing hardening is applied).

Closes #187