### PR TITLE
feat: inbox submit-script local-PDF mode (#206)

### DIFF
--- a/docs/plans/inbox.md
+++ b/docs/plans/inbox.md
@@ -465,14 +465,15 @@ Agents create InboxTasks directly via Lithos MCP. Humans don't. A helper script 
 
 ### 15.2 Behaviour
 
-The script takes a single positional argument that MUST be a URL (URL-only in v1; PDF support arrives in v2 per §16). It validates the URL, builds the InboxTask body, and creates the task via Lithos MCP.
+The script takes a single positional argument, auto-detected by shape: an `http(s)://` URL submits `kind="url"`; any other value is treated as a local PDF path and submits `kind="pdf"` (v2 §16). A URL-shaped value with a non-http scheme (`file:`, `ftp:`, …) is rejected. For a local PDF the script validates the file, resolves `[inbox] pdf_root`, stages the file into it (§16.6), and sends the in-`pdf_root` `local_path`. It then creates the task via Lithos MCP.
 
 ```
 influx-inbox-submit https://example.com/article
 influx-inbox-submit https://arxiv.org/pdf/2401.12345.pdf --title "Some Paper Title"
+influx-inbox-submit ./papers/attention-is-all-you-need.pdf --title "Attention Is All You Need"
 ```
 
-A URL pointing at a PDF works in v1 because the existing `download_archive` + `extract_pdf` cascade handles content-type-based branching.
+A URL pointing at a PDF also works (the URL path's content-type routing handles it); `kind="pdf"` is for PDFs that are only on the local filesystem.
 
 ### 15.3 Optional flags
 
@@ -484,7 +485,8 @@ A URL pointing at a PDF works in v1 because the existing `download_archive` + `e
 | `--source-tag <tag>` | `inbox` | Sets the resulting note's `source:*` tag |
 | `--submitted-by <id>` | `manual:<username>` | Submitter agent identifier; defaults to a `manual:` prefix plus the OS username |
 | `--env <name>` | `staging` | Selects `docker/.env.<name>` for config resolution |
-| `--dry-run` | false | Print the task body that would be sent without creating it |
+| `--pdf-root <path>` | from config | Override `[inbox] pdf_root` for staging a local PDF |
+| `--dry-run` | false | Print the task body that would be sent (no copy, no MCP call) |
 
 ### 15.4 Output
 

--- a/scripts/influx-inbox-submit.py
+++ b/scripts/influx-inbox-submit.py
@@ -34,10 +34,11 @@ from typing import Any
 
 _TASK_TAG = "influx:inbox"
 _SOURCE_TAG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,31}$")
-# An http(s) URL → kind="url".  Any other URI scheme (file:, ftp:, …) is a
-# URL-shaped value we reject as not-http; everything else is a local path.
+# An http(s) URL → kind="url".  Any other URI scheme (file:, ftp:, mailto:,
+# data:, …) on a value that is not an existing file is rejected as not-http;
+# everything else is treated as a local path.
 _HTTP_RE = re.compile(r"^https?://", re.IGNORECASE)
-_URL_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
+_URI_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 
 
 def _repo_root() -> Path:
@@ -137,10 +138,18 @@ def _stage_pdf_into_root(path: Path, pdf_root: Path, *, copy: bool) -> Path:
     root = pdf_root.resolve()
     if resolved.is_relative_to(root):
         return resolved
-    digest = hashlib.sha256(resolved.read_bytes()).hexdigest()
-    dest = root / f"{digest[:16]}-{resolved.name}"
+    h = hashlib.sha256()
+    with resolved.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    dest = root / f"{h.hexdigest()[:16]}-{resolved.name}"
     if copy and not dest.exists():
-        shutil.copy2(resolved, dest)
+        # Atomic publish: copy to a temp sibling then rename, so an
+        # interrupted copy never leaves a partial file that a later run
+        # would skip (dest.exists()) and submit as a valid PDF.
+        tmp = dest.with_name(f".{dest.name}.tmp")
+        shutil.copy2(resolved, tmp)
+        os.replace(tmp, dest)
     return dest
 
 
@@ -221,20 +230,29 @@ def main(argv: list[str] | None = None) -> int:
     _apply_env_to_process(env)
 
     if _HTTP_RE.match(target):
+        from urllib.parse import urlparse
+
+        if not urlparse(target).netloc:
+            print(f"error: URL must have a host, got {target!r}", file=sys.stderr)
+            return 2
         kind = "url"
         metadata = _add_optional_metadata(
             args,
             {"kind": "url", "url": target, "submitted_by": args.submitted_by},
         )
         label = args.title or target
-    elif _URL_SCHEME_RE.match(target):
-        print(f"error: URL must be http(s), got {target!r}", file=sys.stderr)
-        return 2
     else:
         kind = "pdf"
         path = Path(target).expanduser()
         if not path.is_file():
-            print(f"error: PDF file not found: {target!r}", file=sys.stderr)
+            # A non-http URI scheme (file:, ftp:, mailto:, …) is a malformed
+            # URL, not a path; everything else is a missing/non-file path.
+            if path.exists():
+                print(f"error: not a regular file: {target!r}", file=sys.stderr)
+            elif _URI_SCHEME_RE.match(target):
+                print(f"error: URL must be http(s), got {target!r}", file=sys.stderr)
+            else:
+                print(f"error: PDF file not found: {target!r}", file=sys.stderr)
             return 2
         if not _looks_like_pdf(path):
             print(
@@ -250,9 +268,19 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
             return 2
-        if not args.dry_run and not pdf_root.is_dir():
-            print(f"error: pdf_root is not a directory: {pdf_root}", file=sys.stderr)
-            return 2
+        if not pdf_root.is_dir():
+            if args.dry_run:
+                # Preview only — warn but still show the would-be local_path.
+                print(
+                    f"warning: pdf_root does not exist yet: {pdf_root}",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    f"error: pdf_root is not a directory: {pdf_root}",
+                    file=sys.stderr,
+                )
+                return 2
         local_path = _stage_pdf_into_root(path, pdf_root, copy=not args.dry_run)
         metadata = _add_optional_metadata(
             args,

--- a/scripts/influx-inbox-submit.py
+++ b/scripts/influx-inbox-submit.py
@@ -1,14 +1,21 @@
 #!/usr/bin/env python3
-"""Submit a URL to the Influx inbox (docs/plans/inbox.md §15).
+"""Submit a URL or local PDF to the Influx inbox (docs/plans/inbox.md §15/§16).
 
-Creates a single Lithos task tagged ``influx:inbox`` carrying the v1
-submission metadata (``kind="url"``, ``url``, ``submitted_by``, optional
-``title`` / ``summary`` / ``source_tag``).  Influx's inbox tick claims it,
-scores it against every enabled profile, and ingests where it clears.
+Creates a single Lithos task tagged ``influx:inbox``.  The positional
+argument is auto-detected: an ``http(s)://`` URL submits ``kind="url"``
+(``url`` metadata); any other value is treated as a local PDF path and
+submits ``kind="pdf"`` (``local_path`` metadata).  Both carry
+``submitted_by`` and optional ``title`` / ``summary`` / ``source_tag``.
+Influx's inbox tick claims the task, scores it against every enabled
+profile, and ingests where it clears.
+
+For a local PDF the script resolves ``[inbox] pdf_root`` from config and,
+if the file is not already under it, copies it in under a deterministic
+``<sha256-prefix>-<basename>`` name (the original is never moved/deleted);
+the ``local_path`` sent is always the in-``pdf_root`` path.
 
 Write-only against Lithos (one ``lithos_task_create`` MCP call); it makes
-no calls to the Influx service itself.  v1 is URL-only — a public PDF URL
-works (the cascade branches on URL shape); local-PDF support is v2 (§16).
+no calls to the Influx service itself.
 """
 
 from __future__ import annotations
@@ -16,17 +23,21 @@ from __future__ import annotations
 import argparse
 import asyncio
 import getpass
+import hashlib
 import json
 import os
 import re
+import shutil
 import sys
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
 _TASK_TAG = "influx:inbox"
 _SOURCE_TAG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,31}$")
-_ALLOWED_SCHEMES = ("http", "https")
+# An http(s) URL → kind="url".  Any other URI scheme (file:, ftp:, …) is a
+# URL-shaped value we reject as not-http; everything else is a local path.
+_HTTP_RE = re.compile(r"^https?://", re.IGNORECASE)
+_URL_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
 
 
 def _repo_root() -> Path:
@@ -71,12 +82,10 @@ def _resolve_lithos_url(args: argparse.Namespace, env: dict[str, str]) -> str | 
         return None
 
 
-def _build_metadata(args: argparse.Namespace) -> dict[str, Any]:
-    metadata: dict[str, Any] = {
-        "kind": "url",
-        "url": args.url,
-        "submitted_by": args.submitted_by,
-    }
+def _add_optional_metadata(
+    args: argparse.Namespace, metadata: dict[str, Any]
+) -> dict[str, Any]:
+    """Fold the shared optional fields (title/summary/source_tag) into *metadata*."""
     if args.title:
         metadata["title"] = args.title
     summary = args.summary
@@ -89,14 +98,50 @@ def _build_metadata(args: argparse.Namespace) -> dict[str, Any]:
     return metadata
 
 
-def _build_task_body(args: argparse.Namespace) -> dict[str, Any]:
-    label = args.title or args.url
-    return {
-        "title": f"Influx inbox: {label}",
-        "agent": args.submitted_by,
-        "tags": [_TASK_TAG],
-        "metadata": _build_metadata(args),
-    }
+def _looks_like_pdf(path: Path) -> bool:
+    """A ``.pdf`` suffix or a ``%PDF`` magic header (cheap pre-MCP check)."""
+    if path.suffix.lower() == ".pdf":
+        return True
+    try:
+        with path.open("rb") as fh:
+            return fh.read(5).startswith(b"%PDF")
+    except OSError:
+        return False
+
+
+def _resolve_pdf_root(args: argparse.Namespace, env: dict[str, str]) -> Path | None:
+    """Resolve pdf_root: --pdf-root → INFLUX_PDF_ROOT → influx config."""
+    if args.pdf_root:
+        return Path(args.pdf_root)
+    if env.get("INFLUX_PDF_ROOT"):
+        return Path(env["INFLUX_PDF_ROOT"])
+    try:
+        from influx.config import load_config
+
+        root = load_config().inbox.pdf_root
+        return Path(root) if root else None
+    except Exception:  # noqa: BLE001 — best-effort config discovery
+        return None
+
+
+def _stage_pdf_into_root(path: Path, pdf_root: Path, *, copy: bool) -> Path:
+    """Return the in-``pdf_root`` path for *path*, copying it in when outside.
+
+    A file already under *pdf_root* is used in place; otherwise it is copied
+    to a deterministic ``<sha256[:16]>-<basename>`` name (collision-safe and
+    keeps the human-readable name).  The user's original is never moved or
+    deleted.  When *copy* is false (``--dry-run``) the destination path is
+    computed but no file is written.
+    """
+    resolved = path.resolve()
+    root = pdf_root.resolve()
+    if resolved.is_relative_to(root):
+        return resolved
+    digest = hashlib.sha256(resolved.read_bytes()).hexdigest()
+    dest = root / f"{digest[:16]}-{resolved.name}"
+    if copy and not dest.exists():
+        shutil.copy2(resolved, dest)
+    return dest
 
 
 async def _submit(lithos_url: str, body: dict[str, Any]) -> str:
@@ -117,7 +162,11 @@ async def _submit(lithos_url: str, body: dict[str, Any]) -> str:
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("url", help="the URL to submit (http/https)")
+    parser.add_argument(
+        "url",
+        metavar="URL_OR_PDF",
+        help="an http(s) URL, or a path to a local PDF (kind is auto-detected)",
+    )
     parser.add_argument("--title", help="hint for the candidate's title slot")
     summary_group = parser.add_mutually_exclusive_group()
     summary_group.add_argument(
@@ -143,6 +192,10 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--lithos-url", help="override the Lithos SSE URL")
     parser.add_argument(
+        "--pdf-root",
+        help="override [inbox] pdf_root (local PDFs are staged under it)",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="print the task body that would be sent without creating it",
@@ -152,15 +205,9 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
+    target = args.url
 
-    # Validate BEFORE any MCP call (§15.5).
-    parsed = urlparse(args.url)
-    if parsed.scheme not in _ALLOWED_SCHEMES or not parsed.netloc:
-        print(
-            f"error: URL must be http(s) with a host, got {args.url!r}",
-            file=sys.stderr,
-        )
-        return 2
+    # All validation happens BEFORE any MCP call (§15.5).
     if args.source_tag and not _SOURCE_TAG_RE.match(args.source_tag):
         print(
             f"error: --source-tag must match {_SOURCE_TAG_RE.pattern}",
@@ -168,15 +215,66 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
-    body = _build_task_body(args)
+    # Env feeds both pdf_root and Lithos-URL resolution.
+    env_path = _repo_root() / "docker" / f".env.{args.env}"
+    env = _load_env(env_path) if env_path.exists() else {}
+    _apply_env_to_process(env)
+
+    if _HTTP_RE.match(target):
+        kind = "url"
+        metadata = _add_optional_metadata(
+            args,
+            {"kind": "url", "url": target, "submitted_by": args.submitted_by},
+        )
+        label = args.title or target
+    elif _URL_SCHEME_RE.match(target):
+        print(f"error: URL must be http(s), got {target!r}", file=sys.stderr)
+        return 2
+    else:
+        kind = "pdf"
+        path = Path(target).expanduser()
+        if not path.is_file():
+            print(f"error: PDF file not found: {target!r}", file=sys.stderr)
+            return 2
+        if not _looks_like_pdf(path):
+            print(
+                f"error: not a PDF (need a .pdf suffix or %PDF header): {target!r}",
+                file=sys.stderr,
+            )
+            return 2
+        pdf_root = _resolve_pdf_root(args, env)
+        if pdf_root is None:
+            print(
+                "error: could not resolve [inbox] pdf_root — pass --pdf-root or "
+                "set INFLUX_PDF_ROOT",
+                file=sys.stderr,
+            )
+            return 2
+        if not args.dry_run and not pdf_root.is_dir():
+            print(f"error: pdf_root is not a directory: {pdf_root}", file=sys.stderr)
+            return 2
+        local_path = _stage_pdf_into_root(path, pdf_root, copy=not args.dry_run)
+        metadata = _add_optional_metadata(
+            args,
+            {
+                "kind": "pdf",
+                "local_path": str(local_path),
+                "submitted_by": args.submitted_by,
+            },
+        )
+        label = args.title or path.name
+
+    body = {
+        "title": f"Influx inbox: {label}",
+        "agent": args.submitted_by,
+        "tags": [_TASK_TAG],
+        "metadata": metadata,
+    }
 
     if args.dry_run:
         print(json.dumps(body, indent=2))
         return 0
 
-    env_path = _repo_root() / "docker" / f".env.{args.env}"
-    env = _load_env(env_path) if env_path.exists() else {}
-    _apply_env_to_process(env)
     lithos_url = _resolve_lithos_url(args, env)
     if not lithos_url:
         print(
@@ -187,7 +285,7 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     task_id = asyncio.run(_submit(lithos_url, body))
-    print(f"Created task {task_id} (kind=url)")
+    print(f"Created task {task_id} (kind={kind})")
     print(f"Track outcome: lithos task show {task_id}")
     return 0
 

--- a/tests/unit/test_inbox_submit_script.py
+++ b/tests/unit/test_inbox_submit_script.py
@@ -1,11 +1,13 @@
-"""Unit tests for ``scripts/influx-inbox-submit.py`` (Inbox v1 slice 4, §15).
+"""Unit tests for ``scripts/influx-inbox-submit.py`` (Inbox §15/§16).
 
-Covers the URL/source-tag validation that must happen BEFORE any MCP call,
-the ``--dry-run`` task-body shaping, and metadata assembly from flags.
+Covers the URL/PDF auto-detection + validation that must happen BEFORE any
+MCP call, the ``--dry-run`` task-body shaping, metadata assembly from flags,
+and the local-PDF staging into ``pdf_root`` (v2 slice B).
 """
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 import os
@@ -86,7 +88,9 @@ def test_default_submitted_by_uses_username(
     )
 
 
-def test_invalid_url_rejected_before_mcp(capsys: pytest.CaptureFixture) -> None:
+def test_non_http_url_scheme_rejected_before_mcp(
+    capsys: pytest.CaptureFixture,
+) -> None:
     rc = _SUBMIT.main(["file:///etc/passwd", "--dry-run"])
     assert rc == 2
     assert "must be http" in capsys.readouterr().err
@@ -152,3 +156,131 @@ def test_env_file_reaches_load_config(
 
     assert captured["INFLUX_CONFIG"] == "/custom/influx.toml"
     assert rc == 2  # load_config raised → URL unresolved → exit 2
+
+
+# ── Local-PDF mode (v2 §16) ──────────────────────────────────────────
+
+
+def _write_pdf(path: Path) -> Path:
+    path.write_bytes(b"%PDF-1.4 a minimal local pdf body for tests")
+    return path
+
+
+def test_pdf_inside_root_dry_run_body(
+    capsys: pytest.CaptureFixture, tmp_path: Path
+) -> None:
+    root = tmp_path / "pdfs"
+    root.mkdir()
+    pdf = _write_pdf(root / "paper.pdf")
+    rc = _SUBMIT.main([str(pdf), "--pdf-root", str(root), "--dry-run"])
+    assert rc == 0
+    body = json.loads(capsys.readouterr().out)
+    assert body["tags"] == ["influx:inbox"]
+    assert body["title"] == "Influx inbox: paper.pdf"
+    assert body["metadata"]["kind"] == "pdf"
+    # A file already inside pdf_root is used in place.
+    assert body["metadata"]["local_path"] == str(pdf.resolve())
+
+
+def test_pdf_outside_root_dry_run_computes_staged_path(
+    capsys: pytest.CaptureFixture, tmp_path: Path
+) -> None:
+    root = tmp_path / "pdfs"
+    root.mkdir()
+    pdf = _write_pdf(tmp_path / "outside.pdf")
+    rc = _SUBMIT.main([str(pdf), "--pdf-root", str(root), "--dry-run"])
+    assert rc == 0
+    local_path = json.loads(capsys.readouterr().out)["metadata"]["local_path"]
+    assert local_path.startswith(str(root.resolve()))
+    assert local_path.endswith("-outside.pdf")
+    # --dry-run must not actually copy.
+    assert list(root.iterdir()) == []
+
+
+def test_pdf_magic_bytes_detected_without_suffix(
+    capsys: pytest.CaptureFixture, tmp_path: Path
+) -> None:
+    root = tmp_path / "pdfs"
+    root.mkdir()
+    doc = root / "doc"  # no .pdf suffix
+    doc.write_bytes(b"%PDF-1.7 body")
+    rc = _SUBMIT.main([str(doc), "--pdf-root", str(root), "--dry-run"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["metadata"]["kind"] == "pdf"
+
+
+def test_pdf_dry_run_includes_optional_flags(
+    capsys: pytest.CaptureFixture, tmp_path: Path
+) -> None:
+    root = tmp_path / "pdfs"
+    root.mkdir()
+    pdf = _write_pdf(root / "paper.pdf")
+    rc = _SUBMIT.main(
+        [
+            str(pdf),
+            "--pdf-root",
+            str(root),
+            "--dry-run",
+            "--title",
+            "A Paper",
+            "--source-tag",
+            "ai-news",
+        ]
+    )
+    assert rc == 0
+    md = json.loads(capsys.readouterr().out)["metadata"]
+    assert md["title"] == "A Paper"
+    assert md["source_tag"] == "ai-news"
+
+
+def test_nonexistent_pdf_rejected_before_mcp(
+    capsys: pytest.CaptureFixture, tmp_path: Path
+) -> None:
+    rc = _SUBMIT.main([str(tmp_path / "missing.pdf"), "--dry-run"])
+    assert rc == 2
+    assert "not found" in capsys.readouterr().err
+
+
+def test_non_pdf_file_rejected(capsys: pytest.CaptureFixture, tmp_path: Path) -> None:
+    txt = tmp_path / "notes.txt"
+    txt.write_text("just text, not a pdf", encoding="utf-8")
+    rc = _SUBMIT.main([str(txt), "--pdf-root", str(tmp_path), "--dry-run"])
+    assert rc == 2
+    assert "not a PDF" in capsys.readouterr().err
+
+
+def test_pdf_root_unresolved_rejected(
+    capsys: pytest.CaptureFixture, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pdf = _write_pdf(tmp_path / "paper.pdf")
+    monkeypatch.setattr(_SUBMIT, "_resolve_pdf_root", lambda *a, **k: None)
+    rc = _SUBMIT.main([str(pdf), "--dry-run"])
+    assert rc == 2
+    assert "pdf_root" in capsys.readouterr().err
+
+
+def test_stage_copies_when_outside_root(tmp_path: Path) -> None:
+    root = tmp_path / "pdfs"
+    root.mkdir()
+    src = _write_pdf(tmp_path / "src.pdf")
+    dest = _SUBMIT._stage_pdf_into_root(src, root, copy=True)
+    assert dest.parent == root.resolve()
+    assert dest.read_bytes() == src.read_bytes()
+    assert src.exists()  # original never moved/deleted
+    digest = hashlib.sha256(src.read_bytes()).hexdigest()
+    assert dest.name == f"{digest[:16]}-src.pdf"
+
+
+def test_stage_uses_file_in_place_when_inside_root(tmp_path: Path) -> None:
+    root = tmp_path / "pdfs"
+    root.mkdir()
+    inside = _write_pdf(root / "paper.pdf")
+    dest = _SUBMIT._stage_pdf_into_root(inside, root, copy=True)
+    assert dest == inside.resolve()
+    assert list(root.iterdir()) == [inside]  # no duplicate copy
+
+
+def test_url_mode_still_reports_kind_url(capsys: pytest.CaptureFixture) -> None:
+    rc = _SUBMIT.main([_URL, "--dry-run"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["metadata"]["kind"] == "url"

--- a/tests/unit/test_inbox_submit_script.py
+++ b/tests/unit/test_inbox_submit_script.py
@@ -96,9 +96,33 @@ def test_non_http_url_scheme_rejected_before_mcp(
     assert "must be http" in capsys.readouterr().err
 
 
-def test_non_url_argument_rejected(capsys: pytest.CaptureFixture) -> None:
+def test_nonexistent_path_treated_as_pdf_and_rejected(
+    capsys: pytest.CaptureFixture,
+) -> None:
     rc = _SUBMIT.main(["not a url", "--dry-run"])
     assert rc == 2
+    assert "not found" in capsys.readouterr().err
+
+
+def test_http_url_without_host_rejected(capsys: pytest.CaptureFixture) -> None:
+    """Regression: a scheme-only https:// (no host) must not reach MCP."""
+    rc = _SUBMIT.main(["https://", "--dry-run"])
+    assert rc == 2
+    assert "host" in capsys.readouterr().err
+
+
+def test_mailto_scheme_rejected_as_non_http(capsys: pytest.CaptureFixture) -> None:
+    rc = _SUBMIT.main(["mailto:someone@example.com", "--dry-run"])
+    assert rc == 2
+    assert "must be http" in capsys.readouterr().err
+
+
+def test_directory_argument_rejected(
+    capsys: pytest.CaptureFixture, tmp_path: Path
+) -> None:
+    rc = _SUBMIT.main([str(tmp_path), "--dry-run"])
+    assert rc == 2
+    assert "not a regular file" in capsys.readouterr().err
 
 
 def test_invalid_source_tag_rejected(capsys: pytest.CaptureFixture) -> None:


### PR DESCRIPTION
## Summary

Slice B (final) of Inbox v2 (`docs/plans/inbox.md` §16.6): `scripts/influx-inbox-submit.py` learns to submit **local PDFs**, so an operator can run `influx-inbox-submit ./paper.pdf`. Builds on Slice A (#207, merged), which added the server-side `kind="pdf"` path.

## What changed

- **Auto-detection** — the positional argument is detected by shape: an `http(s)://` URL submits `kind="url"` (v1, unchanged); anything else is treated as a local PDF path → `kind="pdf"`. A scheme-only `https://` (no host) and non-http URI schemes (`file:`, `mailto:`, …) are rejected before any MCP call.
- **PDF validation (before any MCP call, §15.5)** — file exists, is a regular file, looks like a PDF (`.pdf` suffix or `%PDF` magic).
- **Staging into `pdf_root`** — resolves `[inbox] pdf_root` (`--pdf-root` → `INFLUX_PDF_ROOT` → config). A file already under `pdf_root` is used in place; one outside is copied in under a deterministic `<sha256[:16]>-<basename>` name (collision-safe, human-legible), published atomically (temp + `os.replace`). The user's original is never moved or deleted; the `local_path` sent is always the in-`pdf_root` path. `--dry-run` computes the staged path without copying.
- **Shared metadata** — `--title/--summary/--source-tag/--submitted-by/--env` apply to both kinds; the output line reports the detected `kind`. New `--pdf-root` flag.
- **Docs** — `inbox.md` §15.2/§15.3 updated for URL+PDF + `--pdf-root`.

## Acceptance criteria

- [x] Positional arg auto-detected (`^https?://` → url; else → pdf).
- [x] Client-side validation before any MCP call (exists / regular file / PDF magic-or-suffix); non-zero exit otherwise.
- [x] `pdf_root` resolved from config/env/flag; file copied in when outside (deterministic name), left in place when inside; original never moved/deleted.
- [x] `local_path` is always the in-`pdf_root` path; `--dry-run` prints the `kind="pdf"` body without copying; existing flags apply.
- [x] Tests cover detection, dry-run body, reject nonexistent/non-PDF/non-http-scheme/directory before MCP, copy-when-outside, no-copy-when-inside, URL path unchanged.
- [x] `make check` green.

## Test plan

- `make check` green — **2490 passed**, ruff + pyright clean.
- New/updated tests: URL-vs-PDF detection (incl. scheme-only host, `mailto:`, directory, nonexistent path); `--dry-run` PDF body (inside vs outside `pdf_root`); `%PDF` magic without `.pdf` suffix; non-PDF rejection; `pdf_root` unresolved; `_stage_pdf_into_root` copy-when-outside (deterministic name, original untouched) and in-place-when-inside; URL path still `kind="url"`.
- A python-reviewer pass was run; its three HIGH findings (netloc regression, single-colon URI schemes, non-atomic copy) plus the streaming-hash / dry-run-warning improvements are addressed in the second commit.

Closes #206
