### PR TITLE
feat: inbox cache-hit replay + coordinator try-acquire-skip (#197)

### DIFF
--- a/src/influx/inbox.py
+++ b/src/influx/inbox.py
@@ -424,6 +424,8 @@ class InboxTick:
             )
             if not candidate_profiles:
                 metrics.inbox_items_processed().add(1, {"outcome": "cache_hit"})
+                # Acquisition is skipped here, so ``archive_path`` is null —
+                # kept in the payload for a stable shape across all outcomes.
                 return _ItemOutcome(
                     outcome=(
                         f"cache_hit: existing note {cache_note_id}; "
@@ -432,9 +434,11 @@ class InboxTick:
                     cited_nodes=[cache_note_id],
                     inbox_result={
                         "source_url": source_url,
+                        "archive_path": None,
                         "cache_hit": True,
                         "note_id": cache_note_id,
                         "per_profile": {},
+                        "processing_time_ms": int((time.monotonic() - started) * 1000),
                     },
                 )
 

--- a/src/influx/inbox.py
+++ b/src/influx/inbox.py
@@ -646,10 +646,18 @@ class InboxTick:
     ) -> list[Any]:
         """Profiles eligible for cache-hit replay (§6): enabled minus those
         that already ingested the note minus operator-suppressed
-        (``influx:rejected:<profile>``).  On read failure, fall back to all
-        profiles (the in-Run merge still dedupes correctly)."""
+        (``influx:rejected:<profile>``).
+
+        Best-effort: on read OR parse failure, fall back to replaying all
+        profiles (the in-Run ``write_note`` merge dedupes already-present
+        entries idempotently).  Cache-hit replay is an optimisation, never a
+        correctness gate — a malformed / non-Influx note sharing the URL must
+        not poison the item (which would crash every retry forever).
+        """
         try:
             note = await client.read_note(note_id=note_id)
+            parsed = parse_note(str(note.get("content") or ""))
+            ingested = {e.profile_name for e in parse_profile_relevance(parsed)}
         except (LithosError, LCMAError):
             logger.warning(
                 "inbox read_note failed for %s; replaying all profiles",
@@ -657,8 +665,13 @@ class InboxTick:
                 exc_info=True,
             )
             return profiles
-        parsed = parse_note(str(note.get("content") or ""))
-        ingested = {entry.profile_name for entry in parse_profile_relevance(parsed)}
+        except Exception:  # noqa: BLE001 — parse of a non-canonical note must not poison
+            logger.warning(
+                "inbox could not parse existing note %s; replaying all profiles",
+                note_id,
+                exc_info=True,
+            )
+            return profiles
         tags = note.get("tags") or []
         suppressed = {
             tag[len(_REJECTED_TAG_PREFIX) :]

--- a/src/influx/inbox.py
+++ b/src/influx/inbox.py
@@ -18,8 +18,10 @@ dispatched to each that clears its threshold, merging into one canonical
 note via the existing ``write_note`` path.  Each dispatch holds the
 per-Profile coordinator lock (so inbox never overlaps a scheduled Run for
 the same profile); when every clearing profile is busy the item is left
-for a later tick.  Cache-hit replay (§6) and the richer §10 reporting
-(cross-tick re-scoring of busy/skipped profiles) arrive in a later slice.
+for a later tick.  A resubmitted URL is a cache-hit replay (§6): only the
+*complement* (profiles that have neither ingested it nor been suppressed)
+is re-scored, which is how a busy-skipped profile is picked up on a later
+tick (§10).
 """
 
 from __future__ import annotations
@@ -41,6 +43,7 @@ from influx.errors import LCMAError, LithosError
 from influx.feedback import build_filter_prompt
 from influx.filter import make_default_batch_scorer
 from influx.lithos_client import LithosClient
+from influx.notes import parse_note, parse_profile_relevance
 from influx.run import ItemProvider, RunOutcome, RunPlan
 from influx.run_service import RunService
 from influx.source import BoundScoredCandidate, Candidate, ScoredCandidate
@@ -49,6 +52,7 @@ from influx.sources.inbox import (
     acquire_inbox_bytes,
     build_inbox_note_item,
 )
+from influx.urls import normalise_url
 
 if TYPE_CHECKING:
     from influx.run_ledger import RunLedger
