### PR TITLE
feat: inbox manual-submission pipeline — slice 1 (#195)

### DIFF
--- a/src/influx/config.py
+++ b/src/influx/config.py
@@ -12,7 +12,7 @@ import os
 import re
 import tomllib
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 from urllib.parse import urlparse
 
 from dotenv import load_dotenv
@@ -30,6 +30,7 @@ __all__ = [
     "ExtractionConfig",
     "FeedbackConfig",
     "FilterTuningConfig",
+    "InboxConfig",
     "InfluxSectionConfig",
     "LithosConfig",
     "ModelSlotConfig",
@@ -96,6 +97,45 @@ class ScheduleConfig(BaseModel):
                 "schedule.initial_jitter_seconds and "
                 "schedule.inter_profile_gap_seconds must be non-negative"
             )
+        return v
+
+
+class InboxConfig(BaseModel):
+    """``[inbox]`` manual-submission inbox settings.
+
+    Opt-in (default ``enabled=False``) intake of agent-submitted URLs via
+    Lithos tasks tagged ``influx:inbox``.  See ``docs/plans/inbox.md``.
+    The task tag is a fixed protocol constant — not operator-tunable — so
+    it lives as a class attribute rather than a config field.
+    """
+
+    TASK_TAG: ClassVar[str] = "influx:inbox"
+
+    enabled: bool = False
+    poll_cron: str = "*/5 * * * *"
+    timezone: str = "UTC"
+    max_items_per_tick: int = 20
+    agent_id: str = "influx-inbox"
+
+    @field_validator("poll_cron")
+    @classmethod
+    def _valid_cron(cls, v: str) -> str:
+        # Fail fast at config-load time rather than at scheduler start.
+        from apscheduler.triggers.cron import CronTrigger
+
+        try:
+            CronTrigger.from_crontab(v)
+        except (ValueError, TypeError) as exc:
+            raise ConfigError(
+                f"inbox.poll_cron is not a valid cron expression: {v!r}"
+            ) from exc
+        return v
+
+    @field_validator("max_items_per_tick")
+    @classmethod
+    def _positive(cls, v: int) -> int:
+        if v < 1:
+            raise ConfigError("inbox.max_items_per_tick must be >= 1")
         return v
 
 
@@ -689,6 +729,7 @@ class AppConfig(BaseModel):
     feedback: FeedbackConfig = Field(default_factory=FeedbackConfig)
     repair: RepairConfig = Field(default_factory=RepairConfig)
     telemetry: TelemetryConfig = Field(default_factory=TelemetryConfig)
+    inbox: InboxConfig = Field(default_factory=InboxConfig)
 
 
 # ══════════════════════════════════════════════════════════════════════

--- a/src/influx/coordinator.py
+++ b/src/influx/coordinator.py
@@ -20,6 +20,7 @@ class RunKind(Enum):
     SCHEDULED = "scheduled"
     MANUAL = "manual"
     BACKFILL = "backfill"
+    INBOX = "inbox"
 
 
 class ProfileBusyError(Exception):

--- a/src/influx/feedback.py
+++ b/src/influx/feedback.py
@@ -11,6 +11,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from influx.config import AppConfig
     from influx.lithos_client import LithosClient
 
 logger = logging.getLogger(__name__)
@@ -98,3 +99,35 @@ async def build_negative_examples_block(
         limit=limit,
     )
     return format_negative_examples(titles, max_title_chars=max_title_chars)
+
+
+async def build_filter_prompt(
+    config: AppConfig,
+    client: LithosClient,
+    *,
+    profile: str,
+) -> str:
+    """Render the per-profile filter prompt (profile description +
+    negative-feedback examples + ``min_score_in_results``).
+
+    Shared by the Run's Stage-2 Feedback (``influx.run._run_feedback_stage``)
+    and the inbox tick (``influx.inbox``) so both filter against the same
+    prompt shape, including negative-feedback examples.  Falls back to the
+    raw template when the ``.format`` placeholders are absent.
+    """
+    profile_cfg = next((p for p in config.profiles if p.name == profile), None)
+    neg_block = await build_negative_examples_block(
+        client,
+        profile=profile,
+        limit=config.feedback.negative_examples_per_profile,
+        max_title_chars=config.filter.negative_example_max_title_chars,
+    )
+    prompt_text = config.prompts.filter.text or ""
+    try:
+        return prompt_text.format(
+            profile_description=(profile_cfg.description if profile_cfg else profile),
+            negative_examples=neg_block,
+            min_score_in_results=config.filter.min_score_in_results,
+        )
+    except (KeyError, IndexError):
+        return prompt_text

--- a/src/influx/inbox.py
+++ b/src/influx/inbox.py
@@ -15,8 +15,10 @@ ingestion pipeline.  See §5.3 of the plan.
 
 **Slice 1 scope.** This is the thin end-to-end happy path: one URL is
 scored against the *first* enabled profile only, and dispatched if it
-clears threshold.  Multi-profile fan-out (§5/§8), cache-hit replay (§6),
-and coordinator try-acquire-skip (§10) arrive in later slices.
+clears threshold.  The dispatch already holds the per-Profile coordinator
+lock (so inbox never overlaps a scheduled Run for the same profile);
+multi-profile fan-out (§5/§8), cache-hit replay (§6), and the richer §10
+try-acquire-skip reporting arrive in later slices.
 """
 
 from __future__ import annotations
@@ -33,7 +35,7 @@ from urllib.parse import urlparse
 
 from influx import metrics
 from influx.config import AppConfig, InboxConfig
-from influx.coordinator import Coordinator, RunKind
+from influx.coordinator import Coordinator, ProfileBusyError, RunKind
 from influx.errors import LCMAError, LithosError
 from influx.feedback import build_filter_prompt
 from influx.filter import Filter, make_default_batch_scorer
@@ -205,9 +207,9 @@ class InboxTick:
     """
 
     config: AppConfig
-    # Reserved for slice 3 (§10 try-acquire-skip): per-Profile dispatches
-    # will be wrapped in ``coordinator.hold(profile)``.  Held now so the
-    # service wiring + construction shape is stable across slices.
+    # Shared per-Profile lock authority — each dispatch is wrapped in
+    # ``coordinator.hold(profile)`` so inbox Runs never overlap scheduled /
+    # manual / backfill Runs for the same profile (FR-SCHED-2/3).
     coordinator: Coordinator
     probe_loop: Any | None = None
     ledger: RunLedger | None = None
@@ -406,18 +408,45 @@ class InboxTick:
 
         scored = scored_list[0]
         run_id = uuid.uuid4().hex
-        outcome = await dispatch_profile(
-            profile_cfg.name,
-            scored=scored,
-            acquired=acquired,
-            source_tag=source_tag,
-            submitted_by=submitted_by,
-            title_hint=title_hint,
-            config=self.config,
-            probe_loop=self.probe_loop,
-            ledger=self.ledger,
-            run_id=run_id,
-        )
+        # Hold the per-Profile coordinator lock so an inbox dispatch never
+        # overlaps a scheduled / manual / backfill Run for the same profile
+        # (the service-wide "at most one Run per profile" invariant,
+        # FR-SCHED-2/3).  On contention skip this profile this tick and
+        # report it — the richer §10 try-acquire-skip reporting + cache-hit
+        # replay land in a later slice.
+        try:
+            async with self.coordinator.hold(profile_cfg.name):
+                outcome = await dispatch_profile(
+                    profile_cfg.name,
+                    scored=scored,
+                    acquired=acquired,
+                    source_tag=source_tag,
+                    submitted_by=submitted_by,
+                    title_hint=title_hint,
+                    config=self.config,
+                    probe_loop=self.probe_loop,
+                    ledger=self.ledger,
+                    run_id=run_id,
+                )
+        except ProfileBusyError:
+            metrics.inbox_items_processed().add(1, {"outcome": "profile_busy_skipped"})
+            return _ItemOutcome(
+                outcome=(
+                    f"profile_busy: {profile_cfg.name} already running; "
+                    "resubmit to retry"
+                ),
+                cited_nodes=[],
+                inbox_result={
+                    "source_url": acquired.source_url,
+                    "per_profile": {
+                        profile_cfg.name: {
+                            "score": scored.score,
+                            "ingested": False,
+                            "reason": "profile_busy",
+                        }
+                    },
+                },
+            )
 
         ingested = outcome.ingested > 0
         # Only recover the note id when a write actually happened — a skipped

--- a/src/influx/inbox.py
+++ b/src/influx/inbox.py
@@ -1,0 +1,512 @@
+"""Inbox manual-submission orchestrator (``docs/plans/inbox.md``).
+
+The InboxTick is a scheduler-side orchestrator that sits *above* the Run
+layer.  It claims pending InboxTasks (Lithos tasks tagged
+``influx:inbox``), acquires each submitted URL once, scores it with the
+existing :class:`~influx.filter.Filter`, and dispatches a real
+single-Profile :class:`~influx.run_service.RunService` execution with
+``RunKind.INBOX`` for each clearing profile.  It is NOT a ``Run``: it
+never calls ``RunLedger.start`` for itself and produces no
+``ProfileRunResult``.
+
+The per-Profile dispatch reuses the unchanged Run pipeline by *injecting*
+a single-item :data:`~influx.run.ItemProvider` — there is no parallel
+ingestion pipeline.  See §5.3 of the plan.
+
+**Slice 1 scope.** This is the thin end-to-end happy path: one URL is
+scored against the *first* enabled profile only, and dispatched if it
+clears threshold.  Multi-profile fan-out (§5/§8), cache-hit replay (§6),
+and coordinator try-acquire-skip (§10) arrive in later slices.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
+
+from influx import metrics
+from influx.config import AppConfig, InboxConfig
+from influx.coordinator import Coordinator, RunKind
+from influx.errors import LCMAError, LithosError
+from influx.feedback import build_filter_prompt
+from influx.filter import Filter, make_default_batch_scorer
+from influx.lithos_client import LithosClient
+from influx.run import ItemProvider, RunOutcome, RunPlan
+from influx.run_service import RunService
+from influx.source import BoundScoredCandidate, Candidate, ScoredCandidate
+from influx.sources.inbox import (
+    InboxAcquisition,
+    acquire_inbox_bytes,
+    build_inbox_note_item,
+)
+
+if TYPE_CHECKING:
+    from influx.run_ledger import RunLedger
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_TAG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,31}$")
+# Submitter ids are free-text agent identifiers (e.g. ``daily-report:ai-news``,
+# ``manual:<user>``) so colons are allowed, but the value reaches a Lithos
+# note tag — strip anything outside a conservative charset to keep tags
+# single-token and free of control characters (§3.2 / §13.2).
+_SUBMITTER_STRIP_RE = re.compile(r"[^A-Za-z0-9:._-]+")
+_DEFAULT_SOURCE_TAG = "inbox"
+_CLAIM_ASPECT = "ingest"
+_ALLOWED_URL_SCHEMES = ("http", "https")
+
+
+def _valid_source_tag(tag: str) -> bool:
+    """Conservative slug check for a submitter-provided ``source_tag`` (§13.1)."""
+    return bool(_SOURCE_TAG_RE.match(tag))
+
+
+def _sanitise_submitter(value: str) -> str:
+    """Reduce a submitter id to a safe, single-token tag value (≤64 chars)."""
+    cleaned = _SUBMITTER_STRIP_RE.sub("-", value).strip("-")[:64]
+    return cleaned or "unknown"
+
+
+def _extract_note_id(body: dict[str, Any]) -> str | None:
+    """Pull a note id out of a ``lithos_cache_lookup`` body (mirrors #148)."""
+    if not body.get("hit"):
+        return None
+    for key in ("id", "note_id", "existing_id"):
+        value = body.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+# ── Seam: single-item provider + per-Profile dispatch ───────────────
+
+
+def make_inbox_item_provider(
+    *,
+    scored: ScoredCandidate,
+    acquired: InboxAcquisition,
+    source_tag: str,
+    submitted_by: str,
+    title_hint: str | None,
+    config: AppConfig,
+) -> ItemProvider:
+    """Build a single-item :data:`ItemProvider` for one (item, profile).
+
+    Yields exactly one already-scored :class:`BoundScoredCandidate` whose
+    ``acquire`` closure returns the prebuilt ``ProfileItem`` from the shared
+    acquisition — so the unchanged Run Acquire/Ingest stages run the
+    cache-lookup + write + merge + LCMA wiring without modification.  The
+    rendered ``filter_prompt`` is ignored: filtering already happened at
+    tick level.
+    """
+
+    async def _provider(
+        profile: str,
+        kind: RunKind,
+        date_window: dict[str, str | int] | None,
+        filter_prompt: str,
+    ) -> list[BoundScoredCandidate]:
+        async def _acquire() -> dict[str, Any] | None:
+            return build_inbox_note_item(
+                acquired=acquired,
+                profile_name=profile,
+                score=scored.score,
+                confidence=scored.confidence,
+                reason=scored.reason,
+                filter_tags=scored.filter_tags,
+                source_tag=source_tag,
+                submitted_by=submitted_by,
+                title_hint=title_hint,
+                config=config,
+            )
+
+        return [
+            BoundScoredCandidate(
+                scored=scored,
+                acquire=_acquire,
+                source_label="inbox",
+            )
+        ]
+
+    return _provider
+
+
+async def dispatch_profile(
+    profile: str,
+    *,
+    scored: ScoredCandidate,
+    acquired: InboxAcquisition,
+    source_tag: str,
+    submitted_by: str,
+    title_hint: str | None,
+    config: AppConfig,
+    probe_loop: Any | None,
+    ledger: RunLedger | None,
+    run_id: str,
+) -> RunOutcome:
+    """Dispatch one real single-Profile ``RunKind.INBOX`` Run for this item.
+
+    The first dispatch for a URL creates the canonical note; later profiles
+    (slice 2+) hit ``cache_lookup`` and merge via ``write_note``.
+    ``skip_repair=False``, ``skip_cache_hits=False``, ``notify=True`` per
+    §11.2.
+    """
+    provider = make_inbox_item_provider(
+        scored=scored,
+        acquired=acquired,
+        source_tag=source_tag,
+        submitted_by=submitted_by,
+        title_hint=title_hint,
+        config=config,
+    )
+    service = RunService(
+        config=config,
+        item_provider=provider,
+        probe_loop=probe_loop,
+        ledger=ledger,
+    )
+    plan = RunPlan(
+        profile=profile,
+        kind=RunKind.INBOX,
+        skip_repair=False,
+        skip_cache_hits=False,
+        notify=True,
+    )
+    return await service.execute(plan, run_id=run_id)
+
+
+# ── Orchestrator ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class _ItemOutcome:
+    """Internal per-item result used to build the task completion."""
+
+    outcome: str
+    cited_nodes: list[str]
+    inbox_result: dict[str, Any]
+
+
+@dataclass
+class InboxTick:
+    """One execution of the inbox-tick orchestrator.
+
+    Built once in the service layer with the shared coordinator, probe
+    loop, and run ledger; :meth:`execute` is invoked on the inbox poll
+    cadence.  ``client_factory`` allows tests to inject a fake
+    :class:`LithosClient`.
+    """
+
+    config: AppConfig
+    # Reserved for slice 3 (§10 try-acquire-skip): per-Profile dispatches
+    # will be wrapped in ``coordinator.hold(profile)``.  Held now so the
+    # service wiring + construction shape is stable across slices.
+    coordinator: Coordinator
+    probe_loop: Any | None = None
+    ledger: RunLedger | None = None
+    client_factory: Callable[[], LithosClient] | None = None
+
+    def _make_client(self) -> LithosClient:
+        if self.client_factory is not None:
+            return self.client_factory()
+        return LithosClient(
+            url=self.config.lithos.url,
+            transport=self.config.lithos.transport,
+        )
+
+    async def execute(self) -> None:
+        """List → claim → process pending InboxTasks for this tick.
+
+        Gated on the same ``lithos_circuit_open`` latch scheduled runs use
+        (§12): when Lithos is unhealthy the tick performs no list/claim/
+        dispatch.  Per-item failures are isolated — one bad item never
+        aborts the rest of the tick.
+        """
+        probe = self.probe_loop
+        circuit_open = getattr(probe, "lithos_circuit_open", None)
+        if circuit_open is not None and circuit_open():
+            logger.info("inbox tick skipped: lithos circuit open")
+            return
+
+        metrics.inbox_tick_started().add(1)
+        client = self._make_client()
+        try:
+            try:
+                body = await client.task_list_body(
+                    tags=[InboxConfig.TASK_TAG],
+                    status="open",
+                )
+            except (LithosError, LCMAError):
+                logger.warning("inbox task_list failed; skipping tick", exc_info=True)
+                return
+
+            tasks = list(body.get("tasks", []))[: self.config.inbox.max_items_per_tick]
+            metrics.inbox_tasks_listed().add(len(tasks))
+
+            for task in tasks:
+                try:
+                    await self._process_task(task, client)
+                except Exception:  # noqa: BLE001 — per-item failure isolation (§5.5)
+                    # A crash before _complete leaves the claim to expire and
+                    # the task ``open``; a later tick re-claims it.  Re-ingest
+                    # is safe because ``lithos_write`` dedupes on source_url.
+                    logger.exception(
+                        "inbox item processing crashed task_id=%s",
+                        task.get("id") if isinstance(task, dict) else "<?>",
+                    )
+        finally:
+            await client.close()
+
+    async def _process_task(self, task: dict[str, Any], client: LithosClient) -> None:
+        """Claim and process one InboxTask end-to-end."""
+        task_id = str(task.get("id") or "")
+        if not task_id:
+            return
+        agent = self.config.inbox.agent_id
+
+        # ── Claim ──────────────────────────────────────────────────
+        try:
+            claim = await client.task_claim_body(
+                task_id=task_id, agent=agent, aspect=_CLAIM_ASPECT
+            )
+        except (LithosError, LCMAError):
+            logger.warning("inbox claim failed task_id=%s", task_id, exc_info=True)
+            return
+        if not claim.get("success"):
+            # Already claimed by another influx instance — skip silently.
+            return
+        metrics.inbox_tasks_claimed().add(1)
+
+        # ── Parse + validate metadata ──────────────────────────────
+        metadata = task.get("metadata") or {}
+        kind = metadata.get("kind")
+        url = metadata.get("url")
+        submitted_by = _sanitise_submitter(
+            str(metadata.get("submitted_by") or "unknown")
+        )
+        title_hint = metadata.get("title")
+        summary_hint = metadata.get("summary")
+        source_tag = metadata.get("source_tag") or _DEFAULT_SOURCE_TAG
+
+        if kind != "url" or not isinstance(url, str) or not url:
+            await self._complete(
+                client,
+                task_id,
+                _ItemOutcome(
+                    outcome="error: invalid submission (kind must be 'url' with a url)",
+                    cited_nodes=[],
+                    inbox_result={"source_url": url, "error": "invalid_submission"},
+                ),
+            )
+            return
+        if urlparse(url).scheme not in _ALLOWED_URL_SCHEMES:
+            await self._complete(
+                client,
+                task_id,
+                _ItemOutcome(
+                    outcome="error: invalid_url_scheme (only http/https accepted)",
+                    cited_nodes=[],
+                    inbox_result={"source_url": url, "error": "invalid_url_scheme"},
+                ),
+            )
+            return
+        if not _valid_source_tag(source_tag):
+            await self._complete(
+                client,
+                task_id,
+                _ItemOutcome(
+                    outcome="error: invalid_source_tag",
+                    cited_nodes=[],
+                    inbox_result={"source_url": url, "error": "invalid_source_tag"},
+                ),
+            )
+            return
+
+        result = await self._ingest_item(
+            client=client,
+            url=url,
+            submitted_by=submitted_by,
+            title_hint=title_hint,
+            summary_hint=summary_hint,
+            source_tag=source_tag,
+        )
+        await self._complete(client, task_id, result)
+
+    async def _ingest_item(
+        self,
+        *,
+        client: LithosClient,
+        url: str,
+        submitted_by: str,
+        title_hint: str | None,
+        summary_hint: str | None,
+        source_tag: str,
+    ) -> _ItemOutcome:
+        """Acquire, score (first profile), dispatch, and report one item.
+
+        Slice 1 scores only the first enabled profile.  Returns the
+        per-item outcome used to complete the task.
+        """
+        started = time.monotonic()
+        profiles = self.config.profiles
+        if not profiles:
+            metrics.inbox_items_processed().add(1, {"outcome": "error"})
+            return _ItemOutcome(
+                outcome="error: no profiles configured",
+                cited_nodes=[],
+                inbox_result={"source_url": url, "error": "no_profiles"},
+            )
+
+        # Acquire once (blocking download/extract → thread).
+        acquired = await asyncio.to_thread(
+            acquire_inbox_bytes, url, config=self.config, summary_hint=summary_hint
+        )
+
+        profile_cfg = profiles[0]
+        scorer = make_default_batch_scorer(self.config)
+        filt = Filter(config=self.config, profile_cfg=profile_cfg, scorer=scorer)
+        filter_prompt = await build_filter_prompt(
+            self.config, client, profile=profile_cfg.name
+        )
+        candidate = Candidate(
+            item_id=f"inbox-{acquired.url_hash}",
+            title=title_hint or acquired.source_url,
+            abstract=acquired.summary,
+            source_url=acquired.source_url,
+        )
+        scored_list = await filt.score(
+            [candidate], filter_prompt=filter_prompt, source="inbox"
+        )
+
+        if not scored_list:
+            metrics.inbox_items_processed().add(1, {"outcome": "filtered_out"})
+            return _ItemOutcome(
+                outcome=(
+                    f"filtered out: below threshold "
+                    f"({profile_cfg.name} threshold {profile_cfg.thresholds.relevance})"
+                ),
+                cited_nodes=[],
+                inbox_result={
+                    "source_url": acquired.source_url,
+                    "per_profile": {
+                        profile_cfg.name: {
+                            "ingested": False,
+                            "reason": "below_threshold",
+                        }
+                    },
+                },
+            )
+
+        scored = scored_list[0]
+        run_id = uuid.uuid4().hex
+        outcome = await dispatch_profile(
+            profile_cfg.name,
+            scored=scored,
+            acquired=acquired,
+            source_tag=source_tag,
+            submitted_by=submitted_by,
+            title_hint=title_hint,
+            config=self.config,
+            probe_loop=self.probe_loop,
+            ledger=self.ledger,
+            run_id=run_id,
+        )
+
+        ingested = outcome.ingested > 0
+        # Only recover the note id when a write actually happened — a skipped
+        # or write-less run would otherwise attach a stale/missing lookup.
+        note_id = (
+            await self._recover_note_id(client, acquired.source_url)
+            if ingested
+            else None
+        )
+        cited = [note_id] if note_id else []
+        elapsed_ms = int((time.monotonic() - started) * 1000)
+
+        per_profile: dict[str, Any] = {
+            profile_cfg.name: {
+                "score": scored.score,
+                "ingested": ingested,
+                "note_id": note_id,
+                "run_id": run_id,
+            }
+        }
+        inbox_result = {
+            "source_url": acquired.source_url,
+            "archive_path": acquired.archive_path,
+            "per_profile": per_profile,
+            "processing_time_ms": elapsed_ms,
+        }
+
+        if ingested:
+            metrics.inbox_items_processed().add(1, {"outcome": "ingested"})
+            outcome_str = f"ingested into 1 profile(s): {profile_cfg.name}"
+        elif outcome.skipped:
+            metrics.inbox_items_processed().add(1, {"outcome": "error"})
+            outcome_str = (
+                f"skipped ({profile_cfg.name}): {outcome.skip_reason or 'unknown'}"
+            )
+        else:
+            metrics.inbox_items_processed().add(1, {"outcome": "error"})
+            detail = outcome.error or "no note written"
+            outcome_str = f"not ingested ({profile_cfg.name}): {detail}"
+
+        return _ItemOutcome(
+            outcome=outcome_str, cited_nodes=cited, inbox_result=inbox_result
+        )
+
+    async def _recover_note_id(
+        self, client: LithosClient, source_url: str
+    ) -> str | None:
+        """Recover the canonical note id for ``cited_nodes`` (§7.2).
+
+        ``RunOutcome`` does not surface the written note id, so re-resolve
+        it by exact source-URL cache lookup after the dispatch.  Best-effort
+        — a recovery miss simply leaves ``cited_nodes`` empty.
+        """
+        try:
+            body = await client.cache_lookup_by_url_body(source_url=source_url)
+        except (LithosError, LCMAError):
+            logger.debug("note-id recovery failed for %s", source_url, exc_info=True)
+            return None
+        return _extract_note_id(body)
+
+    async def _complete(
+        self, client: LithosClient, task_id: str, result: _ItemOutcome
+    ) -> None:
+        """Attach the structured ``inbox_result`` then complete the task.
+
+        ``task_update`` failures are non-fatal: the structured payload is a
+        convenience, the completion + outcome string is the contract.
+        """
+        agent = self.config.inbox.agent_id
+        try:
+            await client.task_update_body(
+                task_id=task_id,
+                agent=agent,
+                metadata={"inbox_result": result.inbox_result},
+            )
+        except (LithosError, LCMAError):
+            logger.warning(
+                "inbox task_update failed task_id=%s; completing anyway",
+                task_id,
+                exc_info=True,
+            )
+        try:
+            await client.task_complete_body(
+                task_id=task_id,
+                agent=agent,
+                outcome=result.outcome,
+                cited_nodes=result.cited_nodes or None,
+            )
+        except (LithosError, LCMAError):
+            logger.warning(
+                "inbox task_complete failed task_id=%s", task_id, exc_info=True
+            )

--- a/src/influx/inbox.py
+++ b/src/influx/inbox.py
@@ -339,6 +339,12 @@ class InboxTick:
             summary_hint=summary_hint,
             source_tag=source_tag,
         )
+        # ``None`` is the skip-this-tick signal (profile busy): leave the task
+        # un-completed so its claim lease expires and a later tick re-claims
+        # and retries it (§5.5 / §10 try-acquire-skip).  Completing here would
+        # permanently drop the submission on a transient lock collision.
+        if result is None:
+            return
         await self._complete(client, task_id, result)
 
     async def _ingest_item(
@@ -350,11 +356,13 @@ class InboxTick:
         title_hint: str | None,
         summary_hint: str | None,
         source_tag: str,
-    ) -> _ItemOutcome:
+    ) -> _ItemOutcome | None:
         """Acquire, score (first profile), dispatch, and report one item.
 
-        Slice 1 scores only the first enabled profile.  Returns the
-        per-item outcome used to complete the task.
+        Slice 1 scores only the first enabled profile.  Returns the per-item
+        outcome used to complete the task, or ``None`` to signal
+        skip-this-tick (profile busy) — the caller then leaves the task
+        un-completed so a later tick retries it.
         """
         started = time.monotonic()
         profiles = self.config.profiles
