### PR TITLE
feat: observe-only empty-source guard at ingest (#189)

### DIFF
--- a/src/influx/metrics.py
+++ b/src/influx/metrics.py
@@ -54,6 +54,7 @@ __all__ = [
     "slug_collision_reclaimed",
     "slug_collision_unresolved",
     "slug_collision_url_recovery",
+    "empty_source_writes",
     "source_acquisition_errors",
     "source_cooldown_skips",
     "summary_thin_drops",
@@ -321,6 +322,43 @@ def summary_thin_drops() -> Any:
             "Items suppressed by the thin-summary rule because their "
             "archive fetch failed and the feed-provided summary was "
             "too thin to keep (issue #166)."
+        ),
+    )
+
+
+def empty_source_writes() -> Any:
+    """Counter of notes written despite having no usable source (#189).
+
+    Increments once per note the source builders write whose ``source:``
+    tag is blank AND whose URL is not one a source can be inferred from
+    (a non-arxiv link) — the would-be ``influx:source-invalid`` zombie
+    population that a #187-class metadata loss would later terminalise.
+
+    Observe-only: the note is **always still written** (these items are
+    often legitimate content with a working link but no reconstructable
+    feed-slug tag), so this counts *writes*, not drops.  Deliberately
+    excluded from ``archive_failures_total`` / ``source_acquisition_errors``
+    and any degraded run reason — a quality/metadata signal, mirroring
+    :func:`summary_thin_drops`.
+
+    Labels:
+
+    - ``profile`` — profile name.
+    - ``source`` — the source-adapter identity, matching the convention
+      used by :func:`summary_thin_drops`: for arXiv the literal
+      ``"arxiv"`` (this never fires there — the abstract carries a
+      ``source:arxiv`` tag and an arxiv URL); for RSS the per-feed
+      ``source_tag``, falling back to ``"rss"`` when that tag is the
+      empty value that triggered the count.
+    - ``reason`` — why the source was unusable; currently the single
+      value ``"no_usable_source"`` (blank tag and no arxiv-inferable
+      URL), carried as a label so future narrower reasons can pivot.
+    """
+    return get_meter().counter(
+        "influx_empty_source_writes_total",
+        description=(
+            "Notes written despite having no usable source tag or "
+            "inferable source URL (issue #189, observe-only)."
         ),
     )
 

--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -319,10 +319,59 @@ def _infer_source_from_note_id(note_id: str) -> str | None:
     return None
 
 
+def _resolve_source_from_tag_or_url(
+    *, source_tag_suffix: str | None, source_url: str | None
+) -> str | None:
+    """Resolve a dispatchable ``source:*`` suffix from the signals that
+    exist at *ingest* time: an explicit source-tag suffix, then an
+    arxiv-inferable URL.
+
+    Single source of truth shared by :func:`infer_note_source` (its tag
+    and top-level-``source_url`` rules) and :func:`has_usable_source`,
+    so the ingest-time guard and the repair sweep agree by construction
+    on what counts as a usable source (#189).  A non-empty
+    *source_tag_suffix* wins verbatim — even one naming a source we
+    don't support yet is well-formed metadata, not our call to
+    second-guess — otherwise fall back to the arxiv-host URL inference.
+    Returns ``None`` when neither signal yields a source.
+    """
+    if source_tag_suffix:
+        return source_tag_suffix
+    return _infer_source_from_url(source_url or "")
+
+
+def has_usable_source(*, source_tag_suffix: str | None, source_url: str | None) -> bool:
+    """Whether a note has a usable, dispatchable source at ingest time (#189).
+
+    ``True`` iff a non-empty ``source:*`` suffix is present, or the
+    source URL is one a suffix can be inferred from (an arxiv host).
+    This is the boolean form of :func:`_resolve_source_from_tag_or_url`
+    and mirrors the terminal (returns-``None``) branch of
+    :func:`infer_note_source`, restricted to the signals that exist
+    *before* a note is written — the note ``path`` / ``id`` fallbacks
+    only exist post-write, so they are repair-only.
+
+    The source builders use this to **count, never drop** notes written
+    with no usable source: exactly the population a future #187-class
+    metadata loss would later strip into an ``influx:source-invalid``
+    zombie.  Observe-only by design (#189) — a blank ``source:`` tag on
+    an item with real content and a working non-arxiv link is still
+    legitimate content we must not discard.
+    """
+    return (
+        _resolve_source_from_tag_or_url(
+            source_tag_suffix=source_tag_suffix, source_url=source_url
+        )
+        is not None
+    )
+
+
 def infer_note_source(note: dict[str, object]) -> str | None:
     """Return a dispatchable ``source:*`` suffix for *note*, or ``None``.
 
-    Resolution order, stopping at the first hit:
+    Resolution order, stopping at the first hit (rules 1–2 share the
+    :func:`_resolve_source_from_tag_or_url` primitive with
+    :func:`has_usable_source` so ingest and repair never drift, #189):
 
     1. Any **non-empty** existing ``source:*`` tag is honoured
        verbatim — even if it names a source we don't support yet
@@ -349,15 +398,17 @@ def infer_note_source(note: dict[str, object]) -> str | None:
     that as a terminal metadata failure (#150) rather than a
     transient extraction failure.
     """