@@ -64,6 +68,7 @@ _SUBMITTER_STRIP_RE = re.compile(r"[^A-Za-z0-9:._-]+")
 _DEFAULT_SOURCE_TAG = "inbox"
 _CLAIM_ASPECT = "ingest"
 _ALLOWED_URL_SCHEMES = ("http", "https")
+_REJECTED_TAG_PREFIX = "influx:rejected:"
 
 
 def _valid_source_tag(tag: str) -> bool:
@@ -403,6 +408,36 @@ class InboxTick:
                 inbox_result={"source_url": url, "error": reason},
             )
 
+        # ── Cache-hit replay (§6) ─────────────────────────────────────
+        # If this URL is already a note, score + dispatch only the
+        # *complement* — profiles that have neither ingested it nor been
+        # operator-suppressed (``influx:rejected:<profile>``).  This both
+        # avoids re-dispatching profiles already present and re-scores
+        # profiles a previous tick left out (e.g. busy-skipped), which is
+        # how the §10 try-acquire-skip work is picked up on a later tick.
+        source_url = normalise_url(url)
+        cache_note_id = await self._lookup_existing(client, source_url)
+        candidate_profiles = profiles
+        if cache_note_id is not None:
+            candidate_profiles = await self._complement_profiles(
+                client, cache_note_id, profiles
+            )
+            if not candidate_profiles:
+                metrics.inbox_items_processed().add(1, {"outcome": "cache_hit"})
+                return _ItemOutcome(
+                    outcome=(
+                        f"cache_hit: existing note {cache_note_id}; "
+                        "no new profiles to consider"
+                    ),
+                    cited_nodes=[cache_note_id],
+                    inbox_result={
+                        "source_url": source_url,
+                        "cache_hit": True,
+                        "note_id": cache_note_id,
+                        "per_profile": {},
+                    },
+                )
+
         # Acquire once (blocking download/extract → thread); bytes + extracted
         # text are reused across every per-profile filter + dispatch below.
         acquired = await asyncio.to_thread(
@@ -447,11 +482,13 @@ class InboxTick:
 
         # gather preserves config order; profile count is small (§17 leaves a
         # tighter concurrency cap as a future tuning knob).
-        scored_profiles = list(await asyncio.gather(*(_score(p) for p in profiles)))
+        scored_profiles = list(
+            await asyncio.gather(*(_score(p) for p in candidate_profiles))
+        )
         clearing = [ps for ps in scored_profiles if ps.clears]
 
         if not clearing:
-            return self._filtered_out_outcome(acquired, scored_profiles, url)
+            return self._filtered_out_outcome(acquired, scored_profiles, cache_note_id)
 
         # ── Per-(item, Profile) dispatch: sequential so the first write
         # creates the canonical note and the rest merge into it ────────
@@ -500,22 +537,29 @@ class InboxTick:
         ingested_names = [
             name for name, (o, _rid) in dispatched.items() if o.ingested > 0
         ]
-        note_id = (
-            await self._recover_note_id(client, acquired.source_url)
-            if ingested_names
-            else None
-        )
+        # On a cache hit the canonical note id is already known; otherwise
+        # recover it after the first write created it.
+        note_id = cache_note_id
+        if note_id is None and ingested_names:
+            note_id = await self._recover_note_id(client, acquired.source_url)
 
         per_profile = self._build_per_profile(
             scored_profiles, dispatched, busy, dispatch_failed, note_id
         )
         filter_errors = [ps.name for ps in scored_profiles if ps.error]
         outcome_str = self._build_outcome_string(
-            ingested_names, dispatched, busy, dispatch_failed, filter_errors
+            ingested_names,
+            dispatched,
+            busy,
+            dispatch_failed,
+            filter_errors,
+            cache_note_id,
         )
-        metrics.inbox_items_processed().add(
-            1, {"outcome": "ingested" if ingested_names else "error"}
-        )
+        if cache_note_id is not None:
+            metric_outcome = "cache_hit"
+        else:
+            metric_outcome = "ingested" if ingested_names else "error"
+        metrics.inbox_items_processed().add(1, {"outcome": metric_outcome})
 
         return _ItemOutcome(
             outcome=outcome_str,
@@ -523,6 +567,7 @@ class InboxTick:
             inbox_result={
                 "source_url": acquired.source_url,
                 "archive_path": acquired.archive_path,
+                "cache_hit": cache_note_id is not None,
                 "per_profile": per_profile,
                 "processing_time_ms": int((time.monotonic() - started) * 1000),
             },
@@ -532,35 +577,92 @@ class InboxTick:
         self,
         acquired: InboxAcquisition,
         scored_profiles: list[_ProfileScore],
-        url: str,
+        cache_note_id: str | None,
     ) -> _ItemOutcome:
-        """Build the terminal outcome when no profile cleared threshold (§7.1)."""
-        metrics.inbox_items_processed().add(1, {"outcome": "filtered_out"})
-        # (score, name, threshold) for every profile the model scored.
-        scored = [
-            (ps.scored.score, ps.name, ps.threshold)
-            for ps in scored_profiles
-            if ps.scored is not None
-        ]
-        if scored:
-            top_score, top_name, top_threshold = max(scored)
+        """Build the terminal outcome when no candidate profile cleared (§7.1).
+
+        Frames as a cache-hit replay (``no new profiles matched``) when this
+        URL is already a note, else a fresh ``filtered out: top score …``.
+        """
+        if cache_note_id is not None:
+            metrics.inbox_items_processed().add(1, {"outcome": "cache_hit"})
             outcome = (
-                f"filtered out: top score {top_score} ({top_name}) "
-                f"below threshold {top_threshold}"
+                f"cache_hit: existing note {cache_note_id}; no new profiles matched"
             )
         else:
-            outcome = "filtered out: no profile scored the item"
+            metrics.inbox_items_processed().add(1, {"outcome": "filtered_out"})
+            # (score, name, threshold) for every profile the model scored.
+            scored = [
+                (ps.scored.score, ps.name, ps.threshold)
+                for ps in scored_profiles
+                if ps.scored is not None
+            ]
+            if scored:
+                top_score, top_name, top_threshold = max(scored)
+                outcome = (
+                    f"filtered out: top score {top_score} ({top_name}) "
+                    f"below threshold {top_threshold}"
+                )
+            else:
+                outcome = "filtered out: no profile scored the item"
         return _ItemOutcome(
             outcome=outcome,
-            cited_nodes=[],
+            cited_nodes=[cache_note_id] if cache_note_id else [],
             inbox_result={
                 "source_url": acquired.source_url,
                 "archive_path": acquired.archive_path,
+                "cache_hit": cache_note_id is not None,
                 "per_profile": self._build_per_profile(
                     scored_profiles, {}, [], {}, None
                 ),
             },
         )
+
+    async def _lookup_existing(
+        self, client: LithosClient, source_url: str
+    ) -> str | None:
+        """Return the existing canonical note id for *source_url*, or ``None``.
+
+        Best-effort: a lookup failure is treated as a miss so the cache-hit
+        replay (§6) is purely an optimisation, never a correctness gate.
+        """
+        try:
+            body = await client.cache_lookup_by_url_body(source_url=source_url)
+        except (LithosError, LCMAError):
+            logger.warning(
+                "inbox cache lookup failed for %s; treating as miss",
+                source_url,
+                exc_info=True,
+            )
+            return None
+        return _extract_note_id(body)
+
+    async def _complement_profiles(
+        self, client: LithosClient, note_id: str, profiles: list[Any]
+    ) -> list[Any]:
+        """Profiles eligible for cache-hit replay (§6): enabled minus those
+        that already ingested the note minus operator-suppressed
+        (``influx:rejected:<profile>``).  On read failure, fall back to all
+        profiles (the in-Run merge still dedupes correctly)."""
+        try:
+            note = await client.read_note(note_id=note_id)
+        except (LithosError, LCMAError):
+            logger.warning(
+                "inbox read_note failed for %s; replaying all profiles",
+                note_id,
+                exc_info=True,
+            )
+            return profiles
+        parsed = parse_note(str(note.get("content") or ""))
+        ingested = {entry.profile_name for entry in parse_profile_relevance(parsed)}
+        tags = note.get("tags") or []
+        suppressed = {
+            tag[len(_REJECTED_TAG_PREFIX) :]
+            for tag in tags
+            if isinstance(tag, str) and tag.startswith(_REJECTED_TAG_PREFIX)
+        }
+        excluded = ingested | suppressed
+        return [p for p in profiles if p.name not in excluded]
 
     @staticmethod
     def _build_per_profile(
@@ -622,6 +724,7 @@ class InboxTick:
         busy: list[str],
         dispatch_failed: dict[str, str],
         filter_errors: list[str],
+        cache_note_id: str | None = None,
     ) -> str:
         """Build the free-text outcome string (§7.1).
 
@@ -630,6 +733,8 @@ class InboxTick:
         and filter-errored.  Profiles that scored below threshold are not
         candidates and are excluded (they surface only in ``per_profile``).
         Filter failures (§5.5 / #196) are reported as ``X filter failed``.
+        When *cache_note_id* is set the item is a cache-hit replay (§6) and
+        the wording shifts to ``cache_hit: … added N profile entr…``.
         """
         total = len(dispatched) + len(busy) + len(dispatch_failed) + len(filter_errors)
         failed = [
@@ -647,15 +752,24 @@ class InboxTick:
         if filter_errors:
             issues.append(f"{', '.join(filter_errors)} filter failed")
 
+        tail = ("; " + "; ".join(issues)) if issues else ""
+        names = ", ".join(ingested_names)
+
+        if cache_note_id is not None:
+            prefix = f"cache_hit: existing note {cache_note_id}; "
+            if not ingested_names:
+                return prefix + f"no new profiles matched{tail}"
+            entry_word = "entry" if len(ingested_names) == 1 else "entries"
+            return (
+                prefix
+                + f"added {len(ingested_names)} profile {entry_word}: {names}{tail}"
+            )
+
         if not ingested_names:
             return f"not ingested ({'; '.join(issues) or 'no note written'})"
-
-        names = ", ".join(ingested_names)
         if not issues and len(ingested_names) == total:
             return f"ingested into {len(ingested_names)} profile(s): {names}"
-
-        head = f"ingested into {len(ingested_names)}/{total} profiles ({names})"
-        return head + ("; " + "; ".join(issues) if issues else "")
+        return f"ingested into {len(ingested_names)}/{total} profiles ({names}){tail}"
 
     async def _recover_note_id(
         self, client: LithosClient, source_url: str

--- a/tests/unit/test_inbox_tick.py
+++ b/tests/unit/test_inbox_tick.py
@@ -66,10 +66,20 @@ class FakeClient:
         tasks: list[dict[str, Any]],
         claim_success: bool = True,
         note_id: str | None = "note-xyz",
+        existing_note_id: str | None = None,
+        existing_note: dict[str, Any] | None = None,
     ) -> None:
         self._tasks = tasks
         self._claim_success = claim_success
+        # ``note_id`` is what post-dispatch recovery resolves for a *fresh*
+        # item; ``existing_note_id`` (+ ``existing_note``) drive the
+        # cache-hit gate + read_note for replay tests.  cache_lookup is
+        # called twice on the fresh path (gate miss, then recovery hit), so
+        # the first call models the gate and later calls model recovery.
         self._note_id = note_id
+        self._existing_note_id = existing_note_id
+        self._existing_note = existing_note or {"content": "", "tags": []}
+        self._gated: set[str] = set()
         self.claimed: list[str] = []
         self.updated: list[tuple[str, dict[str, Any]]] = []
         self.completed: list[dict[str, Any]] = []
@@ -103,9 +113,19 @@ class FakeClient:
         return {"status": "completed"}
 
     async def cache_lookup_by_url_body(self, *, source_url: str) -> dict[str, Any]:
+        # First lookup for a URL is the cache-hit gate; later lookups for the
+        # same URL are post-dispatch note-id recovery (fresh path).
+        if source_url not in self._gated:
+            self._gated.add(source_url)
+            if self._existing_note_id:
+                return {"hit": True, "id": self._existing_note_id}
+            return {"hit": False}
         if self._note_id:
             return {"hit": True, "id": self._note_id}
         return {"hit": False}
+
+    async def read_note(self, *, note_id: str) -> dict[str, Any]:
+        return self._existing_note
 
     async def close(self) -> None:
         return None
@@ -358,7 +378,12 @@ async def test_per_item_failure_isolation() -> None:
     Acquisition raises for the first item — an error that propagates to the
     execute()-level per-item handler (not caught inside dispatch).
     """
-    client = FakeClient(tasks=[_task(task_id="task-1"), _task(task_id="task-2")])
+    client = FakeClient(
+        tasks=[
+            _task(task_id="task-1", url="https://example.com/a"),
+            _task(task_id="task-2", url="https://example.com/b"),
+        ]
+    )
 
     def _acquire_side_effect(*_a: Any, **_k: Any) -> InboxAcquisition:
         if client.claimed and client.claimed[-1] == "task-1":
@@ -609,3 +634,130 @@ async def test_bytes_acquired_once_for_all_profiles() -> None:
         await _tick(client, config).execute()
 
     mock_acquire.assert_called_once()
+
+
+# ── Slice 3: cache-hit replay (§6) ──────────────────────────────────
+
+
+def _note_content(ingested: list[str]) -> str:
+    """Render note body whose ## Profile Relevance lists *ingested* profiles."""
+    from influx.renderer import ProfileRelevanceEntry, render_note
+
+    return render_note(
+        title="Existing",
+        source_url="https://example.com/article",
+        tags=["ingested-by:influx"],
+        confidence=1.0,
+        archive_path=None,
+        summary="s",
+        keywords=[],
+        profile_entries=[
+            ProfileRelevanceEntry(profile_name=n, score=8, reason="r") for n in ingested
+        ],
+    )
+
+
+async def test_cache_hit_replays_only_complement_profiles() -> None:
+    """On a cache hit, only profiles that haven't ingested are re-dispatched."""
+    config = _make_config([("a", 7), ("b", 7), ("c", 7)])
+    client = FakeClient(
+        tasks=[_task()],
+        existing_note_id="note-1",
+        existing_note={"content": _note_content(["a", "b"]), "tags": []},
+    )
+    with (
+        patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_by_profile({"a": 8, "b": 8, "c": 8}),
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch(
+            "influx.inbox.dispatch_profile", return_value=RunOutcome(ingested=1)
+        ) as mock_dispatch,
+    ):
+        await _tick(client, config).execute()
+
+    # a and b already ingested → only c is dispatched.
+    assert [c.args[0] for c in mock_dispatch.call_args_list] == ["c"]
+    outcome = client.completed[0]["outcome"]
+    assert outcome == "cache_hit: existing note note-1; added 1 profile entry: c"
+    assert client.completed[0]["cited_nodes"] == ["note-1"]
+
+
+async def test_cache_hit_excludes_rejected_tag_profiles() -> None:
+    """influx:rejected:<profile> suppresses that profile from replay (§6)."""
+    config = _make_config([("a", 7), ("b", 7), ("c", 7)])
+    client = FakeClient(
+        tasks=[_task()],
+        existing_note_id="note-1",
+        existing_note={
+            "content": _note_content(["a"]),
+            "tags": ["influx:rejected:b"],
+        },
+    )
+    with (
+        patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_by_profile({"c": 8}),
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch(
+            "influx.inbox.dispatch_profile", return_value=RunOutcome(ingested=1)
+        ) as mock_dispatch,
+    ):
+        await _tick(client, config).execute()
+
+    # a ingested, b operator-suppressed → only c is a candidate.
+    assert [c.args[0] for c in mock_dispatch.call_args_list] == ["c"]
+
+
+async def test_cache_hit_no_new_profiles_to_consider_skips_acquire() -> None:
+    """When every profile already ingested, no acquire/dispatch happens."""
+    config = _make_config([("a", 7), ("b", 7)])
+    client = FakeClient(
+        tasks=[_task()],
+        existing_note_id="note-1",
+        existing_note={"content": _note_content(["a", "b"]), "tags": []},
+    )
+    with (
+        patch("influx.inbox.acquire_inbox_bytes") as mock_acquire,
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_by_profile({}),
+        ),
+        patch("influx.inbox.dispatch_profile") as mock_dispatch,
+    ):
+        await _tick(client, config).execute()
+
+    mock_acquire.assert_not_called()
+    mock_dispatch.assert_not_called()
+    assert client.completed[0]["outcome"] == (
+        "cache_hit: existing note note-1; no new profiles to consider"
+    )
+    assert client.completed[0]["cited_nodes"] == ["note-1"]
+
+
+async def test_cache_hit_complement_scored_but_none_clear() -> None:
+    config = _make_config([("a", 7), ("b", 7)])
+    client = FakeClient(
+        tasks=[_task()],
+        existing_note_id="note-1",
+        existing_note={"content": _note_content(["a"]), "tags": []},
+    )
+    with (
+        patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_by_profile({"b": 3}),  # below threshold
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch("influx.inbox.dispatch_profile") as mock_dispatch,
+    ):
+        await _tick(client, config).execute()
+
+    mock_dispatch.assert_not_called()
+    assert client.completed[0]["outcome"] == (
+        "cache_hit: existing note note-1; no new profiles matched"
+    )

--- a/tests/unit/test_inbox_tick.py
+++ b/tests/unit/test_inbox_tick.py
@@ -766,3 +766,34 @@ async def test_cache_hit_complement_scored_but_none_clear() -> None:
     assert client.completed[0]["outcome"] == (
         "cache_hit: existing note note-1; no new profiles matched"
     )
+
+
+async def test_cache_hit_unparseable_note_falls_back_to_all_profiles() -> None:
+    """A same-URL note that read_note returns but parse can't handle must not
+    poison the item — fall back to replaying all profiles (#202 review)."""
+    config = _make_config([("a", 7), ("b", 7)])
+    client = FakeClient(
+        tasks=[_task()],
+        existing_note_id="note-1",
+        existing_note={"content": "garbage that is not a canonical note", "tags": []},
+        note_id="note-1",
+    )
+    with (
+        patch(
+            "influx.inbox.parse_note", side_effect=RuntimeError("not a canonical note")
+        ),
+        patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_by_profile({"a": 8, "b": 8}),
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch(
+            "influx.inbox.dispatch_profile", return_value=RunOutcome(ingested=1)
+        ) as mock_dispatch,
+    ):
+        await _tick(client, config).execute()
+
+    # Parse failure → fell back to replaying ALL profiles (not crashed/skipped).
+    assert sorted(c.args[0] for c in mock_dispatch.call_args_list) == ["a", "b"]
+    assert len(client.completed) == 1

--- a/tests/unit/test_inbox_tick.py
+++ b/tests/unit/test_inbox_tick.py
@@ -737,6 +737,11 @@ async def test_cache_hit_no_new_profiles_to_consider_skips_acquire() -> None:
         "cache_hit: existing note note-1; no new profiles to consider"
     )
     assert client.completed[0]["cited_nodes"] == ["note-1"]