@@ -429,24 +437,16 @@ class InboxTick:
                     run_id=run_id,
                 )
         except ProfileBusyError:
+            # Skip this tick: leave the task un-completed so its claim lease
+            # expires and a later tick re-claims + retries (§5.5 / §10).  Do
+            # NOT terminally complete — that would drop the submission on a
+            # transient collision (no inbox-level auto-retry, §5.6).
             metrics.inbox_items_processed().add(1, {"outcome": "profile_busy_skipped"})
-            return _ItemOutcome(
-                outcome=(
-                    f"profile_busy: {profile_cfg.name} already running; "
-                    "resubmit to retry"
-                ),
-                cited_nodes=[],
-                inbox_result={
-                    "source_url": acquired.source_url,
-                    "per_profile": {
-                        profile_cfg.name: {
-                            "score": scored.score,
-                            "ingested": False,
-                            "reason": "profile_busy",
-                        }
-                    },
-                },
+            logger.info(
+                "inbox profile %s busy; leaving task to retry on a later tick",
+                profile_cfg.name,
             )
+            return None
 
         ingested = outcome.ingested > 0
         # Only recover the note id when a write actually happened — a skipped

--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -1675,11 +1675,19 @@ class LithosClient:
         task_id: str,
         agent: str,
         outcome: str | None = None,
+        cited_nodes: list[str] | None = None,
     ) -> mcp_types.CallToolResult:
