### PR TITLE
feat: inbox operational surface — /status, submit script, docs (#198)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,7 +55,7 @@ _Avoid_: job, task (Lithos has its own `lithos_task_*`), tick.
 The data-driven specification a Run executes: profile, kind, date window, `skip_repair`, `skip_cache_hits`, `notify`, ledger ID, request ID. Built once per request type by the scheduler.
 
 **RunKind**:
-One of `scheduled`, `manual`, `backfill`. Carried as a tag for ledger and metric labels even though behaviour is driven by the boolean flags on the RunPlan.
+One of `scheduled`, `manual`, `backfill`, `inbox`. Carried as a tag for ledger and metric labels even though behaviour is driven by the boolean flags on the RunPlan. `inbox` marks the per-(item, Profile) Runs an InboxTick dispatches; it is excluded from the scheduled-only stall heuristics.
 
 **RunOutcome**:
 The post-execution record: `sources_checked`, `ingested`, `error`, `degraded`, `degraded_reasons`, `source_acquisition_errors`, plus the items needed for post-run notification dispatch.
@@ -71,6 +71,20 @@ The post-write step that calls `lithos_retrieve` for related notes, upserts `rel
 
 **RunService**:
 The collaborator that owns "build RunPlan → execute Run → dispatch notifications → record outcome" for one request. The scheduler's three entry points (scheduled tick, `POST /runs`, `POST /backfills`) are thin RunPlan builders that hand off to RunService. Lives in `src/influx/run_service.py` as `RunService.execute()`.
+
+### Domain — Inbox (manual submission)
+
+**InboxTask**:
+A Lithos task tagged `influx:inbox` carrying submission metadata (`kind="url"`, `url`, `submitted_by`, optional `title`/`summary`/`source_tag`). Created by external agents via `lithos_task_create`; consumed by the InboxTick. Each task is one candidate URL. See `docs/plans/inbox.md`.
+
+**InboxTick**:
+One execution of the inbox-tick scheduler entry (`influx-inbox-tick`, registered only when `[inbox] enabled`). Claims pending InboxTasks, acquires each URL once, scores it against every enabled Profile, and dispatches a real single-Profile `RunKind.INBOX` Run for each Profile that clears threshold (merging into one canonical note), then completes the task with an outcome string + `cited_nodes`. NOT itself a `Run` — an orchestrator above the Run layer. Lives in `src/influx/inbox.py` as `InboxTick.execute()`.
+
+**Submitter**:
+The external agent that creates an InboxTask, identified by the `submitted_by` metadata field (sanitised into a `submitter:<id>` note tag).
+
+**Cache-hit replay**:
+On a resubmitted URL the InboxTick re-scores only the *complement* of Profiles — enabled minus those already in the note's `## Profile Relevance` minus operator-suppressed (`influx:rejected:<profile>`) — so a Profile skipped earlier (e.g. busy) is picked up on a later tick. Best-effort: a read/parse failure falls back to replaying all Profiles (the write merge dedupes).
 
 ### Domain — Lithos integration
 
@@ -89,7 +103,7 @@ The recovery strategy when `lithos_write` returns `slug_collision`. Influx reads
 ### Operational state
 
 **RunLedger**:
-The local persistent record of Run history. Lives under `storage.state_dir` as `active-runs.json` (in-flight) plus `runs.jsonl` (terminal). Owns the `ingestion_stall` heuristic (consecutive zero-ingestion scheduled runs for the same Profile, backfills excluded). Not stored in Lithos — operational state, not knowledge.
+The local persistent record of Run history. Lives under `storage.state_dir` as `active-runs.json` (in-flight) plus `runs.jsonl` (terminal). Owns the `ingestion_stall` heuristic (consecutive zero-ingestion scheduled runs for the same Profile; non-scheduled kinds — backfill, inbox — excluded). Not stored in Lithos — operational state, not knowledge.
 
 **Degraded reasons**:
 The structured list on a Run's ledger entry explaining why it was marked `degraded`. Current values: `source_acquisition` (a source-fetch error was swallowed), `ingestion_stall` (this and the prior scheduled run both ingested zero with `sources_checked > 0`).

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -197,7 +197,7 @@ The admin API is intended to bind to loopback by default. Non-loopback bind host
 
 - `GET /live`: always returns `200 {"live": true}` while the process is alive.
 - `GET /ready`: returns `200` when cached probes are ready, otherwise `503`.
-- `GET /status`: returns process status, readiness, version, dependency probe states, and per-profile scheduler, busy, and last-run state.
+- `GET /status`: returns process status, readiness, version, dependency probe states, and per-profile scheduler, busy, and last-run state. When the inbox is wired it also includes an `inbox` block (`enabled`, `pending`, `in_flight`, `last_tick_at`, `last_tick_outcome`) sourced from cached tick state — never a per-request `lithos_task_list` (§17).
 - `GET /runs/recent`: returns active runs and recent terminal run ledger entries. Query parameters are `limit` and `profile`.
 - `POST /runs`: accepts `{"profile": "<name>"}` or `{"all_profiles": true}`.
 - `POST /backfills`: accepts `{"profile": "<name>", "days": n}` or `{"profile": "<name>", "from": "...", "to": "..."}`; `all_profiles` is also supported.
@@ -593,7 +593,7 @@ Notification configuration:
   - `type`
   - `url`
   - `enabled`
-  - `notify_on`
+  - `notify_on` (`scheduled`, `manual`, `backfill`, `inbox`; webhooks opt in to inbox-run notifications by listing `inbox`)
   - `event_mode`
   - optional `min_score`
   - optional `auth_token_env`
@@ -774,3 +774,29 @@ Known warnings in the suite:
 7. RSS filtering requires a configured `models.filter` slot and provider; failed RSS filter batches are skipped.
 8. Source archives and Lithos notes can diverge when archive download fails; repair tags mark those notes for later recovery.
 9. All profiles share a single global cron expression. Within a tick they run sequentially in declared order, separated by `schedule.inter_profile_gap_seconds`, with an initial random jitter of `[0, schedule.initial_jitter_seconds]`. True per-profile cadence (different cron expressions per profile) is not yet supported; tracked separately under issue #90.
+
+## 17. Inbox (Manual Submission)
+
+Opt-in pathway for external agents to submit candidate URLs into the existing ingestion pipeline. Design source of truth: `docs/plans/inbox.md`. Default-off — with `[inbox]` absent or `enabled = false`, no inbox-tick job is registered and behaviour is unchanged.
+
+### 17.1 Submission
+
+A submitter creates a Lithos task tagged `influx:inbox` (via `lithos_task_create`) with metadata `{kind: "url", url, submitted_by, optional title/summary/source_tag}`. The `scripts/influx-inbox-submit.py` helper builds and creates this task (URL-only in v1; a public PDF URL works). No HTTP intake endpoint and no Profile selection — multi-profile fan-out is the model.
+
+### 17.2 InboxTick
+
+A dedicated scheduler job (`influx-inbox-tick`, cadence `[inbox] poll_cron`) runs the tick when `enabled`. Each tick: lists open InboxTasks (capped at `max_items_per_tick`), claims each (aspect `ingest`, `agent_id`), and per item: acquires the URL once into `archive_root/inbox/YYYY/MM/<url_hash>`, scores it against every enabled Profile, and dispatches a real single-Profile `RunKind.INBOX` Run for each Profile that clears its `relevance` threshold. The first dispatch creates the canonical note; the rest merge their `## Profile Relevance` entry into it. The tick is not a Run — it never writes a ledger entry for itself; each per-(item, Profile) dispatch is an ordinary single-Profile Run with `kind="inbox"`.
+
+Each dispatch holds the per-Profile coordinator lock, so an inbox Run never overlaps a scheduled/manual/backfill Run for the same Profile. A busy Profile is skipped for the tick; if every clearing Profile is busy the task is left un-completed for a later tick. A per-Profile filter or dispatch failure is isolated and reported in the outcome; it does not sink the item.
+
+### 17.3 Cache-hit replay
+
+A resubmitted URL is detected by `lithos_cache_lookup`; the tick reads the existing note and re-scores only the complement — enabled Profiles minus those already in `## Profile Relevance` minus operator-suppressed (`influx:rejected:<profile>`). This is also how a Profile skipped on an earlier tick (e.g. busy) is eventually ingested. There is no persisted filter-rejection memory: a previously below-threshold Profile is re-scored on resubmission. Cache-hit replay is best-effort — a read/parse failure falls back to replaying all Profiles (the write merge dedupes).
+
+### 17.4 Outcomes and observability
+
+Each task is completed with a free-text outcome (`ingested into N profile(s): …`, `cache_hit: …`, `filtered out: top score K …`, partial `… ; X profile_busy / X filter failed`) plus `cited_nodes` (the canonical note id) and a structured `inbox_result` (`per_profile` scores/ingested/run_id, `source_url`, `archive_path`, `processing_time_ms`). Metrics: `influx_inbox_tick_started_total`, `influx_inbox_tasks_listed_total`, `influx_inbox_tasks_claimed_total`, and `influx_inbox_items_processed_total{outcome}`; per-(item, Profile) Runs also carry `run_type="inbox"` on the standard run metrics. The `/status` `inbox` block (§5.2) surfaces tick state from cache.
+
+### 17.5 v1 constraints
+
+URL-only (local PDF is the planned v2, `docs/plans/inbox.md` §16). PDF vs HTML extraction is currently chosen by URL shape, not the response Content-Type (tracked as a follow-up). The inbox-tick scheduler/coordinator is in-process (the same multi-process caveat as scheduled runs).

--- a/docs/plans/inbox.md
+++ b/docs/plans/inbox.md
@@ -1,11 +1,11 @@
 # Influx Inbox — Manual Submission Pipeline
 
-Status: **Plan / Not Yet Implemented**
-Date: 2026-05-09
+Status: **v1 Shipped** (slices #195 fan-out groundwork → #198 operational surface)
+Date: 2026-05-09 (design) · v1 landed 2026-06
 
 Forward spec for a manual-submission pathway into the existing Influx ingestion pipeline. Submitting agents (e.g. daily-report agents) hand Influx a URL; Influx treats the item the way it treats RSS-discovered candidates — runs the same Filter, Cascade, Renderer, write, and LCMA wiring — except submitters don't pick a Profile.
 
-This document describes design decisions only. It is not yet reflected in code. `docs/SPECIFICATION.md` continues to describe what is actually shipped.
+v1 is implemented (default-off `[inbox]` block; opt in to enable). This document remains the design source of truth; `docs/SPECIFICATION.md` describes the shipped behaviour. v2 (local PDF, §16) is not yet implemented.
 
 **Scope:** v1 covers URL submission only. Local PDF support is a planned v2 addition; see §16 for the design that v2 will implement.
 
@@ -37,12 +37,12 @@ This document describes design decisions only. It is not yet reflected in code. 
 
 ## 2. Vocabulary additions
 
-These extend the vocabulary defined in `CONTEXT.md`. Once v1 lands, the `_(proposed)_` markers below should be dropped and the entries moved into `CONTEXT.md` proper.
+These extend the vocabulary defined in `CONTEXT.md`. v1 has landed (slices #195–#198); these entries are now also recorded in `CONTEXT.md` proper.
 
-**InboxTask** _(proposed)_:
+**InboxTask**:
 A Lithos task tagged `influx:inbox` carrying submission metadata. Created by external agents via `lithos_task_create`; consumed by Influx's inbox tick. Each task represents one candidate URL.
 
-**InboxTick** _(proposed)_:
+**InboxTick**:
 One execution of the inbox-tick scheduler entry. Claims pending InboxTasks, fans out per-(item, Profile) ingestion across enabled Profiles, dispatches each ingestion as a real single-Profile Run, and writes outcomes back via `lithos_task_complete`. NOT itself a `Run` — it is an orchestrator above the Run layer.
 
 **Submitter**:

--- a/influx.example.toml
+++ b/influx.example.toml
@@ -376,3 +376,18 @@ console_fallback = false
 service_name = "influx"
 # environment = "staging"        # usually supplied by env INFLUX_ENVIRONMENT
 export_interval_ms = 30000
+
+# ---------------------------------------------------------------------------
+# Inbox (manual submission) — docs/plans/inbox.md
+# ---------------------------------------------------------------------------
+# Opt-in intake of agent-submitted URLs via Lithos tasks tagged
+# "influx:inbox". Default-off: with [inbox] absent or enabled=false no
+# inbox-tick job is registered and behaviour is unchanged.
+
+[inbox]
+enabled = false                 # opt in to register the influx-inbox-tick job
+poll_cron = "*/5 * * * *"       # how often to poll for pending InboxTasks
+timezone = "UTC"
+max_items_per_tick = 20         # cap on items claimed+processed per tick
+agent_id = "influx-inbox"       # agent id used for task claim/update/complete
+# task_tag is the fixed protocol constant "influx:inbox" (not tunable)

--- a/scripts/influx-inbox-submit.py
+++ b/scripts/influx-inbox-submit.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Submit a URL to the Influx inbox (docs/plans/inbox.md §15).
+
+Creates a single Lithos task tagged ``influx:inbox`` carrying the v1
+submission metadata (``kind="url"``, ``url``, ``submitted_by``, optional
+``title`` / ``summary`` / ``source_tag``).  Influx's inbox tick claims it,
+scores it against every enabled profile, and ingests where it clears.
+
+Write-only against Lithos (one ``lithos_task_create`` MCP call); it makes
+no calls to the Influx service itself.  v1 is URL-only — a public PDF URL
+works (the cascade branches on URL shape); local-PDF support is v2 (§16).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import getpass
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+_TASK_TAG = "influx:inbox"
+_SOURCE_TAG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,31}$")
+_ALLOWED_SCHEMES = ("http", "https")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _load_env(path: Path) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        env[key.strip()] = value.strip().strip('"').strip("'")
+    return env
+
+
+def _resolve_lithos_url(args: argparse.Namespace, env: dict[str, str]) -> str | None:
+    """Resolve the Lithos SSE URL: --lithos-url → LITHOS_URL → influx config."""
+    if args.lithos_url:
+        return args.lithos_url
+    if env.get("LITHOS_URL"):
+        return env["LITHOS_URL"]
+    try:
+        from influx.config import load_config
+
+        return load_config().lithos.url
+    except Exception:  # noqa: BLE001 — best-effort config discovery
+        return None
+
+
+def _build_metadata(args: argparse.Namespace) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "kind": "url",
+        "url": args.url,
+        "submitted_by": args.submitted_by,
+    }
+    if args.title:
+        metadata["title"] = args.title
+    summary = args.summary
+    if args.summary_file:
+        summary = Path(args.summary_file).read_text(encoding="utf-8")
+    if summary:
+        metadata["summary"] = summary
+    if args.source_tag:
+        metadata["source_tag"] = args.source_tag
+    return metadata
+
+
+def _build_task_body(args: argparse.Namespace) -> dict[str, Any]:
+    label = args.title or args.url
+    return {
+        "title": f"Influx inbox: {label}",
+        "agent": args.submitted_by,
+        "tags": [_TASK_TAG],
+        "metadata": _build_metadata(args),
+    }
+
+
+async def _submit(lithos_url: str, body: dict[str, Any]) -> str:
+    from influx.lithos_client import LithosClient
+
+    client = LithosClient(url=lithos_url)
+    try:
+        result = await client.task_create_body(
+            title=body["title"],
+            agent=body["agent"],
+            tags=body["tags"],
+            metadata=body["metadata"],
+        )
+    finally:
+        await client.close()
+    return str(result.get("task_id") or result.get("id") or "<unknown>")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("url", help="the URL to submit (http/https)")
+    parser.add_argument("--title", help="hint for the candidate's title slot")
+    parser.add_argument("--summary", help="pre-fetched summary for the filter prompt")
+    parser.add_argument(
+        "--summary-file",
+        help="read the summary from a file (alternative to --summary)",
+    )
+    parser.add_argument(
+        "--source-tag",
+        help="resulting note's source:* tag (default: inbox); conservative slug",
+    )
+    parser.add_argument(
+        "--submitted-by",
+        default=f"manual:{getpass.getuser()}",
+        help="submitter identifier (default: manual:<username>)",
+    )
+    parser.add_argument(
+        "--env",
+        default="staging",
+        help="environment name matching docker/.env.<name> (default: staging)",
+    )
+    parser.add_argument("--lithos-url", help="override the Lithos SSE URL")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the task body that would be sent without creating it",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    # Validate BEFORE any MCP call (§15.5).
+    parsed = urlparse(args.url)
+    if parsed.scheme not in _ALLOWED_SCHEMES or not parsed.netloc:
+        print(
+            f"error: URL must be http(s) with a host, got {args.url!r}",
+            file=sys.stderr,
+        )
+        return 2
+    if args.source_tag and not _SOURCE_TAG_RE.match(args.source_tag):
+        print(
+            f"error: --source-tag must match {_SOURCE_TAG_RE.pattern}",
+            file=sys.stderr,
+        )
+        return 2
+
+    body = _build_task_body(args)
+
+    if args.dry_run:
+        print(json.dumps(body, indent=2))
+        return 0
+
+    env_path = _repo_root() / "docker" / f".env.{args.env}"
+    env = _load_env(env_path) if env_path.exists() else {}
+    lithos_url = _resolve_lithos_url(args, env)
+    if not lithos_url:
+        print(
+            "error: could not resolve the Lithos URL — pass --lithos-url or set "
+            "LITHOS_URL",
+            file=sys.stderr,
+        )
+        return 2
+
+    task_id = asyncio.run(_submit(lithos_url, body))
+    print(f"Created task {task_id} (kind=url)")
+    print(f"Track outcome: lithos task show {task_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/influx-inbox-submit.py
+++ b/scripts/influx-inbox-submit.py
@@ -17,6 +17,7 @@ import argparse
 import asyncio
 import getpass
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -41,6 +42,19 @@ def _load_env(path: Path) -> dict[str, str]:
         key, value = line.split("=", 1)
         env[key.strip()] = value.strip().strip('"').strip("'")
     return env
+
+
+def _apply_env_to_process(env: dict[str, str]) -> None:
+    """Make ``docker/.env.<env>`` values visible to ``influx.config.load_config``.
+
+    ``load_config`` discovers ``INFLUX_CONFIG``/``LITHOS_URL``/etc. from
+    ``os.environ`` (config.py:749, :780), not from our local dict — so without
+    this the ``--env`` file never influences the config-loader fallback path.
+    ``setdefault`` keeps an explicitly-exported process var winning over the
+    file (the file is the fallback, never an override).
+    """
+    for key, value in env.items():
+        os.environ.setdefault(key, value)
 
 
 def _resolve_lithos_url(args: argparse.Namespace, env: dict[str, str]) -> str | None:
@@ -162,6 +176,7 @@ def main(argv: list[str] | None = None) -> int:
 
     env_path = _repo_root() / "docker" / f".env.{args.env}"
     env = _load_env(env_path) if env_path.exists() else {}
+    _apply_env_to_process(env)
     lithos_url = _resolve_lithos_url(args, env)
     if not lithos_url:
         print(

--- a/scripts/influx-inbox-submit.py
+++ b/scripts/influx-inbox-submit.py
@@ -105,8 +105,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("url", help="the URL to submit (http/https)")
     parser.add_argument("--title", help="hint for the candidate's title slot")
-    parser.add_argument("--summary", help="pre-fetched summary for the filter prompt")
-    parser.add_argument(
+    summary_group = parser.add_mutually_exclusive_group()
+    summary_group.add_argument(
+        "--summary", help="pre-fetched summary for the filter prompt"
+    )
+    summary_group.add_argument(
         "--summary-file",
         help="read the summary from a file (alternative to --summary)",
     )

--- a/src/influx/http_api.py
+++ b/src/influx/http_api.py
@@ -233,6 +233,13 @@ async def status(request: Request) -> JSONResponse:
         },
         "profiles": profiles,
     }
+
+    # Inbox section (§13.6) — sourced from the cached InboxStatus the tick
+    # writes; never a per-request lithos_task_list (FR-HTTP-7).
+    inbox_status = getattr(request.app.state, "inbox_status", None)
+    if inbox_status is not None:
+        body["inbox"] = inbox_status.snapshot()
+
     return JSONResponse(body, status_code=200)
 
 

--- a/src/influx/inbox.py
+++ b/src/influx/inbox.py
@@ -210,6 +210,8 @@ class InboxStatus:
     last_tick_outcome: str | None = None
 
     def snapshot(self) -> dict[str, Any]:
+        # ``last_tick_outcome`` reflects the most recently *completed* tick; it
+        # is unchanged while a tick is in progress (``in_flight > 0``).
         return {
             "enabled": self.enabled,
             "pending": self.pending,

--- a/src/influx/inbox.py
+++ b/src/influx/inbox.py
@@ -33,6 +33,7 @@ import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
@@ -193,6 +194,31 @@ async def dispatch_profile(
 # ── Orchestrator ────────────────────────────────────────────────────
 
 
+@dataclass
+class InboxStatus:
+    """Mutable snapshot of inbox-tick state for the ``/status`` endpoint.
+
+    Written by the tick, read by the ``/status`` handler — so ``/status``
+    never issues a per-request ``lithos_task_list`` (FR-HTTP-7, §13.6).
+    ``pending`` is the open-task count as of the last tick's list call.
+    """
+
+    enabled: bool = False
+    pending: int = 0
+    in_flight: int = 0
+    last_tick_at: str | None = None
+    last_tick_outcome: str | None = None
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "pending": self.pending,
+            "in_flight": self.in_flight,
+            "last_tick_at": self.last_tick_at,
+            "last_tick_outcome": self.last_tick_outcome,
+        }
+
+
 @dataclass(frozen=True)
 class _ItemOutcome:
     """Internal per-item result used to build the task completion."""
@@ -241,6 +267,9 @@ class InboxTick:
     probe_loop: Any | None = None
     ledger: RunLedger | None = None
     client_factory: Callable[[], LithosClient] | None = None
+    # Shared snapshot the /status handler reads (FR-HTTP-7); the tick writes
+    # pending / in_flight / last_tick_* here so /status never lists tasks.
+    status: InboxStatus | None = None
 
     def _make_client(self) -> LithosClient:
         if self.client_factory is not None:
@@ -258,14 +287,21 @@ class InboxTick:
         dispatch.  Per-item failures are isolated — one bad item never
         aborts the rest of the tick.
         """
+        status = self.status
+        if status is not None:
+            status.last_tick_at = datetime.now(UTC).isoformat()
+
         probe = self.probe_loop
         circuit_open = getattr(probe, "lithos_circuit_open", None)
         if circuit_open is not None and circuit_open():
             logger.info("inbox tick skipped: lithos circuit open")
+            if status is not None:
+                status.last_tick_outcome = "skipped: lithos circuit open"
             return
 
         metrics.inbox_tick_started().add(1)
         client = self._make_client()
+        tick_outcome = "success"
         try:
             try:
                 body = await client.task_list_body(
@@ -274,22 +310,35 @@ class InboxTick:
                 )
             except (LithosError, LCMAError):
                 logger.warning("inbox task_list failed; skipping tick", exc_info=True)
+                if status is not None:
+                    status.last_tick_outcome = "error: task_list failed"
                 return
 
-            tasks = list(body.get("tasks", []))[: self.config.inbox.max_items_per_tick]
+            all_tasks = list(body.get("tasks", []))
+            if status is not None:
+                status.pending = len(all_tasks)
+            tasks = all_tasks[: self.config.inbox.max_items_per_tick]
             metrics.inbox_tasks_listed().add(len(tasks))
 
             for task in tasks:
+                if status is not None:
+                    status.in_flight += 1
                 try:
                     await self._process_task(task, client)
                 except Exception:  # noqa: BLE001 — per-item failure isolation (§5.5)
                     # A crash before _complete leaves the claim to expire and
                     # the task ``open``; a later tick re-claims it.  Re-ingest
                     # is safe because ``lithos_write`` dedupes on source_url.
+                    tick_outcome = "error"
                     logger.exception(
                         "inbox item processing crashed task_id=%s",
                         task.get("id") if isinstance(task, dict) else "<?>",
                     )
+                finally:
+                    if status is not None:
+                        status.in_flight -= 1
+            if status is not None:
+                status.last_tick_outcome = tick_outcome
         finally:
             await client.close()
 

--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -1649,12 +1649,21 @@ class LithosClient:
         title: str,
         agent: str,
         tags: list[str],
+        description: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> mcp_types.CallToolResult:
-        """Call ``lithos_task_create`` (FR-LCMA-5)."""
-        return await self._call_lcma_tool(
-            "lithos_task_create",
-            {"title": title, "agent": agent, "tags": tags},
-        )
+        """Call ``lithos_task_create`` (FR-LCMA-5).
+
+        ``description`` + ``metadata`` (inbox submission, ``docs/plans/inbox.md``
+        §3) are omitted from the RPC when ``None`` so existing per-Run task
+        callers are unaffected.
+        """
+        args: dict[str, Any] = {"title": title, "agent": agent, "tags": tags}
+        if description is not None:
+            args["description"] = description
+        if metadata is not None:
+            args["metadata"] = metadata
+        return await self._call_lcma_tool("lithos_task_create", args)
 
     async def task_create_body(
         self,
@@ -1662,10 +1671,18 @@ class LithosClient:
         title: str,
         agent: str,
         tags: list[str],
+        description: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Run ``task_create`` and decode the JSON body."""
         return self._result_json_dict(
-            await self.task_create(title=title, agent=agent, tags=tags),
+            await self.task_create(
+                title=title,
+                agent=agent,
+                tags=tags,
+                description=description,
+                metadata=metadata,
+            ),
             operation="task_create",
         )
 

--- a/src/influx/service.py
+++ b/src/influx/service.py
@@ -28,7 +28,7 @@ from influx.coordinator import Coordinator, RunKind
 from influx.errors import ConfigError
 from influx.filter import make_default_arxiv_filter_scorer
 from influx.http_api import install_exception_handlers, router
-from influx.inbox import InboxTick
+from influx.inbox import InboxStatus, InboxTick
 from influx.lithos_client import LithosClient
 from influx.notifications import ProfileRunResult, dispatch_notifications
 from influx.probes import ProbeLoop
@@ -210,12 +210,15 @@ def create_app(
     # Inbox manual-submission orchestrator (docs/plans/inbox.md).  Wired
     # unconditionally but only registered as a cron job when
     # ``[inbox] enabled`` (see InfluxScheduler.start).  Shares the
-    # coordinator + probe loop + ledger with scheduled runs.
+    # coordinator + probe loop + ledger with scheduled runs.  ``inbox_status``
+    # is the shared snapshot the ``/status`` handler reads (FR-HTTP-7).
+    inbox_status = InboxStatus(enabled=config.inbox.enabled)
     inbox_tick = InboxTick(
         config=config,
         coordinator=coordinator,
         probe_loop=probe_loop,
         ledger=run_ledger,
+        status=inbox_status,
     )
 
     scheduler = InfluxScheduler(
@@ -237,6 +240,7 @@ def create_app(
     app.state.item_provider = item_provider
     app.state.fetch_cache = fetch_cache
     app.state.run_ledger = run_ledger
+    app.state.inbox_status = inbox_status
     app.state.close_lithos_probe_client = _close_lithos_probe_client
 
     return app

--- a/tests/integration/test_http_api.py
+++ b/tests/integration/test_http_api.py
@@ -26,6 +26,7 @@ from influx.config import (
 )
 from influx.coordinator import Coordinator
 from influx.http_api import install_exception_handlers, router
+from influx.inbox import InboxStatus
 from influx.probes import ProbeLoop
 from influx.run_ledger import RunLedger
 from influx.scheduler import InfluxScheduler
@@ -76,6 +77,7 @@ def app_with_state(fake_lithos_sse_url: str, tmp_path: Path) -> FastAPI:
     app.state.scheduler = scheduler
     app.state.probe_loop = probe_loop
     app.state.run_ledger = RunLedger(Path(config.storage.state_dir))
+    app.state.inbox_status = InboxStatus(enabled=config.inbox.enabled)
 
     return app
 
@@ -1120,3 +1122,44 @@ class TestBackfillObservability:
         assert request_level_completed == [], [
             r.message for r in request_level_completed
         ]
+
+
+class TestStatusInboxSection:
+    """``GET /status`` exposes the inbox section from cached state (§13.6)."""
+
+    def test_inbox_section_present_from_default_state(self, client: TestClient) -> None:
+        body = client.get("/status").json()
+        assert "inbox" in body
+        assert body["inbox"]["enabled"] is False
+
+    def test_inbox_section_reads_cached_state_no_task_list(
+        self, app_with_state: FastAPI
+    ) -> None:
+        # Populate the cached snapshot the tick would have written.  A fresh
+        # lithos_task_list against the empty fake server would yield pending=0,
+        # so pending=7 here proves /status reads the cache, not a live list
+        # (FR-HTTP-7).
+        app_with_state.state.inbox_status = InboxStatus(
+            enabled=True,
+            pending=7,
+            in_flight=2,
+            last_tick_at="2026-06-02T12:00:00+00:00",
+            last_tick_outcome="success",
+        )
+        body = TestClient(app_with_state).get("/status").json()
+        assert body["inbox"] == {
+            "enabled": True,
+            "pending": 7,
+            "in_flight": 2,
+            "last_tick_at": "2026-06-02T12:00:00+00:00",
+            "last_tick_outcome": "success",
+        }
+
+    def test_inbox_section_omitted_when_state_absent(
+        self, app_with_state: FastAPI
+    ) -> None:
+        # Back-compat: a deployment without inbox_status wired returns no
+        # inbox key rather than erroring.
+        delattr(app_with_state.state, "inbox_status")
+        body = TestClient(app_with_state).get("/status").json()
+        assert "inbox" not in body

--- a/tests/unit/test_inbox_stall_exclusion.py
+++ b/tests/unit/test_inbox_stall_exclusion.py
@@ -1,0 +1,58 @@
+"""Regression: inbox (RunKind.INBOX) runs are excluded from the scheduled-only
+stall heuristics (Inbox v1 slice 4, §11.3).
+
+An inbox Run that filters everything out (ingested==0, sources_checked>0) is a
+low-score candidate, not an ``ingestion_stall``; and a prior inbox run must not
+count toward a later scheduled run's consecutive-stall ratchet.  The behaviour
+is enforced by ``run_ledger`` gating on ``kind == "scheduled"`` — these tests
+lock it in (no code change in this slice).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from influx.run_ledger import RunLedger
+
+
+def _run(
+    ledger: RunLedger,
+    *,
+    run_id: str,
+    kind: str,
+    profile: str = "p",
+    sources_checked: int = 1,
+    ingested: int = 0,
+) -> list[str]:
+    ledger.start(run_id=run_id, profile=profile, kind=kind, run_range=None)
+    return ledger.complete(
+        run_id=run_id,
+        sources_checked=sources_checked,
+        ingested=ingested,
+        fetched_total=sources_checked,
+    )
+
+
+def test_inbox_zero_ingestion_run_is_not_ingestion_stall(tmp_path: Path) -> None:
+    ledger = RunLedger(tmp_path / "state")
+    # Two consecutive zero-ingestion inbox runs — would be a stall if scheduled.
+    _run(ledger, run_id="i-1", kind="inbox")
+    reasons = _run(ledger, run_id="i-2", kind="inbox")
+    assert "ingestion_stall" not in reasons
+
+
+def test_prior_inbox_run_does_not_feed_scheduled_stall_walk(tmp_path: Path) -> None:
+    ledger = RunLedger(tmp_path / "state")
+    # A prior zero-ingestion inbox run must not count toward the scheduled
+    # run's consecutive ratchet, so the single scheduled run does not stall.
+    _run(ledger, run_id="i-1", kind="inbox")
+    reasons = _run(ledger, run_id="s-1", kind="scheduled")
+    assert "ingestion_stall" not in reasons
+
+
+def test_two_scheduled_zero_runs_do_stall_baseline(tmp_path: Path) -> None:
+    """Baseline: the heuristic still fires for genuine scheduled stalls."""
+    ledger = RunLedger(tmp_path / "state")
+    _run(ledger, run_id="s-1", kind="scheduled")
+    reasons = _run(ledger, run_id="s-2", kind="scheduled")
+    assert "ingestion_stall" in reasons

--- a/tests/unit/test_inbox_submit_script.py
+++ b/tests/unit/test_inbox_submit_script.py
@@ -100,3 +100,9 @@ def test_invalid_source_tag_rejected(capsys: pytest.CaptureFixture) -> None:
     rc = _SUBMIT.main([_URL, "--dry-run", "--source-tag", "Not A Slug"])
     assert rc == 2
     assert "source-tag" in capsys.readouterr().err
+
+
+def test_summary_and_summary_file_are_mutually_exclusive() -> None:
+    with pytest.raises(SystemExit) as exc:
+        _SUBMIT.main([_URL, "--dry-run", "--summary", "x", "--summary-file", "y"])
+    assert exc.value.code == 2

--- a/tests/unit/test_inbox_submit_script.py
+++ b/tests/unit/test_inbox_submit_script.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -106,3 +107,48 @@ def test_summary_and_summary_file_are_mutually_exclusive() -> None:
     with pytest.raises(SystemExit) as exc:
         _SUBMIT.main([_URL, "--dry-run", "--summary", "x", "--summary-file", "y"])
     assert exc.value.code == 2
+
+
+def test_apply_env_to_process_uses_setdefault(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Process-exported vars win over the env file; absent keys are filled in."""
+    monkeypatch.setenv("INFLUX_INBOX_WINS", "from-process")
+    monkeypatch.delenv("INFLUX_INBOX_FILLED", raising=False)
+    _SUBMIT._apply_env_to_process(
+        {"INFLUX_INBOX_WINS": "from-file", "INFLUX_INBOX_FILLED": "from-file"}
+    )
+    assert os.environ["INFLUX_INBOX_WINS"] == "from-process"
+    assert os.environ["INFLUX_INBOX_FILLED"] == "from-file"
+
+
+def test_env_file_reaches_load_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``docker/.env.<env>`` values are visible to the load_config fallback.
+
+    Regression for the #198 helper-script contract: with no --lithos-url and no
+    LITHOS_URL in the file, resolution falls through to load_config(), which
+    reads INFLUX_CONFIG from os.environ — so the env file must be applied there.
+    """
+    docker = tmp_path / "docker"
+    docker.mkdir()
+    (docker / ".env.test").write_text(
+        "INFLUX_CONFIG=/custom/influx.toml\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(_SUBMIT, "_repo_root", lambda: tmp_path)
+    monkeypatch.delenv("INFLUX_CONFIG", raising=False)
+    monkeypatch.delenv("LITHOS_URL", raising=False)
+
+    captured: dict[str, str | None] = {}
+
+    import influx.config as influx_config
+
+    def _fake_load_config() -> Any:
+        captured["INFLUX_CONFIG"] = os.environ.get("INFLUX_CONFIG")
+        raise RuntimeError("stop before real load")
+
+    monkeypatch.setattr(influx_config, "load_config", _fake_load_config)
+
+    rc = _SUBMIT.main([_URL, "--env", "test"])
+
+    assert captured["INFLUX_CONFIG"] == "/custom/influx.toml"
+    assert rc == 2  # load_config raised → URL unresolved → exit 2

--- a/tests/unit/test_inbox_submit_script.py
+++ b/tests/unit/test_inbox_submit_script.py
@@ -1,0 +1,102 @@
+"""Unit tests for ``scripts/influx-inbox-submit.py`` (Inbox v1 slice 4, §15).
+
+Covers the URL/source-tag validation that must happen BEFORE any MCP call,
+the ``--dry-run`` task-body shaping, and metadata assembly from flags.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_script() -> Any:
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "influx_inbox_submit",
+        repo_root / "scripts" / "influx-inbox-submit.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_SUBMIT = _load_script()
+_URL = "https://example.com/article"
+
+
+def test_dry_run_prints_task_body_without_mcp(capsys: pytest.CaptureFixture) -> None:
+    rc = _SUBMIT.main([_URL, "--dry-run", "--submitted-by", "agent:test"])
+    assert rc == 0
+    body = json.loads(capsys.readouterr().out)
+    assert body["tags"] == ["influx:inbox"]
+    assert body["agent"] == "agent:test"
+    assert body["title"] == f"Influx inbox: {_URL}"
+    assert body["metadata"] == {
+        "kind": "url",
+        "url": _URL,
+        "submitted_by": "agent:test",
+    }
+
+
+def test_dry_run_includes_optional_flags(capsys: pytest.CaptureFixture) -> None:
+    rc = _SUBMIT.main(
+        [
+            _URL,
+            "--dry-run",
+            "--title",
+            "A Paper",
+            "--summary",
+            "an excerpt",
+            "--source-tag",
+            "ai-news",
+        ]
+    )
+    assert rc == 0
+    md = json.loads(capsys.readouterr().out)["metadata"]
+    assert md["title"] == "A Paper"
+    assert md["summary"] == "an excerpt"
+    assert md["source_tag"] == "ai-news"
+
+
+def test_summary_file_is_read(capsys: pytest.CaptureFixture, tmp_path: Path) -> None:
+    f = tmp_path / "s.txt"
+    f.write_text("summary from file", encoding="utf-8")
+    rc = _SUBMIT.main([_URL, "--dry-run", "--summary-file", str(f)])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["metadata"]["summary"] == (
+        "summary from file"
+    )
+
+
+def test_default_submitted_by_uses_username(
+    capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(_SUBMIT.getpass, "getuser", lambda: "dave")
+    rc = _SUBMIT.main([_URL, "--dry-run"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["metadata"]["submitted_by"] == (
+        "manual:dave"
+    )
+
+
+def test_invalid_url_rejected_before_mcp(capsys: pytest.CaptureFixture) -> None:
+    rc = _SUBMIT.main(["file:///etc/passwd", "--dry-run"])
+    assert rc == 2
+    assert "must be http" in capsys.readouterr().err
+
+
+def test_non_url_argument_rejected(capsys: pytest.CaptureFixture) -> None:
+    rc = _SUBMIT.main(["not a url", "--dry-run"])
+    assert rc == 2
+
+
+def test_invalid_source_tag_rejected(capsys: pytest.CaptureFixture) -> None:
+    rc = _SUBMIT.main([_URL, "--dry-run", "--source-tag", "Not A Slug"])
+    assert rc == 2
+    assert "source-tag" in capsys.readouterr().err

--- a/tests/unit/test_inbox_tick.py
+++ b/tests/unit/test_inbox_tick.py
@@ -797,3 +797,74 @@ async def test_cache_hit_unparseable_note_falls_back_to_all_profiles() -> None:
     # Parse failure → fell back to replaying ALL profiles (not crashed/skipped).
     assert sorted(c.args[0] for c in mock_dispatch.call_args_list) == ["a", "b"]
     assert len(client.completed) == 1
+
+
+# ── Slice 4: InboxStatus updates across exit paths ──────────────────
+
+
+async def test_status_records_circuit_open_skip() -> None:
+    from influx.inbox import InboxStatus
+
+    class _Probe:
+        def lithos_circuit_open(self) -> bool:
+            return True
+
+    status = InboxStatus(enabled=True)
+    client = FakeClient(tasks=[_task()])
+    tick = InboxTick(
+        config=_make_config(),
+        coordinator=Coordinator(),
+        probe_loop=_Probe(),
+        status=status,
+        client_factory=lambda: client,  # type: ignore[arg-type]
+    )
+    await tick.execute()
+    assert status.last_tick_at is not None
+    assert status.last_tick_outcome == "skipped: lithos circuit open"
+    assert client.list_calls == 0
+
+
+async def test_status_records_task_list_failure() -> None:
+    from influx.errors import LithosError
+    from influx.inbox import InboxStatus
+
+    class _BadListClient(FakeClient):
+        async def task_list_body(self, **_: Any) -> dict[str, Any]:
+            raise LithosError("boom", operation="task_list")
+
+    status = InboxStatus(enabled=True)
+    client = _BadListClient(tasks=[])
+    tick = InboxTick(
+        config=_make_config(),
+        coordinator=Coordinator(),
+        status=status,
+        client_factory=lambda: client,  # type: ignore[arg-type]
+    )
+    await tick.execute()
+    assert status.last_tick_outcome == "error: task_list failed"
+
+
+async def test_status_records_success_and_pending() -> None:
+    from influx.inbox import InboxStatus
+
+    status = InboxStatus(enabled=True)
+    client = FakeClient(tasks=[_task(), _task(task_id="task-2")], note_id="n")
+    with (
+        patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_returning(8),
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch("influx.inbox.dispatch_profile", return_value=RunOutcome(ingested=1)),
+    ):
+        tick = InboxTick(
+            config=_make_config(),
+            coordinator=Coordinator(),
+            status=status,
+            client_factory=lambda: client,  # type: ignore[arg-type]
+        )
+        await tick.execute()
+    assert status.last_tick_outcome == "success"
+    assert status.pending == 2
+    assert status.in_flight == 0  # balanced after the tick


### PR DESCRIPTION
## Summary

Slice 4 (final) of the Influx Inbox v1 feature (design spec: `docs/plans/inbox.md` §11/§13/§15): the operational surface that makes the inbox observable and human-submittable, plus docs. Builds on slices 1–3 (#199/#201/#202, merged).

## What changed

- **`/status` inbox section** (`http_api.py`): a new `inbox` block (`enabled`, `pending`, `in_flight`, `last_tick_at`, `last_tick_outcome`) read from a cached `InboxStatus` snapshot the tick writes — **never a per-request `lithos_task_list`** (FR-HTTP-7). The tick updates pending/in_flight/last_tick_* each run; `/status` only reads it. Omitted gracefully when the inbox isn't wired.
- **Helper script** `scripts/influx-inbox-submit.py` (§15): argparse mirroring `influx-report.py`/`influx-diagnose.py`. Positional URL; `--title/--summary/--summary-file/--source-tag/--submitted-by/--env/--lithos-url/--dry-run`. Validates URL scheme + source-tag slug **before** any MCP call; `--dry-run` prints the task body; otherwise a single `lithos_task_create` (tags `["influx:inbox"]`, `kind="url"` metadata). The `LithosClient.task_create` wrapper gained optional `metadata`/`description` (additive).
- **Metrics**: the tick's `inbox_tick_started`/`inbox_tasks_listed`/`inbox_tasks_claimed`/`inbox_items_processed{outcome}` were added in slice 1; this slice locks in the `/status` + stall surface around them.
- **Stall-heuristic regression test** (§11.3): no code change — `RunKind.INBOX` runs are already excluded from `ingestion_stall`/`fetch_stall`/`filter_stall` (gate on `kind=="scheduled"`). Tests pin it: an inbox zero-ingestion run isn't a stall, and a prior inbox run doesn't feed a later scheduled run's consecutive-stall walk (with a scheduled baseline that does stall).
- **Docs**: dropped the `_(proposed)_` markers + flipped the status header in `docs/plans/inbox.md`; folded the InboxTask/InboxTick/Submitter/cache-hit-replay vocabulary into `CONTEXT.md` (+ `RunKind` now lists `inbox`); documented the `[inbox]` block in `influx.example.toml`; added §17 (Inbox) to `docs/SPECIFICATION.md` with `/status` + `notify_on` touch-ups.

## Test plan

- `make check` green (ruff + pyright + full pytest suite).
- New tests: `/status` inbox section (cached, reads `pending=7` that a live list would report as 0 → proves no fresh `task_list`; back-compat when absent); `influx-inbox-submit.py` (dry-run body shaping, all flags, `--summary-file`, default `manual:<user>`, URL/source-tag validation before MCP); stall-exclusion regression (3 cases incl. scheduled baseline).

Closes #198