+    # Rules 1–2: existing non-empty tag, then top-level ``source_url``
+    # pointing at arxiv.  Shared with :func:`has_usable_source` via the
+    # resolver so the ingest guard and the sweep stay in lock-step (#189).
     existing = _note_source_tag(note)
-    if existing:
-        return existing
-
     top_level_url = note.get("source_url")
     top_level_url_str = top_level_url if isinstance(top_level_url, str) else ""
-    inferred = _infer_source_from_url(top_level_url_str)
-    if inferred is not None:
-        return inferred
+    resolved = _resolve_source_from_tag_or_url(
+        source_tag_suffix=existing, source_url=top_level_url_str
+    )
+    if resolved is not None:
+        return resolved
 
     source_url = _parse_source_url_from_note(note) or ""
     inferred = _infer_source_from_url(source_url)

--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -548,6 +548,12 @@ class RunLedger:
             # Stays ``None`` while the run is in flight; populated from
             # the per-run contextvar at ``complete`` time.
             "summary_thin_drops_total": None,
+            # Issue #189: per-run total of notes written despite having no
+            # usable source (blank source tag AND no arxiv-inferable URL).
+            # Observe-only signal, distinct from any failure total and
+            # never a degraded reason.  Stays ``None`` in flight; populated
+            # from the per-run contextvar at ``complete`` time.
+            "empty_source_writes_total": None,
             "error": None,
             "degraded": False,
             "degraded_reasons": [],
@@ -601,6 +607,7 @@ class RunLedger:
         invalid_url_rejections_total: int | None = None,
         archive_failures_total: int | None = None,
         summary_thin_drops_total: int | None = None,
+        empty_source_writes_total: int | None = None,
         source_acquisition_errors: list[dict[str, str]] | None = None,
         source_cooldown_skips: list[dict[str, str]] | None = None,
         source_retry_counts: dict[str, dict[str, int]] | None = None,
@@ -904,6 +911,7 @@ class RunLedger:
             invalid_url_rejections_total=invalid_url_rejections_total,
             archive_failures_total=archive_failures_total,
             summary_thin_drops_total=summary_thin_drops_total,
+            empty_source_writes_total=empty_source_writes_total,
             error=None,
             degraded=bool(reasons),
             source_acquisition_errors=errors,
@@ -1262,6 +1270,7 @@ class RunLedger:
         invalid_url_rejections_total: int | None = None,
         archive_failures_total: int | None = None,
         summary_thin_drops_total: int | None = None,