-        """Call ``lithos_task_complete`` (FR-LCMA-5)."""
+        """Call ``lithos_task_complete`` (FR-LCMA-5).
+
+        ``cited_nodes`` (inbox, ``docs/plans/inbox.md`` §7.2) links the
+        task to the canonical note(s) the work produced.  Omitted from the
+        RPC when ``None`` so scheduled-run callers are unaffected.
+        """
         args: dict[str, Any] = {"task_id": task_id, "agent": agent}
         if outcome is not None:
             args["outcome"] = outcome
+        if cited_nodes is not None:
+            args["cited_nodes"] = cited_nodes
         return await self._call_lcma_tool("lithos_task_complete", args)
 
     async def task_complete_body(
@@ -1688,11 +1696,116 @@ class LithosClient:
         task_id: str,
         agent: str,
         outcome: str | None = None,
+        cited_nodes: list[str] | None = None,
     ) -> dict[str, Any]:
         """Run ``task_complete`` and decode the JSON body."""
         return self._result_json_dict(
-            await self.task_complete(task_id=task_id, agent=agent, outcome=outcome),
+            await self.task_complete(
+                task_id=task_id,
+                agent=agent,
+                outcome=outcome,
+                cited_nodes=cited_nodes,
+            ),
             operation="task_complete",
+        )
+
+    async def task_list(
+        self,
+        *,
+        tags: list[str] | None = None,
+        status: str | None = None,
+        agent: str | None = None,
+    ) -> mcp_types.CallToolResult:
+        """Call ``lithos_task_list`` (inbox intake, ``docs/plans/inbox.md`` §4.1).
+
+        ``limit`` is enforced by the inbox tick (max-items-per-tick) rather
+        than the server — ``lithos_task_list`` has no ``limit`` parameter.
+        """
+        args: dict[str, Any] = {}
+        if tags is not None:
+            args["tags"] = tags
+        if status is not None:
+            args["status"] = status
+        if agent is not None:
+            args["agent"] = agent
+        return await self._call_lcma_tool("lithos_task_list", args)
+
+    async def task_list_body(
+        self,
+        *,
+        tags: list[str] | None = None,
+        status: str | None = None,
+        agent: str | None = None,
+    ) -> dict[str, Any]:
+        """Run ``task_list`` and decode the JSON body (``{"tasks": [...]}``)."""
+        return self._result_json_dict(
+            await self.task_list(tags=tags, status=status, agent=agent),
+            operation="task_list",
+        )
+
+    async def task_claim(
+        self,
+        *,
+        task_id: str,
+        agent: str,
+        aspect: str,
+        ttl_minutes: int = 60,
+    ) -> mcp_types.CallToolResult:
+        """Call ``lithos_task_claim`` (inbox intake, ``docs/plans/inbox.md`` §4.1)."""
+        return await self._call_lcma_tool(
+            "lithos_task_claim",
+            {
+                "task_id": task_id,
+                "aspect": aspect,
+                "agent": agent,
+                "ttl_minutes": ttl_minutes,
+            },
+        )
+
+    async def task_claim_body(
+        self,
+        *,
+        task_id: str,
+        agent: str,
+        aspect: str,
+        ttl_minutes: int = 60,
+    ) -> dict[str, Any]:
+        """Run ``task_claim`` and decode the body (``{"success", "expires_at"}``)."""
+        return self._result_json_dict(
+            await self.task_claim(
+                task_id=task_id, agent=agent, aspect=aspect, ttl_minutes=ttl_minutes
+            ),
+            operation="task_claim",
+        )
+
+    async def task_update(
+        self,
+        *,
+        task_id: str,
+        agent: str,
+        metadata: dict[str, Any],
+    ) -> mcp_types.CallToolResult:
+        """Call ``lithos_task_update`` (inbox intake, ``docs/plans/inbox.md`` §7.3).
+
+        Attaches the structured ``inbox_result`` payload before completion.
+        ``metadata`` is applied as an additive per-key merge by the server.
+        """
+        return await self._call_lcma_tool(
+            "lithos_task_update",
+            {"task_id": task_id, "agent": agent, "metadata": metadata},
+        )
+
+    async def task_update_body(
+        self,
+        *,
+        task_id: str,
+        agent: str,
+        metadata: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Run ``task_update`` and decode the JSON body (``{"success", "message"}``)."""
+        return self._result_json_dict(
+            await self.task_update(task_id=task_id, agent=agent, metadata=metadata),
+            operation="task_update",
         )
 
     async def call_tool(

--- a/src/influx/metrics.py
+++ b/src/influx/metrics.py
@@ -55,6 +55,10 @@ __all__ = [
     "slug_collision_unresolved",
     "slug_collision_url_recovery",
     "empty_source_writes",
+    "inbox_tick_started",
+    "inbox_tasks_listed",
+    "inbox_tasks_claimed",
+    "inbox_items_processed",
     "source_acquisition_errors",
     "source_cooldown_skips",
     "summary_thin_drops",
@@ -70,6 +74,53 @@ def run_starts() -> Any:
     return get_meter().counter(
         "influx_run_starts_total",
         description="Number of influx runs started.",
+    )
+
+
+def inbox_tick_started() -> Any:
+    """Counter incremented once per inbox poll tick that runs.
+
+    No labels.  See ``docs/plans/inbox.md`` §13.5.
+    """
+    return get_meter().counter(
+        "influx_inbox_tick_started_total",
+        description="Number of inbox poll ticks started.",
+    )
+
+
+def inbox_tasks_listed() -> Any:
+    """Counter of InboxTasks returned by ``lithos_task_list`` per tick.
+
+    No labels.
+    """
+    return get_meter().counter(
+        "influx_inbox_tasks_listed_total",
+        description="InboxTasks returned by lithos_task_list across ticks.",
+    )
+
+
+def inbox_tasks_claimed() -> Any:
+    """Counter of InboxTasks successfully claimed for processing.
+
+    No labels.
+    """
+    return get_meter().counter(
+        "influx_inbox_tasks_claimed_total",
+        description="InboxTasks claimed by the inbox tick.",
+    )
+
+
+def inbox_items_processed() -> Any:
+    """Counter of inbox items processed, by terminal outcome.
+
+    Labels: ``outcome`` (``ingested`` | ``filtered_out`` | ``cache_hit`` |
+    ``profile_busy_skipped`` | ``error``).  Slice 1 emits ``ingested`` /
+    ``filtered_out`` / ``error``; ``cache_hit`` and ``profile_busy_skipped``
+    are reserved for the cache-hit-replay + coordinator-skip slices.
+    """
+    return get_meter().counter(
+        "influx_inbox_items_processed_total",
+        description="Inbox items processed, labelled by terminal outcome.",
     )
 
 

--- a/src/influx/run.py
+++ b/src/influx/run.py
@@ -41,7 +41,7 @@ from typing import Any, Literal
 from influx import metrics
 from influx.config import AppConfig
 from influx.coordinator import RunKind
-from influx.feedback import build_negative_examples_block
+from influx.feedback import build_filter_prompt
 from influx.lcma_wiring import CascadeOutput, LcmaWiringDeps
 from influx.lcma_wiring import wire as lcma_wire
 from influx.lithos_client import LithosClient
@@ -372,25 +372,7 @@ async def _run_feedback_stage(
     config: AppConfig,
 ) -> tuple[FeedbackResult, StageDiagnostics]:
     """Stage 2 — feedback ingestion + filter prompt rendering."""
-    profile_cfg = next((p for p in config.profiles if p.name == plan.profile), None)
-    neg_block = await build_negative_examples_block(
-        client,
-        profile=plan.profile,
-        limit=config.feedback.negative_examples_per_profile,
-        max_title_chars=config.filter.negative_example_max_title_chars,
-    )
-    prompt_text = config.prompts.filter.text or ""
-    try:
-        filter_prompt = prompt_text.format(
-            profile_description=(
-                profile_cfg.description if profile_cfg else plan.profile
-            ),
-            negative_examples=neg_block,
-            min_score_in_results=config.filter.min_score_in_results,
-        )
-    except (KeyError, IndexError):
-        filter_prompt = prompt_text
-
+    filter_prompt = await build_filter_prompt(config, client, profile=plan.profile)
     return FeedbackResult(filter_prompt=filter_prompt), StageDiagnostics()
 
 

--- a/src/influx/scheduler.py
+++ b/src/influx/scheduler.py
@@ -177,10 +177,15 @@ class InfluxScheduler:
         probe_loop: Any | None = None,
         fetch_cache: Any | None = None,
         item_provider_factory: ItemProviderFactory | None = None,
+        inbox_tick: Any | None = None,
     ) -> None:
         self._config = config
         self._coordinator = coordinator
         self._scheduler = AsyncIOScheduler()
+        # Optional inbox-tick orchestrator (``influx.inbox.InboxTick``).
+        # When wired and ``[inbox] enabled``, a second cron job fires it on
+        # the inbox poll cadence, independent of the per-Profile tick.
+        self._inbox_tick = inbox_tick
         # Optional shared set for tracking in-flight scheduler fires so
         # that the service layer can await them within
         # ``schedule.shutdown_grace_seconds`` during graceful shutdown
@@ -239,6 +244,19 @@ class InfluxScheduler:
                 coalesce=True,
                 misfire_grace_time=self._config.schedule.misfire_grace_seconds,
             )
+        if self._config.inbox.enabled and self._inbox_tick is not None:
+            inbox_trigger = CronTrigger.from_crontab(
+                self._config.inbox.poll_cron,
+                timezone=self._config.inbox.timezone,
+            )
+            self._scheduler.add_job(
+                self._inbox_dispatch,
+                trigger=inbox_trigger,
+                id="influx-inbox-tick",
+                max_instances=_TICK_MAX_INSTANCES,
+                coalesce=True,
+                misfire_grace_time=self._config.schedule.misfire_grace_seconds,
+            )
         self._scheduler.start()
 
     def pause(self) -> None:
@@ -289,6 +307,25 @@ class InfluxScheduler:
         task = asyncio.create_task(
             self._fire_tick(provider=tick_provider, cache=tick_cache),
             name="influx-tick-fanout",
+        )
+        if self._active_tasks is not None:
+            self._active_tasks.add(task)
+            task.add_done_callback(self._active_tasks.discard)
+        return task
+
+    async def _inbox_dispatch(self) -> asyncio.Task[None]:
+        """Cron entrypoint for the inbox tick — spawn + return immediately.
+
+        Mirrors :meth:`_cron_dispatch`: the orchestrator runs as a tracked
+        background task so APScheduler's instance slot is never the gate on
+        a slow tick, and graceful shutdown can await it within the
+        shutdown grace window.
+        """
+        if self._inbox_tick is None:  # pragma: no cover — job only registered when set
+            raise RuntimeError("inbox dispatch fired without an inbox_tick wired")
+        task = asyncio.create_task(
+            self._inbox_tick.execute(),
+            name="influx-inbox-tick",
         )
         if self._active_tasks is not None:
             self._active_tasks.add(task)

--- a/src/influx/service.py
+++ b/src/influx/service.py
@@ -28,6 +28,7 @@ from influx.coordinator import Coordinator, RunKind
 from influx.errors import ConfigError
 from influx.filter import make_default_arxiv_filter_scorer
 from influx.http_api import install_exception_handlers, router
+from influx.inbox import InboxTick
 from influx.lithos_client import LithosClient
 from influx.notifications import ProfileRunResult, dispatch_notifications
 from influx.probes import ProbeLoop
@@ -203,6 +204,20 @@ def create_app(
         )
         return provider, cache
 
+    run_ledger = RunLedger(Path(config.storage.state_dir))
+    run_ledger.abandon_active(reason="Influx process restarted")
+
+    # Inbox manual-submission orchestrator (docs/plans/inbox.md).  Wired
+    # unconditionally but only registered as a cron job when
+    # ``[inbox] enabled`` (see InfluxScheduler.start).  Shares the
+    # coordinator + probe loop + ledger with scheduled runs.
+    inbox_tick = InboxTick(
+        config=config,
+        coordinator=coordinator,
+        probe_loop=probe_loop,
+        ledger=run_ledger,
+    )
+
     scheduler = InfluxScheduler(
         config,
         coordinator,
@@ -211,10 +226,8 @@ def create_app(
         item_provider=item_provider,
         fetch_cache=fetch_cache,
         item_provider_factory=_scheduled_tick_provider_factory,
+        inbox_tick=inbox_tick,
     )
-
-    run_ledger = RunLedger(Path(config.storage.state_dir))
-    run_ledger.abandon_active(reason="Influx process restarted")
 
     app.state.config = config
     app.state.coordinator = coordinator

--- a/src/influx/sources/inbox.py
+++ b/src/influx/sources/inbox.py
@@ -1,0 +1,275 @@
+"""Inbox manual-submission acquisition + note builder (``docs/plans/inbox.md``).
+
+Mirrors :func:`influx.sources.rss.build_rss_note_item` for agent-submitted
+URLs.  Two differences from the RSS path:
+
+- **Fixed archive subtree.** Submitted items archive under
+  ``archive_root/inbox/YYYY/MM/<url_hash>.<ext>`` regardless of the
+  submitter's ``source_tag`` (§13.1) — archive layout is Influx-owned
+  operational state, not submitter-controlled.
+- **Acquire once, build per profile.** :func:`acquire_inbox_bytes`
+  downloads + extracts the URL a single time; :func:`build_inbox_note_item`
+  is then called once per scoring profile, reusing that acquisition so the
+  URL is fetched only once per inbox item (§5.2/§5.3).
+
+A public PDF URL works in v1: the path branches on a ``.pdf`` URL shape to
+archive with a ``.pdf`` extension and extract via :func:`extract_pdf`;
+everything else takes the HTML article-extraction path.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
+
+from influx.cascade import Acquired, Cascade, TextFlavour
+from influx.errors import ExtractionError, NetworkError
+from influx.extraction.article import extract_article
+from influx.extraction.pdf import extract_pdf
+from influx.renderer import render
+from influx.storage import download_archive
+from influx.thin_summary import is_thin_summary
+from influx.urls import normalise_url, url_hash
+
+if TYPE_CHECKING:
+    from influx.config import AppConfig
+
+_log = logging.getLogger(__name__)
+
+# Fixed archive subtree + default ``source:`` tag (§13.1).
+INBOX_SOURCE = "inbox"
+
+
+def _is_pdf_url(url: str) -> bool:
+    """Syntactic check — does the URL path point at a PDF?"""
+    try:
+        return urlparse(url).path.lower().endswith(".pdf")
+    except (TypeError, ValueError):
+        return False
+
+
+@dataclass(frozen=True, slots=True)
+class InboxAcquisition:
+    """One inbox URL acquired once: archive state + extracted body.
+
+    Reused across every per-profile :func:`build_inbox_note_item` call for
+    the same item so the URL is downloaded + extracted only once.
+    """
+
+    source_url: str
+    url_hash: str
+    archive_path: str | None
+    archive_missing: bool
+    extracted_text: str | None
+    summary: str
+    text_flavour: TextFlavour
+
+
+def acquire_inbox_bytes(
+    url: str,
+    *,
+    config: AppConfig,
+    summary_hint: str | None = None,
+) -> InboxAcquisition:
+    """Download + extract one inbox URL into the fixed inbox archive subtree.
+
+    Branches on a ``.pdf`` URL shape: PDF URLs archive with a ``.pdf``
+    extension and extract via :func:`extract_pdf` over the archived bytes;
+    all other URLs archive as ``.html`` and extract via
+    :func:`extract_article`.  On extraction failure the *summary_hint* (a
+    submitter-provided excerpt, if any) is the fallback body.
+    """
+    archive_root = Path(config.storage.archive_dir)
+    source_url = normalise_url(url)
+    hash_val = url_hash(url)
+    now = datetime.now(UTC)
+    is_pdf = _is_pdf_url(url)
+    ext = ".pdf" if is_pdf else ".html"
+    expected: Any = "pdf" if is_pdf else "html"
+
+    archive_result = download_archive(
+        url=url,
+        archive_root=archive_root,
+        source=INBOX_SOURCE,
+        item_id=hash_val,
+        published_year=now.year,
+        published_month=now.month,
+        ext=ext,
+        allow_private_ips=config.security.allow_private_ips,
+        max_download_bytes=config.storage.max_download_bytes,
+        timeout_seconds=config.storage.download_timeout_seconds,
+        expected_content_type=expected,
+    )
+    archive_path = archive_result.rel_posix_path
+    archive_missing = not archive_result.ok
+
+    extracted_text: str | None = None
+    summary = summary_hint or ""
+    flavour: TextFlavour = "summary-fallback"
+    try:
+        if is_pdf:
+            if archive_path is not None:
+                pdf_bytes = (archive_root / archive_path).read_bytes()
+                extracted_text = extract_pdf(pdf_bytes, source_url=source_url).text
+                summary = extracted_text
+                flavour = "pdf"
+        else:
+            extracted_text = extract_article(
+                url,
+                min_web_chars=config.extraction.min_web_chars,
+                strip_tags=config.extraction.strip_tags,
+                allow_private_ips=config.security.allow_private_ips,
+                max_download_bytes=config.storage.max_download_bytes,
+                timeout_seconds=config.storage.download_timeout_seconds,
+            ).text
+            summary = extracted_text
+            flavour = "html"
+    except (ExtractionError, NetworkError, OSError) as exc:
+        _log.debug("inbox extraction failed for %s, using summary hint: %s", url, exc)
+
+    return InboxAcquisition(
+        source_url=source_url,
+        url_hash=hash_val,
+        archive_path=archive_path,
+        archive_missing=archive_missing,
+        extracted_text=extracted_text,
+        summary=summary,
+        text_flavour=flavour,
+    )
+
+
+def build_inbox_note_item(
+    *,
+    acquired: InboxAcquisition,
+    profile_name: str,
+    score: int,
+    confidence: float,
+    reason: str,
+    filter_tags: tuple[str, ...],
+    source_tag: str,
+    submitted_by: str,
+    title_hint: str | None,
+    config: AppConfig,
+) -> dict[str, Any] | None:
+    """Build a complete ``ProfileItem`` for one (item, profile) ingestion.
+
+    Returns ``None`` when the thin-summary rule (#166) suppresses the item:
+    no body was extracted and the fallback summary is structurally thin, so
+    writing a summary-only note would add no value.  ``None`` is the tick's
+    signal to skip the dispatch for this profile.
+    """
+    from influx.config import ProfileThresholds
+
+    source_url = acquired.source_url
+    # extract_article does not recover an HTML <title>; title falls back
+    # to the submitter hint, then the URL (§3.2).
+    title = (title_hint or "").strip() or source_url
+    profile_cfg = next((p for p in config.profiles if p.name == profile_name), None)
+
+    # Thin-summary suppression (#166): only when no body was extracted.
+    if acquired.extracted_text is None:
+        thin, thin_rule = is_thin_summary(
+            summary=acquired.summary,
+            title=title,
+            min_chars=config.extraction.min_summary_chars,
+        )
+        if thin:
+            _log.info(
+                "inbox thin-summary drop url=%s profile=%s rule=%s",
+                source_url,
+                profile_name,
+                thin_rule,
+            )
+            return None
+
+    acquired_bundle = Acquired(
+        item_id=f"inbox-{acquired.url_hash}",
+        source_url=source_url,
+        title=title,
+        abstract=acquired.summary,
+        identity_tags=(),
+        archive_path=acquired.archive_path,
+        archive_missing=acquired.archive_missing,
+        extracted_text=acquired.extracted_text,
+        text_flavour=(
+            acquired.text_flavour
+            if acquired.extracted_text is not None
+            else "summary-fallback"
+        ),
+    )
+
+    cascade = Cascade(
+        config=config,
+        profile_name=profile_name,
+        profile_summary=profile_cfg.description if profile_cfg else "",
+        thresholds=profile_cfg.thresholds if profile_cfg else ProfileThresholds(),
+        tier2_extractor=None,
+    )
+    sections = cascade.enrich(acquired_bundle, score)
+
+    tags: list[str] = [
+        f"profile:{profile_name}",
+        f"source:{source_tag}",
+        f"submitter:{submitted_by}",
+        "ingested-by:influx",
+        f"schema:{config.influx.note_schema_version}",
+    ]
+    if acquired.archive_missing:
+        tags.append("influx:archive-missing")
+        if "influx:repair-needed" not in tags:
+            tags.append("influx:repair-needed")
+    if sections.full_text is not None:
+        tags.append("full-text")
+    if sections.tier3 is not None:
+        tags.append("influx:deep-extracted")
+    for flag in sections.repair_flags:
+        if flag not in tags:
+            tags.append(flag)
+    for flag in sections.terminal_flags:
+        if flag not in tags:
+            tags.append(flag)
+
+    now = datetime.now(UTC)
+    path = f"articles/{source_tag}/{now.year}/{now.month:02d}"
+
+    # Suppress fallback summary when Tier 1 was attempted but failed
+    # (AC-07-A / FR-ENR-6) — mirrors the RSS builder.
+    summary_for_note = (
+        "" if sections.tier1_attempted and sections.tier1 is None else acquired.summary
+    )
+
+    content = render(
+        title=title,
+        source_url=source_url,
+        tags=tags,
+        confidence=confidence,
+        archive_path=acquired.archive_path,
+        summary=summary_for_note,
+        profile_name=profile_name,
+        score=score,
+        reason=reason,
+        tier1_enrichment=sections.tier1,
+        full_text=sections.full_text,
+        tier3_extraction=sections.tier3,
+    )
+
+    return {
+        "id": f"inbox-{acquired.url_hash}",
+        "title": title,
+        "source": INBOX_SOURCE,
+        "source_url": source_url,
+        "content": content,
+        "tags": tags,
+        "filter_tags": list(filter_tags),
+        "score": score,
+        "confidence": confidence,
+        "reason": reason,
+        "path": path,
+        "abstract_or_summary": acquired.summary,
+        "contributions": sections.tier1.contributions if sections.tier1 else None,
+        "builds_on": list(sections.tier3.builds_on) if sections.tier3 else None,
+    }

--- a/tests/contract/test_lithos_client.py
+++ b/tests/contract/test_lithos_client.py
@@ -56,6 +56,9 @@ class FakeLithosServer:
         self.edge_upsert_responses: list[str] = []
         self.task_create_responses: list[str] = []
         self.task_complete_responses: list[str] = []
+        self.task_list_responses: list[str] = []
+        self.task_claim_responses: list[str] = []
+        self.task_update_responses: list[str] = []
         # When True, lithos_retrieve raises to simulate unknown_tool (FR-LCMA-6).
         self.raise_on_retrieve: bool = False
         self._register_tools()
@@ -72,6 +75,9 @@ class FakeLithosServer:
         edge_upsert_responses = self.edge_upsert_responses
         task_create_responses = self.task_create_responses
         task_complete_responses = self.task_complete_responses
+        task_list_responses = self.task_list_responses
+        task_claim_responses = self.task_claim_responses
+        task_update_responses = self.task_update_responses
         server_self = self  # capture for closures that need mutable flags
 
         @self._mcp.tool(name="lithos_ping")
@@ -268,16 +274,71 @@ class FakeLithosServer:
             task_id: str = "",
             agent: str = "",
             outcome: str | None = None,
+            cited_nodes: list[str] | None = None,
         ) -> str:
             calls.append(
                 (
                     "lithos_task_complete",
-                    {"task_id": task_id, "agent": agent, "outcome": outcome},
+                    {
+                        "task_id": task_id,
+                        "agent": agent,
+                        "outcome": outcome,
+                        "cited_nodes": cited_nodes,
+                    },
                 )
             )
             if task_complete_responses:
                 return task_complete_responses.pop(0)
             return _json.dumps({"status": "completed"})
