### PR TITLE
fix: fetch-once acquisition + real-Content-Type routing (inbox + RSS) (#200)

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -799,4 +799,4 @@ Each task is completed with a free-text outcome (`ingested into N profile(s): �
 
 ### 17.5 v1 constraints
 
-URL-only (local PDF is the planned v2, `docs/plans/inbox.md` §16). PDF vs HTML extraction is currently chosen by URL shape, not the response Content-Type (tracked as a follow-up). The inbox-tick scheduler/coordinator is in-process (the same multi-process caveat as scheduled runs).
+URL-only (local PDF is the planned v2, `docs/plans/inbox.md` §16). A submitted URL is fetched once and the PDF vs HTML extraction branch is chosen from the response `Content-Type` (issue #200), so a PDF served from a non-`.pdf` URL is extracted correctly; the fetched bytes are reused for both archiving and extraction (no second fetch). RSS shares the same fetch-once reuse; arXiv keeps its HTML→PDF cascade (it deliberately fetches a different representation for extraction). The inbox-tick scheduler/coordinator is in-process (the same multi-process caveat as scheduled runs).

--- a/src/influx/extraction/article.py
+++ b/src/influx/extraction/article.py
@@ -17,7 +17,11 @@ from influx.errors import ExtractionError
 from influx.extraction.html import _clean_html_fragments, _strip_tags
 from influx.http_client import guarded_fetch
 
-__all__ = ["ArticleExtractionResult", "extract_article"]
+__all__ = [
+    "ArticleExtractionResult",
+    "extract_article",
+    "extract_article_from_html",
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,6 +30,80 @@ class ArticleExtractionResult:
 
     text: str
     source: Literal["article"]
+
+
+def extract_article_from_html(
+    html_body: str,
+    *,
+    url: str,
+    min_web_chars: int | None = None,
+    strip_tags: list[str] | None = None,
+) -> ArticleExtractionResult:
+    """Extract article text from an already-fetched HTML body.
+
+    This is the network-free core of :func:`extract_article`: it strips
+    dangerous tags, runs trafilatura, cleans residual fragments, and
+    enforces the minimum length.  Callers that already hold the HTML
+    bytes (e.g. an archive download that returns the response body) use
+    this to avoid a second fetch (issue #200).
+
+    Parameters
+    ----------
+    html_body:
+        The raw HTML markup to extract from.
+    url:
+        The source URL, used only for :class:`ExtractionError` context.
+    min_web_chars:
+        Minimum character count for the extracted text.  Below this an
+        ``ExtractionError`` is raised.  ``None`` resolves to the
+        :class:`~influx.config.ExtractionConfig` default (AC-X-1).
+    strip_tags:
+        HTML tag names whose elements are stripped before extraction.
+        ``None`` resolves to the
+        :class:`~influx.config.ExtractionConfig` default.
+
+    Returns
+    -------
+    ArticleExtractionResult
+        On success with extracted text >= *min_web_chars*.
+
+    Raises
+    ------
+    ExtractionError
+        When extraction fails or extracted text is below *min_web_chars*.
+    """
+    if min_web_chars is None or strip_tags is None:
+        _extraction_defaults = ExtractionConfig()
+        if min_web_chars is None:
+            min_web_chars = _extraction_defaults.min_web_chars
+        if strip_tags is None:
+            strip_tags = list(_extraction_defaults.strip_tags)
+
+    # Strip dangerous tags before extraction
+    html_body = _strip_tags(html_body, strip_tags)
+
+    extracted = trafilatura.extract(html_body, favor_recall=True)
+
+    if extracted is None:
+        raise ExtractionError(
+            "trafilatura returned no content",
+            url=url,
+            stage="extract",
+            detail="trafilatura.extract() returned None",
+        )
+
+    # Verify no HTML fragments remain
+    extracted = _clean_html_fragments(extracted)
+
+    if len(extracted) < min_web_chars:
+        raise ExtractionError(
+            f"Extracted text too short ({len(extracted)} < {min_web_chars} chars)",
+            url=url,
+            stage="min_length",
+            detail=f"Got {len(extracted)} chars, need {min_web_chars}",
+        )
+
+    return ArticleExtractionResult(text=extracted, source="article")
 
 
 def extract_article(
@@ -74,12 +152,6 @@ def extract_article(
     NetworkError
         When the HTTP fetch fails (propagated from guarded_fetch).
     """
-    if min_web_chars is None or strip_tags is None:
-        _extraction_defaults = ExtractionConfig()
-        if min_web_chars is None:
-            min_web_chars = _extraction_defaults.min_web_chars
-        if strip_tags is None:
-            strip_tags = list(_extraction_defaults.strip_tags)
     if max_download_bytes is None or timeout_seconds is None:
         _storage_defaults = StorageConfig()
         if max_download_bytes is None:
@@ -97,28 +169,9 @@ def extract_article(
 
     html_body = result.body.decode("utf-8", errors="replace")
 
-    # Strip dangerous tags before extraction
-    html_body = _strip_tags(html_body, strip_tags)
-
-    extracted = trafilatura.extract(html_body, favor_recall=True)
-
-    if extracted is None:
-        raise ExtractionError(
-            "trafilatura returned no content",
-            url=url,
-            stage="extract",
-            detail="trafilatura.extract() returned None",
-        )
-
-    # Verify no HTML fragments remain
-    extracted = _clean_html_fragments(extracted)
-
-    if len(extracted) < min_web_chars:
-        raise ExtractionError(
-            f"Extracted text too short ({len(extracted)} < {min_web_chars} chars)",
-            url=url,
-            stage="min_length",
-            detail=f"Got {len(extracted)} chars, need {min_web_chars}",
-        )
-
-    return ArticleExtractionResult(text=extracted, source="article")
+    return extract_article_from_html(
+        html_body,
+        url=url,
+        min_web_chars=min_web_chars,
+        strip_tags=strip_tags,
+    )

--- a/src/influx/http_client.py
+++ b/src/influx/http_client.py
@@ -29,6 +29,7 @@ __all__ = [
     "FetchResult",
     "aguarded_fetch",
     "aguarded_post_json_fetch",
+    "content_type_family",
     "guarded_fetch",
     "guarded_outbound_post",
     "guarded_post_json",
@@ -144,6 +145,22 @@ def _ssrf_check(url: str, *, allow_private_ips: bool) -> None:
 
 
 # ── Public API ───────────────────────────────────────────────────────
+
+
+def content_type_family(content_type: str) -> ContentTypeFamily | None:
+    """Classify a raw ``Content-Type`` header into its family, or ``None``.
+
+    Parses the bare MIME type (drops parameters like ``; charset=utf-8``)
+    and maps it through :data:`_CONTENT_TYPE_FAMILIES`.  Used by callers
+    that fetch with no ``expected_content_type`` guard and route on the
+    actual response type (issue #200 — inbox auto-detect acquisition).
+    Returns ``None`` for any MIME not in a known family.
+    """
+    mime = content_type.split(";")[0].strip().lower()
+    for family, allowed in _CONTENT_TYPE_FAMILIES.items():
+        if mime in allowed:
+            return family
+    return None
 
 
 def _check_content_type(

--- a/src/influx/sources/inbox.py
+++ b/src/influx/sources/inbox.py
@@ -122,6 +122,17 @@ def acquire_inbox_bytes(
             ).text
             summary = extracted_text
             flavour = "html"
+        elif body is not None:
+            # Fetched bytes whose Content-Type is neither HTML nor PDF
+            # (e.g. an XML feed URL submitted to the inbox): no extractor
+            # applies, so fall through to the summary hint.  Logged so an
+            # operator can see why a submitted URL produced no body.
+            _log.info(
+                "inbox content-type not extractable url=%s family=%r, "
+                "using summary fallback",
+                url,
+                family or archive_result.content_type,
+            )
     except (ExtractionError, NetworkError, OSError) as exc:
         _log.debug("inbox extraction failed for %s, using summary hint: %s", url, exc)
 

--- a/src/influx/sources/inbox.py
+++ b/src/influx/sources/inbox.py
@@ -12,9 +12,13 @@ URLs.  Two differences from the RSS path:
   is then called once per scoring profile, reusing that acquisition so the
   URL is fetched only once per inbox item (§5.2/§5.3).
 
-A public PDF URL works in v1: the path branches on a ``.pdf`` URL shape to
-archive with a ``.pdf`` extension and extract via :func:`extract_pdf`;
-everything else takes the HTML article-extraction path.
+The URL is fetched a single time and the extraction branch is chosen from
+the response ``Content-Type`` (issue #200): a PDF response extracts via
+:func:`extract_pdf` over the fetched bytes, an HTML response via
+:func:`extract_article_from_html` over the same bytes, and anything else
+falls back to the submitter's summary hint.  A public PDF works even when
+served from a non-``.pdf`` URL because routing is content-type driven, not
+URL-shape driven.
 """
 
 from __future__ import annotations
@@ -24,14 +28,13 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse
 
 from influx.cascade import Acquired, Cascade, TextFlavour
 from influx.errors import ExtractionError, NetworkError
-from influx.extraction.article import extract_article
+from influx.extraction.article import extract_article_from_html
 from influx.extraction.pdf import extract_pdf
 from influx.renderer import render
-from influx.storage import download_archive
+from influx.storage import download_archive_autodetect
 from influx.thin_summary import is_thin_summary
 from influx.urls import normalise_url, url_hash
 
@@ -42,14 +45,6 @@ _log = logging.getLogger(__name__)
 
 # Fixed archive subtree + default ``source:`` tag (§13.1).
 INBOX_SOURCE = "inbox"
-
-
-def _is_pdf_url(url: str) -> bool:
-    """Syntactic check — does the URL path point at a PDF?"""
-    try:
-        return urlparse(url).path.lower().endswith(".pdf")
-    except (TypeError, ValueError):
-        return False
 
 
 @dataclass(frozen=True, slots=True)
@@ -77,54 +72,53 @@ def acquire_inbox_bytes(
 ) -> InboxAcquisition:
     """Download + extract one inbox URL into the fixed inbox archive subtree.
 
-    Branches on a ``.pdf`` URL shape: PDF URLs archive with a ``.pdf``
-    extension and extract via :func:`extract_pdf` over the archived bytes;
-    all other URLs archive as ``.html`` and extract via
-    :func:`extract_article`.  On extraction failure the *summary_hint* (a
-    submitter-provided excerpt, if any) is the fallback body.
+    Fetches the URL **once** via :func:`download_archive_autodetect` and
+    routes the extraction branch on the response ``Content-Type`` (issue
+    #200): a ``pdf`` response extracts via :func:`extract_pdf` over the
+    fetched bytes; an ``html`` response via
+    :func:`extract_article_from_html` over the same bytes.  Extraction
+    runs off the in-memory bytes returned by the fetch, so it succeeds
+    even when the archive disk-write failed, and the archived artifact
+    and the scored text always come from the same response.  On any
+    failure the *summary_hint* (a submitter-provided excerpt, if any) is
+    the fallback body.
     """
     archive_root = Path(config.storage.archive_dir)
     source_url = normalise_url(url)
     hash_val = url_hash(url)
     now = datetime.now(UTC)
-    is_pdf = _is_pdf_url(url)
-    ext = ".pdf" if is_pdf else ".html"
-    expected: Any = "pdf" if is_pdf else "html"
 
-    archive_result = download_archive(
+    archive_result = download_archive_autodetect(
         url=url,
         archive_root=archive_root,
         source=INBOX_SOURCE,
         item_id=hash_val,
         published_year=now.year,
         published_month=now.month,
-        ext=ext,
         allow_private_ips=config.security.allow_private_ips,
         max_download_bytes=config.storage.max_download_bytes,
         timeout_seconds=config.storage.download_timeout_seconds,
-        expected_content_type=expected,
     )
     archive_path = archive_result.rel_posix_path
     archive_missing = not archive_result.ok
+    body = archive_result.body
+    family = archive_result.content_type_family
 
     extracted_text: str | None = None
     summary = summary_hint or ""
     flavour: TextFlavour = "summary-fallback"
     try:
-        if is_pdf:
-            if archive_path is not None:
-                pdf_bytes = (archive_root / archive_path).read_bytes()
-                extracted_text = extract_pdf(pdf_bytes, source_url=source_url).text
-                summary = extracted_text
-                flavour = "pdf"
-        else:
-            extracted_text = extract_article(
-                url,
+        if family == "pdf" and body is not None:
+            extracted_text = extract_pdf(body, source_url=source_url).text
+            summary = extracted_text
+            flavour = "pdf"
+        elif family == "html" and body is not None:
+            html_body = body.decode("utf-8", errors="replace")
+            extracted_text = extract_article_from_html(
+                html_body,
+                url=url,
                 min_web_chars=config.extraction.min_web_chars,
                 strip_tags=config.extraction.strip_tags,
-                allow_private_ips=config.security.allow_private_ips,
-                max_download_bytes=config.storage.max_download_bytes,
-                timeout_seconds=config.storage.download_timeout_seconds,
             ).text
             summary = extracted_text
             flavour = "html"

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -43,7 +43,7 @@ from influx.archive_policy import (
 from influx.cascade import Acquired, Cascade
 from influx.coordinator import RunKind
 from influx.errors import ExtractionError, NetworkError
-from influx.extraction.article import extract_article
+from influx.extraction.article import extract_article, extract_article_from_html
 from influx.filter import FilterScorerError, _acall_filter_model_with_retry
 from influx.http_client import aguarded_fetch as _aguarded_fetch
 from influx.renderer import render
@@ -482,14 +482,29 @@ def build_rss_note_item(
     extracted_text: str | None = None
     summary = item.summary
     try:
-        extraction = extract_article(
-            item.url,
-            min_web_chars=config.extraction.min_web_chars,
-            strip_tags=config.extraction.strip_tags,
-            allow_private_ips=config.security.allow_private_ips,
-            max_download_bytes=config.storage.max_download_bytes,
-            timeout_seconds=config.storage.download_timeout_seconds,
-        )
+        if archive_result.ok and archive_result.body is not None:
+            # Issue #200: the archive download already fetched this exact
+            # URL's HTML — reuse those bytes for extraction instead of a
+            # redundant second fetch (same URL, same representation), so
+            # the archived artifact and the scored text never diverge.
+            extraction = extract_article_from_html(
+                archive_result.body.decode("utf-8", errors="replace"),
+                url=item.url,
+                min_web_chars=config.extraction.min_web_chars,
+                strip_tags=config.extraction.strip_tags,
+            )
+        else:
+            # No archived bytes (policy skip/block, non-HTML short-circuit,
+            # HTTP error, write failure, …) — fall back to a direct fetch
+            # so policy-skipped items still get an extraction attempt.
+            extraction = extract_article(
+                item.url,
+                min_web_chars=config.extraction.min_web_chars,
+                strip_tags=config.extraction.strip_tags,
+                allow_private_ips=config.security.allow_private_ips,
+                max_download_bytes=config.storage.max_download_bytes,
+                timeout_seconds=config.storage.download_timeout_seconds,
+            )
         summary = extraction.text
         extracted_text = extraction.text
     except (ExtractionError, NetworkError) as exc:

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -482,11 +482,15 @@ def build_rss_note_item(
     extracted_text: str | None = None
     summary = item.summary
     try:
-        if archive_result.ok and archive_result.body is not None:
+        if archive_result.body is not None:
             # Issue #200: the archive download already fetched this exact
             # URL's HTML — reuse those bytes for extraction instead of a
             # redundant second fetch (same URL, same representation), so
             # the archived artifact and the scored text never diverge.
+            # ``download_archive`` only populates ``body`` on a successful
+            # HTML fetch (incl. the write-failure case, which still holds
+            # the fetched bytes), so reusing it whenever present avoids a
+            # redundant fetch even when the disk write failed.
             extraction = extract_article_from_html(
                 archive_result.body.decode("utf-8", errors="replace"),
                 url=item.url,
@@ -495,7 +499,7 @@ def build_rss_note_item(
             )
         else:
             # No archived bytes (policy skip/block, non-HTML short-circuit,
-            # HTTP error, write failure, …) — fall back to a direct fetch
+            # HTTP error, network failure, …) — fall back to a direct fetch
             # so policy-skipped items still get an extraction attempt.
             extraction = extract_article(
                 item.url,

--- a/src/influx/storage.py
+++ b/src/influx/storage.py
@@ -516,6 +516,19 @@ def download_archive_autodetect(
             domain=domain,
         )
 
+    # AC-04-C: reject unsafe ``source`` / ``item_id`` (path traversal,
+    # invalid slug, archive-root escape) BEFORE any network fetch, matching
+    # :func:`download_archive`.  Path safety is independent of the file
+    # extension, so this early call validates with the default ext; the real
+    # path is rebuilt from the detected family after the fetch below.
+    build_archive_path(
+        archive_root=archive_root,
+        source=source,
+        item_id=item_id,
+        published_year=published_year,
+        published_month=published_month,
+    )
+
     try:
         result = guarded_fetch(
             url,

--- a/src/influx/storage.py
+++ b/src/influx/storage.py
@@ -29,7 +29,12 @@ from influx.archive_policy import (
 )
 from influx.config import StorageConfig
 from influx.errors import InfluxError, NetworkError
-from influx.http_client import ContentTypeFamily, guarded_fetch
+from influx.http_client import (
+    ContentTypeFamily,
+    FetchResult,
+    content_type_family,
+    guarded_fetch,
+)
 from influx.slugs import is_valid_slug
 from influx.source_kind import classify_source_kind
 
@@ -38,6 +43,7 @@ __all__ = [
     "ArchiveResult",
     "build_archive_path",
     "download_archive",
+    "download_archive_autodetect",
 ]
 
 _log = logging.getLogger(__name__)
@@ -166,6 +172,16 @@ class ArchiveResult:
     # Domain (host) of the URL the policy was applied against.
     # Convenience field so callers don't have to re-parse the URL.
     domain: str = ""
+    # Issue #200: the response Content-Type seen on the fetch (raw
+    # header, e.g. ``application/pdf; charset=...``) and its classified
+    # family (``"html"`` / ``"pdf"`` / …), plus the fetched bytes.
+    # Populated on a successful network fetch so callers can route
+    # extraction on the real content type and reuse the bytes without a
+    # second fetch.  Empty / ``None`` when no fetch happened (policy
+    # short-circuit) or on failure.
+    content_type: str = ""
+    content_type_family: str = ""
+    body: bytes | None = None
 
 
 # ── Archive download ────────────────────────────────────────────────
@@ -367,9 +383,37 @@ def download_archive(
             domain=domain,
         )
 
+    return _persist_archive_body(
+        fetched=result,
+        fs_path=fs_path,
+        rel_posix=rel_posix,
+        family=content_type_family(result.content_type),
+        policy_mode=policy.mode,
+        domain=domain,
+    )
+
+
+def _persist_archive_body(
+    *,
+    fetched: FetchResult,
+    fs_path: Path,
+    rel_posix: str,
+    family: ContentTypeFamily | None,
+    policy_mode: str,
+    domain: str,
+) -> ArchiveResult:
+    """Write a fetched response body to *fs_path* and build the result.
+
+    Shared by :func:`download_archive` and
+    :func:`download_archive_autodetect` so the archive-write step plus
+    the issue #200 body / content-type surfacing live in one place.  The
+    fetched bytes and content type are carried on the returned
+    :class:`ArchiveResult` even on a write failure, so a caller can still
+    extract from the in-memory bytes when the disk write fails.
+    """
     try:
         fs_path.parent.mkdir(parents=True, exist_ok=True)
-        fs_path.write_bytes(result.body)
+        fs_path.write_bytes(fetched.body)
     except OSError as exc:
         error = f"write: {exc}"
         _log.warning("Archive write failed for %s: %s", fs_path, exc)
@@ -378,8 +422,11 @@ def download_archive(
             rel_posix_path=None,
             error=error,
             failure_kind="write",
-            policy_mode=policy.mode,
+            policy_mode=policy_mode,
             domain=domain,
+            content_type=fetched.content_type,
+            content_type_family=family or "",
+            body=fetched.body,
         )
 
     return ArchiveResult(
@@ -387,6 +434,172 @@ def download_archive(
         rel_posix_path=rel_posix,
         error="",
         failure_kind="",
+        policy_mode=policy_mode,
+        domain=domain,
+        content_type=fetched.content_type,
+        content_type_family=family or "",
+        body=fetched.body,
+    )
+
+
+_DEFAULT_EXT_BY_FAMILY: dict[ContentTypeFamily, str] = {
+    "html": ".html",
+    "pdf": ".pdf",
+    "xml": ".xml",
+}
+
+
+def download_archive_autodetect(
+    *,
+    url: str,
+    archive_root: Path,
+    source: str,
+    item_id: str,
+    published_year: int,
+    published_month: int,
+    acceptable_families: tuple[ContentTypeFamily, ...] = ("html", "pdf"),
+    allow_private_ips: bool = False,
+    max_download_bytes: int | None = None,
+    timeout_seconds: int | None = None,
+    policy_registry: ArchivePolicyRegistry | None = None,
+) -> ArchiveResult:
+    """Fetch a URL once and archive it, routing on the real Content-Type.
+
+    Unlike :func:`download_archive` — which is told the expected content
+    type and file extension up front — this fetches with **no**
+    content-type guard, classifies the response via
+    :func:`~influx.http_client.content_type_family`, derives the archive
+    extension from that family, and returns the fetched bytes on the
+    :class:`ArchiveResult` so the caller can extract without a second
+    fetch (issue #200).  Used by the inbox source, where a submitter
+    hands an arbitrary URL whose true type is only known after the fetch.
+
+    ``skip`` / ``unsupported`` domain policies short-circuit before any
+    network call, exactly as in :func:`download_archive`.  The issue
+    #160 non-HTML-source URL-shape short-circuit is intentionally *not*
+    applied here: routing happens on the actual response type, so a
+    URL-shape guard would be redundant and could wrongly reject a real
+    article served from a feed-shaped URL.
+
+    A response whose family is not in *acceptable_families* yields an
+    ``ok=False`` result with ``failure_kind="content_type_mismatch"``
+    but still carries ``content_type`` + ``body`` for the caller's
+    fallback and diagnostics.
+    """
+    if max_download_bytes is None or timeout_seconds is None:
+        _storage_defaults = StorageConfig()
+        if max_download_bytes is None:
+            max_download_bytes = _storage_defaults.max_download_bytes
+        if timeout_seconds is None:
+            timeout_seconds = _storage_defaults.download_timeout_seconds
+
+    registry = policy_registry if policy_registry is not None else default_registry()
+    policy = registry.policy_for(url)
+    domain = _domain_from_url(url)
+
+    if policy.mode in ("skip", "unsupported"):
+        note = policy.note or f"archive {policy.mode} by policy"
+        _log.info(
+            "archive download skipped (policy=%s) url=%s domain=%s note=%s",
+            policy.mode,
+            url,
+            domain,
+            policy.note,
+        )
+        failure_kind = "missing_by_policy" if policy.mode == "skip" else "unsupported"
+        return ArchiveResult(
+            ok=False,
+            rel_posix_path=None,
+            error=f"{failure_kind}: {note}",
+            failure_kind=failure_kind,
+            policy_mode=policy.mode,
+            domain=domain,
+        )
+
+    try:
+        result = guarded_fetch(
+            url,
+            allow_private_ips=allow_private_ips,
+            max_download_bytes=max_download_bytes,
+            timeout_seconds=timeout_seconds,
+            expected_content_type=None,
+        )
+    except NetworkError as exc:
+        error = f"{exc.kind}: {exc}"
+        failure_kind = classify_failure_kind(error=error, policy_mode=policy.mode)
+        _log.warning(
+            "Archive download failed for %s: [%s] %s (failure_kind=%s "
+            "policy=%s domain=%s)",
+            url,
+            exc.kind,
+            exc,
+            failure_kind,
+            policy.mode,
+            domain,
+        )
+        return ArchiveResult(
+            ok=False,
+            rel_posix_path=None,
+            error=error,
+            failure_kind=failure_kind,
+            policy_mode=policy.mode,
+            domain=domain,
+        )
+
+    if result.status_code >= 400:
+        msg = f"HTTP {result.status_code} for {url}"
+        failure_kind = classify_failure_kind(error=msg, policy_mode=policy.mode)
+        _log.warning(
+            "Archive download failed: %s (failure_kind=%s policy=%s domain=%s)",
+            msg,
+            failure_kind,
+            policy.mode,
+            domain,
+        )
+        return ArchiveResult(
+            ok=False,
+            rel_posix_path=None,
+            error=msg,
+            failure_kind=failure_kind,
+            policy_mode=policy.mode,
+            domain=domain,
+            content_type=result.content_type,
+            body=result.body,
+        )
+
+    family = content_type_family(result.content_type)
+    if family is None or family not in acceptable_families:
+        msg = (
+            f"content_type_mismatch: {result.content_type!r} "
+            f"(family={family!r}) not in {acceptable_families}"
+        )
+        _log.info("archive autodetect content-type mismatch url=%s %s", url, msg)
+        return ArchiveResult(
+            ok=False,
+            rel_posix_path=None,
+            error=msg,
+            failure_kind="content_type_mismatch",
+            policy_mode=policy.mode,
+            domain=domain,
+            content_type=result.content_type,
+            content_type_family=family or "",
+            body=result.body,
+        )
+
+    fs_path, rel_posix = build_archive_path(
+        archive_root=archive_root,
+        source=source,
+        item_id=item_id,
+        published_year=published_year,
+        published_month=published_month,
+        ext=_DEFAULT_EXT_BY_FAMILY[family],
+    )
+
+    return _persist_archive_body(
+        fetched=result,
+        fs_path=fs_path,
+        rel_posix=rel_posix,
+        family=family,
         policy_mode=policy.mode,
         domain=domain,
     )

--- a/tests/integration/test_otel_spans.py
+++ b/tests/integration/test_otel_spans.py
@@ -314,10 +314,13 @@ async def _run_rss_scenario(
                     ok=True,
                     rel_posix_path="blog/2026/04/test.html",
                     error="",
+                    content_type="text/html",
+                    content_type_family="html",
+                    body=b"<html>article</html>",
                 ),
             ),
             patch(
-                "influx.sources.rss.extract_article",
+                "influx.sources.rss.extract_article_from_html",
                 return_value=MagicMock(text="Extracted text", source_tag="html"),
             ),
         ):

--- a/tests/unit/test_archive_download.py
+++ b/tests/unit/test_archive_download.py
@@ -7,9 +7,15 @@ from unittest.mock import patch
 
 import pytest
 
+from influx.archive_policy import build_registry
 from influx.errors import NetworkError
 from influx.http_client import FetchResult
-from influx.storage import ArchivePathError, ArchiveResult, download_archive
+from influx.storage import (
+    ArchivePathError,
+    ArchiveResult,
+    download_archive,
+    download_archive_autodetect,
+)
 
 _URL = "https://arxiv.org/pdf/2601.12345"
 
@@ -255,3 +261,119 @@ class TestPathSafetyBeforeDownload:
         """Unsafe IDs are rejected before any network call."""
         with pytest.raises(ArchivePathError):
             _dl(tmp_path, item_id="../../etc/passwd")
+
+
+class TestSuccessResultCarriesBody:
+    """Issue #200: download_archive surfaces the fetched bytes + content type."""
+
+    @patch("influx.storage.guarded_fetch")
+    def test_success_carries_body_and_content_type(
+        self, mock_fetch: object, tmp_path: Path
+    ) -> None:
+        mock_fetch.return_value = _make_fetch_result()  # type: ignore[union-attr]
+        result = _dl(tmp_path)
+
+        assert result.ok is True
+        assert result.body == b"%PDF-1.4 sample"
+        assert result.content_type == "application/pdf"
+        assert result.content_type_family == "pdf"
+
+
+def _autodetect(
+    tmp_path: Path,
+    *,
+    url: str = "https://example.com/article",
+    item_id: str = "abc123",
+    source: str = "inbox",
+    **kwargs: object,
+) -> ArchiveResult:
+    return download_archive_autodetect(
+        url=url,
+        archive_root=tmp_path,
+        source=source,
+        item_id=item_id,
+        published_year=2026,
+        published_month=6,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+class TestDownloadArchiveAutodetect:
+    """Issue #200: fetch-once + route on the real response Content-Type."""
+
+    @patch("influx.storage.guarded_fetch")
+    def test_html_response_archives_as_html(
+        self, mock_fetch: object, tmp_path: Path
+    ) -> None:
+        mock_fetch.return_value = _make_fetch_result(  # type: ignore[union-attr]
+            body=b"<html>x</html>",
+            content_type="text/html; charset=utf-8",
+        )
+        result = _autodetect(tmp_path)
+
+        assert result.ok is True
+        assert result.rel_posix_path == "inbox/2026/06/abc123.html"
+        assert result.content_type_family == "html"
+        assert result.body == b"<html>x</html>"
+        assert (tmp_path / "inbox" / "2026" / "06" / "abc123.html").exists()
+
+    @patch("influx.storage.guarded_fetch")
+    def test_pdf_at_non_pdf_url_routes_on_content_type(
+        self, mock_fetch: object, tmp_path: Path
+    ) -> None:
+        """A PDF served from a non-.pdf URL archives as .pdf (AC-1)."""
+        mock_fetch.return_value = _make_fetch_result(  # type: ignore[union-attr]
+            body=b"%PDF-1.4 ok",
+            content_type="application/pdf",
+        )
+        result = _autodetect(tmp_path, url="https://example.com/download?doc=42")
+
+        assert result.ok is True
+        assert result.rel_posix_path == "inbox/2026/06/abc123.pdf"
+        assert result.content_type_family == "pdf"
+
+    @patch("influx.storage.guarded_fetch")
+    def test_unacceptable_type_is_content_type_mismatch(
+        self, mock_fetch: object, tmp_path: Path
+    ) -> None:
+        mock_fetch.return_value = _make_fetch_result(  # type: ignore[union-attr]
+            body=b"\x89PNG...",
+            content_type="image/png",
+        )
+        result = _autodetect(tmp_path)
+
+        assert result.ok is False
+        assert result.failure_kind == "content_type_mismatch"
+        assert result.rel_posix_path is None
+        # Body + content type are still carried for caller fallback.
+        assert result.content_type == "image/png"
+        assert result.body == b"\x89PNG..."
+        assert not (tmp_path / "inbox").exists()
+
+    @patch("influx.storage.guarded_fetch")
+    def test_http_4xx_returns_failure(self, mock_fetch: object, tmp_path: Path) -> None:
+        mock_fetch.return_value = _make_fetch_result(  # type: ignore[union-attr]
+            status_code=404, content_type="text/html"
+        )
+        result = _autodetect(tmp_path)
+
+        assert result.ok is False
+        assert "404" in result.error
+        assert result.rel_posix_path is None
+
+    def test_skip_policy_short_circuits_before_fetch(self, tmp_path: Path) -> None:
+        registry = build_registry(
+            skip={"blocked.example": "permanent skip"},
+            include_defaults=False,
+        )
+        with patch("influx.storage.guarded_fetch") as mock_fetch:
+            result = _autodetect(
+                tmp_path,
+                url="https://blocked.example/article",
+                policy_registry=registry,
+            )
+        mock_fetch.assert_not_called()
+        assert result.ok is False
+        assert result.failure_kind == "missing_by_policy"
+        assert result.policy_mode == "skip"
+        assert not (tmp_path / "inbox").exists()

--- a/tests/unit/test_archive_download.py
+++ b/tests/unit/test_archive_download.py
@@ -391,3 +391,12 @@ class TestDownloadArchiveAutodetect:
         assert result.failure_kind == "missing_by_policy"
         assert result.policy_mode == "skip"
         assert not (tmp_path / "inbox").exists()
+
+    def test_traversal_item_id_raises_before_fetch(self, tmp_path: Path) -> None:
+        """AC-04-C: unsafe item_id is rejected before any network fetch."""
+        with (
+            patch("influx.storage.guarded_fetch") as mock_fetch,
+            pytest.raises(ArchivePathError),
+        ):
+            _autodetect(tmp_path, item_id="../../etc/passwd")
+        mock_fetch.assert_not_called()

--- a/tests/unit/test_archive_download.py
+++ b/tests/unit/test_archive_download.py
@@ -361,6 +361,20 @@ class TestDownloadArchiveAutodetect:
         assert "404" in result.error
         assert result.rel_posix_path is None
 
+    @patch("influx.storage.guarded_fetch")
+    def test_acceptable_families_override_rejects_disallowed(
+        self, mock_fetch: object, tmp_path: Path
+    ) -> None:
+        """Narrowing acceptable_families rejects an otherwise-valid family."""
+        mock_fetch.return_value = _make_fetch_result(  # type: ignore[union-attr]
+            body=b"%PDF-1.4 ok", content_type="application/pdf"
+        )
+        result = _autodetect(tmp_path, acceptable_families=("html",))
+
+        assert result.ok is False
+        assert result.failure_kind == "content_type_mismatch"
+        assert result.content_type_family == "pdf"
+
     def test_skip_policy_short_circuits_before_fetch(self, tmp_path: Path) -> None:
         registry = build_registry(
             skip={"blocked.example": "permanent skip"},

--- a/tests/unit/test_article_extraction.py
+++ b/tests/unit/test_article_extraction.py
@@ -12,7 +12,11 @@ from unittest.mock import patch
 import pytest
 
 from influx.errors import ExtractionError, NetworkError
-from influx.extraction.article import ArticleExtractionResult, extract_article
+from influx.extraction.article import (
+    ArticleExtractionResult,
+    extract_article,
+    extract_article_from_html,
+)
 from influx.http_client import FetchResult
 
 _FIXTURES = Path(__file__).resolve().parent.parent / "fixtures" / "extraction"
@@ -228,3 +232,50 @@ class TestFailurePropagation:
 
         with pytest.raises(ExtractionError, match="no content"):
             extract_article("https://example.com/article/123")
+
+
+# -- From-HTML seam (issue #200) ------------------------------------------
+
+
+class TestExtractArticleFromHtml:
+    """The network-free core extracts from an already-fetched HTML string."""
+
+    def test_extracts_from_string_without_fetching(self) -> None:
+        html = _read_fixture("web_article.html").decode("utf-8")
+        result = extract_article_from_html(
+            html, url="https://example.com/article/123", min_web_chars=100
+        )
+        assert isinstance(result, ArticleExtractionResult)
+        assert result.source == "article"
+        assert len(result.text) >= 100
+        assert "<" not in result.text
+
+    def test_strips_dangerous_tags(self) -> None:
+        html = _read_fixture("web_with_script.html").decode("utf-8")
+        result = extract_article_from_html(
+            html, url="https://example.com/x", min_web_chars=10
+        )
+        assert "malicious_web_script" not in result.text
+        assert "document.cookie" not in result.text
+
+    def test_rejects_below_min_length(self) -> None:
+        html = _read_fixture("short_web_article.html").decode("utf-8")
+        with pytest.raises(ExtractionError, match="too short"):
+            extract_article_from_html(
+                html, url="https://example.com/short", min_web_chars=500
+            )
+
+    def test_trafilatura_none_raises(self) -> None:
+        with pytest.raises(ExtractionError, match="no content"):
+            extract_article_from_html(
+                "<html><body></body></html>", url="https://example.com/x"
+            )
+
+    @patch("influx.extraction.article.guarded_fetch")
+    def test_extract_article_delegates_to_from_html(self, mock_fetch: object) -> None:
+        """extract_article fetches once then delegates (behavior preserved)."""
+        html = _read_fixture("web_article.html")
+        mock_fetch.return_value = _make_fetch_result(html)  # type: ignore[union-attr]
+        result = extract_article("https://example.com/article/123", min_web_chars=100)
+        assert isinstance(result, ArticleExtractionResult)
+        mock_fetch.assert_called_once()  # type: ignore[union-attr]

--- a/tests/unit/test_inbox_builder.py
+++ b/tests/unit/test_inbox_builder.py
@@ -1,10 +1,11 @@
 """Unit tests for the inbox acquisition + note builder (Inbox v1 slice 1).
 
 Covers :func:`influx.sources.inbox.acquire_inbox_bytes` (fixed archive
-subtree, content-type branch) and
+subtree, real-Content-Type routing — issue #200) and
 :func:`influx.sources.inbox.build_inbox_note_item` (title fallback,
-ProfileItem key set, tags, thin-summary suppression).  ``download_archive``
-and ``extract_article`` / ``extract_pdf`` are patched — no network IO.
+ProfileItem key set, tags, thin-summary suppression).
+``download_archive_autodetect`` and ``extract_article_from_html`` /
+``extract_pdf`` are patched — no network IO.
 """
 
 from __future__ import annotations
@@ -23,7 +24,7 @@ from influx.config import (
     SecurityConfig,
     StorageConfig,
 )
-from influx.errors import NetworkError
+from influx.http_client import FetchResult
 from influx.sources.inbox import (
     INBOX_SOURCE,
     acquire_inbox_bytes,
@@ -40,10 +41,12 @@ _LONG_BODY = (
 )
 
 
-def _make_config(*, min_summary_chars: int = 80) -> AppConfig:
+def _make_config(
+    *, min_summary_chars: int = 80, archive_dir: str = "/archive"
+) -> AppConfig:
     return AppConfig(
         lithos=LithosConfig(url="http://localhost:0/sse"),
-        storage=StorageConfig(archive_dir="/archive"),
+        storage=StorageConfig(archive_dir=archive_dir),
         profiles=[
             ProfileConfig(
                 name="ai-robotics",
@@ -63,11 +66,27 @@ def _make_config(*, min_summary_chars: int = 80) -> AppConfig:
     )
 
 
-def _ok_html_archive(url: str = _URL) -> ArchiveResult:
+def _ok_html_archive(
+    url: str = _URL, *, body: bytes = b"<html>article</html>"
+) -> ArchiveResult:
     return ArchiveResult(
         ok=True,
         rel_posix_path=f"inbox/2026/06/{url_hash(url)}.html",
         error="",
+        content_type="text/html; charset=utf-8",
+        content_type_family="html",
+        body=body,
+    )
+
+
+def _ok_pdf_archive(url: str, *, body: bytes = b"%PDF-1.4 ...") -> ArchiveResult:
+    return ArchiveResult(
+        ok=True,
+        rel_posix_path=f"inbox/2026/06/{url_hash(url)}.pdf",
+        error="",
+        content_type="application/pdf",
+        content_type_family="pdf",
+        body=body,
     )
 
 
@@ -89,14 +108,15 @@ class _Extraction:
 
 
 def test_acquire_archives_into_fixed_inbox_subtree() -> None:
-    """HTML URLs archive under inbox/YYYY/MM/<url_hash>.html (§13.1)."""
+    """HTML responses archive under inbox/YYYY/MM/<url_hash>.html (§13.1)."""
     config = _make_config()
     with (
         patch(
-            "influx.sources.inbox.download_archive", return_value=_ok_html_archive()
+            "influx.sources.inbox.download_archive_autodetect",
+            return_value=_ok_html_archive(),
         ) as mock_dl,
         patch(
-            "influx.sources.inbox.extract_article",
+            "influx.sources.inbox.extract_article_from_html",
             return_value=_Extraction(_LONG_BODY),
         ),
     ):
@@ -105,50 +125,89 @@ def test_acquire_archives_into_fixed_inbox_subtree() -> None:
     kwargs = mock_dl.call_args.kwargs
     assert kwargs["source"] == INBOX_SOURCE
     assert kwargs["item_id"] == url_hash(_URL)
-    assert kwargs["ext"] == ".html"
-    assert kwargs["expected_content_type"] == "html"
+    # No ext / expected_content_type is passed any more — the extension is
+    # derived from the response Content-Type by the autodetect helper.
+    assert "ext" not in kwargs
+    assert "expected_content_type" not in kwargs
     assert acquired.archive_path == f"inbox/2026/06/{url_hash(_URL)}.html"
     assert acquired.extracted_text == _LONG_BODY
     assert acquired.text_flavour == "html"
 
 
-def test_acquire_pdf_url_uses_pdf_branch() -> None:
-    """A .pdf URL archives with a .pdf ext and extracts via extract_pdf."""
+def test_acquire_routes_pdf_on_content_type_not_url_shape() -> None:
+    """A PDF served at a NON-.pdf URL still extracts as a PDF (issue #200 AC-1)."""
     config = _make_config()
-    pdf_url = "https://arxiv.org/pdf/2401.12345.pdf"
-    ok_pdf = ArchiveResult(
-        ok=True, rel_posix_path=f"inbox/2026/06/{url_hash(pdf_url)}.pdf", error=""
-    )
+    # URL has no .pdf suffix — only the response Content-Type marks it PDF.
+    pdf_url = "https://example.com/download?doc=42"
     with (
-        patch("influx.sources.inbox.download_archive", return_value=ok_pdf) as mock_dl,
-        patch("pathlib.Path.read_bytes", return_value=b"%PDF-1.4 ..."),
         patch(
-            "influx.sources.inbox.extract_pdf", return_value=_Extraction(_LONG_BODY)
+            "influx.sources.inbox.download_archive_autodetect",
+            return_value=_ok_pdf_archive(pdf_url, body=b"%PDF-1.4 bytes"),
+        ),
+        patch(
+            "influx.sources.inbox.extract_pdf",
+            return_value=_Extraction(_LONG_BODY),
         ) as mock_pdf,
+        patch("influx.sources.inbox.extract_article_from_html") as mock_html,
     ):
         acquired = acquire_inbox_bytes(pdf_url, config=config)
 
-    assert mock_dl.call_args.kwargs["ext"] == ".pdf"
-    assert mock_dl.call_args.kwargs["expected_content_type"] == "pdf"
     mock_pdf.assert_called_once()
+    # The PDF bytes from the fetch are what get extracted (not re-read).
+    assert mock_pdf.call_args.args[0] == b"%PDF-1.4 bytes"
+    mock_html.assert_not_called()
     assert acquired.text_flavour == "pdf"
     assert acquired.extracted_text == _LONG_BODY
 
 
-def test_acquire_falls_back_to_summary_hint_on_extraction_failure() -> None:
+def test_acquire_falls_back_to_summary_hint_on_archive_failure() -> None:
     config = _make_config()
-    with (
-        patch("influx.sources.inbox.download_archive", return_value=_failed_archive()),
-        patch(
-            "influx.sources.inbox.extract_article",
-            side_effect=NetworkError("boom", url=_URL, kind="timeout"),
-        ),
+    with patch(
+        "influx.sources.inbox.download_archive_autodetect",
+        return_value=_failed_archive(),
     ):
         acquired = acquire_inbox_bytes(_URL, config=config, summary_hint="a hint")
 
     assert acquired.extracted_text is None
     assert acquired.summary == "a hint"
     assert acquired.archive_missing is True
+    assert acquired.text_flavour == "summary-fallback"
+
+
+def test_acquire_html_item_fetches_url_exactly_once(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """An HTML inbox item triggers exactly one network fetch (issue #200 AC-2).
+
+    The bytes that get archived and the bytes that get extracted come from
+    the *same* response — there is no second fetch in the extraction step.
+    """
+    config = _make_config(archive_dir=str(tmp_path))
+    html = (
+        "<html><body><article><p>" + _LONG_BODY + "</p></article></body></html>"
+    ).encode("utf-8")
+    fetched = FetchResult(
+        body=html,
+        status_code=200,
+        content_type="text/html; charset=utf-8",
+        final_url=_URL,
+    )
+    seen: list[str] = []
+
+    with (
+        # Patch the fetch where the autodetect helper imported it.
+        patch("influx.storage.guarded_fetch", return_value=fetched) as mock_fetch,
+        # Capture what the extractor receives without invoking trafilatura.
+        patch(
+            "influx.sources.inbox.extract_article_from_html",
+            side_effect=lambda body, **_: seen.append(body) or _Extraction(_LONG_BODY),
+        ),
+    ):
+        acquired = acquire_inbox_bytes(_URL, config=config)
+
+    assert mock_fetch.call_count == 1
+    # The extractor saw exactly the fetched (decoded) bytes — same response.
+    assert seen == [html.decode("utf-8")]
+    assert acquired.text_flavour == "html"
+    assert acquired.archive_missing is False
 
 
 # ── build_inbox_note_item ───────────────────────────────────────────
@@ -156,9 +215,12 @@ def test_acquire_falls_back_to_summary_hint_on_extraction_failure() -> None:
 
 def _acquire_ok(config: AppConfig) -> object:
     with (
-        patch("influx.sources.inbox.download_archive", return_value=_ok_html_archive()),
         patch(
-            "influx.sources.inbox.extract_article",
+            "influx.sources.inbox.download_archive_autodetect",
+            return_value=_ok_html_archive(),
+        ),
+        patch(
+            "influx.sources.inbox.extract_article_from_html",
             return_value=_Extraction(_LONG_BODY),
         ),
     ):
@@ -228,12 +290,9 @@ def test_build_item_title_falls_back_to_url() -> None:
 def test_build_item_thin_summary_suppressed() -> None:
     """No body extracted + thin fallback summary → None (suppressed)."""
     config = _make_config()
-    with (
-        patch("influx.sources.inbox.download_archive", return_value=_failed_archive()),
-        patch(
-            "influx.sources.inbox.extract_article",
-            side_effect=NetworkError("boom", url=_URL, kind="timeout"),
-        ),
+    with patch(
+        "influx.sources.inbox.download_archive_autodetect",
+        return_value=_failed_archive(),
     ):
         acquired = acquire_inbox_bytes(_URL, config=config, summary_hint="tiny")
 

--- a/tests/unit/test_inbox_builder.py
+++ b/tests/unit/test_inbox_builder.py
@@ -160,6 +160,40 @@ def test_acquire_routes_pdf_on_content_type_not_url_shape() -> None:
     assert acquired.extracted_text == _LONG_BODY
 
 
+def test_acquire_non_extractable_type_uses_summary_fallback(
+    caplog: object,
+) -> None:
+    """A fetched body whose type is neither HTML nor PDF falls back + logs."""
+    import logging
+
+    config = _make_config()
+    mismatch = ArchiveResult(
+        ok=False,
+        rel_posix_path=None,
+        error="content_type_mismatch: 'application/xml'",
+        failure_kind=cast("str", "content_type_mismatch"),
+        content_type="application/xml",
+        content_type_family="xml",
+        body=b"<rss></rss>",
+    )
+    with (
+        patch(
+            "influx.sources.inbox.download_archive_autodetect",
+            return_value=mismatch,
+        ),
+        caplog.at_level(logging.INFO, logger="influx.sources.inbox"),  # type: ignore[attr-defined]
+    ):
+        acquired = acquire_inbox_bytes(_URL, config=config, summary_hint="a hint")
+
+    assert acquired.extracted_text is None
+    assert acquired.text_flavour == "summary-fallback"
+    assert acquired.summary == "a hint"
+    assert any(
+        "content-type not extractable" in r.message
+        for r in caplog.records  # type: ignore[attr-defined]
+    )
+
+
 def test_acquire_falls_back_to_summary_hint_on_archive_failure() -> None:
     config = _make_config()
     with patch(

--- a/tests/unit/test_rss_fetch_once.py
+++ b/tests/unit/test_rss_fetch_once.py
@@ -1,0 +1,151 @@
+"""RSS reuses the archived bytes for extraction — no second fetch (issue #200).
+
+``build_rss_note_item`` archives ``item.url`` as HTML via ``download_archive``
+and previously re-fetched the same URL through ``extract_article``.  These
+tests pin the fetch-once behavior: when the archive download returns bytes,
+extraction runs off those bytes via ``extract_article_from_html``; only when
+there are no archived bytes does it fall back to a direct ``extract_article``
+fetch.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+from influx.config import (
+    AppConfig,
+    ArchivePolicyConfig,
+    ExtractionConfig,
+    LithosConfig,
+    ProfileConfig,
+    ProfileThresholds,
+    PromptEntryConfig,
+    PromptsConfig,
+    SecurityConfig,
+    StorageConfig,
+)
+from influx.sources.rss import RssFeedItem, build_rss_note_item
+from influx.storage import ArchiveResult
+
+_URL = "https://example.com/article"
+_LONG_BODY = (
+    "This is a substantial extracted article body, long enough to clear the "
+    "default thin-summary and min-length thresholds without any trouble at all."
+)
+
+
+def _config() -> AppConfig:
+    return AppConfig(
+        lithos=LithosConfig(url="http://localhost:0/sse"),
+        storage=StorageConfig(
+            archive_dir="/archive",
+            archive_policy=ArchivePolicyConfig(include_defaults=False),
+        ),
+        profiles=[
+            ProfileConfig(
+                name="ai-robotics",
+                description="AI and robotics research",
+                thresholds=ProfileThresholds(
+                    relevance=7, full_text=100, deep_extract=100
+                ),
+            )
+        ],
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="x"),
+            tier1_enrich=PromptEntryConfig(text="x"),
+            tier3_extract=PromptEntryConfig(text="x"),
+        ),
+        security=SecurityConfig(allow_private_ips=True),
+        extraction=ExtractionConfig(min_summary_chars=80),
+    )
+
+
+def _item() -> RssFeedItem:
+    return RssFeedItem(
+        title="Test Article",
+        url=_URL,
+        published=datetime(2026, 4, 25, tzinfo=UTC),
+        summary="A short feed summary.",
+        source_tag="rss",
+        feed_name="example-feed",
+    )
+
+
+def _ok_archive_with_body(body: bytes) -> ArchiveResult:
+    return ArchiveResult(
+        ok=True,
+        rel_posix_path="rss/example-feed/2026/04/abcd1234.html",
+        error="",
+        content_type="text/html; charset=utf-8",
+        content_type_family="html",
+        body=body,
+    )
+
+
+def _skipped_archive() -> ArchiveResult:
+    return ArchiveResult(
+        ok=False,
+        rel_posix_path=None,
+        error="missing_by_policy: skipped",
+        failure_kind="missing_by_policy",
+        policy_mode="skip",
+    )
+
+
+class _Extraction:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+def test_reuses_archived_bytes_without_second_fetch() -> None:
+    """A successful archive feeds its bytes to from-html extraction (no re-fetch)."""
+    html = (
+        b"<html><body><article>"
+        + _LONG_BODY.encode("utf-8")
+        + b"</article></body></html>"
+    )
+    with (
+        patch(
+            "influx.sources.rss.download_archive",
+            return_value=_ok_archive_with_body(html),
+        ),
+        patch(
+            "influx.sources.rss.extract_article_from_html",
+            return_value=_Extraction(_LONG_BODY),
+        ) as mock_from_html,
+        patch("influx.sources.rss.extract_article") as mock_fetch_extract,
+    ):
+        result = build_rss_note_item(
+            item=_item(), profile_name="ai-robotics", config=_config()
+        )
+
+    assert result is not None
+    # Extraction ran off the archived bytes — the URL was not fetched again.
+    mock_from_html.assert_called_once()
+    assert mock_from_html.call_args.args[0] == html.decode("utf-8")
+    mock_fetch_extract.assert_not_called()
+    assert result["abstract_or_summary"] == _LONG_BODY
+
+
+def test_falls_back_to_fetch_when_no_archived_bytes() -> None:
+    """A policy-skipped archive (no bytes) still attempts a direct extraction."""
+    with (
+        patch(
+            "influx.sources.rss.download_archive",
+            return_value=_skipped_archive(),
+        ),
+        patch(
+            "influx.sources.rss.extract_article",
+            return_value=_Extraction(_LONG_BODY),
+        ) as mock_fetch_extract,
+        patch("influx.sources.rss.extract_article_from_html") as mock_from_html,
+    ):
+        result = build_rss_note_item(
+            item=_item(), profile_name="ai-robotics", config=_config()
+        )
+
+    assert result is not None
+    mock_fetch_extract.assert_called_once()
+    assert mock_fetch_extract.call_args.args[0] == _URL
+    mock_from_html.assert_not_called()

--- a/tests/unit/test_telemetry_wiring.py
+++ b/tests/unit/test_telemetry_wiring.py
@@ -1472,10 +1472,13 @@ class TestInfluxArchiveDownloadSpan:
                         ok=True,
                         rel_posix_path="blog/2024/06/test.html",
                         error="",
+                        content_type="text/html",
+                        content_type_family="html",
+                        body=b"<html>article</html>",
                     ),
                 ),
                 patch(
-                    "influx.sources.rss.extract_article",
+                    "influx.sources.rss.extract_article_from_html",
                     return_value=MagicMock(text="Extracted text", source_tag="html"),
                 ),
             ):
@@ -1558,10 +1561,13 @@ class TestInfluxArchiveDownloadSpan:
                     ok=True,
                     rel_posix_path="blog/2024/06/test.html",
                     error="",
+                    content_type="text/html",
+                    content_type_family="html",
+                    body=b"<html>article</html>",
                 ),
             ) as mock_download,
             patch(
-                "influx.sources.rss.extract_article",
+                "influx.sources.rss.extract_article_from_html",
                 return_value=MagicMock(text="Extracted text", source_tag="html"),
             ),
         ):


### PR DESCRIPTION
## Summary

Fixes the two coupled acquisition limitations surfaced in the PR #199 review: inbox routed PDF-vs-HTML on a `.pdf` URL-suffix check (so a PDF served behind a non-`.pdf` URL was misclassified and extraction failed), and HTML items were fetched twice (`download_archive` + a second fetch inside `extract_article`).

A submitted URL is now fetched **once**, the extraction branch is chosen from the real response `Content-Type`, and the fetched bytes are reused for both archiving and extraction. The same redundant double-fetch is also removed from RSS. arXiv is intentionally left unchanged — its extraction cascade deliberately fetches a *different* representation (the HTML endpoint) and only falls back to the archived PDF, so its two fetches are not a redundancy.

## What changed

- **`extraction/article.py`** — new `extract_article_from_html(html_body, *, url, …)`: the network-free core (strip → trafilatura → clean → min-length). `extract_article(url, …)` keeps its signature and delegates (fetch → decode → core), so behaviour is unchanged.
- **`http_client.py`** — new `content_type_family(content_type)` classifier over the existing `_CONTENT_TYPE_FAMILIES` map.
- **`storage.py`** — `ArchiveResult` gains `content_type` / `content_type_family` / `body` (all defaulted; the frozen dataclass is never destructured, so additive). Shared `_persist_archive_body` helper (path-build + write + result), used by both `download_archive` (observable behaviour identical; now also surfaces the body) and the new **`download_archive_autodetect`** — fetches with **no content-type guard** (scheme/SSRF/redirect/size/timeout guards all still apply; only the content-type *rejection* is relaxed), classifies the response, derives the archive extension from the family, and returns the bytes.
- **`sources/inbox.py`** — `acquire_inbox_bytes` rewritten to fetch once via `download_archive_autodetect`, route on `content_type_family`, and extract off the returned bytes (PDF at a non-`.pdf` URL works; extraction survives a failed disk write). Deleted `_is_pdf_url`. Logs at INFO when a fetched body is neither HTML nor PDF before the summary fallback.
- **`sources/rss.py`** — `build_rss_note_item` reuses the bytes `download_archive` already fetched (same URL/representation) via `extract_article_from_html`, falling back to a direct fetch only when there are no archived bytes (policy skip/block, HTTP error, network failure).
- **Docs** — `SPECIFICATION.md` §17.5 updated from URL-shape to genuine content-type routing.

## Acceptance criteria

- [x] A PDF served at a non-`.pdf` URL is extracted as a PDF (routed on real `Content-Type`).
- [x] An HTML inbox item triggers exactly one network fetch; archived bytes == extracted bytes.
- [x] RSS and arXiv behaviour: RSS fetch-once added (regression-covered); arXiv unchanged.
- [x] Inbox docs/wording updated from URL-shape to content-type routing.

## Test plan

- `make check` green — **2453 passed**, ruff + pyright clean.
- New/updated: `extract_article_from_html` (string-in, strip-tags, min-length, delegation); `download_archive_autodetect` (html→`.html`, PDF-at-non-`.pdf`-URL→`.pdf`, content-type-mismatch, http_4xx, skip-policy short-circuit, `acceptable_families` override, success carries `body`); inbox (`download_archive_autodetect` routing, **AC-1** PDF-on-content-type, **AC-2** single-fetch via `guarded_fetch` counter, non-extractable-type fallback+log); RSS (`test_rss_fetch_once`: body-reuse vs no-bytes fallback); telemetry/otel fixtures repointed to the production primary path.
- A code review (python-reviewer) was run; its findings (RSS write-failure byte reuse, mismatch logging, stale telemetry fixtures, `acceptable_families` coverage) are addressed in the second commit.

Closes #200