+        empty_source_writes_total: int | None = None,
         degraded: bool = False,
         source_acquisition_errors: list[dict[str, str]] | None = None,
         source_cooldown_skips: list[dict[str, str]] | None = None,
@@ -1303,6 +1312,10 @@ class RunLedger:
                     # suppressions so operators can see how many items
                     # the rule is dropping without scraping logs.
                     "summary_thin_drops_total": summary_thin_drops_total,
+                    # Issue #189: persist per-run count of source-less
+                    # writes so operators can measure the rate without
+                    # scraping logs.  Observe-only; not a failure total.
+                    "empty_source_writes_total": empty_source_writes_total,
                     "error": error,
                     "degraded": degraded,
                     "degraded_reasons": list(degraded_reasons or []),

--- a/src/influx/run_service.py
+++ b/src/influx/run_service.py
@@ -46,6 +46,7 @@ from influx.run import (
 from influx.run_ledger import RunLedger
 from influx.telemetry import (
     current_cache_hits,
+    current_empty_source_writes,
     current_fetched_total,
     current_filter_errors,
     current_invalid_url_rejections,
@@ -197,6 +198,16 @@ async def ledger_lifecycle(
     summary_thin_drops_counter: list[int] = [0]
     summary_thin_drops_token = current_summary_thin_drops.set(
         summary_thin_drops_counter
+    )
+    # #189: per-run count of notes written despite having no usable
+    # source (blank source tag AND no arxiv-inferable URL).  Source
+    # builders increment via :func:`record_empty_source_write`.  Surfaced
+    # on the run-ledger entry as ``empty_source_writes_total`` so an
+    # operator can measure how often this happens; observe-only, never a
+    # drop and never a degraded reason (mirrors summary_thin_drops).
+    empty_source_writes_counter: list[int] = [0]
+    empty_source_writes_token = current_empty_source_writes.set(
+        empty_source_writes_counter
     )
     # #129: per-run counter of recovered source-fetch retries (i.e.
     # retries followed by another attempt, distinct from the swallowed
@@ -350,6 +361,10 @@ async def ledger_lifecycle(
         # Deliberately distinct from archive_failures_total — these
         # items never reached the write loop.
         summary_thin_drops_total = summary_thin_drops_counter[0]
+        # #189: total per-run notes written with no usable source.
+        # Observe-only — distinct from any failure total; never feeds a
+        # degraded reason.
+        empty_source_writes_total = empty_source_writes_counter[0]
         # #152: total cache hits this run, surfaced under the
         # degradation summary's ``totals.cache_hits``.
         cache_hits_total = cache_hits_counter[0]
@@ -362,6 +377,7 @@ async def ledger_lifecycle(
             invalid_url_rejections_total=invalid_url_rejections_total,
             archive_failures_total=archive_failures_total,
             summary_thin_drops_total=summary_thin_drops_total,
+            empty_source_writes_total=empty_source_writes_total,
             source_acquisition_errors=source_errors,
             # Issue #146: cooldown skips are run-level state distinct
             # from swallowed acquisition errors — the ledger fires the
@@ -612,6 +628,23 @@ async def ledger_lifecycle(
                 run_id,
                 summary_thin_drops_total,
             )
+        # Issue #189: surface per-run empty-source writes at INFO so an
+        # operator sees "we wrote N notes with no usable source this run"
+        # — observe-only, never dropped, never a degraded reason.  This
+        # is the signal that tells us whether a future #187-class
+        # metadata loss is silently producing source-invalid candidates.
+        if empty_source_writes_total > 0:
+            logger.info(
+                "run empty_source_writes profile=%s kind=%s run_id=%s "
+                "written_items=%d "
+                "(notes written with a blank source tag AND no "
+                "arxiv-inferable URL; still written, not counted toward "
+                "archive_failures_total or any degraded reason)",
+                profile,
+                plan.kind.value,
+                run_id,
+                empty_source_writes_total,
+            )
 
         # Issue #164: classify the degraded reasons into the
         # ``severity`` bucket the ledger entry stores so the metric
@@ -713,6 +746,7 @@ async def ledger_lifecycle(
         current_filter_errors.reset(filter_errors_token)
         current_invalid_url_rejections.reset(invalid_url_rejections_token)
         current_summary_thin_drops.reset(summary_thin_drops_token)
+        current_empty_source_writes.reset(empty_source_writes_token)
         current_source_retry_counts.reset(source_retry_counts_token)
         current_tier3_fallback_counts.reset(tier3_fallback_counts_token)
         current_cache_hits.reset(cache_hits_token)

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -52,12 +52,14 @@ from influx.extraction.pipeline import extract_arxiv_text
 from influx.filter import FilterScorerError
 from influx.http_client import guarded_fetch
 from influx.renderer import render
+from influx.repair_hooks import has_usable_source
 from influx.source import BoundScoredCandidate, Candidate, ScoredCandidate
 from influx.storage import download_archive
 from influx.telemetry import (
     current_archive_terminal_arxiv_ids,
     current_run_id,
     get_tracer,
+    record_empty_source_write,
     record_fetched_items,
     record_filter_error,
     record_source_acquisition_error,
@@ -1206,6 +1208,30 @@ def build_arxiv_note_item(
                 thin_rule,
             )
             return None
+
+    # Issue #189: observe-only empty-source guard, for per-source
+    # consistency with the RSS builder.  arXiv notes always carry a
+    # ``source:arxiv`` tag and an arxiv ``source_url``, so this never
+    # fires here — but wiring it identically keeps the two builders
+    # symmetric and guards against a future arXiv code path that somehow
+    # produces a tag-less item.  Counts, never drops (mirrors RSS).
+    if not has_usable_source(source_tag_suffix="arxiv", source_url=source_url):
+        metrics.empty_source_writes().add(
+            1,
+            {
+                "profile": profile_name,
+                "source": "arxiv",
+                "reason": "no_usable_source",
+            },
+        )
+        record_empty_source_write()
+        _log.info(
+            "empty-source write source=arxiv profile=%s arxiv_id=%s "
+            "url=%s reason=no_usable_source",
+            profile_name,
+            item.arxiv_id,
+            source_url,
+        )
 
     # Issue #166 review: the item survived the thin-summary suppression
     # check and will be written below.  Bump the archive-missing-side

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -47,12 +47,14 @@ from influx.extraction.article import extract_article
 from influx.filter import FilterScorerError, _acall_filter_model_with_retry
 from influx.http_client import aguarded_fetch as _aguarded_fetch
 from influx.renderer import render
+from influx.repair_hooks import has_usable_source
 from influx.slugs import slugify_feed_name
 from influx.source import BoundScoredCandidate, Candidate, ScoredCandidate
 from influx.storage import download_archive
 from influx.telemetry import (
     current_run_id,
     get_tracer,
+    record_empty_source_write,
     record_fetched_items,
     record_filter_error,
     record_invalid_url_rejection,
@@ -540,6 +542,37 @@ def build_rss_note_item(
                 thin_rule,
             )
             return None
+
+    # Issue #189: observe-only empty-source guard.  The item survived the
+    # thin-summary check and WILL be written below.  When it has no usable
+    # source — a blank ``source:`` tag AND a URL we can't infer a source
+    # from (a non-arxiv link) — it is exactly the population a future
+    # #187-class metadata loss would later strip into an
+    # ``influx:source-invalid`` zombie.  We do NOT drop it (a real article
+    # with a working link but no reconstructable feed-slug tag is still
+    # legitimate content); we count + log it so the real-world fire-rate
+    # is measurable.  Shares ``has_usable_source`` with the repair sweep's
+    # ``infer_note_source`` so ingest and repair agree on "usable source".
+    if not has_usable_source(source_tag_suffix=item.source_tag, source_url=source_url):
+        metrics.empty_source_writes().add(
+            1,
+            {
+                "profile": profile_name,
+                # The guard only fires when ``item.source_tag`` is blank
+                # (that is the trigger), so there is no per-feed suffix to
+                # label with — use the stable adapter identity.
+                "source": "rss",
+                "reason": "no_usable_source",
+            },
+        )
+        record_empty_source_write()
+        _log.info(
+            "empty-source write source=rss profile=%s feed-slug=%s "
+            "url=%s reason=no_usable_source",
+            profile_name,
+            feed_slug,
+            source_url,
+        )
 
     # Issue #166 review: the item survived the thin-summary suppression
     # check and will be written below.  Bump the deferred

--- a/src/influx/telemetry.py
+++ b/src/influx/telemetry.py
@@ -36,6 +36,7 @@ __all__ = [
     "WriteOutcomeCounts",
     "current_archive_terminal_arxiv_ids",
     "current_cache_hits",
+    "current_empty_source_writes",
     "current_fetched_total",
     "current_filter_errors",
     "current_invalid_url_rejections",
@@ -49,6 +50,7 @@ __all__ = [
     "get_meter",
     "get_tracer",
     "record_cache_hit",
+    "record_empty_source_write",
     "record_fetched_items",
     "record_filter_error",
     "record_invalid_url_rejection",
@@ -339,6 +341,45 @@ def record_summary_thin_drop(count: int = 1) -> None:
     if count <= 0:
         return
     counter = current_summary_thin_drops.get()
+    if counter is None:
+        return
+    counter[0] += count
+
+
+# Per-run count of notes written despite having no usable source (#189).
+# Set to ``[0]`` at run start by ``run_service.ledger_lifecycle``; the
+# source builders increment via :func:`record_empty_source_write` when a
+# note is built whose ``source:`` tag is blank AND whose URL is not one a
+# source can be inferred from (a non-arxiv link) — the would-be
+# ``influx:source-invalid`` zombie population.
+#
+# Surfaced on the run-ledger entry as ``empty_source_writes_total`` so an
+# operator can measure how often this happens before any decision to drop.
+# This is a *write* count, not a drop: the note is always still written
+# (#189 ships observe-only — those items are often legitimate content with
+# a working non-arxiv link but no reconstructable feed-slug tag).
+# Deliberately does NOT contribute to ``archive_failures_total``,
+# ``source_acquisition_errors``, or any degraded run reason — like the
+# thin-summary counter, it is a quality/metadata signal, not a failure.
+current_empty_source_writes: ContextVar[list[int] | None] = ContextVar(
+    "current_empty_source_writes",
+    default=None,
+)
+
+
+def record_empty_source_write(count: int = 1) -> None:
+    """Add *count* to the current run's ``empty_source_writes_total`` (#189).
+
+    Safe to call outside a run context — silently no-ops when
+    :data:`current_empty_source_writes` is unset.  Source builders call
+    this once per source-less note, alongside the per-note INFO log line
+    and the ``influx_empty_source_writes_total`` metric bump, so the
+    ledger entry can carry the per-run total without re-scanning written
+    notes.
+    """
+    if count <= 0:
+        return
+    counter = current_empty_source_writes.get()
     if counter is None:
         return
     counter[0] += count

--- a/tests/unit/test_empty_source_write_observability.py
+++ b/tests/unit/test_empty_source_write_observability.py
@@ -1,0 +1,269 @@
+"""Tests for the observe-only empty-source guard (issue #189).
+
+The guard counts — but never drops — notes written with no usable source
+(a blank ``source:`` tag AND a URL no source can be inferred from). It is
+the belt-and-braces observability layer at ingest for the #187 zombie
+class, deliberately shipped observe-only because the population it catches
+is often legitimate content (a real article with a working non-arxiv link
+whose feed-slug tag was never populated).
+
+Verifies, at the RSS builder level, the wiring from
+:func:`influx.sources.rss.build_rss_note_item` into
+:func:`influx.repair_hooks.has_usable_source` and the per-note telemetry:
+
+* Blank source tag + non-arxiv URL → note is **still written**; the
+  contextvar counter / OTel metric / INFO log all fire.
+* A present source tag → not counted (note written as today).
+* Blank source tag + an arxiv URL → rescued by URL inference, not counted.
+
+Plus a run-ledger test pinning the triage decision that an empty-source
+write contributes **no degraded reason** (mirrors #166 thin-summary).
+
+``extract_article`` is patched to raise so the feed summary is used
+verbatim — no network IO — and a healthy archive is used so the
+thin-summary suppression path never runs and the empty-source guard is
+exercised in isolation.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+
+from influx.config import (
+    AppConfig,
+    ArchivePolicyConfig,
+    ExtractionConfig,
+    LithosConfig,
+    ProfileConfig,
+    ProfileThresholds,
+    PromptEntryConfig,
+    PromptsConfig,
+    ScheduleConfig,
+    SecurityConfig,
+    StorageConfig,
+)
+from influx.errors import NetworkError
+from influx.run_ledger import _KNOWN_DEGRADED_REASONS, RunLedger
+from influx.sources.rss import RssFeedItem, build_rss_note_item
+from influx.storage import ArchiveResult
+from influx.telemetry import current_empty_source_writes
+
+_LONG_SUMMARY = (
+    "This is a substantial article body discussing the subject in "
+    "enough detail that no structural thin-summary rule should ever "
+    "trip on it under default configuration."
+)
+
+
+def _make_config() -> AppConfig:
+    return AppConfig(
+        lithos=LithosConfig(url="http://localhost:0/sse"),
+        schedule=ScheduleConfig(),
+        storage=StorageConfig(
+            archive_dir="/archive",
+            archive_policy=ArchivePolicyConfig(include_defaults=False),
+        ),
+        profiles=[
+            ProfileConfig(
+                name="ai-robotics",
+                description="AI and robotics research",
+                thresholds=ProfileThresholds(
+                    relevance=7, full_text=100, deep_extract=100
+                ),
+            )
+        ],
+        providers={},
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="x"),
+            tier1_enrich=PromptEntryConfig(text="x"),
+            tier3_extract=PromptEntryConfig(text="x"),
+        ),
+        security=SecurityConfig(allow_private_ips=True),
+        extraction=ExtractionConfig(),
+    )
+
+
+def _make_item(
+    *,
+    source_tag: str,
+    url: str = "https://example.com/article",
+    summary: str = _LONG_SUMMARY,
+) -> RssFeedItem:
+    return RssFeedItem(
+        title="Test Article",
+        url=url,
+        published=datetime(2026, 4, 25, tzinfo=UTC),
+        summary=summary,
+        source_tag=source_tag,
+        feed_name="example-feed",
+    )
+
+
+def _ok_archive() -> ArchiveResult:
+    # Healthy archive so the #166 thin-summary path never runs — the
+    # empty-source guard is exercised on its own.
+    return ArchiveResult(
+        ok=True,
+        rel_posix_path="rss/example-feed/2026/04/abcd1234.html",
+        error="",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_counter() -> object:
+    """Each test gets its own ``current_empty_source_writes`` bucket."""
+    bucket: list[int] = [0]
+    token = current_empty_source_writes.set(bucket)
+    try:
+        yield bucket
+    finally:
+        current_empty_source_writes.reset(token)
+
+
+@pytest.fixture(autouse=True)
+def _force_extraction_failure() -> object:
+    """Force ``extract_article`` to raise so the feed summary is used verbatim."""
+    with patch(
+        "influx.sources.rss.extract_article",
+        side_effect=NetworkError(
+            "test forced",
+            url="https://example.com/article",
+            kind="timeout",
+        ),
+    ) as patched:
+        yield patched
+
+
+class TestEmptySourceWriteCounted:
+    """Blank source tag + non-arxiv URL → counted, logged, still written."""
+
+    @patch("influx.sources.rss.download_archive")
+    def test_blank_source_tag_non_arxiv_url_counts_and_writes(
+        self,
+        mock_dl: object,
+        _isolate_counter: list[int],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        mock_dl.return_value = _ok_archive()  # type: ignore[attr-defined]
+        item = _make_item(source_tag="", url="https://example.com/article")
+
+        with caplog.at_level(logging.INFO, logger="influx.sources.rss"):
+            result = build_rss_note_item(
+                item=item,
+                profile_name="ai-robotics",
+                config=_make_config(),
+            )
+
+        # Observe-only: the note is STILL written.
+        assert result is not None
+        assert _isolate_counter[0] == 1
+        assert any(
+            "empty-source write source=rss" in record.message
+            and "reason=no_usable_source" in record.message
+            for record in caplog.records
+        )
+
+    @patch("influx.sources.rss.metrics.empty_source_writes")
+    @patch("influx.sources.rss.download_archive")
+    def test_blank_source_tag_bumps_metric(
+        self,
+        mock_dl: object,
+        mock_metric: object,
+        _isolate_counter: list[int],
+    ) -> None:
+        mock_dl.return_value = _ok_archive()  # type: ignore[attr-defined]
+        item = _make_item(source_tag="")
+
+        result = build_rss_note_item(
+            item=item,
+            profile_name="ai-robotics",
+            config=_make_config(),
+        )
+
+        assert result is not None
+        mock_metric.return_value.add.assert_called_once()  # type: ignore[attr-defined]
+
+
+class TestEmptySourceWriteNotCounted:
+    """The guard must NOT fire when a usable source exists."""
+
+    @patch("influx.sources.rss.metrics.empty_source_writes")
+    @patch("influx.sources.rss.download_archive")
+    def test_present_source_tag_not_counted(
+        self,
+        mock_dl: object,
+        mock_metric: object,
+        _isolate_counter: list[int],
+    ) -> None:
+        mock_dl.return_value = _ok_archive()  # type: ignore[attr-defined]
+        item = _make_item(source_tag="rss-blog")
+
+        result = build_rss_note_item(
+            item=item,
+            profile_name="ai-robotics",
+            config=_make_config(),
+        )
+
+        assert result is not None
+        assert _isolate_counter[0] == 0
+        mock_metric.return_value.add.assert_not_called()  # type: ignore[attr-defined]
+
+    @patch("influx.sources.rss.metrics.empty_source_writes")
+    @patch("influx.sources.rss.download_archive")
+    def test_blank_source_tag_arxiv_url_is_rescued(
+        self,
+        mock_dl: object,
+        mock_metric: object,
+        _isolate_counter: list[int],
+    ) -> None:
+        # No source tag, but an arxiv URL → has_usable_source infers the
+        # source, so the guard does not fire (URL-rescue).
+        mock_dl.return_value = _ok_archive()  # type: ignore[attr-defined]
+        item = _make_item(source_tag="", url="https://arxiv.org/abs/2401.00001")
+
+        result = build_rss_note_item(
+            item=item,
+            profile_name="ai-robotics",
+            config=_make_config(),
+        )
+
+        assert result is not None
+        assert _isolate_counter[0] == 0
+        mock_metric.return_value.add.assert_not_called()  # type: ignore[attr-defined]
+
+
+class TestEmptySourceWriteNoDegradedReason:
+    """Triage decision (#189, mirrors #166): an empty-source write is a
+    quality/observability signal and must never degrade the run."""
+
+    def test_not_a_known_degraded_reason(self) -> None:
+        assert "empty_source_writes" not in _KNOWN_DEGRADED_REASONS
+        assert "empty_source" not in _KNOWN_DEGRADED_REASONS
+
+    def test_empty_source_writes_do_not_degrade_run(self, tmp_path: Path) -> None:
+        ledger = RunLedger(tmp_path / "state")
+        ledger.start(run_id="r-1", profile="p", kind="scheduled", run_range=None)
+        reasons = ledger.complete(
+            run_id="r-1",
+            sources_checked=5,
+            ingested=3,
+            empty_source_writes_total=5,
+        )
+
+        assert reasons == []
+        entry = ledger.recent()[0]
+        assert entry["empty_source_writes_total"] == 5
+        assert entry["degraded"] is False
+        assert entry["degradation_severity"] == "success"
+
+    def test_field_defaults_none_in_flight(self, tmp_path: Path) -> None:
+        ledger = RunLedger(tmp_path / "state")
+        ledger.start(run_id="r-2", profile="p", kind="scheduled", run_range=None)
+        active = cast(list[dict[str, object]], ledger.active_runs())
+        assert active[0]["empty_source_writes_total"] is None


### PR DESCRIPTION
## Summary

Adds a defensive, **observe-only** ingest-time layer for the #187 `influx:source-invalid` zombie class. #187's root cause (the repair sweep stripping source metadata post-ingest) was fixed in #188; this is the belt-and-braces layer at the *other* end of the pipeline.

Per triage (#189), this ships **observe-only — it never drops a note**. The population an ingest "no usable source" check catches is exactly *legitimate articles that have real content and a working link but no reconstructable `source:` provenance tag* (e.g. an RSS item from a feed whose feed-slug tag wasn't populated, with a normal non-arXiv URL). Discarding those would lose good content. Genuinely contentless items are already handled by the #166 thin-summary guard. Whether a *narrower* drop is ever justified is deferred to a future issue, informed by the telemetry this adds.

## What it does

- **One source of truth** — `repair_hooks.has_usable_source(*, source_tag_suffix, source_url)` + a shared `_resolve_source_from_tag_or_url` primitive; `infer_note_source` rules 1–2 refactored to use it. **Pure refactor, no behaviour change** (existing repair tests pass unchanged) — ingest and the repair sweep now agree on "usable source" by construction.
- **Observe-only guard** in `build_rss_note_item` / `build_arxiv_note_item`, after the thin-summary check: on no-usable-source, bump counter + ContextVar + INFO log, but **always still write the note**. arXiv passes a constant `source:arxiv` tag so the guard is inert there (present for symmetry).
- **Telemetry** mirroring #166: `influx_empty_source_writes_total` OTel counter, `current_empty_source_writes` ContextVar + `record_empty_source_write()`, run-service init/read/reset, and an `empty_source_writes_total` run-ledger field (`None` in flight, populated at complete).
- **No degraded reason** (mirrors #166): a quality/metadata signal, not a pipeline failure — excluded from `archive_failures_total` / `source_acquisition_errors` and never added to `_KNOWN_DEGRADED_REASONS`.
- Names reflect a **write**, not a drop, throughout (metric / ContextVar / ledger field / log lines).

## Test plan

- [x] `make check` (ruff + pyright + pytest) — **2370 passed** (7 new)
- [x] Blank source tag + non-arxiv URL → counted + logged + **still written**
- [x] Present source tag → not counted (metric not called)
- [x] Blank source tag + arxiv URL → rescued by URL inference, not counted
- [x] `empty_source_writes_total` does not degrade the run; not in `_KNOWN_DEGRADED_REASONS`; `None` in-flight
- [x] `infer_note_source` refactor behaviour-preserving (existing repair suites green)

## Out of scope (per triage)

- Any drop / suppression of notes — observe-only.
- A narrower future drop predicate (source-less **and** thin) — deferred to a separate issue.
- The #187 repair-sweep fix (#188) and the #190 chokepoint guard — separate.

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)