+
+        @self._mcp.tool(name="lithos_task_list")
+        async def lithos_task_list(
+            agent: str | None = None,
+            status: str | None = None,
+            tags: list[str] | None = None,
+        ) -> str:
+            calls.append(
+                (
+                    "lithos_task_list",
+                    {"agent": agent, "status": status, "tags": tags or []},
+                )
+            )
+            if task_list_responses:
+                return task_list_responses.pop(0)
+            return _json.dumps({"tasks": []})
+
+        @self._mcp.tool(name="lithos_task_claim")
+        async def lithos_task_claim(
+            task_id: str = "",
+            aspect: str = "",
+            agent: str = "",
+            ttl_minutes: int = 60,
+        ) -> str:
+            calls.append(
+                (
+                    "lithos_task_claim",
+                    {"task_id": task_id, "aspect": aspect, "agent": agent},
+                )
+            )
+            if task_claim_responses:
+                return task_claim_responses.pop(0)
+            return _json.dumps({"success": True, "expires_at": "2099-01-01T00:00:00Z"})
+
+        @self._mcp.tool(name="lithos_task_update")
+        async def lithos_task_update(
+            task_id: str = "",
+            agent: str = "",
+            metadata: dict[str, Any] | None = None,
+        ) -> str:
+            calls.append(
+                (
+                    "lithos_task_update",
+                    {"task_id": task_id, "agent": agent, "metadata": metadata or {}},
+                )
+            )
+            if task_update_responses:
+                return task_update_responses.pop(0)
+            return _json.dumps({"success": True, "message": "updated"})
 
     def start(self) -> None:
         app = self._mcp.sse_app()

