### PR TITLE
fix: raise Tier3Extraction.claims cap to TIER3_LIST_MAX (#186)

### DIFF
--- a/src/influx/schemas.py
+++ b/src/influx/schemas.py
@@ -53,7 +53,10 @@ class Tier3Extraction(BaseModel):
     """Tier-3 deep extraction output validated against FR-ENR-5 (PRD 07 §5.3).
 
     Constraints:
-    - ``claims`` length must be in ``[1, 10]`` inclusive.
+    - ``claims`` length must be in ``[1, TIER3_LIST_MAX]`` inclusive
+      (issue #186 — raised from 10 for the same reason as #81 below;
+      models returned up to 20 claims on claim-rich papers, discarding
+      the whole extraction).
     - ``datasets`` and ``builds_on`` lengths must be in
       ``[0, TIER3_LIST_MAX]`` inclusive (issue #81 — raised from 10 to
       accommodate structured-output models routinely returning 14-39
@@ -64,7 +67,7 @@ class Tier3Extraction(BaseModel):
     - Empty/whitespace-only elements fail validation.
     """
 
-    claims: list[str] = Field(min_length=1, max_length=10)
+    claims: list[str] = Field(min_length=1, max_length=TIER3_LIST_MAX)
     datasets: list[str] = Field(default_factory=list, max_length=TIER3_LIST_MAX)
     builds_on: list[str] = Field(default_factory=list, max_length=TIER3_LIST_MAX)
     open_questions: list[str] = Field(default_factory=list, max_length=10)

--- a/tests/unit/test_enrich.py
+++ b/tests/unit/test_enrich.py
@@ -367,6 +367,39 @@ class TestTier3ExtractSuccess:
 
         assert len(result.claims) == 10
 
+    def test_twenty_claims_no_longer_discarded(
+        self, influx_config_env: Any, tmp_path: Any
+    ) -> None:
+        """Issue #186: the observed 20-claim response now validates and
+        persists through the deep-extraction path instead of raising
+        ``LCMAError`` and feeding the Tier-3 terminal-flip counter."""
+        config = load_config()
+        payload = _valid_tier3_response(claims=[f"Claim {i}" for i in range(20)])
+
+        with patch("influx.enrich._call_json_model", return_value=payload):
+            result = tier3_extract(
+                title="Title",
+                full_text="Full text",
+                config=config,
+            )
+
+        assert len(result.claims) == 20
+
+    def test_claims_at_cap(self, influx_config_env: Any, tmp_path: Any) -> None:
+        config = load_config()
+        payload = _valid_tier3_response(
+            claims=[f"Claim {i}" for i in range(TIER3_LIST_MAX)]
+        )
+
+        with patch("influx.enrich._call_json_model", return_value=payload):
+            result = tier3_extract(
+                title="Title",
+                full_text="Full text",
+                config=config,
+            )
+
+        assert len(result.claims) == TIER3_LIST_MAX
+
     def test_optional_lists_empty(self, influx_config_env: Any, tmp_path: Any) -> None:
         config = load_config()
         payload = _valid_tier3_response(
@@ -445,7 +478,10 @@ class TestTier3ExtractValidationFailure:
         self, influx_config_env: Any, tmp_path: Any
     ) -> None:
         config = load_config()
-        payload = _valid_tier3_response(claims=[f"c{i}" for i in range(11)])
+        # Over the raised cap (issue #186): TIER3_LIST_MAX + 1 still hard-fails.
+        payload = _valid_tier3_response(
+            claims=[f"c{i}" for i in range(TIER3_LIST_MAX + 1)]
+        )
 
         with (
             patch("influx.enrich._call_json_model", return_value=payload),

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -181,7 +181,7 @@ class TestTier3Extraction:
 
     def test_too_many_claims(self) -> None:
         with pytest.raises(ValidationError):
-            Tier3Extraction(claims=[f"c{i}" for i in range(11)])
+            Tier3Extraction(claims=[f"c{i}" for i in range(TIER3_LIST_MAX + 1)])
 
     def test_no_claims_rejected(self) -> None:
         with pytest.raises(ValidationError):

--- a/tests/unit/test_tier3_schema.py
+++ b/tests/unit/test_tier3_schema.py
@@ -32,6 +32,19 @@ class TestTier3ExtractionPositive:
         t = Tier3Extraction(**_valid(claims=[f"c{i}" for i in range(10)]))
         assert len(t.claims) == 10
 
+    def test_claims_length_at_cap(self) -> None:
+        """Issue #186: claims accepts up to TIER3_LIST_MAX items."""
+        t = Tier3Extraction(**_valid(claims=[f"c{i}" for i in range(TIER3_LIST_MAX)]))
+        assert len(t.claims) == TIER3_LIST_MAX
+
+    @pytest.mark.parametrize("size", [11, 20, TIER3_LIST_MAX])
+    def test_claims_over_10_now_parse(self, size: int) -> None:
+        """Issue #186: >10 claims (observed up to 20) now parse and
+        round-trip instead of discarding the whole extraction."""
+        claims = [f"c{i}" for i in range(size)]
+        t = Tier3Extraction(**_valid(claims=claims))
+        assert t.claims == claims
+
     def test_datasets_length_0(self) -> None:
         t = Tier3Extraction(**_valid(datasets=[]))
         assert len(t.datasets) == 0
@@ -120,9 +133,13 @@ class TestTier3ExtractionNegative:
         with pytest.raises(ValidationError):
             Tier3Extraction(**_valid(claims=[]))
 
-    def test_claims_length_11(self) -> None:
+    def test_claims_length_over_cap(self) -> None:
+        """Issue #186: claims length TIER3_LIST_MAX + 1 is still rejected
+        (raised the bound, did not remove it)."""
         with pytest.raises(ValidationError):
-            Tier3Extraction(**_valid(claims=[f"c{i}" for i in range(11)]))
+            Tier3Extraction(
+                **_valid(claims=[f"c{i}" for i in range(TIER3_LIST_MAX + 1)])
+            )
 
     def test_datasets_length_over_cap(self) -> None:
         """Issue #81: datasets length TIER3_LIST_MAX + 1 is still rejected."""
@@ -222,5 +239,6 @@ class TestTier3ListMaxConstant:
         ``TIER3_LIST_MAX`` so a future bump propagates without code drift.
         """
         schema = Tier3Extraction.model_json_schema()
+        assert schema["properties"]["claims"]["maxItems"] == TIER3_LIST_MAX
         assert schema["properties"]["datasets"]["maxItems"] == TIER3_LIST_MAX
         assert schema["properties"]["builds_on"]["maxItems"] == TIER3_LIST_MAX


### PR DESCRIPTION
## Summary

`Tier3Extraction.claims` was capped at `max_length=10`. When the Tier-3 extraction model returns more than 10 claims (observed: up to 20) on claim-rich papers, the **entire extraction** failed Pydantic validation and surfaced as `LCMAError`, advancing the per-note Tier-3 counted-failure counter toward `influx:tier3-terminal` — silently dropping enrichment on the highest-value papers.

This raises the `claims` cap to the shared `TIER3_LIST_MAX` constant (30) — the same remedy issue #81 applied to the sibling `datasets`/`builds_on` fields, which `claims` was missed in. `min_length=1`, the element trim/500-char-truncate validators, and the `open_questions`/`potential_connections` caps are all unchanged. The prompt suffix is intentionally left alone (a prompt-side claim instruction is a separate, deferred enhancement).

## Changes

- `src/influx/schemas.py` — `claims` `max_length` `10` → `TIER3_LIST_MAX`; docstring updated to `[1, TIER3_LIST_MAX]` with issue #186 rationale.
- Tests — updated 3 assertions that assumed a cap of 10 (now `TIER3_LIST_MAX + 1` for the rejection boundary) across `test_tier3_schema.py`, `test_schemas.py`, `test_enrich.py`; added at-cap, over-cap, parametrized 11/20/30, a 20-claim deep-extraction regression, and a `claims` `maxItems` single-source-of-truth assertion.

## Test plan

- [x] `make check` (ruff + pyright + pytest) — 2362 passed
- [x] 11–`TIER3_LIST_MAX` claims validate and round-trip
- [x] `> TIER3_LIST_MAX` claims still rejected
- [x] 0 claims still rejected (`min_length=1` preserved)
- [x] 20-claim extraction no longer raises `LCMAError` in the deep-extraction path
- [x] Element-level trim/truncate + empty-element rejection unchanged
- [x] Docstring reflects the new bound

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)