### PR TITLE
feat: inbox multi-profile fan-out + Profile Relevance merge (#196)

### DIFF
--- a/src/influx/config.py
+++ b/src/influx/config.py
@@ -242,7 +242,7 @@ NotificationWebhookType = Literal[
     "openclaw_agent",
 ]
 NotificationEventMode = Literal["digest", "article"]
-NotificationRunKind = Literal["scheduled", "manual", "backfill"]
+NotificationRunKind = Literal["scheduled", "manual", "backfill", "inbox"]
 
 
 _WEBHOOK_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")

--- a/src/influx/inbox.py
+++ b/src/influx/inbox.py
@@ -509,8 +509,9 @@ class InboxTick:
         per_profile = self._build_per_profile(
             scored_profiles, dispatched, busy, dispatch_failed, note_id
         )
+        filter_errors = [ps.name for ps in scored_profiles if ps.error]
         outcome_str = self._build_outcome_string(
-            ingested_names, dispatched, busy, dispatch_failed
+            ingested_names, dispatched, busy, dispatch_failed, filter_errors
         )
         metrics.inbox_items_processed().add(
             1, {"outcome": "ingested" if ingested_names else "error"}
@@ -620,35 +621,41 @@ class InboxTick:
         dispatched: dict[str, tuple[RunOutcome, str]],
         busy: list[str],
         dispatch_failed: dict[str, str],
+        filter_errors: list[str],
     ) -> str:
         """Build the free-text outcome string (§7.1).
 
-        ``total`` counts only profiles that cleared threshold (dispatched +
-        busy + dispatch-failed); profiles that never scored / scored below
-        threshold are not ingestion candidates and are excluded.
+        ``total`` counts profiles that were ingestion candidates or failed
+        being made into one — cleared-and-dispatched, busy, dispatch-failed,
+        and filter-errored.  Profiles that scored below threshold are not
+        candidates and are excluded (they surface only in ``per_profile``).
+        Filter failures (§5.5 / #196) are reported as ``X filter failed``.
         """
-        total = len(dispatched) + len(busy) + len(dispatch_failed)
+        total = len(dispatched) + len(busy) + len(dispatch_failed) + len(filter_errors)
         failed = [
             (name, (o.skip_reason or o.error or "no note written"))
             for name, (o, _rid) in dispatched.items()
             if o.ingested == 0
         ]
         failed += list(dispatch_failed.items())
+
+        issues: list[str] = []
+        if busy:
+            issues.append(f"{', '.join(busy)} profile_busy")
+        for name, reason in failed:
+            issues.append(f"{name} failed: {reason}")
+        if filter_errors:
+            issues.append(f"{', '.join(filter_errors)} filter failed")
+
         if not ingested_names:
-            details = "; ".join(f"{n}: {r}" for n, r in failed) or "no note written"
-            return f"not ingested ({details})"
+            return f"not ingested ({'; '.join(issues) or 'no note written'})"
 
         names = ", ".join(ingested_names)
-        if len(ingested_names) == total and not busy and not failed:
+        if not issues and len(ingested_names) == total:
             return f"ingested into {len(ingested_names)} profile(s): {names}"
 
         head = f"ingested into {len(ingested_names)}/{total} profiles ({names})"
-        tail: list[str] = []
-        if busy:
-            tail.append(f"{', '.join(busy)} profile_busy")
-        for name, reason in failed:
-            tail.append(f"{name} failed: {reason}")
-        return head + ("; " + "; ".join(tail) if tail else "")
+        return head + ("; " + "; ".join(issues) if issues else "")
 
     async def _recover_note_id(
         self, client: LithosClient, source_url: str

--- a/src/influx/inbox.py
+++ b/src/influx/inbox.py
@@ -13,12 +13,13 @@ The per-Profile dispatch reuses the unchanged Run pipeline by *injecting*
 a single-item :data:`~influx.run.ItemProvider` — there is no parallel
 ingestion pipeline.  See §5.3 of the plan.
 
-**Slice 1 scope.** This is the thin end-to-end happy path: one URL is
-scored against the *first* enabled profile only, and dispatched if it
-clears threshold.  The dispatch already holds the per-Profile coordinator
-lock (so inbox never overlaps a scheduled Run for the same profile);
-multi-profile fan-out (§5/§8), cache-hit replay (§6), and the richer §10
-try-acquire-skip reporting arrive in later slices.
+**Scope.** A URL is scored against *every* enabled profile (§5/§8) and
+dispatched to each that clears its threshold, merging into one canonical
+note via the existing ``write_note`` path.  Each dispatch holds the
+per-Profile coordinator lock (so inbox never overlaps a scheduled Run for
+the same profile); when every clearing profile is busy the item is left
+for a later tick.  Cache-hit replay (§6) and the richer §10 reporting
+(cross-tick re-scoring of busy/skipped profiles) arrive in a later slice.
 """
 
 from __future__ import annotations
@@ -38,7 +39,7 @@ from influx.config import AppConfig, InboxConfig
 from influx.coordinator import Coordinator, ProfileBusyError, RunKind
 from influx.errors import LCMAError, LithosError
 from influx.feedback import build_filter_prompt
-from influx.filter import Filter, make_default_batch_scorer
+from influx.filter import make_default_batch_scorer
 from influx.lithos_client import LithosClient
 from influx.run import ItemProvider, RunOutcome, RunPlan
 from influx.run_service import RunService
@@ -194,6 +195,27 @@ class _ItemOutcome:
     outcome: str
     cited_nodes: list[str]
     inbox_result: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _ProfileScore:
+    """One profile's filter result for an inbox item (pre-dispatch).
+
+    ``scored`` is the raw :class:`ScoredCandidate` from the filter model
+    (carrying the 1–10 score regardless of threshold), or ``None`` when the
+    model omitted the item.  ``error`` is ``True`` when the filter call
+    raised — kept distinct so a per-profile filter failure isolates to that
+    profile rather than sinking the whole item (§5.5).
+    """
+
+    name: str
+    threshold: int
+    scored: ScoredCandidate | None
+    error: bool
+
+    @property
+    def clears(self) -> bool:
+        return self.scored is not None and self.scored.score >= self.threshold
 
 
 @dataclass
@@ -357,33 +379,34 @@ class InboxTick:
         summary_hint: str | None,
         source_tag: str,
     ) -> _ItemOutcome | None:
-        """Acquire, score (first profile), dispatch, and report one item.
+        """Acquire once, score every enabled profile, fan out, and report.
 
-        Slice 1 scores only the first enabled profile.  Returns the per-item
-        outcome used to complete the task, or ``None`` to signal
-        skip-this-tick (profile busy) — the caller then leaves the task
-        un-completed so a later tick retries it.
+        Scores the item against all enabled profiles (in parallel, reusing
+        the single acquisition), dispatches a ``RunKind.INBOX`` Run for each
+        profile that clears its threshold (sequentially, so the first creates
+        the canonical note and the rest merge into it), and aggregates the
+        result.
+
+        Returns the per-item outcome used to complete the task, or ``None``
+        to signal skip-this-tick — used when *every* clearing profile is busy
+        (§5.5 / §10): the task is left un-completed so a later tick retries.
         """
         started = time.monotonic()
         profiles = self.config.profiles
-        if not profiles:
+        scorer = make_default_batch_scorer(self.config)
+        if not profiles or scorer is None:
             metrics.inbox_items_processed().add(1, {"outcome": "error"})
+            reason = "no_profiles" if not profiles else "no_filter_model"
             return _ItemOutcome(
-                outcome="error: no profiles configured",
+                outcome=f"error: {reason}",
                 cited_nodes=[],
-                inbox_result={"source_url": url, "error": "no_profiles"},
+                inbox_result={"source_url": url, "error": reason},
             )
 
-        # Acquire once (blocking download/extract → thread).
+        # Acquire once (blocking download/extract → thread); bytes + extracted
+        # text are reused across every per-profile filter + dispatch below.
         acquired = await asyncio.to_thread(
             acquire_inbox_bytes, url, config=self.config, summary_hint=summary_hint
-        )
-
-        profile_cfg = profiles[0]
-        scorer = make_default_batch_scorer(self.config)
-        filt = Filter(config=self.config, profile_cfg=profile_cfg, scorer=scorer)
-        filter_prompt = await build_filter_prompt(
-            self.config, client, profile=profile_cfg.name
         )
         candidate = Candidate(
             item_id=f"inbox-{acquired.url_hash}",
@@ -391,105 +414,241 @@ class InboxTick:
             abstract=acquired.summary,
             source_url=acquired.source_url,
         )
-        scored_list = await filt.score(
-            [candidate], filter_prompt=filter_prompt, source="inbox"
-        )
 
-        if not scored_list:
-            metrics.inbox_items_processed().add(1, {"outcome": "filtered_out"})
-            return _ItemOutcome(
-                outcome=(
-                    f"filtered out: below threshold "
-                    f"({profile_cfg.name} threshold {profile_cfg.thresholds.relevance})"
-                ),
-                cited_nodes=[],
-                inbox_result={
-                    "source_url": acquired.source_url,
-                    "per_profile": {
-                        profile_cfg.name: {
-                            "ingested": False,
-                            "reason": "below_threshold",
-                        }
-                    },
-                },
-            )
-
-        scored = scored_list[0]
-        run_id = uuid.uuid4().hex
-        # Hold the per-Profile coordinator lock so an inbox dispatch never
-        # overlaps a scheduled / manual / backfill Run for the same profile
-        # (the service-wide "at most one Run per profile" invariant,
-        # FR-SCHED-2/3).  On contention skip this profile this tick and
-        # report it — the richer §10 try-acquire-skip reporting + cache-hit
-        # replay land in a later slice.
-        try:
-            async with self.coordinator.hold(profile_cfg.name):
-                outcome = await dispatch_profile(
-                    profile_cfg.name,
-                    scored=scored,
-                    acquired=acquired,
-                    source_tag=source_tag,
-                    submitted_by=submitted_by,
-                    title_hint=title_hint,
-                    config=self.config,
-                    probe_loop=self.probe_loop,
-                    ledger=self.ledger,
-                    run_id=run_id,
+        # ── Filter fan-out: score every profile in parallel (§8) ──────
+        # Call the batch scorer directly (not Filter.score) so the raw
+        # per-profile score is available even below threshold — needed for
+        # the per_profile payload (§7.3) and the "top score K" outcome.
+        # Trade-off: inbox scoring does not emit the per-decision
+        # ``articles_filtered`` metric that Filter.score does (the inbox
+        # surfaces outcomes via ``inbox_items_processed`` instead).
+        async def _score(profile_cfg: Any) -> _ProfileScore:
+            threshold = profile_cfg.thresholds.relevance
+            try:
+                prompt = await build_filter_prompt(
+                    self.config, client, profile=profile_cfg.name
                 )
-        except ProfileBusyError:
-            # Skip this tick: leave the task un-completed so its claim lease
-            # expires and a later tick re-claims + retries (§5.5 / §10).  Do
-            # NOT terminally complete — that would drop the submission on a
-            # transient collision (no inbox-level auto-retry, §5.6).
+                scores = await scorer([candidate], profile_cfg.name, prompt)
+                return _ProfileScore(
+                    name=profile_cfg.name,
+                    threshold=threshold,
+                    scored=scores.get(candidate.item_id),
+                    error=False,
+                )
+            except Exception:  # noqa: BLE001 — per-profile filter isolation (§5.5)
+                logger.warning(
+                    "inbox filter failed for profile %s",
+                    profile_cfg.name,
+                    exc_info=True,
+                )
+                return _ProfileScore(
+                    name=profile_cfg.name, threshold=threshold, scored=None, error=True
+                )
+
+        # gather preserves config order; profile count is small (§17 leaves a
+        # tighter concurrency cap as a future tuning knob).
+        scored_profiles = list(await asyncio.gather(*(_score(p) for p in profiles)))
+        clearing = [ps for ps in scored_profiles if ps.clears]
+
+        if not clearing:
+            return self._filtered_out_outcome(acquired, scored_profiles, url)
+
+        # ── Per-(item, Profile) dispatch: sequential so the first write
+        # creates the canonical note and the rest merge into it ────────
+        dispatched: dict[str, tuple[RunOutcome, str]] = {}
+        busy: list[str] = []
+        dispatch_failed: dict[str, str] = {}
+        for ps in clearing:
+            if ps.scored is None:  # ps.clears guarantees this; defensive guard
+                continue
+            run_id = uuid.uuid4().hex
+            try:
+                async with self.coordinator.hold(ps.name):
+                    outcome = await dispatch_profile(
+                        ps.name,
+                        scored=ps.scored,
+                        acquired=acquired,
+                        source_tag=source_tag,
+                        submitted_by=submitted_by,
+                        title_hint=title_hint,
+                        config=self.config,
+                        probe_loop=self.probe_loop,
+                        ledger=self.ledger,
+                        run_id=run_id,
+                    )
+                dispatched[ps.name] = (outcome, run_id)
+            except ProfileBusyError:
+                busy.append(ps.name)
+                logger.info("inbox profile %s busy; skipping this tick", ps.name)
+            except Exception:  # noqa: BLE001 — per-profile dispatch isolation (§5.5)
+                # A dispatch failure for one profile must not abandon the item:
+                # the lock is already released, sibling profiles still run, and
+                # the item completes with a partial outcome.  Abandoning here
+                # would orphan an earlier profile's write and double its ledger
+                # entry on the retry.
+                logger.warning(
+                    "inbox dispatch failed for profile %s", ps.name, exc_info=True
+                )
+                dispatch_failed[ps.name] = "dispatch_error"
+
+        if not dispatched and not dispatch_failed:
+            # Every clearing profile was busy — skip this tick and let a later
+            # tick retry the whole item (§5.5 / §10); do NOT complete.
             metrics.inbox_items_processed().add(1, {"outcome": "profile_busy_skipped"})
-            logger.info(
-                "inbox profile %s busy; leaving task to retry on a later tick",
-                profile_cfg.name,
-            )
             return None
 
-        ingested = outcome.ingested > 0
-        # Only recover the note id when a write actually happened — a skipped
-        # or write-less run would otherwise attach a stale/missing lookup.
+        ingested_names = [
+            name for name, (o, _rid) in dispatched.items() if o.ingested > 0
+        ]
         note_id = (
             await self._recover_note_id(client, acquired.source_url)
-            if ingested
+            if ingested_names
             else None
         )
-        cited = [note_id] if note_id else []
-        elapsed_ms = int((time.monotonic() - started) * 1000)
 
-        per_profile: dict[str, Any] = {
-            profile_cfg.name: {
-                "score": scored.score,
-                "ingested": ingested,
-                "note_id": note_id,
-                "run_id": run_id,
-            }
-        }
-        inbox_result = {
-            "source_url": acquired.source_url,
-            "archive_path": acquired.archive_path,
-            "per_profile": per_profile,
-            "processing_time_ms": elapsed_ms,
-        }
-
-        if ingested:
-            metrics.inbox_items_processed().add(1, {"outcome": "ingested"})
-            outcome_str = f"ingested into 1 profile(s): {profile_cfg.name}"
-        elif outcome.skipped:
-            metrics.inbox_items_processed().add(1, {"outcome": "error"})
-            outcome_str = (
-                f"skipped ({profile_cfg.name}): {outcome.skip_reason or 'unknown'}"
-            )
-        else:
-            metrics.inbox_items_processed().add(1, {"outcome": "error"})
-            detail = outcome.error or "no note written"
-            outcome_str = f"not ingested ({profile_cfg.name}): {detail}"
+        per_profile = self._build_per_profile(
+            scored_profiles, dispatched, busy, dispatch_failed, note_id
+        )
+        outcome_str = self._build_outcome_string(
+            ingested_names, dispatched, busy, dispatch_failed
+        )
+        metrics.inbox_items_processed().add(
+            1, {"outcome": "ingested" if ingested_names else "error"}
+        )
 
         return _ItemOutcome(
-            outcome=outcome_str, cited_nodes=cited, inbox_result=inbox_result
+            outcome=outcome_str,
+            cited_nodes=[note_id] if note_id else [],
+            inbox_result={
+                "source_url": acquired.source_url,
+                "archive_path": acquired.archive_path,
+                "per_profile": per_profile,
+                "processing_time_ms": int((time.monotonic() - started) * 1000),
+            },
         )
+
+    def _filtered_out_outcome(
+        self,
+        acquired: InboxAcquisition,
+        scored_profiles: list[_ProfileScore],
+        url: str,
+    ) -> _ItemOutcome:
+        """Build the terminal outcome when no profile cleared threshold (§7.1)."""
+        metrics.inbox_items_processed().add(1, {"outcome": "filtered_out"})
+        # (score, name, threshold) for every profile the model scored.
+        scored = [
+            (ps.scored.score, ps.name, ps.threshold)
+            for ps in scored_profiles
+            if ps.scored is not None
+        ]
+        if scored:
+            top_score, top_name, top_threshold = max(scored)
+            outcome = (
+                f"filtered out: top score {top_score} ({top_name}) "
+                f"below threshold {top_threshold}"
+            )
+        else:
+            outcome = "filtered out: no profile scored the item"
+        return _ItemOutcome(
+            outcome=outcome,
+            cited_nodes=[],
+            inbox_result={
+                "source_url": acquired.source_url,
+                "archive_path": acquired.archive_path,
+                "per_profile": self._build_per_profile(
+                    scored_profiles, {}, [], {}, None
+                ),
+            },
+        )
+
+    @staticmethod
+    def _build_per_profile(
+        scored_profiles: list[_ProfileScore],
+        dispatched: dict[str, tuple[RunOutcome, str]],
+        busy: list[str],
+        dispatch_failed: dict[str, str],
+        note_id: str | None,
+    ) -> dict[str, Any]:
+        """Assemble the structured ``per_profile`` payload (§7.3)."""
+        per_profile: dict[str, Any] = {}
+        for ps in scored_profiles:
+            # score is present for every dispatched / busy / failed profile
+            # (all drawn from ``clearing``, which requires a non-None score).
+            score = ps.scored.score if ps.scored is not None else None
+            if ps.name in dispatched:
+                outcome, run_id = dispatched[ps.name]
+                ingested = outcome.ingested > 0
+                entry: dict[str, Any] = {
+                    "score": score,
+                    "ingested": ingested,
+                    "run_id": run_id,
+                }
+                if ingested:
+                    entry["note_id"] = note_id
+                else:
+                    entry["reason"] = (
+                        outcome.skip_reason or outcome.error or "not_ingested"
+                    )
+                per_profile[ps.name] = entry
+            elif ps.name in dispatch_failed:
+                per_profile[ps.name] = {
+                    "score": score,
+                    "ingested": False,
+                    "reason": dispatch_failed[ps.name],
+                }
+            elif ps.name in busy:
+                per_profile[ps.name] = {
+                    "score": score,
+                    "ingested": False,
+                    "reason": "profile_busy",
+                }
+            elif ps.error:
+                per_profile[ps.name] = {"ingested": False, "reason": "filter_error"}
+            elif ps.scored is None:
+                per_profile[ps.name] = {"ingested": False, "reason": "not_scored"}
+            else:
+                per_profile[ps.name] = {
+                    "score": score,
+                    "ingested": False,
+                    "reason": "below_threshold",
+                }
+        return per_profile
+
+    @staticmethod
+    def _build_outcome_string(
+        ingested_names: list[str],
+        dispatched: dict[str, tuple[RunOutcome, str]],
+        busy: list[str],
+        dispatch_failed: dict[str, str],
+    ) -> str:
+        """Build the free-text outcome string (§7.1).
+
+        ``total`` counts only profiles that cleared threshold (dispatched +
+        busy + dispatch-failed); profiles that never scored / scored below
+        threshold are not ingestion candidates and are excluded.
+        """
+        total = len(dispatched) + len(busy) + len(dispatch_failed)
+        failed = [
+            (name, (o.skip_reason or o.error or "no note written"))
+            for name, (o, _rid) in dispatched.items()
+            if o.ingested == 0
+        ]
+        failed += list(dispatch_failed.items())
+        if not ingested_names:
+            details = "; ".join(f"{n}: {r}" for n, r in failed) or "no note written"
+            return f"not ingested ({details})"
+
+        names = ", ".join(ingested_names)
+        if len(ingested_names) == total and not busy and not failed:
+            return f"ingested into {len(ingested_names)} profile(s): {names}"
+
+        head = f"ingested into {len(ingested_names)}/{total} profiles ({names})"
+        tail: list[str] = []
+        if busy:
+            tail.append(f"{', '.join(busy)} profile_busy")
+        for name, reason in failed:
+            tail.append(f"{name} failed: {reason}")
+        return head + ("; " + "; ".join(tail) if tail else "")
 
     async def _recover_note_id(
         self, client: LithosClient, source_url: str

--- a/tests/integration/test_inbox_fanout.py
+++ b/tests/integration/test_inbox_fanout.py
@@ -1,0 +1,180 @@
+"""Integration test for inbox multi-profile fan-out (Inbox v1 slice 2).
+
+Drives the full :class:`~influx.inbox.InboxTick` end-to-end through real
+:class:`~influx.run_service.RunService` dispatches and a real
+:class:`~influx.run_ledger.RunLedger` against the in-process
+:class:`FakeLithosServer`.  Proves the slice-2 acceptance: an item clearing
+N profiles produces N ``RunKind.INBOX`` ledger entries (one per profile)
+from a single acquisition.
+
+Only the URL acquisition and the filter scorer are stubbed (no network /
+no LLM); the dispatch, write, ledger, and task lifecycle are real.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from influx.config import (
+    AppConfig,
+    ExtractionConfig,
+    FeedbackConfig,
+    InboxConfig,
+    LithosConfig,
+    NotificationsConfig,
+    ProfileConfig,
+    ProfileThresholds,
+    PromptEntryConfig,
+    PromptsConfig,
+    ScheduleConfig,
+    SecurityConfig,
+)
+from influx.coordinator import Coordinator
+from influx.inbox import InboxTick
+from influx.lithos_client import LithosClient
+from influx.run_ledger import RunLedger
+from influx.source import Candidate, ScoredCandidate
+from influx.sources.inbox import InboxAcquisition
+from tests.contract.test_lithos_client import FakeLithosServer
+
+_URL = "https://example.com/article"
+_PROFILES = ("ai-robotics", "web-tech", "ml-systems")
+
+
+def _make_config(lithos_url: str) -> AppConfig:
+    return AppConfig(
+        lithos=LithosConfig(url=lithos_url),
+        schedule=ScheduleConfig(cron="0 6 * * *", timezone="UTC"),
+        profiles=[
+            ProfileConfig(
+                name=name,
+                description=f"{name} profile",
+                thresholds=ProfileThresholds(
+                    relevance=7, full_text=100, deep_extract=100
+                ),
+            )
+            for name in _PROFILES
+        ],
+        providers={},
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="x"),
+            tier1_enrich=PromptEntryConfig(text="x"),
+            tier3_extract=PromptEntryConfig(text="x"),
+        ),
+        notifications=NotificationsConfig(webhook_url="", timeout_seconds=5),
+        security=SecurityConfig(allow_private_ips=True),
+        extraction=ExtractionConfig(),
+        feedback=FeedbackConfig(),
+        inbox=InboxConfig(enabled=True),
+    )
+
+
+@pytest.fixture(scope="module")
+def fake_lithos() -> Generator[FakeLithosServer, None, None]:
+    server = FakeLithosServer()
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.fixture(scope="module")
+def fake_lithos_url(fake_lithos: FakeLithosServer) -> str:
+    return f"http://127.0.0.1:{fake_lithos.port}/sse"
+
+
+@pytest.fixture(autouse=True)
+def _clear(fake_lithos: FakeLithosServer) -> None:
+    fake_lithos.calls.clear()
+    for queue in (
+        fake_lithos.write_responses,
+        fake_lithos.cache_lookup_responses,
+        fake_lithos.list_responses,
+        fake_lithos.task_create_responses,
+        fake_lithos.task_complete_responses,
+        fake_lithos.task_list_responses,
+        fake_lithos.task_claim_responses,
+        fake_lithos.task_update_responses,
+    ):
+        queue.clear()
+
+
+def _acquisition() -> InboxAcquisition:
+    return InboxAcquisition(
+        source_url=_URL,
+        url_hash="abc1234567",
+        archive_path="inbox/2026/06/abc1234567.html",
+        archive_missing=False,
+        extracted_text="A sufficiently long article body to clear thin checks.",
+        summary="A sufficiently long article body to clear thin checks.",
+        text_flavour="html",
+    )
+
+
+def _clearing_scorer():
+    async def _scorer(
+        candidates: list[Candidate], profile: str, filter_prompt: str
+    ) -> dict[str, ScoredCandidate]:
+        return {
+            c.item_id: ScoredCandidate(
+                candidate=c, score=8, confidence=0.9, reason="r", filter_tags=()
+            )
+            for c in candidates
+        }
+
+    return _scorer
+
+
+def _calls(fake: FakeLithosServer, tool: str) -> list[dict[str, Any]]:
+    return [args for name, args in fake.calls if name == tool]
+
+
+def test_fanout_produces_one_inbox_ledger_entry_per_clearing_profile(
+    fake_lithos: FakeLithosServer,
+    fake_lithos_url: str,
+    tmp_path: Path,
+) -> None:
+    config = _make_config(fake_lithos_url)
+    ledger = RunLedger(tmp_path)
+    # One pending inbox task to claim.
+    fake_lithos.task_list_responses.append(
+        '{"tasks": [{"id": "task-1", "metadata": '
+        '{"kind": "url", "url": "' + _URL + '", "submitted_by": "agent:test"}}]}'
+    )
+
+    tick = InboxTick(
+        config=config,
+        coordinator=Coordinator(),
+        probe_loop=None,
+        ledger=ledger,
+        client_factory=lambda: LithosClient(url=fake_lithos_url),
+    )
+
+    with (
+        patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+        patch(
+            "influx.inbox.make_default_batch_scorer", return_value=_clearing_scorer()
+        ),
+    ):
+        asyncio.run(tick.execute())
+
+    # One real RunKind.INBOX ledger entry per clearing profile.
+    recent = ledger.recent(limit=10)
+    assert len(recent) == 3
+    assert {e["kind"] for e in recent} == {"inbox"}
+    assert {e["profile"] for e in recent} == set(_PROFILES)
+    assert all(e["sources_checked"] == 1 for e in recent)
+
+    # Three real writes (the canonical note + per-profile merge attempts).
+    assert len(_calls(fake_lithos, "lithos_write")) == 3
+
+    # The task was claimed and completed with a multi-profile outcome.
+    complete_calls = _calls(fake_lithos, "lithos_task_complete")
+    inbox_complete = [c for c in complete_calls if c["agent"] == "influx-inbox"]
+    assert len(inbox_complete) == 1
+    assert "ingested into 3 profile(s)" in inbox_complete[0]["outcome"]

--- a/tests/unit/test_inbox_notifications.py
+++ b/tests/unit/test_inbox_notifications.py
@@ -1,0 +1,74 @@
+"""Inbox notification opt-in (Inbox v1 slice 2).
+
+``"inbox"`` is a valid ``notify_on`` value; webhooks opt in to inbox-run
+notifications by listing it.  Webhooks without it stay silent on inbox runs
+(backwards-compatible with existing scheduled-only configs).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from influx.config import (
+    AppConfig,
+    NotificationsConfig,
+    NotificationWebhookConfig,
+    ProfileConfig,
+    PromptEntryConfig,
+    PromptsConfig,
+)
+from influx.coordinator import RunKind
+from influx.notifications import ProfileRunResult, RunStats, dispatch_notifications
+
+
+def _webhook(name: str, notify_on: list[str]) -> NotificationWebhookConfig:
+    return NotificationWebhookConfig(
+        name=name,
+        type="generic_digest",
+        url="https://hooks.example.com/x",
+        notify_on=notify_on,  # type: ignore[arg-type]
+        event_mode="digest",
+    )
+
+
+def _config(webhooks: list[NotificationWebhookConfig]) -> AppConfig:
+    return AppConfig(
+        profiles=[ProfileConfig(name="alpha")],
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="x"),
+            tier1_enrich=PromptEntryConfig(text="x"),
+            tier3_extract=PromptEntryConfig(text="x"),
+        ),
+        notifications=NotificationsConfig(webhooks=webhooks),
+    )
+
+
+def _result() -> ProfileRunResult:
+    return ProfileRunResult(
+        run_date="2026-06-01",
+        profile="alpha",
+        stats=RunStats(sources_checked=1, ingested=1),
+        items=[],
+    )
+
+
+def test_inbox_run_only_notifies_opted_in_webhook() -> None:
+    config = _config(
+        [
+            _webhook("inbox-hook", ["inbox"]),
+            _webhook("scheduled-hook", ["scheduled"]),
+        ]
+    )
+    with patch("influx.notifications._deliver_payload") as deliver:
+        dispatch_notifications(_result(), config, kind=RunKind.INBOX)
+
+    delivered = {call.args[0].name for call in deliver.call_args_list}
+    assert delivered == {"inbox-hook"}
+
+
+def test_scheduled_only_webhook_silent_on_inbox_run() -> None:
+    """A pre-existing scheduled-only webhook stays silent (backwards-compat)."""
+    config = _config([_webhook("scheduled-hook", ["scheduled"])])
+    with patch("influx.notifications._deliver_payload") as deliver:
+        dispatch_notifications(_result(), config, kind=RunKind.INBOX)
+    deliver.assert_not_called()

--- a/tests/unit/test_inbox_tick.py
+++ b/tests/unit/test_inbox_tick.py
@@ -523,7 +523,11 @@ async def test_filter_failure_isolated_to_one_profile() -> None:
         await _tick(client, config).execute()
 
     assert [c.args[0] for c in mock_dispatch.call_args_list] == ["a"]
-    assert client.completed[0]["outcome"] == "ingested into 1 profile(s): a"
+    # The filter failure is reported in the human outcome (#196), not just
+    # the structured payload.
+    assert client.completed[0]["outcome"] == (
+        "ingested into 1/2 profiles (a); b filter failed"
+    )
     per_profile = client.updated[0][1]["inbox_result"]["per_profile"]
     assert per_profile["b"] == {"ingested": False, "reason": "filter_error"}
 

--- a/tests/unit/test_inbox_tick.py
+++ b/tests/unit/test_inbox_tick.py
@@ -33,15 +33,21 @@ from influx.source import Candidate, ScoredCandidate
 from influx.sources.inbox import InboxAcquisition
 
 
-def _make_config() -> AppConfig:
+def _make_config(
+    profiles: list[tuple[str, int]] | None = None,
+) -> AppConfig:
+    """Config with the given ``(profile_name, relevance_threshold)`` profiles
+    (defaults to a single ``alpha`` profile at threshold 7)."""
+    specs = profiles if profiles is not None else [("alpha", 7)]
     return AppConfig(
         lithos=LithosConfig(url="http://localhost:0/sse"),
         profiles=[
             ProfileConfig(
-                name="alpha",
-                description="Alpha profile",
-                thresholds=ProfileThresholds(relevance=7),
+                name=name,
+                description=f"{name} profile",
+                thresholds=ProfileThresholds(relevance=threshold),
             )
+            for name, threshold in specs
         ],
         prompts=PromptsConfig(
             filter=PromptEntryConfig(text="x"),
@@ -117,20 +123,39 @@ def _acquisition() -> InboxAcquisition:
     )
 
 
+def _scored(c: Candidate, score: int) -> ScoredCandidate:
+    return ScoredCandidate(
+        candidate=c, score=score, confidence=0.9, reason="relevant", filter_tags=("t",)
+    )
+
+
 def _scorer_returning(score: int):
+    """Raw batch scorer that returns *score* for every profile."""
+
     async def _scorer(
         candidates: list[Candidate], profile: str, filter_prompt: str
     ) -> dict[str, ScoredCandidate]:
-        return {
-            c.item_id: ScoredCandidate(
-                candidate=c,
-                score=score,
-                confidence=0.9,
-                reason="relevant",
-                filter_tags=("t",),
-            )
-            for c in candidates
-        }
+        return {c.item_id: _scored(c, score) for c in candidates}
+
+    return _scorer
+
+
+def _scorer_by_profile(scores: dict[str, int], *, raise_for: set[str] | None = None):
+    """Raw batch scorer keyed by profile name.
+
+    A profile absent from *scores* returns an empty dict (model omitted the
+    item); a profile in *raise_for* raises to exercise filter-error isolation.
+    """
+    raises = raise_for or set()
+
+    async def _scorer(
+        candidates: list[Candidate], profile: str, filter_prompt: str
+    ) -> dict[str, ScoredCandidate]:
+        if profile in raises:
+            raise RuntimeError(f"filter boom for {profile}")
+        if profile not in scores:
+            return {}
+        return {c.item_id: _scored(c, scores[profile]) for c in candidates}
 
     return _scorer
 
@@ -150,9 +175,9 @@ def _task(
     return {"id": task_id, "metadata": metadata}
 
 
-def _tick(client: FakeClient) -> InboxTick:
+def _tick(client: FakeClient, config: AppConfig | None = None) -> InboxTick:
     return InboxTick(
-        config=_make_config(),
+        config=config or _make_config(),
         coordinator=Coordinator(),
         probe_loop=None,
         ledger=None,
@@ -253,7 +278,7 @@ async def test_skipped_run_reported_as_skipped_without_note_recovery() -> None:
     ):
         await _tick(client).execute()
     done = client.completed[0]
-    assert "skipped" in done["outcome"]
+    assert "not ingested" in done["outcome"]
     assert "lithos_unhealthy" in done["outcome"]
     # No write happened → no note-id recovery → empty cited_nodes.
     assert done["cited_nodes"] is None
@@ -328,31 +353,67 @@ async def test_busy_profile_skipped_this_tick_not_completed() -> None:
 
 
 async def test_per_item_failure_isolation() -> None:
-    """A crashing item does not prevent sibling items from completing."""
-    client = FakeClient(
-        tasks=[_task(task_id="task-1"), _task(task_id="task-2")],
-    )
+    """A hard crash on one item does not prevent siblings from completing.
 
-    def _dispatch_side_effect(profile: str, **_: Any) -> RunOutcome:
+    Acquisition raises for the first item — an error that propagates to the
+    execute()-level per-item handler (not caught inside dispatch).
+    """
+    client = FakeClient(tasks=[_task(task_id="task-1"), _task(task_id="task-2")])
+
+    def _acquire_side_effect(*_a: Any, **_k: Any) -> InboxAcquisition:
         if client.claimed and client.claimed[-1] == "task-1":
-            raise RuntimeError("boom on first item")
+            raise RuntimeError("boom acquiring first item")
+        return _acquisition()
+
+    with (
+        patch("influx.inbox.acquire_inbox_bytes", side_effect=_acquire_side_effect),
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_returning(8),
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch("influx.inbox.dispatch_profile", return_value=RunOutcome(ingested=1)),
+    ):
+        await _tick(client).execute()
+
+    # Both claimed; task-1 crashed (left for retry), task-2 still completed.
+    assert client.claimed == ["task-1", "task-2"]
+    completed_ids = {c["task_id"] for c in client.completed}
+    assert completed_ids == {"task-2"}
+
+
+async def test_per_profile_dispatch_failure_isolated() -> None:
+    """A dispatch failure for one profile is contained; the item completes.
+
+    Profile b's dispatch raises (non-busy); profile a still ingests and the
+    task completes with a partial outcome rather than crashing the item
+    (which would orphan a's write and double its ledger entry on retry)."""
+    config = _make_config([("a", 7), ("b", 7)])
+    client = FakeClient(tasks=[_task()], note_id="note-1")
+
+    async def _dispatch(profile: str, **_: Any) -> RunOutcome:
+        if profile == "b":
+            raise RuntimeError("write blew up for b")
         return RunOutcome(ingested=1)
 
     with (
         patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
         patch(
             "influx.inbox.make_default_batch_scorer",
-            return_value=_scorer_returning(8),
+            return_value=_scorer_by_profile({"a": 8, "b": 8}),
         ),
         patch("influx.inbox.build_filter_prompt", return_value="prompt"),
-        patch("influx.inbox.dispatch_profile", side_effect=_dispatch_side_effect),
+        patch("influx.inbox.dispatch_profile", side_effect=_dispatch),
     ):
-        await _tick(client).execute()
+        await _tick(client, config).execute()
 
-    # Both claimed; the second completed despite the first crashing.
-    assert client.claimed == ["task-1", "task-2"]
-    completed_ids = {c["task_id"] for c in client.completed}
-    assert "task-2" in completed_ids
+    assert len(client.completed) == 1
+    outcome = client.completed[0]["outcome"]
+    assert "ingested into 1/2 profiles (a)" in outcome
+    assert "b failed" in outcome
+    per_profile = client.updated[0][1]["inbox_result"]["per_profile"]
+    assert per_profile["a"]["ingested"] is True
+    assert per_profile["b"]["ingested"] is False
 
 
 def test_extract_note_id_key_fallback() -> None:
@@ -362,3 +423,185 @@ def test_extract_note_id_key_fallback() -> None:
     assert _extract_note_id({"hit": True, "existing_id": "n3"}) == "n3"
     assert _extract_note_id({"hit": False, "id": "n1"}) is None
     assert _extract_note_id({"hit": True}) is None
+
+
+# ── Slice 2: multi-profile fan-out ──────────────────────────────────
+
+
+async def test_fans_out_to_all_clearing_profiles() -> None:
+    """Every profile clearing threshold is dispatched; outcome lists them."""
+    config = _make_config([("a", 7), ("b", 7), ("c", 7)])
+    client = FakeClient(tasks=[_task()], note_id="note-1")
+    with (
+        patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_by_profile({"a": 8, "b": 9, "c": 7}),
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch(
+            "influx.inbox.dispatch_profile", return_value=RunOutcome(ingested=1)
+        ) as mock_dispatch,
+    ):
+        await _tick(client, config).execute()
+
+    dispatched_profiles = sorted(call.args[0] for call in mock_dispatch.call_args_list)
+    assert dispatched_profiles == ["a", "b", "c"]
+    done = client.completed[0]
+    assert done["outcome"].startswith("ingested into 3 profile(s):")
+    per_profile = client.updated[0][1]["inbox_result"]["per_profile"]
+    assert {p for p in per_profile if per_profile[p]["ingested"]} == {"a", "b", "c"}
+    # All profiles merge into one canonical note → single cited node.
+    assert done["cited_nodes"] == ["note-1"]
+
+
+async def test_below_threshold_profiles_excluded_and_top_score_reported() -> None:
+    """No profile clears → filtered_out outcome reports the top score."""
+    config = _make_config([("a", 7), ("b", 7)])
+    client = FakeClient(tasks=[_task()])
+    with (
+        patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_by_profile({"a": 4, "b": 5}),
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch("influx.inbox.dispatch_profile") as mock_dispatch,
+    ):
+        await _tick(client, config).execute()
+
+    mock_dispatch.assert_not_called()
+    outcome = client.completed[0]["outcome"]
+    assert outcome == "filtered out: top score 5 (b) below threshold 7"
+    per_profile = client.updated[0][1]["inbox_result"]["per_profile"]
+    assert per_profile["a"] == {
+        "score": 4,
+        "ingested": False,
+        "reason": "below_threshold",
+    }
+
+
+async def test_partial_fanout_one_clears_one_below() -> None:
+    """Mixed scores: only the clearing profile dispatches."""
+    config = _make_config([("a", 7), ("b", 7)])
+    client = FakeClient(tasks=[_task()], note_id="note-1")
+    with (
+        patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_by_profile({"a": 8, "b": 3}),
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch(
+            "influx.inbox.dispatch_profile", return_value=RunOutcome(ingested=1)
+        ) as mock_dispatch,
+    ):
+        await _tick(client, config).execute()
+
+    assert [c.args[0] for c in mock_dispatch.call_args_list] == ["a"]
+    assert client.completed[0]["outcome"] == "ingested into 1 profile(s): a"
+    per_profile = client.updated[0][1]["inbox_result"]["per_profile"]
+    assert per_profile["a"]["ingested"] is True
+    assert per_profile["b"]["reason"] == "below_threshold"
+
+
+async def test_filter_failure_isolated_to_one_profile() -> None:
+    """A filter error on profile b does not sink profile a's ingestion."""
+    config = _make_config([("a", 7), ("b", 7)])
+    client = FakeClient(tasks=[_task()], note_id="note-1")
+    with (
+        patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_by_profile({"a": 8}, raise_for={"b"}),
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch(
+            "influx.inbox.dispatch_profile", return_value=RunOutcome(ingested=1)
+        ) as mock_dispatch,
+    ):
+        await _tick(client, config).execute()
+
+    assert [c.args[0] for c in mock_dispatch.call_args_list] == ["a"]
+    assert client.completed[0]["outcome"] == "ingested into 1 profile(s): a"
+    per_profile = client.updated[0][1]["inbox_result"]["per_profile"]
+    assert per_profile["b"] == {"ingested": False, "reason": "filter_error"}
+
+
+async def test_one_clears_one_busy_partial_outcome() -> None:
+    """A busy clearing profile is reported; the free profile still ingests."""
+    config = _make_config([("a", 7), ("b", 7)])
+    client = FakeClient(tasks=[_task()], note_id="note-1")
+    coordinator = Coordinator()
+    tick = InboxTick(
+        config=config,
+        coordinator=coordinator,
+        client_factory=lambda: client,  # type: ignore[arg-type]
+    )
+
+    async def _dispatch(profile: str, **_: Any) -> RunOutcome:
+        return RunOutcome(ingested=1)
+
+    async with coordinator.hold("b"):  # b is busy for the whole tick
+        with (
+            patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+            patch(
+                "influx.inbox.make_default_batch_scorer",
+                return_value=_scorer_by_profile({"a": 8, "b": 8}),
+            ),
+            patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+            patch("influx.inbox.dispatch_profile", side_effect=_dispatch),
+        ):
+            await tick.execute()
+
+    outcome = client.completed[0]["outcome"]
+    assert outcome == "ingested into 1/2 profiles (a); b profile_busy"
+    per_profile = client.updated[0][1]["inbox_result"]["per_profile"]
+    assert per_profile["b"]["reason"] == "profile_busy"
+
+
+async def test_all_clearing_profiles_busy_skips_tick() -> None:
+    """When every clearing profile is busy, the task is left for retry."""
+    config = _make_config([("a", 7), ("b", 7)])
+    client = FakeClient(tasks=[_task()])
+    coordinator = Coordinator()
+    tick = InboxTick(
+        config=config,
+        coordinator=coordinator,
+        client_factory=lambda: client,  # type: ignore[arg-type]
+    )
+    async with coordinator.hold("a"), coordinator.hold("b"):
+        with (
+            patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+            patch(
+                "influx.inbox.make_default_batch_scorer",
+                return_value=_scorer_by_profile({"a": 8, "b": 8}),
+            ),
+            patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+            patch("influx.inbox.dispatch_profile") as mock_dispatch,
+        ):
+            await tick.execute()
+
+    mock_dispatch.assert_not_called()
+    assert client.claimed == ["task-1"]
+    assert client.completed == []  # left un-completed → retried next tick
+
+
+async def test_bytes_acquired_once_for_all_profiles() -> None:
+    """acquire_inbox_bytes runs exactly once regardless of profile count."""
+    config = _make_config([("a", 7), ("b", 7), ("c", 7)])
+    client = FakeClient(tasks=[_task()], note_id="note-1")
+    with (
+        patch(
+            "influx.inbox.acquire_inbox_bytes", return_value=_acquisition()
+        ) as mock_acquire,
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_by_profile({"a": 8, "b": 8, "c": 8}),
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch("influx.inbox.dispatch_profile", return_value=RunOutcome(ingested=1)),
+    ):
+        await _tick(client, config).execute()
+
+    mock_acquire.assert_called_once()


### PR DESCRIPTION
## Summary

Slice 2 of the Influx Inbox v1 feature (design spec: `docs/plans/inbox.md` §3/§5/§7/§8/§9). Thickens the slice-1 happy path from one profile to **multi-profile fan-out**: a submitted URL is scored against *every* enabled profile, and each profile that clears its own threshold contributes a Profile Relevance entry to one shared canonical note via the existing `write_note` merge machinery.

Builds on slice 1 (#195, merged in #199). The acquisition + single-item dispatch seam are unchanged; this slice generalises the orchestrator's scoring + dispatch from "first profile" to "all profiles."

## What changed

- **Filter fan-out** (`inbox.py`): the tick scores all enabled profiles in parallel (`asyncio.gather`), reusing the **single** acquisition (URL fetched/extracted once). Scoring calls the batch scorer directly so per-profile scores are available for below-threshold profiles too (drives the §7.3 `per_profile` payload and the "top score K" outcome).
- **Per-profile dispatch**: clearing profiles are dispatched **sequentially** so the first creates the canonical note and the rest hit `cache_lookup` → `write_note` slug-collision → `_merge_profile_relevance_in_content` (existing path — no new merge code). Each dispatch holds `coordinator.hold(profile)`.
- **Contention** (§5.5/§10): a busy profile is skipped for this tick. If at least one profile ran, the task completes with results; if *every* clearing profile is busy, the task is left un-completed for a later tick (no terminal drop).
- **Outcome strings** (§7.1): `ingested into N profile(s): a, b`; partial `ingested into M/N profiles (a); b profile_busy; c failed: …`; `filtered out: top score K (profile) below threshold T`.
- **`inbox_result.per_profile`** (§7.3): `{score, ingested, note_id, run_id, reason}` for every scored profile.
- **Failure isolation** (§5.5): a per-profile filter error is contained to that profile (reported `filter_error`); the other profiles still score and ingest.
- **Notifications**: `"inbox"` added to the `NotificationRunKind` literal. Per-profile INBOX Runs flow through the existing pipeline; webhooks opt in via `notify_on=["inbox"]` — existing scheduled-only configs stay silent (backwards-compatible).

## Out of scope (later slices)

Cache-hit replay (§6) and the richer §10 reporting (cross-tick re-scoring of busy/skipped profiles) — slice 3 (#197). `/status` + submit script — slice 4 (#198). Content-type-accurate single-fetch acquisition — #200.

## Test plan

- `make check` green (ruff + pyright + full pytest suite).
- New unit tests (`test_inbox_tick.py`): fan-out to all clearing profiles; below-threshold exclusion + top-score outcome; partial fan-out; per-profile filter-error isolation; one-clears-one-busy partial outcome; all-clearing-busy → skip-this-tick; bytes acquired once.
- New integration test (`test_inbox_fanout.py`): full tick → 3 real `RunKind.INBOX` ledger entries (one per profile) + 3 writes from a single acquisition, via real `RunService`/`RunLedger`/`FakeLithosServer`.
- New notification test (`test_inbox_notifications.py`): inbox run notifies only opted-in webhooks; scheduled-only webhook stays silent.

Closes #196