--- a/tests/integration/test_inbox_dispatch.py
+++ b/tests/integration/test_inbox_dispatch.py
@@ -1,0 +1,160 @@
+"""Integration test for the inbox per-Profile dispatch seam (Inbox v1 slice 1).
+
+Drives :func:`influx.inbox.dispatch_profile` end-to-end through a real
+:class:`~influx.run_service.RunService` and :class:`~influx.run_ledger.RunLedger`
+against the in-process :class:`FakeLithosServer`.  Proves the §5.3 seam: a
+pre-acquired, pre-scored inbox item flows through the unchanged Run pipeline
+and lands as a ``RunKind.INBOX`` ledger entry with a real ``lithos_write``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from influx.config import (
+    AppConfig,
+    ExtractionConfig,
+    FeedbackConfig,
+    LithosConfig,
+    NotificationsConfig,
+    ProfileConfig,
+    ProfileThresholds,
+    PromptEntryConfig,
+    PromptsConfig,
+    ScheduleConfig,
+    SecurityConfig,
+)
+from influx.inbox import dispatch_profile
+from influx.run_ledger import RunLedger
+from influx.source import Candidate, ScoredCandidate
+from influx.sources.inbox import InboxAcquisition
+from tests.contract.test_lithos_client import FakeLithosServer
+
+_URL = "https://example.com/article"
+
+
+def _make_config(lithos_url: str) -> AppConfig:
+    return AppConfig(
+        lithos=LithosConfig(url=lithos_url),
+        schedule=ScheduleConfig(cron="0 6 * * *", timezone="UTC"),
+        profiles=[
+            ProfileConfig(
+                name="alpha",
+                description="Alpha profile",
+                thresholds=ProfileThresholds(
+                    relevance=7, full_text=100, deep_extract=100
+                ),
+            ),
+        ],
+        providers={},
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="x"),
+            tier1_enrich=PromptEntryConfig(text="x"),
+            tier3_extract=PromptEntryConfig(text="x"),
+        ),
+        notifications=NotificationsConfig(webhook_url="", timeout_seconds=5),
+        security=SecurityConfig(allow_private_ips=True),
+        extraction=ExtractionConfig(),
+        feedback=FeedbackConfig(),
+    )
+
+
+@pytest.fixture(scope="module")
+def fake_lithos() -> Generator[FakeLithosServer, None, None]:
+    server = FakeLithosServer()
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.fixture(scope="module")
+def fake_lithos_url(fake_lithos: FakeLithosServer) -> str:
+    return f"http://127.0.0.1:{fake_lithos.port}/sse"
+
+
+@pytest.fixture(autouse=True)
+def _clear(fake_lithos: FakeLithosServer) -> None:
+    fake_lithos.calls.clear()
+    fake_lithos.write_responses.clear()
+    fake_lithos.cache_lookup_responses.clear()
+    fake_lithos.list_responses.clear()
+    fake_lithos.task_create_responses.clear()
+    fake_lithos.task_complete_responses.clear()
+
+
+def _scored() -> ScoredCandidate:
+    return ScoredCandidate(
+        candidate=Candidate(
+            item_id="inbox-abc1234567",
+            title="A Submitted Article",
+            abstract="body text here",
+            source_url=_URL,
+        ),
+        score=8,
+        confidence=0.9,
+        reason="relevant to alpha",
+        filter_tags=("ml",),
+    )
+
+
+def _acquired() -> InboxAcquisition:
+    return InboxAcquisition(
+        source_url=_URL,
+        url_hash="abc1234567",
+        archive_path="inbox/2026/06/abc1234567.html",
+        archive_missing=False,
+        extracted_text="A reasonably long article body that survives any thin checks.",
+        summary="A reasonably long article body that survives any thin checks.",
+        text_flavour="html",
+    )
+
+
+def _calls(fake: FakeLithosServer, tool: str) -> list[dict]:
+    return [args for name, args in fake.calls if name == tool]
+
+
+def test_dispatch_writes_note_and_records_inbox_ledger_entry(
+    fake_lithos: FakeLithosServer,
+    fake_lithos_url: str,
+    tmp_path: Path,
+) -> None:
+    config = _make_config(fake_lithos_url)
+    ledger = RunLedger(tmp_path)
+
+    outcome = asyncio.run(
+        dispatch_profile(
+            "alpha",
+            scored=_scored(),
+            acquired=_acquired(),
+            source_tag="inbox",
+            submitted_by="agent:test",
+            title_hint="A Submitted Article",
+            config=config,
+            probe_loop=None,
+            ledger=ledger,
+            run_id="run-inbox-1",
+        )
+    )
+
+    # One note written through the unchanged ingest pipeline.
+    assert outcome.ingested == 1
+    write_calls = _calls(fake_lithos, "lithos_write")
+    assert len(write_calls) == 1
+    tags = write_calls[0]["tags"]
+    assert "profile:alpha" in tags
+    assert "source:inbox" in tags
+    assert "submitter:agent:test" in tags
+    assert write_calls[0]["source_url"] == _URL
+
+    # Recorded as a real single-Profile RunKind.INBOX ledger entry.
+    recent = ledger.recent(limit=5)
+    assert len(recent) == 1
+    entry = recent[0]
+    assert entry["kind"] == "inbox"
+    assert entry["profile"] == "alpha"
+    assert entry["sources_checked"] == 1
+    assert entry["ingested"] == 1

--- a/tests/integration/test_otel_metrics.py
+++ b/tests/integration/test_otel_metrics.py
@@ -225,7 +225,7 @@ async def _run_arxiv_scenario(meter: InfluxMeter, config: Any) -> None:
         ),
         patch("influx.run.LithosClient", return_value=mock_client),
         patch(
-            "influx.run.build_negative_examples_block",
+            "influx.feedback.build_negative_examples_block",
             new_callable=AsyncMock,
             return_value="",
         ),
@@ -413,7 +413,7 @@ class TestOtelDisabledZeroMetrics:
             ),
             patch("influx.run.LithosClient", return_value=mock_client),
             patch(
-                "influx.run.build_negative_examples_block",
+                "influx.feedback.build_negative_examples_block",
                 new_callable=AsyncMock,
                 return_value="",
             ),

--- a/tests/integration/test_otel_spans.py
+++ b/tests/integration/test_otel_spans.py
@@ -249,7 +249,7 @@ async def _run_arxiv_scenario(
         # Scheduler + Run infrastructure (#58 dispatch)
         patch("influx.run.LithosClient", return_value=mock_client),
         patch(
-            "influx.run.build_negative_examples_block",
+            "influx.feedback.build_negative_examples_block",
             new_callable=AsyncMock,
             return_value="",
         ),
@@ -485,7 +485,7 @@ class TestOtelDisabledZeroSpans:
             # Scheduler + Run infrastructure (#58 dispatch)
             patch("influx.run.LithosClient", return_value=mock_client),
             patch(
-                "influx.run.build_negative_examples_block",
+                "influx.feedback.build_negative_examples_block",
                 new_callable=AsyncMock,
                 return_value="",
             ),

--- a/tests/unit/test_inbox_builder.py
+++ b/tests/unit/test_inbox_builder.py
@@ -1,0 +1,252 @@
+"""Unit tests for the inbox acquisition + note builder (Inbox v1 slice 1).
+
+Covers :func:`influx.sources.inbox.acquire_inbox_bytes` (fixed archive
+subtree, content-type branch) and
+:func:`influx.sources.inbox.build_inbox_note_item` (title fallback,
+ProfileItem key set, tags, thin-summary suppression).  ``download_archive``
+and ``extract_article`` / ``extract_pdf`` are patched — no network IO.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import patch
+
+from influx.config import (
+    AppConfig,
+    ExtractionConfig,
+    LithosConfig,
+    ProfileConfig,
+    ProfileThresholds,
+    PromptEntryConfig,
+    PromptsConfig,
+    SecurityConfig,
+    StorageConfig,
+)
+from influx.errors import NetworkError
+from influx.sources.inbox import (
+    INBOX_SOURCE,
+    acquire_inbox_bytes,
+    build_inbox_note_item,
+)
+from influx.storage import ArchiveResult
+from influx.urls import url_hash
+
+_URL = "https://example.com/article"
+_LONG_BODY = (
+    "This is a substantial article body discussing the subject in enough "
+    "detail that no structural thin-summary rule should trip on it under "
+    "default configuration thresholds."
+)
+
+
+def _make_config(*, min_summary_chars: int = 80) -> AppConfig:
+    return AppConfig(
+        lithos=LithosConfig(url="http://localhost:0/sse"),
+        storage=StorageConfig(archive_dir="/archive"),
+        profiles=[
+            ProfileConfig(
+                name="ai-robotics",
+                description="AI and robotics research",
+                thresholds=ProfileThresholds(
+                    relevance=7, full_text=100, deep_extract=100
+                ),
+            )
+        ],
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="x"),
+            tier1_enrich=PromptEntryConfig(text="x"),
+            tier3_extract=PromptEntryConfig(text="x"),
+        ),
+        security=SecurityConfig(allow_private_ips=True),
+        extraction=ExtractionConfig(min_summary_chars=min_summary_chars),
+    )
+
+
+def _ok_html_archive(url: str = _URL) -> ArchiveResult:
+    return ArchiveResult(
+        ok=True,
+        rel_posix_path=f"inbox/2026/06/{url_hash(url)}.html",
+        error="",
+    )
+
+
+def _failed_archive() -> ArchiveResult:
+    return ArchiveResult(
+        ok=False,
+        rel_posix_path=None,
+        error="HTTP 404",
+        failure_kind=cast("str", "http_404"),
+    )
+
+
+class _Extraction:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+# ── acquire_inbox_bytes ─────────────────────────────────────────────
+
+
+def test_acquire_archives_into_fixed_inbox_subtree() -> None:
+    """HTML URLs archive under inbox/YYYY/MM/<url_hash>.html (§13.1)."""
+    config = _make_config()
+    with (
+        patch(
+            "influx.sources.inbox.download_archive", return_value=_ok_html_archive()
+        ) as mock_dl,
+        patch(
+            "influx.sources.inbox.extract_article",
+            return_value=_Extraction(_LONG_BODY),
+        ),
+    ):
+        acquired = acquire_inbox_bytes(_URL, config=config)
+
+    kwargs = mock_dl.call_args.kwargs
+    assert kwargs["source"] == INBOX_SOURCE
+    assert kwargs["item_id"] == url_hash(_URL)
+    assert kwargs["ext"] == ".html"
+    assert kwargs["expected_content_type"] == "html"
+    assert acquired.archive_path == f"inbox/2026/06/{url_hash(_URL)}.html"
+    assert acquired.extracted_text == _LONG_BODY
+    assert acquired.text_flavour == "html"
+
+
+def test_acquire_pdf_url_uses_pdf_branch() -> None:
+    """A .pdf URL archives with a .pdf ext and extracts via extract_pdf."""
+    config = _make_config()
+    pdf_url = "https://arxiv.org/pdf/2401.12345.pdf"
+    ok_pdf = ArchiveResult(
+        ok=True, rel_posix_path=f"inbox/2026/06/{url_hash(pdf_url)}.pdf", error=""
+    )
+    with (
+        patch("influx.sources.inbox.download_archive", return_value=ok_pdf) as mock_dl,
+        patch("pathlib.Path.read_bytes", return_value=b"%PDF-1.4 ..."),
+        patch(
+            "influx.sources.inbox.extract_pdf", return_value=_Extraction(_LONG_BODY)
+        ) as mock_pdf,
+    ):
+        acquired = acquire_inbox_bytes(pdf_url, config=config)
+
+    assert mock_dl.call_args.kwargs["ext"] == ".pdf"
+    assert mock_dl.call_args.kwargs["expected_content_type"] == "pdf"
+    mock_pdf.assert_called_once()
+    assert acquired.text_flavour == "pdf"
+    assert acquired.extracted_text == _LONG_BODY
+
+
+def test_acquire_falls_back_to_summary_hint_on_extraction_failure() -> None:
+    config = _make_config()
+    with (
+        patch("influx.sources.inbox.download_archive", return_value=_failed_archive()),
+        patch(
+            "influx.sources.inbox.extract_article",
+            side_effect=NetworkError("boom", url=_URL, kind="timeout"),
+        ),
+    ):
+        acquired = acquire_inbox_bytes(_URL, config=config, summary_hint="a hint")
+
+    assert acquired.extracted_text is None
+    assert acquired.summary == "a hint"
+    assert acquired.archive_missing is True
+
+
+# ── build_inbox_note_item ───────────────────────────────────────────
+
+
+def _acquire_ok(config: AppConfig) -> object:
+    with (
+        patch("influx.sources.inbox.download_archive", return_value=_ok_html_archive()),
+        patch(
+            "influx.sources.inbox.extract_article",
+            return_value=_Extraction(_LONG_BODY),
+        ),
+    ):
+        return acquire_inbox_bytes(_URL, config=config)
+
+
+def test_build_item_has_full_profile_item_key_set() -> None:
+    config = _make_config()
+    acquired = _acquire_ok(config)
+    item = build_inbox_note_item(
+        acquired=acquired,  # type: ignore[arg-type]
+        profile_name="ai-robotics",
+        score=8,
+        confidence=0.9,
+        reason="relevant",
+        filter_tags=("ml",),
+        source_tag="inbox",
+        submitted_by="daily-report:ai-news",
+        title_hint="Some Title",
+        config=config,
+    )
+    assert item is not None
+    expected_keys = {
+        "id",
+        "title",
+        "source",
+        "source_url",
+        "content",
+        "tags",
+        "filter_tags",
+        "score",
+        "confidence",
+        "reason",
+        "path",
+        "abstract_or_summary",
+        "contributions",
+        "builds_on",
+    }
+    assert expected_keys <= set(item)
+    assert item["source"] == "inbox"
+    assert item["source_url"] == _URL
+    assert item["title"] == "Some Title"
+    assert "profile:ai-robotics" in item["tags"]
+    assert "source:inbox" in item["tags"]
+    assert "submitter:daily-report:ai-news" in item["tags"]
+
+
+def test_build_item_title_falls_back_to_url() -> None:
+    config = _make_config()
+    acquired = _acquire_ok(config)
+    item = build_inbox_note_item(
+        acquired=acquired,  # type: ignore[arg-type]
+        profile_name="ai-robotics",
+        score=8,
+        confidence=0.9,
+        reason="relevant",
+        filter_tags=(),
+        source_tag="inbox",
+        submitted_by="x",
+        title_hint=None,
+        config=config,
+    )
+    assert item is not None
+    assert item["title"] == _URL
+
+
+def test_build_item_thin_summary_suppressed() -> None:
+    """No body extracted + thin fallback summary → None (suppressed)."""
+    config = _make_config()
+    with (
+        patch("influx.sources.inbox.download_archive", return_value=_failed_archive()),
+        patch(
+            "influx.sources.inbox.extract_article",
+            side_effect=NetworkError("boom", url=_URL, kind="timeout"),
+        ),
+    ):
+        acquired = acquire_inbox_bytes(_URL, config=config, summary_hint="tiny")
+
+    item = build_inbox_note_item(
+        acquired=acquired,
+        profile_name="ai-robotics",
+        score=8,
+        confidence=0.9,
+        reason="relevant",
+        filter_tags=(),
+        source_tag="inbox",
+        submitted_by="x",
+        title_hint="Title",
+        config=config,
+    )
+    assert item is None

