### PR TITLE
fix: resolve relative inbox pdf local_path against pdf_root (#209)

### DIFF
--- a/docs/plans/inbox.md
+++ b/docs/plans/inbox.md
@@ -522,13 +522,13 @@ The metadata `kind` enum extends to accept `"pdf"`. New metadata fields:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `local_path` | string | Required when `kind="pdf"`. Absolute path on the Influx host filesystem; MUST resolve inside `[inbox] pdf_root`. |
+| `local_path` | string | Required when `kind="pdf"`. A path on the Influx host that MUST resolve inside `[inbox] pdf_root`. An absolute path is used as-is; a relative path is resolved **against `pdf_root`** (not the server's CWD), so `papers/foo.pdf` works regardless of where the service was started. |
 
 The `url` field becomes mutually exclusive with `local_path` based on `kind`. v1 submitters that send `kind="url"` are unaffected.
 
 ### 16.3 v2 path trust model
 
-A new `[inbox] pdf_root` config setting names a directory under which all submitted `local_path` values must resolve. Influx canonicalises (`Path(local_path).resolve()`) and rejects anything not under `pdf_root` with a terminal `outcome="error: path_not_in_pdf_root"`.
+A new `[inbox] pdf_root` config setting names a directory under which all submitted `local_path` values must resolve. A relative `local_path` is anchored to `pdf_root`; an absolute one is taken as-is. Influx canonicalises the result (`Path.resolve()`, which also collapses `..` and follows symlinks) and rejects anything not under `pdf_root` with a terminal `outcome="error: path_not_in_pdf_root"`.
 
 This mirrors the existing security posture (`security.allow_private_ips=false`, SSRF-guarded HTTP fetch) on the file-system side.
 

--- a/src/influx/storage.py
+++ b/src/influx/storage.py
@@ -508,16 +508,22 @@ def archive_bytes(
 
 
 def resolve_within_root(path: str | Path, root: Path) -> Path:
-    """Resolve *path* and confirm it lives under *root*; else raise.
+    """Resolve *path* against *root* and confirm it lives under it; else raise.
 
-    Canonicalises both via :meth:`Path.resolve` (which follows symlinks,
-    so a symlink escaping *root* is caught) and checks containment with
-    :meth:`Path.is_relative_to`.  Returns the resolved path.  Does NOT
-    check existence — callers distinguish "outside root" from "missing
-    file" separately (inbox §16.3 vs §16.5).
+    A **relative** *path* is anchored to *root* (not the process CWD), so a
+    submitter can send ``papers/foo.pdf`` regardless of where the server was
+    started (inbox §16.3); an **absolute** *path* is used as-is.  Both are
+    canonicalised via :meth:`Path.resolve` (which follows symlinks, so a
+    symlink — or a ``..`` segment — escaping *root* is caught) and checked
+    with :meth:`Path.is_relative_to`.  Returns the resolved path.  Does NOT
+    check existence — callers distinguish "outside root" from "missing file"
+    separately (§16.3 vs §16.5).
     """
-    resolved = Path(path).expanduser().resolve()
     root_resolved = root.resolve()
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        candidate = root_resolved / candidate
+    resolved = candidate.resolve()
     if not resolved.is_relative_to(root_resolved):
         raise ArchivePathError(
             f"Path {path} (resolved to {resolved}) escapes root {root_resolved}"

--- a/tests/unit/test_archive_download.py
+++ b/tests/unit/test_archive_download.py
@@ -309,6 +309,21 @@ class TestResolveWithinRoot:
         target.write_bytes(b"%PDF")
         assert resolve_within_root(target, root) == target.resolve()
 
+    def test_relative_path_anchored_to_root_not_cwd(self, tmp_path: Path) -> None:
+        # Regression #209: a relative path resolves against root, not the CWD.
+        root = tmp_path / "pdfs"
+        (root / "sub").mkdir(parents=True)
+        target = root / "sub" / "paper.pdf"
+        target.write_bytes(b"%PDF")
+        assert resolve_within_root("sub/paper.pdf", root) == target.resolve()
+
+    def test_relative_dotdot_escape_raises(self, tmp_path: Path) -> None:
+        root = tmp_path / "pdfs"
+        root.mkdir()
+        (tmp_path / "secret.pdf").write_bytes(b"%PDF")
+        with pytest.raises(ArchivePathError):
+            resolve_within_root("../secret.pdf", root)
+
     def test_path_outside_root_raises(self, tmp_path: Path) -> None:
         root = tmp_path / "pdfs"
         root.mkdir()

--- a/tests/unit/test_archive_download.py
+++ b/tests/unit/test_archive_download.py
@@ -324,6 +324,14 @@ class TestResolveWithinRoot:
         with pytest.raises(ArchivePathError):
             resolve_within_root("../secret.pdf", root)
 
+    def test_home_expansion_path_rejected(self, tmp_path: Path) -> None:
+        # A ``~``-prefixed path expands to an absolute home dir outside the
+        # tmp pdf_root, so it is taken as absolute and rejected by containment.
+        root = tmp_path / "pdfs"
+        root.mkdir()
+        with pytest.raises(ArchivePathError):
+            resolve_within_root("~/outside.pdf", root)
+
     def test_path_outside_root_raises(self, tmp_path: Path) -> None:
         root = tmp_path / "pdfs"
         root.mkdir()

--- a/tests/unit/test_inbox_tick.py
+++ b/tests/unit/test_inbox_tick.py
@@ -1006,6 +1006,35 @@ async def test_pdf_happy_path_ingests(tmp_path: Path) -> None:
     assert client.completed[0]["cited_nodes"] == ["note-pdf"]
 
 
+async def test_pdf_relative_local_path_resolves_against_pdf_root(
+    tmp_path: Path,
+) -> None:
+    """Regression #209: a relative local_path resolves under pdf_root, not CWD."""
+    pdf_root = tmp_path / "pdfs"
+    pdf_root.mkdir()
+    pdf = pdf_root / "paper.pdf"
+    pdf.write_bytes(b"%PDF-1.4 body")
+    config = _make_pdf_config(pdf_root, tmp_path / "archive")
+    # Submitter sends a path relative to pdf_root.
+    client = FakeClient(tasks=[_task_pdf(local_path="paper.pdf")], note_id="note-pdf")
+    with (
+        patch(
+            "influx.inbox.acquire_inbox_pdf", return_value=_pdf_acquisition()
+        ) as mock_acquire,
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_returning(8),
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch("influx.inbox.dispatch_profile", return_value=RunOutcome(ingested=1)),
+    ):
+        await _tick(client, config).execute()
+
+    mock_acquire.assert_called_once()
+    assert Path(mock_acquire.call_args.args[0]) == pdf.resolve()
+    assert "ingested into 1 profile(s): alpha" in client.completed[0]["outcome"]
+
+
 async def test_pdf_dedup_cache_hit_no_new_profiles(tmp_path: Path) -> None:
     """A re-submitted PDF whose note already lists the profile is a cache hit.
 


### PR DESCRIPTION
## Summary

Fixes #209. `resolve_within_root` (used by the inbox `kind="pdf"` path-trust check) canonicalised with `Path(path).resolve()`, which anchors a **relative** `local_path` to the process CWD before the `pdf_root` containment check. A submitter sending `papers/foo.pdf` was therefore rejected as `path_not_in_pdf_root` unless the server happened to run from `pdf_root`.

## What changed

- `storage.resolve_within_root`: a relative path is now anchored to `root` before `resolve()`; absolute paths are unchanged. `..`/symlink escapes are still caught (the join is followed by `resolve()` + `is_relative_to`).
- `docs/plans/inbox.md` §16.2/§16.3: reconciled — a relative `local_path` resolves against `pdf_root`, an absolute one is taken as-is.

## Test plan

- `make check` green — **2493 passed**, ruff + pyright clean.
- New tests: relative path anchored to root (not CWD); relative `../secret.pdf` escape rejected; end-to-end tick test that a relative `local_path` resolves under `pdf_root` and ingests. Existing absolute-path + symlink-escape tests unchanged.

Closes #209