+    # Stable inbox_result shape even when acquisition is skipped.
+    result = client.updated[0][1]["inbox_result"]
+    assert result["cache_hit"] is True
+    assert result["archive_path"] is None
+    assert "processing_time_ms" in result
 
 
 async def test_cache_hit_complement_scored_but_none_clear() -> None:


### PR DESCRIPTION
## Summary

Slice 3 of the Influx Inbox v1 feature (design spec: `docs/plans/inbox.md` §6/§10). Handles the two correctness paths the happy path skipped: **cache-hit replay** of an already-ingested URL, and **coordinator try-acquire-skip** under contention (the lock itself landed in slice 1; this slice completes the cross-tick retry semantics that depend on replay).

Builds on slice 2 (#196, merged in #201).

## What changed

- **Cache-hit replay (§6):** before acquiring, the tick does a `cache_lookup` on the normalised URL. On a hit it reads the existing note, parses `## Profile Relevance` (`parse_profile_relevance`) for already-ingested profiles and `influx:rejected:<profile>` tags for operator suppression, and computes the **complement** = enabled − ingested − suppressed. Only the complement is re-scored and dispatched; newly-clearing profiles merge into the existing canonical note via the existing `write_note` path. No persisted filter-rejection memory (§6.1) — a previously below-threshold profile is re-scored on resubmission.
- **Cross-tick retry (§10):** a profile skipped for busyness is never recorded in Profile Relevance, so on the next submission it falls into the complement and is re-scored — this is how the slice-1/2 try-acquire-skip work is actually picked up later. No blocking wait / `task_renew` (§10.2/10.3).
- **Outcome strings (§7.1):** cache-hit items report `cache_hit: existing note <id>; added N profile entr…: …`, `…; no new profiles matched`, or `…; no new profiles to consider` (complement empty → no acquire/dispatch). `inbox_result.cache_hit` flag added; `inbox_items_processed{outcome="cache_hit"}` emitted.

## Out of scope (later slices)

`/status` section + `influx-inbox-submit` helper script + docs — slice 4 (#198). Content-type-accurate single-fetch acquisition — #200.

## Test plan

- `make check` green (ruff + pyright + full pytest suite).
- New unit tests (`test_inbox_tick.py`): replay dispatches only the complement; `influx:rejected:<profile>` exclusion; complement-empty skips acquire/dispatch (`no new profiles to consider`); complement scored but none clear (`no new profiles matched`). The `FakeClient` now models the two-phase lookup (gate miss → recovery hit, per source_url) and `read_note` for replay.

Closes #197