--- a/tests/unit/test_inbox_config.py
+++ b/tests/unit/test_inbox_config.py
@@ -1,0 +1,51 @@
+"""Unit tests for ``[inbox]`` config (Inbox v1 slice 1).
+
+Covers the ``InboxConfig`` schema: default-disabled, the fixed task-tag
+constant, cron validation, and the positive ``max_items_per_tick`` guard.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from influx.config import AppConfig, InboxConfig, PromptEntryConfig, PromptsConfig
+from influx.errors import ConfigError
+
+
+def _prompts() -> PromptsConfig:
+    return PromptsConfig(
+        filter=PromptEntryConfig(text="x"),
+        tier1_enrich=PromptEntryConfig(text="x"),
+        tier3_extract=PromptEntryConfig(text="x"),
+    )
+
+
+def test_inbox_defaults_disabled() -> None:
+    """The inbox is opt-in: an AppConfig without ``[inbox]`` is disabled."""
+    config = AppConfig(prompts=_prompts())
+    assert config.inbox.enabled is False
+    assert config.inbox.poll_cron == "*/5 * * * *"
+    assert config.inbox.max_items_per_tick == 20
+    assert config.inbox.agent_id == "influx-inbox"
+
+
+def test_task_tag_is_fixed_constant() -> None:
+    """The task tag is a protocol constant, not an operator-tunable field."""
+    assert InboxConfig.TASK_TAG == "influx:inbox"
+    # It is a ClassVar, so it is not part of the model's fields.
+    assert "TASK_TAG" not in InboxConfig.model_fields
+
+
+def test_poll_cron_validates_as_cron() -> None:
+    """A malformed cron expression is rejected at config-build time."""
+    with pytest.raises(ConfigError, match="poll_cron is not a valid cron"):
+        InboxConfig(poll_cron="not a cron")
+
+
+def test_poll_cron_accepts_valid_cron() -> None:
+    InboxConfig(poll_cron="*/10 * * * *")  # no raise
+
+
+def test_max_items_per_tick_must_be_positive() -> None:
+    with pytest.raises(ConfigError, match="max_items_per_tick must be >= 1"):
+        InboxConfig(max_items_per_tick=0)

--- a/tests/unit/test_inbox_scheduler.py
+++ b/tests/unit/test_inbox_scheduler.py
@@ -1,0 +1,79 @@
+"""Inbox-tick scheduler registration tests (Inbox v1 slice 1).
+
+The ``influx-inbox-tick`` cron job is registered only when ``[inbox]``
+is enabled AND an ``inbox_tick`` orchestrator is wired — independent of
+the per-Profile ``influx-tick`` job.
+"""
+
+from __future__ import annotations
+
+from influx.config import (
+    AppConfig,
+    InboxConfig,
+    ProfileConfig,
+    PromptEntryConfig,
+    PromptsConfig,
+    ScheduleConfig,
+)
+from influx.coordinator import Coordinator
+from influx.scheduler import InfluxScheduler
+
+
+def _config(*, inbox: InboxConfig | None = None) -> AppConfig:
+    return AppConfig(
+        schedule=ScheduleConfig(),
+        profiles=[ProfileConfig(name="alpha")],
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="x"),
+            tier1_enrich=PromptEntryConfig(text="x"),
+            tier3_extract=PromptEntryConfig(text="x"),
+        ),
+        inbox=inbox or InboxConfig(),
+    )
+
+
+class _StubInboxTick:
+    async def execute(self) -> None:  # pragma: no cover — never fired in unit test
+        return None
+
+
+async def test_no_inbox_job_when_disabled() -> None:
+    sched = InfluxScheduler(
+        _config(inbox=InboxConfig(enabled=False)),
+        Coordinator(),
+        inbox_tick=_StubInboxTick(),
+    )
+    sched.start()
+    try:
+        job_ids = {j.id for j in sched.jobs}
+        assert "influx-inbox-tick" not in job_ids
+        assert "influx-tick" in job_ids
+    finally:
+        sched.stop()
+
+
+async def test_inbox_job_registered_when_enabled() -> None:
+    sched = InfluxScheduler(
+        _config(inbox=InboxConfig(enabled=True, poll_cron="*/5 * * * *")),
+        Coordinator(),
+        inbox_tick=_StubInboxTick(),
+    )
+    sched.start()
+    try:
+        job_ids = {j.id for j in sched.jobs}
+        assert "influx-inbox-tick" in job_ids
+    finally:
+        sched.stop()
+
+
+async def test_no_inbox_job_when_enabled_but_no_tick_wired() -> None:
+    """Enabled config without an orchestrator wired registers no inbox job."""
+    sched = InfluxScheduler(
+        _config(inbox=InboxConfig(enabled=True)),
+        Coordinator(),
+    )
+    sched.start()
+    try:
+        assert "influx-inbox-tick" not in {j.id for j in sched.jobs}
+    finally:
+        sched.stop()

--- a/tests/unit/test_inbox_tick.py
+++ b/tests/unit/test_inbox_tick.py
@@ -295,8 +295,9 @@ async def test_circuit_open_skips_whole_tick() -> None:
     assert client.completed == []
 
 
-async def test_busy_profile_is_skipped_not_overlapped() -> None:
-    """When the profile lock is held, the dispatch is skipped (no overlap)."""
+async def test_busy_profile_skipped_this_tick_not_completed() -> None:
+    """A busy profile is skipped (no overlap) AND the task is left un-completed
+    so a later tick retries it — not terminally dropped (§5.5 / §10)."""
     client = FakeClient(tasks=[_task()])
     coordinator = Coordinator()
     tick = InboxTick(
@@ -319,10 +320,11 @@ async def test_busy_profile_is_skipped_not_overlapped() -> None:
         ):
             await tick.execute()
 
-    # The Run is never dispatched while the profile is busy.
+    # The Run is never dispatched while the profile is busy …
     mock_dispatch.assert_not_called()
-    assert "profile_busy" in client.completed[0]["outcome"]
-    assert client.completed[0]["cited_nodes"] is None
+    # … the task was claimed but NOT completed (claim lease expires → retry).
+    assert client.claimed == ["task-1"]
+    assert client.completed == []
 
 
 async def test_per_item_failure_isolation() -> None:

--- a/tests/unit/test_inbox_tick.py
+++ b/tests/unit/test_inbox_tick.py
@@ -295,6 +295,36 @@ async def test_circuit_open_skips_whole_tick() -> None:
     assert client.completed == []
 
 
+async def test_busy_profile_is_skipped_not_overlapped() -> None:
+    """When the profile lock is held, the dispatch is skipped (no overlap)."""
+    client = FakeClient(tasks=[_task()])
+    coordinator = Coordinator()
+    tick = InboxTick(
+        config=_make_config(),
+        coordinator=coordinator,
+        probe_loop=None,
+        ledger=None,
+        client_factory=lambda: client,  # type: ignore[arg-type]
+    )
+    # Hold the lock for the whole tick so dispatch hits ProfileBusyError.
+    async with coordinator.hold("alpha"):
+        with (
+            patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+            patch(
+                "influx.inbox.make_default_batch_scorer",
+                return_value=_scorer_returning(8),
+            ),
+            patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+            patch("influx.inbox.dispatch_profile") as mock_dispatch,
+        ):
+            await tick.execute()
+
+    # The Run is never dispatched while the profile is busy.
+    mock_dispatch.assert_not_called()
+    assert "profile_busy" in client.completed[0]["outcome"]
+    assert client.completed[0]["cited_nodes"] is None
+
+
 async def test_per_item_failure_isolation() -> None:
     """A crashing item does not prevent sibling items from completing."""
     client = FakeClient(

--- a/tests/unit/test_inbox_tick.py
+++ b/tests/unit/test_inbox_tick.py
@@ -1,0 +1,332 @@
+"""Unit tests for the InboxTick orchestrator (Inbox v1 slice 1).
+
+Exercises the novel orchestration logic with a lightweight fake
+``LithosClient`` and patched seams (``acquire_inbox_bytes``, the filter
+scorer, ``build_filter_prompt``, ``dispatch_profile``):
+
+- happy path: list → claim → score → dispatch → update + complete with
+  ``cited_nodes`` and a structured ``inbox_result``;
+- filtered-out: no dispatch, terminal "filtered out" completion;
+- invalid submission / invalid source_tag: terminal error completion;
+- already-claimed task: skipped silently;
+- lithos circuit open: whole tick skipped, no list/claim;
+- per-item failure isolation: a crashing item does not sink siblings.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from influx.config import (
+    AppConfig,
+    LithosConfig,
+    ProfileConfig,
+    ProfileThresholds,
+    PromptEntryConfig,
+    PromptsConfig,
+)
+from influx.coordinator import Coordinator
+from influx.inbox import InboxTick, _extract_note_id
+from influx.run import RunOutcome
+from influx.source import Candidate, ScoredCandidate
+from influx.sources.inbox import InboxAcquisition
+
+
+def _make_config() -> AppConfig:
+    return AppConfig(
+        lithos=LithosConfig(url="http://localhost:0/sse"),
+        profiles=[
+            ProfileConfig(
+                name="alpha",
+                description="Alpha profile",
+                thresholds=ProfileThresholds(relevance=7),
+            )
+        ],
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="x"),
+            tier1_enrich=PromptEntryConfig(text="x"),
+            tier3_extract=PromptEntryConfig(text="x"),
+        ),
+    )
+
+
+class FakeClient:
+    """Minimal LithosClient double for the tick's task lifecycle calls."""
+
+    def __init__(
+        self,
+        *,
+        tasks: list[dict[str, Any]],
+        claim_success: bool = True,
+        note_id: str | None = "note-xyz",
+    ) -> None:
+        self._tasks = tasks
+        self._claim_success = claim_success
+        self._note_id = note_id
+        self.claimed: list[str] = []
+        self.updated: list[tuple[str, dict[str, Any]]] = []
+        self.completed: list[dict[str, Any]] = []
+        self.list_calls = 0
+
+    async def task_list_body(self, **_: Any) -> dict[str, Any]:
+        self.list_calls += 1
+        return {"tasks": self._tasks}
+
+    async def task_claim_body(self, *, task_id: str, **_: Any) -> dict[str, Any]:
+        self.claimed.append(task_id)
+        return {"success": self._claim_success}
+
+    async def task_update_body(
+        self, *, task_id: str, agent: str, metadata: dict[str, Any]
+    ) -> dict[str, Any]:
+        self.updated.append((task_id, metadata))
+        return {"success": True}
+
+    async def task_complete_body(
+        self,
+        *,
+        task_id: str,
+        agent: str,
+        outcome: str | None = None,
+        cited_nodes: list[str] | None = None,
+    ) -> dict[str, Any]:
+        self.completed.append(
+            {"task_id": task_id, "outcome": outcome, "cited_nodes": cited_nodes}
+        )
+        return {"status": "completed"}
+
+    async def cache_lookup_by_url_body(self, *, source_url: str) -> dict[str, Any]:
+        if self._note_id:
+            return {"hit": True, "id": self._note_id}
+        return {"hit": False}
+
+    async def close(self) -> None:
+        return None
+
+
+def _acquisition() -> InboxAcquisition:
+    return InboxAcquisition(
+        source_url="https://example.com/article",
+        url_hash="abc1234567",
+        archive_path="inbox/2026/06/abc1234567.html",
+        archive_missing=False,
+        extracted_text="body text",
+        summary="body text",
+        text_flavour="html",
+    )
+
+
+def _scorer_returning(score: int):
+    async def _scorer(
+        candidates: list[Candidate], profile: str, filter_prompt: str
+    ) -> dict[str, ScoredCandidate]:
+        return {
+            c.item_id: ScoredCandidate(
+                candidate=c,
+                score=score,
+                confidence=0.9,
+                reason="relevant",
+                filter_tags=("t",),
+            )
+            for c in candidates
+        }
+
+    return _scorer
+
+
+def _task(
+    *,
+    task_id: str = "task-1",
+    kind: str = "url",
+    url: str | None = "https://example.com/article",
+    source_tag: str | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {"kind": kind, "submitted_by": "agent:test"}
+    if url is not None:
+        metadata["url"] = url
+    if source_tag is not None:
+        metadata["source_tag"] = source_tag
+    return {"id": task_id, "metadata": metadata}
+
+
+def _tick(client: FakeClient) -> InboxTick:
+    return InboxTick(
+        config=_make_config(),
+        coordinator=Coordinator(),
+        probe_loop=None,
+        ledger=None,
+        client_factory=lambda: client,  # type: ignore[arg-type]
+    )
+
+
+async def test_happy_path_ingests_and_completes_with_cited_nodes() -> None:
+    client = FakeClient(tasks=[_task()], note_id="note-xyz")
+    with (
+        patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_returning(8),
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch(
+            "influx.inbox.dispatch_profile", return_value=RunOutcome(ingested=1)
+        ) as mock_dispatch,
+    ):
+        await _tick(client).execute()
+
+    mock_dispatch.assert_called_once()
+    assert mock_dispatch.call_args.args[0] == "alpha"
+    assert client.claimed == ["task-1"]
+    assert len(client.completed) == 1
+    done = client.completed[0]
+    assert "ingested into 1 profile(s): alpha" in done["outcome"]
+    assert done["cited_nodes"] == ["note-xyz"]
+    # Structured inbox_result attached before completion.
+    assert client.updated[0][1]["inbox_result"]["per_profile"]["alpha"]["ingested"]
+
+
+async def test_filtered_out_does_not_dispatch() -> None:
+    client = FakeClient(tasks=[_task()])
+    with (
+        patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_returning(3),  # below threshold 7
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch("influx.inbox.dispatch_profile") as mock_dispatch,
+    ):
+        await _tick(client).execute()
+
+    mock_dispatch.assert_not_called()
+    assert "filtered out" in client.completed[0]["outcome"]
+    assert client.completed[0]["cited_nodes"] is None
+
+
+async def test_invalid_submission_completes_with_error() -> None:
+    client = FakeClient(tasks=[_task(kind="pdf", url=None)])
+    with patch("influx.inbox.dispatch_profile") as mock_dispatch:
+        await _tick(client).execute()
+    mock_dispatch.assert_not_called()
+    assert "invalid submission" in client.completed[0]["outcome"]
+
+
+async def test_invalid_url_scheme_completes_with_error() -> None:
+    client = FakeClient(tasks=[_task(url="file:///etc/passwd")])
+    with patch("influx.inbox.dispatch_profile") as mock_dispatch:
+        await _tick(client).execute()
+    mock_dispatch.assert_not_called()
+    assert "invalid_url_scheme" in client.completed[0]["outcome"]
+
+
+async def test_submitter_is_sanitised_before_dispatch() -> None:
+    task = _task()
+    task["metadata"]["submitted_by"] = "agent name\nwith spaces"
+    client = FakeClient(tasks=[task])
+    with (
+        patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_returning(8),
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch(
+            "influx.inbox.dispatch_profile", return_value=RunOutcome(ingested=1)
+        ) as mock_dispatch,
+    ):
+        await _tick(client).execute()
+    assert mock_dispatch.call_args.kwargs["submitted_by"] == "agent-name-with-spaces"
+
+
+async def test_skipped_run_reported_as_skipped_without_note_recovery() -> None:
+    client = FakeClient(tasks=[_task()], note_id="should-not-be-used")
+    skipped = RunOutcome(skipped=True, skip_reason="lithos_unhealthy", ingested=0)
+    with (
+        patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_returning(8),
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch("influx.inbox.dispatch_profile", return_value=skipped),
+    ):
+        await _tick(client).execute()
+    done = client.completed[0]
+    assert "skipped" in done["outcome"]
+    assert "lithos_unhealthy" in done["outcome"]
+    # No write happened → no note-id recovery → empty cited_nodes.
+    assert done["cited_nodes"] is None
+
+
+async def test_invalid_source_tag_completes_terminally() -> None:
+    client = FakeClient(tasks=[_task(source_tag="Not A Slug")])
+    with (
+        patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+        patch("influx.inbox.dispatch_profile") as mock_dispatch,
+    ):
+        await _tick(client).execute()
+    mock_dispatch.assert_not_called()
+    assert client.completed[0]["outcome"] == "error: invalid_source_tag"
+
+
+async def test_already_claimed_task_is_skipped() -> None:
+    client = FakeClient(tasks=[_task()], claim_success=False)
+    with patch("influx.inbox.dispatch_profile") as mock_dispatch:
+        await _tick(client).execute()
+    mock_dispatch.assert_not_called()
+    assert client.completed == []
+
+
+async def test_circuit_open_skips_whole_tick() -> None:
+    class _Probe:
+        def lithos_circuit_open(self) -> bool:
+            return True
+
+    client = FakeClient(tasks=[_task()])
+    tick = InboxTick(
+        config=_make_config(),
+        coordinator=Coordinator(),
+        probe_loop=_Probe(),
+        client_factory=lambda: client,  # type: ignore[arg-type]
+    )
+    await tick.execute()
+    assert client.list_calls == 0
+    assert client.completed == []
+
+
+async def test_per_item_failure_isolation() -> None:
+    """A crashing item does not prevent sibling items from completing."""
+    client = FakeClient(
+        tasks=[_task(task_id="task-1"), _task(task_id="task-2")],
+    )
+
+    def _dispatch_side_effect(profile: str, **_: Any) -> RunOutcome:
+        if client.claimed and client.claimed[-1] == "task-1":
+            raise RuntimeError("boom on first item")
+        return RunOutcome(ingested=1)
+
+    with (
+        patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_returning(8),
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch("influx.inbox.dispatch_profile", side_effect=_dispatch_side_effect),
+    ):
+        await _tick(client).execute()
+
+    # Both claimed; the second completed despite the first crashing.
+    assert client.claimed == ["task-1", "task-2"]
+    completed_ids = {c["task_id"] for c in client.completed}
+    assert "task-2" in completed_ids
+
+
+def test_extract_note_id_key_fallback() -> None:
+    """note-id recovery tolerates id / note_id / existing_id; miss → None."""
+    assert _extract_note_id({"hit": True, "id": "n1"}) == "n1"
+    assert _extract_note_id({"hit": True, "note_id": "n2"}) == "n2"
+    assert _extract_note_id({"hit": True, "existing_id": "n3"}) == "n3"
+    assert _extract_note_id({"hit": False, "id": "n1"}) is None
+    assert _extract_note_id({"hit": True}) is None

--- a/tests/unit/test_inbox_wrappers.py
+++ b/tests/unit/test_inbox_wrappers.py
@@ -1,0 +1,106 @@
+"""Unit tests for the inbox ``LithosClient`` task wrappers (Inbox v1 slice 1).
+
+Verifies arg-shaping + JSON decode for ``task_list`` / ``task_claim`` /
+``task_update`` and the new ``cited_nodes`` pass-through on
+``task_complete`` — mirroring the existing ``task_create`` wrapper
+semantics (decode via ``_result_json_dict``).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+from influx.lithos_client import LithosClient
+
+
+def _tool_result(payload: object, *, is_error: bool = False) -> MagicMock:
+    text_content = MagicMock()
+    text_content.text = payload if isinstance(payload, str) else json.dumps(payload)
+    result = MagicMock()
+    result.content = [text_content]
+    result.isError = is_error
+    return result
+
+
+def _client() -> LithosClient:
+    return LithosClient(url="http://localhost:1234/sse")
+
+
+async def test_task_list_shapes_args_and_decodes() -> None:
+    client = _client()
+    client.call_tool = AsyncMock(  # type: ignore[method-assign]
+        return_value=_tool_result({"tasks": [{"id": "t1"}]})
+    )
+    body = await client.task_list_body(tags=["influx:inbox"], status="open")
+    assert body == {"tasks": [{"id": "t1"}]}
+    name, args = client.call_tool.call_args.args
+    assert name == "lithos_task_list"
+    assert args == {"tags": ["influx:inbox"], "status": "open"}
+
+
+async def test_task_claim_shapes_args_and_decodes() -> None:
+    client = _client()
+    client.call_tool = AsyncMock(  # type: ignore[method-assign]
+        return_value=_tool_result(
+            {"success": True, "expires_at": "2099-01-01T00:00:00Z"}
+        )
+    )
+    body = await client.task_claim_body(
+        task_id="t1", agent="influx-inbox", aspect="ingest"
+    )
+    assert body["success"] is True
+    name, args = client.call_tool.call_args.args
+    assert name == "lithos_task_claim"
+    assert args == {
+        "task_id": "t1",
+        "aspect": "ingest",
+        "agent": "influx-inbox",
+        "ttl_minutes": 60,
+    }
+
+
+async def test_task_update_shapes_args_and_decodes() -> None:
+    client = _client()
+    client.call_tool = AsyncMock(  # type: ignore[method-assign]
+        return_value=_tool_result({"success": True, "message": "updated"})
+    )
+    body = await client.task_update_body(
+        task_id="t1", agent="influx-inbox", metadata={"inbox_result": {"x": 1}}
+    )
+    assert body["success"] is True
+    name, args = client.call_tool.call_args.args
+    assert name == "lithos_task_update"
+    assert args == {
+        "task_id": "t1",
+        "agent": "influx-inbox",
+        "metadata": {"inbox_result": {"x": 1}},
+    }
+
+
+async def test_task_complete_passes_cited_nodes_when_present() -> None:
+    client = _client()
+    client.call_tool = AsyncMock(  # type: ignore[method-assign]
+        return_value=_tool_result({"status": "completed"})
+    )
+    await client.task_complete_body(
+        task_id="t1",
+        agent="influx-inbox",
+        outcome="ingested into 1 profile(s): alpha",
+        cited_nodes=["note-1"],
+    )
+    name, args = client.call_tool.call_args.args
+    assert name == "lithos_task_complete"
+    assert args["cited_nodes"] == ["note-1"]
+    assert args["outcome"] == "ingested into 1 profile(s): alpha"
+
+
+async def test_task_complete_omits_cited_nodes_when_none() -> None:
+    """Scheduled-run callers (no cited_nodes) are unaffected — key omitted."""
+    client = _client()
+    client.call_tool = AsyncMock(  # type: ignore[method-assign]
+        return_value=_tool_result({"status": "completed"})
+    )
+    await client.task_complete_body(task_id="t1", agent="influx", outcome="success")
+    _name, args = client.call_tool.call_args.args
+    assert "cited_nodes" not in args

--- a/tests/unit/test_run_module.py
+++ b/tests/unit/test_run_module.py
@@ -249,7 +249,10 @@ async def test_run_execute_happy_path_returns_outcome() -> None:
     with (
         patch("influx.run.LithosClient", return_value=client),
         patch("influx.run.repair_sweep", new_callable=AsyncMock, return_value=[]),
-        patch("influx.run.build_negative_examples_block", side_effect=_empty_neg_block),
+        patch(
+            "influx.feedback.build_negative_examples_block",
+            side_effect=_empty_neg_block,
+        ),
         patch("influx.service.post_run_webhook_hook"),
     ):
         outcome = await Run(plan, deps).execute()
@@ -293,7 +296,10 @@ async def test_run_execute_retries_task_complete_after_reconnect() -> None:
     with (
         patch("influx.run.LithosClient", return_value=client),
         patch("influx.run.repair_sweep", new_callable=AsyncMock, return_value=[]),
-        patch("influx.run.build_negative_examples_block", side_effect=_empty_neg_block),
+        patch(
+            "influx.feedback.build_negative_examples_block",
+            side_effect=_empty_neg_block,
+        ),
         patch("influx.service.post_run_webhook_hook"),
     ):
         outcome = await Run(plan, deps).execute()
@@ -325,7 +331,10 @@ async def test_run_execute_suppresses_terminal_task_complete_failure_after_retry
     with (
         patch("influx.run.LithosClient", return_value=client),
         patch("influx.run.repair_sweep", new_callable=AsyncMock, return_value=[]),
-        patch("influx.run.build_negative_examples_block", side_effect=_empty_neg_block),
+        patch(
+            "influx.feedback.build_negative_examples_block",
+            side_effect=_empty_neg_block,
+        ),
         patch("influx.service.post_run_webhook_hook"),
     ):
         outcome = await Run(plan, deps).execute()
@@ -401,7 +410,10 @@ async def test_run_execute_clears_repair_latch_on_success() -> None:
     with (
         patch("influx.run.LithosClient", return_value=client),
         patch("influx.run.repair_sweep", new_callable=AsyncMock, return_value=[]),
-        patch("influx.run.build_negative_examples_block", side_effect=_empty_neg_block),
+        patch(
+            "influx.feedback.build_negative_examples_block",
+            side_effect=_empty_neg_block,
+        ),
         patch("influx.service.post_run_webhook_hook"),
     ):
         await Run(plan, deps).execute()
@@ -420,7 +432,10 @@ async def test_run_execute_skips_repair_for_backfill() -> None:
     with (
         patch("influx.run.LithosClient", return_value=client),
         patch("influx.run.repair_sweep", new=sweep_mock),
-        patch("influx.run.build_negative_examples_block", side_effect=_empty_neg_block),
+        patch(
+            "influx.feedback.build_negative_examples_block",
+            side_effect=_empty_neg_block,
+        ),
         patch("influx.service.post_run_webhook_hook"),
     ):
         await Run(plan, deps).execute()
@@ -480,7 +495,10 @@ async def test_run_execute_walks_provider_and_writes_per_item() -> None:
     with (
         patch("influx.run.LithosClient", return_value=mock_client),
         patch("influx.run.repair_sweep", new_callable=AsyncMock, return_value=[]),
-        patch("influx.run.build_negative_examples_block", side_effect=_empty_neg_block),
+        patch(
+            "influx.feedback.build_negative_examples_block",
+            side_effect=_empty_neg_block,
+        ),
         patch("influx.run.lcma_wire", new_callable=AsyncMock, return_value=[]) as wire,
         patch("influx.service.post_run_webhook_hook"),
     ):
@@ -564,7 +582,10 @@ async def test_run_execute_threads_tags_source_url_confidence_to_lithos_write() 
     with (
         patch("influx.run.LithosClient", return_value=mock_client),
         patch("influx.run.repair_sweep", new_callable=AsyncMock, return_value=[]),
-        patch("influx.run.build_negative_examples_block", side_effect=_empty_neg_block),
+        patch(
+            "influx.feedback.build_negative_examples_block",
+            side_effect=_empty_neg_block,
+        ),
         patch("influx.run.lcma_wire", new_callable=AsyncMock, return_value=[]),
         patch("influx.service.post_run_webhook_hook"),
     ):
@@ -669,7 +690,10 @@ async def test_run_execute_continues_after_lcma_wiring_failure() -> None:
     with (
         patch("influx.run.LithosClient", return_value=mock_client),
         patch("influx.run.repair_sweep", new_callable=AsyncMock, return_value=[]),
-        patch("influx.run.build_negative_examples_block", side_effect=_empty_neg_block),
+        patch(
+            "influx.feedback.build_negative_examples_block",
+            side_effect=_empty_neg_block,
+        ),
         patch(
             "influx.run.lcma_wire",
             new_callable=AsyncMock,
@@ -743,7 +767,10 @@ async def test_run_execute_persists_unresolved_slug_collision_without_injected_l
     with (
         patch("influx.run.LithosClient", return_value=mock_client),
         patch("influx.run.repair_sweep", new_callable=AsyncMock, return_value=[]),
-        patch("influx.run.build_negative_examples_block", side_effect=_empty_neg_block),
+        patch(
+            "influx.feedback.build_negative_examples_block",
+            side_effect=_empty_neg_block,
+        ),
         patch("influx.service.post_run_webhook_hook"),
     ):
         outcome = await Run(plan, deps).execute()

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -805,11 +805,11 @@ class TestSweepWriteErrorMarksReadinessDegraded:
             patch("influx.run.LithosClient", return_value=_NoopClient()),
             patch("influx.run.LithosClient", return_value=_NoopClient()),
             patch(
-                "influx.run.build_negative_examples_block",
+                "influx.feedback.build_negative_examples_block",
                 side_effect=_empty_neg_block,
             ),
             patch(
-                "influx.run.build_negative_examples_block",
+                "influx.feedback.build_negative_examples_block",
                 side_effect=_empty_neg_block,
             ),
             patch("influx.service.post_run_webhook_hook"),
@@ -876,11 +876,11 @@ class TestSweepWriteErrorMarksReadinessDegraded:
             patch("influx.run.LithosClient", return_value=_NoopClient()),
             patch("influx.run.LithosClient", return_value=_NoopClient()),
             patch(
-                "influx.run.build_negative_examples_block",
+                "influx.feedback.build_negative_examples_block",
                 side_effect=_empty_neg_block,
             ),
             patch(
-                "influx.run.build_negative_examples_block",
+                "influx.feedback.build_negative_examples_block",
                 side_effect=_empty_neg_block,
             ),
             patch("influx.service.post_run_webhook_hook"),
@@ -970,11 +970,11 @@ class TestScheduledFireInvokesRepairSweep:
             patch("influx.run.LithosClient", return_value=_NoopClient()),
             patch("influx.run.LithosClient", return_value=_NoopClient()),
             patch(
-                "influx.run.build_negative_examples_block",
+                "influx.feedback.build_negative_examples_block",
                 side_effect=empty_neg_block,
             ),
             patch(
-                "influx.run.build_negative_examples_block",
+                "influx.feedback.build_negative_examples_block",
                 side_effect=empty_neg_block,
             ),
             patch("influx.service.post_run_webhook_hook"),
@@ -1078,11 +1078,11 @@ class TestNegativeExampleMaxTitleCharsWired:
             patch("influx.run.LithosClient", return_value=_NoopClient()),
             patch("influx.run.LithosClient", return_value=_NoopClient()),
             patch(
-                "influx.run.build_negative_examples_block",
+                "influx.feedback.build_negative_examples_block",
                 side_effect=fake_neg_block,
             ),
             patch(
-                "influx.run.build_negative_examples_block",
+                "influx.feedback.build_negative_examples_block",
                 side_effect=fake_neg_block,
             ),
             patch("influx.service.post_run_webhook_hook"),
@@ -1370,7 +1370,7 @@ class TestManualRunDispatchesToRunModule:
             patch("influx.run.LithosClient", return_value=_NoopClient()),
             patch("influx.run.LithosClient", return_value=_NoopClient()),
             patch(
-                "influx.run.build_negative_examples_block",
+                "influx.feedback.build_negative_examples_block",
                 side_effect=_empty_neg_block,
             ),
             patch("influx.service.post_run_webhook_hook"),
@@ -1478,7 +1478,7 @@ class TestBackfillRunDispatchesToRunModule:
             patch("influx.run.repair_sweep", side_effect=_run_sweep),
             patch("influx.run.LithosClient", return_value=_NoopClient()),
             patch(
-                "influx.run.build_negative_examples_block",
+                "influx.feedback.build_negative_examples_block",
                 side_effect=_empty_neg_block,
             ),
             patch("influx.service.post_run_webhook_hook", side_effect=_webhook),

--- a/tests/unit/test_telemetry_wiring.py
+++ b/tests/unit/test_telemetry_wiring.py
@@ -1180,12 +1180,12 @@ class TestInfluxLithosWriteSpan:
                 patch("influx.run.LithosClient") as mock_client_cls,
                 patch("influx.run.LithosClient") as mock_client_cls_run,
                 patch(
-                    "influx.run.build_negative_examples_block",
+                    "influx.feedback.build_negative_examples_block",
                     new_callable=AsyncMock,
                     return_value="",
                 ),
                 patch(
-                    "influx.run.build_negative_examples_block",
+                    "influx.feedback.build_negative_examples_block",
                     new_callable=AsyncMock,
                     return_value="",
                 ),
@@ -1284,12 +1284,12 @@ class TestInfluxLithosWriteSpan:
             patch("influx.run.LithosClient") as mock_client_cls,
             patch("influx.run.LithosClient") as mock_client_cls_run,
             patch(
-                "influx.run.build_negative_examples_block",
+                "influx.feedback.build_negative_examples_block",
                 new_callable=AsyncMock,
                 return_value="",
             ),
             patch(
-                "influx.run.build_negative_examples_block",
+                "influx.feedback.build_negative_examples_block",
                 new_callable=AsyncMock,
                 return_value="",
             ),


### PR DESCRIPTION
## Summary

Slice 1 of the Influx Inbox v1 feature (design spec: `docs/plans/inbox.md`) — the **thin end-to-end happy path** for manual URL submission. An agent submits a URL as a Lithos task tagged `influx:inbox`; an independent inbox-tick scheduler claims it, downloads + extracts the content once, scores it against the **first** enabled profile, and — if it clears threshold — ingests it through the **unchanged** Run pipeline as a `RunKind.INBOX` run, then completes the task with an outcome string and `cited_nodes`.

This is the first tracer-bullet slice: it proves the central design seam (DI into `RunService`, shared filter-prompt helper, post-dispatch note-id recovery) end-to-end before later slices add multi-profile fan-out (#196), cache-hit replay + coordinator skip (#197), and the operational surface (#198).

### The seam (no Run changes)

`docs/plans/inbox.md` §5.3's "pre-acquired single-item" path is achieved purely by dependency injection — **no change to `Run.execute` or any stage function**. The tick builds a single-item `ItemProvider` yielding one already-scored `BoundScoredCandidate` whose `acquire()` returns the prebuilt `ProfileItem`, and dispatches it via `RunService(item_provider=…).execute(RunPlan(kind=RunKind.INBOX, …))`.

## What's included

- **Foundation:** `RunKind.INBOX`; `[inbox]` config block (`InboxConfig`, default-disabled); `LithosClient` wrappers `task_list` / `task_claim` / `task_update` (+ `cited_nodes` on `task_complete`).
- **Acquisition + builder** (`src/influx/sources/inbox.py`): `acquire_inbox_bytes` (fixed `inbox/YYYY/MM/<url_hash>.<ext>` subtree; PDF vs HTML chosen by **URL shape** — a `.pdf` path) and `build_inbox_note_item` (full `ProfileItem`, `source:`/`submitter:` tags, thin-summary suppression), templated on `build_rss_note_item`. _True response-Content-Type routing + single-fetch acquisition is tracked as a follow-up in #200 (it needs a shared extraction/storage refactor that also touches RSS/arXiv)._
- **Shared `build_filter_prompt`** extracted from `_run_feedback_stage` into `influx.feedback` and reused by both the Run feedback stage and the tick (so inbox filtering gets the same negative-feedback examples).
- **Orchestrator** (`src/influx/inbox.py`): `InboxTick` (list → claim → acquire-once → score-first-profile → dispatch → `task_update` + `task_complete` with `cited_nodes`), `make_inbox_item_provider`, `dispatch_profile`. Each dispatch holds the per-Profile `coordinator.hold(profile)` lock so inbox Runs never overlap scheduled/manual/backfill Runs for the same profile (FR-SCHED-2/3); on contention the item completes with a `profile_busy` outcome. Probe-gated on `lithos_circuit_open`; per-item failure isolation; http/https URL-scheme validation; `submitted_by` sanitisation.
- **Wiring:** independent `influx-inbox-tick` APScheduler job registered only when `[inbox] enabled`, sharing the coordinator / probe loop / ledger.
- **Metrics:** `inbox_tick_started`, `inbox_tasks_listed`, `inbox_tasks_claimed`, `inbox_items_processed{outcome}`.

## Out of scope (later slices)

Multi-profile fan-out, Profile-Relevance merge, cache-hit replay (§6), the **richer** §10 try-acquire-skip reporting (the lock itself is in this slice), `/status` section, and the `influx-inbox-submit` helper script. Content-type-accurate single-fetch acquisition is tracked in #200.

## Review fixes applied

Two review passes; addressed: coordinator-lock-per-profile (was missing — could overlap scheduled Runs), `outcome.skipped` handling, `submitted_by` tag sanitisation, http/https scheme validation, conditional note-id recovery, and a removed `type: ignore`. Each has a regression test.

## Test plan

- `make check` green (ruff + pyright + full pytest suite).
- New tests: `test_inbox_config`, `test_inbox_wrappers`, `test_inbox_builder`, `test_inbox_tick` (happy path, filtered-out, invalid submission, invalid source_tag, already-claimed skip, circuit-open skip, per-item failure isolation), `test_inbox_scheduler` (job registration), and `test_inbox_dispatch` (integration: real `RunService` + `RunLedger` + `FakeLithosServer` → one `kind="inbox"` ledger entry, `sources_checked=1`, note written).
- The shared `build_filter_prompt` extraction moved the feedback-stage patch target from `influx.run.build_negative_examples_block` to `influx.feedback.build_negative_examples_block` in existing tests.

Closes #195
