### PR TITLE
feat: recover HTML title for inbox URL items (#210)

### DIFF
--- a/docs/plans/inbox.md
+++ b/docs/plans/inbox.md
@@ -522,13 +522,13 @@ The metadata `kind` enum extends to accept `"pdf"`. New metadata fields:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `local_path` | string | Required when `kind="pdf"`. Absolute path on the Influx host filesystem; MUST resolve inside `[inbox] pdf_root`. |
+| `local_path` | string | Required when `kind="pdf"`. A path on the Influx host that MUST resolve inside `[inbox] pdf_root`. An absolute path is used as-is; a relative path is resolved **against `pdf_root`** (not the server's CWD), so `papers/foo.pdf` works regardless of where the service was started. |
 
 The `url` field becomes mutually exclusive with `local_path` based on `kind`. v1 submitters that send `kind="url"` are unaffected.
 
 ### 16.3 v2 path trust model
 
-A new `[inbox] pdf_root` config setting names a directory under which all submitted `local_path` values must resolve. Influx canonicalises (`Path(local_path).resolve()`) and rejects anything not under `pdf_root` with a terminal `outcome="error: path_not_in_pdf_root"`.
+A new `[inbox] pdf_root` config setting names a directory under which all submitted `local_path` values must resolve. A relative `local_path` is anchored to `pdf_root`; an absolute one is taken as-is. Influx canonicalises the result (`Path.resolve()`, which also collapses `..` and follows symlinks) and rejects anything not under `pdf_root` with a terminal `outcome="error: path_not_in_pdf_root"`.
 
 This mirrors the existing security posture (`security.allow_private_ips=false`, SSRF-guarded HTTP fetch) on the file-system side.
 

--- a/src/influx/extraction/article.py
+++ b/src/influx/extraction/article.py
@@ -28,8 +28,8 @@ __all__ = [
 # Title recovery (issue #210): prefer the document ``<title>``, then an
 # ``og:title`` meta tag, then the first ``<h1>``.  Regex-based to avoid a
 # heavier HTML-parse dependency; titles only feed the candidate/note title
-# slot, so best-effort recovery is acceptable.  All patterns use negated
-# character classes (linear-time; no catastrophic backtracking).
+# heavier HTML-parse dependency; titles only feed the candidate/note title
+# slot, so best-effort recovery is acceptable. Patterns are intentionally simple to avoid catastrophic backtracking.
 _TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
 _H1_RE = re.compile(r"<h1[^>]*>(.*?)</h1>", re.IGNORECASE | re.DOTALL)
 # og:title via two passes (a single regex can't handle both attribute orders,

--- a/src/influx/extraction/article.py
+++ b/src/influx/extraction/article.py
@@ -36,8 +36,12 @@ _H1_RE = re.compile(r"<h1[^>]*>(.*?)</h1>", re.IGNORECASE | re.DOTALL)
 # `content=` before or after `property=`): find each <meta> tag, keep the one
 # whose attrs name og:title, then pull its content value.
 _META_TAG_RE = re.compile(r"<meta\b([^>]*)>", re.IGNORECASE)
-_OG_TITLE_PROP_RE = re.compile(r"(?:property|name)\s*=\s*[\"']og:title[\"']", re.IGNORECASE)
-_META_CONTENT_RE = re.compile(r"content\s*=\s*[\"'](.*?)[\"']", re.IGNORECASE | re.DOTALL)
+_OG_TITLE_PROP_RE = re.compile(
+    r"(?:property|name)\s*=\s*[\"']og:title[\"']", re.IGNORECASE
+)
+_META_CONTENT_RE = re.compile(
+    r"content\s*=\s*[\"'](.*?)[\"']", re.IGNORECASE | re.DOTALL
+)
 _CDATA_RE = re.compile(r"<!\[CDATA\[(.*?)\]\]>", re.DOTALL)
 _CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 _TITLE_MAX_CHARS = 300

--- a/src/influx/extraction/article.py
+++ b/src/influx/extraction/article.py
@@ -28,8 +28,9 @@ __all__ = [
 # Title recovery (issue #210): prefer the document ``<title>``, then an
 # ``og:title`` meta tag, then the first ``<h1>``.  Regex-based to avoid a
 # heavier HTML-parse dependency; titles only feed the candidate/note title
-# heavier HTML-parse dependency; titles only feed the candidate/note title
-# slot, so best-effort recovery is acceptable. Patterns are intentionally simple to avoid catastrophic backtracking.
+# slot, so best-effort recovery is acceptable.  All patterns use negated
+# character classes / lazy quantifiers (linear-time; no catastrophic
+# backtracking).
 _TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
 _H1_RE = re.compile(r"<h1[^>]*>(.*?)</h1>", re.IGNORECASE | re.DOTALL)
 # og:title via two passes (a single regex can't handle both attribute orders,

--- a/src/influx/extraction/article.py
+++ b/src/influx/extraction/article.py
@@ -36,8 +36,8 @@ _H1_RE = re.compile(r"<h1[^>]*>(.*?)</h1>", re.IGNORECASE | re.DOTALL)
 # `content=` before or after `property=`): find each <meta> tag, keep the one
 # whose attrs name og:title, then pull its content value.
 _META_TAG_RE = re.compile(r"<meta\b([^>]*)>", re.IGNORECASE)
-_OG_TITLE_PROP_RE = re.compile(r"(?:property|name)=[\"']og:title[\"']", re.IGNORECASE)
-_META_CONTENT_RE = re.compile(r"content=[\"'](.*?)[\"']", re.IGNORECASE | re.DOTALL)
+_OG_TITLE_PROP_RE = re.compile(r"(?:property|name)\s*=\s*[\"']og:title[\"']", re.IGNORECASE)
+_META_CONTENT_RE = re.compile(r"content\s*=\s*[\"'](.*?)[\"']", re.IGNORECASE | re.DOTALL)
 _CDATA_RE = re.compile(r"<!\[CDATA\[(.*?)\]\]>", re.DOTALL)
 _CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 _TITLE_MAX_CHARS = 300

--- a/src/influx/extraction/article.py
+++ b/src/influx/extraction/article.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from html import unescape
 from typing import Literal
 
 import trafilatura
@@ -27,25 +28,56 @@ __all__ = [
 # Title recovery (issue #210): prefer the document ``<title>``, then an
 # ``og:title`` meta tag, then the first ``<h1>``.  Regex-based to avoid a
 # heavier HTML-parse dependency; titles only feed the candidate/note title
-# slot, so best-effort recovery is acceptable.
+# slot, so best-effort recovery is acceptable.  All patterns use negated
+# character classes (linear-time; no catastrophic backtracking).
 _TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
-_OG_TITLE_RE = re.compile(
-    r"<meta[^>]+(?:property|name)=[\"']og:title[\"'][^>]+content=[\"'](.*?)[\"']",
-    re.IGNORECASE,
-)
 _H1_RE = re.compile(r"<h1[^>]*>(.*?)</h1>", re.IGNORECASE | re.DOTALL)
+# og:title via two passes (a single regex can't handle both attribute orders,
+# `content=` before or after `property=`): find each <meta> tag, keep the one
+# whose attrs name og:title, then pull its content value.
+_META_TAG_RE = re.compile(r"<meta\b([^>]*)>", re.IGNORECASE)
+_OG_TITLE_PROP_RE = re.compile(r"(?:property|name)=[\"']og:title[\"']", re.IGNORECASE)
+_META_CONTENT_RE = re.compile(r"content=[\"'](.*?)[\"']", re.IGNORECASE | re.DOTALL)
+_CDATA_RE = re.compile(r"<!\[CDATA\[(.*?)\]\]>", re.DOTALL)
+_CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 _TITLE_MAX_CHARS = 300
+
+
+def _og_title(html: str) -> str | None:
+    """Content of the first ``og:title`` meta tag (attribute-order agnostic)."""
+    for m in _META_TAG_RE.finditer(html):
+        attrs = m.group(1)
+        if _OG_TITLE_PROP_RE.search(attrs):
+            content = _META_CONTENT_RE.search(attrs)
+            if content:
+                return content.group(1)
+    return None
+
+
+def _clean_title(raw: str) -> str | None:
+    """Normalise a raw title fragment: CDATA, tags, entities, control chars."""
+    inner = _CDATA_RE.sub(r"\1", raw)
+    text = unescape(_clean_html_fragments(inner))
+    text = _CONTROL_RE.sub("", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text[:_TITLE_MAX_CHARS] if text else None
 
 
 def _recover_html_title(html: str) -> str | None:
     """Best-effort document title from *html* (``<title>`` → og:title → h1)."""
-    for rx in (_TITLE_RE, _OG_TITLE_RE, _H1_RE):
-        m = rx.search(html)
-        if not m:
+    title_match = _TITLE_RE.search(html)
+    h1_match = _H1_RE.search(html)
+    raw_candidates = [
+        title_match.group(1) if title_match else None,
+        _og_title(html),
+        h1_match.group(1) if h1_match else None,
+    ]
+    for raw in raw_candidates:
+        if raw is None:
             continue
-        title = re.sub(r"\s+", " ", _clean_html_fragments(m.group(1))).strip()
-        if title:
-            return title[:_TITLE_MAX_CHARS]
+        cleaned = _clean_title(raw)
+        if cleaned:
+            return cleaned
     return None
 
 

--- a/src/influx/extraction/article.py
+++ b/src/influx/extraction/article.py
@@ -7,6 +7,7 @@ trafilatura.  Rejects output below ``extraction.min_web_chars``.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Literal
 
@@ -23,13 +24,42 @@ __all__ = [
     "extract_article_from_html",
 ]
 
+# Title recovery (issue #210): prefer the document ``<title>``, then an
+# ``og:title`` meta tag, then the first ``<h1>``.  Regex-based to avoid a
+# heavier HTML-parse dependency; titles only feed the candidate/note title
+# slot, so best-effort recovery is acceptable.
+_TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+_OG_TITLE_RE = re.compile(
+    r"<meta[^>]+(?:property|name)=[\"']og:title[\"'][^>]+content=[\"'](.*?)[\"']",
+    re.IGNORECASE,
+)
+_H1_RE = re.compile(r"<h1[^>]*>(.*?)</h1>", re.IGNORECASE | re.DOTALL)
+_TITLE_MAX_CHARS = 300
+
+
+def _recover_html_title(html: str) -> str | None:
+    """Best-effort document title from *html* (``<title>`` → og:title → h1)."""
+    for rx in (_TITLE_RE, _OG_TITLE_RE, _H1_RE):
+        m = rx.search(html)
+        if not m:
+            continue
+        title = re.sub(r"\s+", " ", _clean_html_fragments(m.group(1))).strip()
+        if title:
+            return title[:_TITLE_MAX_CHARS]
+    return None
+
 
 @dataclass(frozen=True, slots=True)
 class ArticleExtractionResult:
-    """Result of a successful web article extraction."""
+    """Result of a successful web article extraction.
+
+    ``title`` is the best-effort recovered document title (issue #210), or
+    ``None`` when none could be found.
+    """
 
     text: str
     source: Literal["article"]
+    title: str | None = None
 
 
 def extract_article_from_html(
@@ -79,6 +109,9 @@ def extract_article_from_html(
         if strip_tags is None:
             strip_tags = list(_extraction_defaults.strip_tags)
 
+    # Recover the title from the original markup before tag-stripping.
+    title = _recover_html_title(html_body)
+
     # Strip dangerous tags before extraction
     html_body = _strip_tags(html_body, strip_tags)
 
@@ -103,7 +136,7 @@ def extract_article_from_html(
             detail=f"Got {len(extracted)} chars, need {min_web_chars}",
         )
 
-    return ArticleExtractionResult(text=extracted, source="article")
+    return ArticleExtractionResult(text=extracted, source="article", title=title)
 
 
 def extract_article(

--- a/src/influx/inbox.py
+++ b/src/influx/inbox.py
@@ -715,7 +715,9 @@ class InboxTick:
             acquired = await asyncio.to_thread(acquire)
         candidate = Candidate(
             item_id=f"inbox-{acquired.url_hash}",
-            title=title_hint or acquired.source_url,
+            # Title preference (#210): submitter hint → recovered HTML title
+            # → bare URL — so the filter scores a real title, not a raw URL.
+            title=title_hint or acquired.extracted_title or acquired.source_url,
             abstract=acquired.summary,
             source_url=acquired.source_url,
         )

--- a/src/influx/inbox.py
+++ b/src/influx/inbox.py
@@ -717,7 +717,13 @@ class InboxTick:
             item_id=f"inbox-{acquired.url_hash}",
             # Title preference (#210): submitter hint → recovered HTML title
             # → bare URL — so the filter scores a real title, not a raw URL.
-            title=title_hint or acquired.extracted_title or acquired.source_url,
+            # ``.strip()`` mirrors build_inbox_note_item so a whitespace-only
+            # hint doesn't win over a real recovered title.
+            title=(
+                (title_hint or "").strip()
+                or acquired.extracted_title
+                or acquired.source_url
+            ),
             abstract=acquired.summary,
             source_url=acquired.source_url,
         )

--- a/src/influx/sources/inbox.py
+++ b/src/influx/sources/inbox.py
@@ -65,6 +65,10 @@ class InboxAcquisition:
     extracted_text: str | None
     summary: str
     text_flavour: TextFlavour
+    # Best-effort title recovered from the fetched HTML (issue #210), or
+    # ``None`` (PDFs, extraction failure, no recoverable title).  Used as the
+    # title fallback below the submitter hint and above the bare URL.
+    extracted_title: str | None = None
 
 
 def acquire_inbox_bytes(
@@ -108,6 +112,7 @@ def acquire_inbox_bytes(
     family = archive_result.content_type_family
 
     extracted_text: str | None = None
+    extracted_title: str | None = None
     summary = summary_hint or ""
     flavour: TextFlavour = "summary-fallback"
     try:
@@ -117,12 +122,14 @@ def acquire_inbox_bytes(
             flavour = "pdf"
         elif family == "html" and body is not None:
             html_body = body.decode("utf-8", errors="replace")
-            extracted_text = extract_article_from_html(
+            article = extract_article_from_html(
                 html_body,
                 url=url,
                 min_web_chars=config.extraction.min_web_chars,
                 strip_tags=config.extraction.strip_tags,
-            ).text
+            )
+            extracted_text = article.text
+            extracted_title = article.title
             summary = extracted_text
             flavour = "html"
         elif body is not None:
@@ -147,6 +154,7 @@ def acquire_inbox_bytes(
         extracted_text=extracted_text,
         summary=summary,
         text_flavour=flavour,
+        extracted_title=extracted_title,
     )
 
 
@@ -243,9 +251,13 @@ def build_inbox_note_item(
     from influx.config import ProfileThresholds
 
     source_url = acquired.source_url
-    # extract_article does not recover an HTML <title>; title falls back
-    # to the submitter hint, then the URL (§3.2).
-    title = (title_hint or "").strip() or source_url
+    # Title preference (§3.2 / #210): submitter hint → recovered HTML title
+    # → bare URL.
+    title = (
+        (title_hint or "").strip()
+        or (acquired.extracted_title or "").strip()
+        or source_url
+    )
     profile_cfg = next((p for p in config.profiles if p.name == profile_name), None)
 
     # Thin-summary suppression (#166): only when no body was extracted.

--- a/src/influx/storage.py
+++ b/src/influx/storage.py
@@ -508,16 +508,22 @@ def archive_bytes(
 
 
 def resolve_within_root(path: str | Path, root: Path) -> Path:
-    """Resolve *path* and confirm it lives under *root*; else raise.
+    """Resolve *path* against *root* and confirm it lives under it; else raise.
 
-    Canonicalises both via :meth:`Path.resolve` (which follows symlinks,
-    so a symlink escaping *root* is caught) and checks containment with
-    :meth:`Path.is_relative_to`.  Returns the resolved path.  Does NOT
-    check existence — callers distinguish "outside root" from "missing
-    file" separately (inbox §16.3 vs §16.5).
+    A **relative** *path* is anchored to *root* (not the process CWD), so a
+    submitter can send ``papers/foo.pdf`` regardless of where the server was
+    started (inbox §16.3); an **absolute** *path* is used as-is.  Both are
+    canonicalised via :meth:`Path.resolve` (which follows symlinks, so a
+    symlink — or a ``..`` segment — escaping *root* is caught) and checked
+    with :meth:`Path.is_relative_to`.  Returns the resolved path.  Does NOT
+    check existence — callers distinguish "outside root" from "missing file"
+    separately (§16.3 vs §16.5).
     """
-    resolved = Path(path).expanduser().resolve()
     root_resolved = root.resolve()
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        candidate = root_resolved / candidate
+    resolved = candidate.resolve()
     if not resolved.is_relative_to(root_resolved):
         raise ArchivePathError(
             f"Path {path} (resolved to {resolved}) escapes root {root_resolved}"

--- a/tests/unit/test_archive_download.py
+++ b/tests/unit/test_archive_download.py
@@ -309,6 +309,21 @@ class TestResolveWithinRoot:
         target.write_bytes(b"%PDF")
         assert resolve_within_root(target, root) == target.resolve()
 
+    def test_relative_path_anchored_to_root_not_cwd(self, tmp_path: Path) -> None:
+        # Regression #209: a relative path resolves against root, not the CWD.
+        root = tmp_path / "pdfs"
+        (root / "sub").mkdir(parents=True)
+        target = root / "sub" / "paper.pdf"
+        target.write_bytes(b"%PDF")
+        assert resolve_within_root("sub/paper.pdf", root) == target.resolve()
+
+    def test_relative_dotdot_escape_raises(self, tmp_path: Path) -> None:
+        root = tmp_path / "pdfs"
+        root.mkdir()
+        (tmp_path / "secret.pdf").write_bytes(b"%PDF")
+        with pytest.raises(ArchivePathError):
+            resolve_within_root("../secret.pdf", root)
+
     def test_path_outside_root_raises(self, tmp_path: Path) -> None:
         root = tmp_path / "pdfs"
         root.mkdir()

--- a/tests/unit/test_archive_download.py
+++ b/tests/unit/test_archive_download.py
@@ -324,6 +324,14 @@ class TestResolveWithinRoot:
         with pytest.raises(ArchivePathError):
             resolve_within_root("../secret.pdf", root)
 
+    def test_home_expansion_path_rejected(self, tmp_path: Path) -> None:
+        # A ``~``-prefixed path expands to an absolute home dir outside the
+        # tmp pdf_root, so it is taken as absolute and rejected by containment.
+        root = tmp_path / "pdfs"
+        root.mkdir()
+        with pytest.raises(ArchivePathError):
+            resolve_within_root("~/outside.pdf", root)
+
     def test_path_outside_root_raises(self, tmp_path: Path) -> None:
         root = tmp_path / "pdfs"
         root.mkdir()

--- a/tests/unit/test_article_extraction.py
+++ b/tests/unit/test_article_extraction.py
@@ -14,6 +14,7 @@ import pytest
 from influx.errors import ExtractionError, NetworkError
 from influx.extraction.article import (
     ArticleExtractionResult,
+    _recover_html_title,
     extract_article,
     extract_article_from_html,
 )
@@ -279,3 +280,40 @@ class TestExtractArticleFromHtml:
         result = extract_article("https://example.com/article/123", min_web_chars=100)
         assert isinstance(result, ArticleExtractionResult)
         mock_fetch.assert_called_once()  # type: ignore[union-attr]
+
+
+# -- Title recovery (issue #210) ------------------------------------------
+
+
+class TestTitleRecovery:
+    """_recover_html_title: <title> → og:title → <h1>, else None."""
+
+    def test_prefers_title_tag_and_collapses_whitespace(self) -> None:
+        html = "<title>  Hello   World </title><h1>Other</h1>"
+        assert _recover_html_title(html) == "Hello World"
+
+    def test_og_title_fallback_when_no_title_tag(self) -> None:
+        html = '<head><meta property="og:title" content="OG Title"></head>'
+        assert _recover_html_title(html) == "OG Title"
+
+    def test_h1_fallback_strips_inner_tags(self) -> None:
+        html = "<body><h1>Heading <b>Bold</b></h1></body>"
+        assert _recover_html_title(html) == "Heading Bold"
+
+    def test_none_when_no_title_present(self) -> None:
+        assert _recover_html_title("<p>just a paragraph</p>") is None
+
+    def test_caps_overlong_title(self) -> None:
+        html = f"<title>{'x' * 500}</title>"
+        recovered = _recover_html_title(html)
+        assert recovered is not None
+        assert len(recovered) == 300
+
+    def test_extract_article_from_html_threads_title(self) -> None:
+        html = _read_fixture("web_article.html").decode("utf-8")
+        result = extract_article_from_html(
+            html, url="https://example.com/article/123", min_web_chars=100
+        )
+        assert result.title == (
+            "Building Reliable Distributed Systems with Consensus Protocols"
+        )

--- a/tests/unit/test_article_extraction.py
+++ b/tests/unit/test_article_extraction.py
@@ -303,6 +303,29 @@ class TestTitleRecovery:
     def test_none_when_no_title_present(self) -> None:
         assert _recover_html_title("<p>just a paragraph</p>") is None
 
+    def test_decodes_html_entities(self) -> None:
+        assert _recover_html_title("<title>AT&amp;T &lt;2025&gt;</title>") == (
+            "AT&T <2025>"
+        )
+
+    def test_og_title_content_before_property(self) -> None:
+        # WordPress/Ghost emit content= before property= — must still match.
+        html = '<meta content="Reversed Order" property="og:title">'
+        assert _recover_html_title(html) == "Reversed Order"
+
+    def test_og_title_name_attribute(self) -> None:
+        html = '<meta name="og:title" content="Via Name Attr">'
+        assert _recover_html_title(html) == "Via Name Attr"
+
+    def test_cdata_title_recovered(self) -> None:
+        html = "<title><![CDATA[CDATA Title & More]]></title>"
+        assert _recover_html_title(html) == "CDATA Title & More"
+
+    def test_strips_control_characters(self) -> None:
+        assert _recover_html_title("<title>\x00clean\x01 title\x7f</title>") == (
+            "clean title"
+        )
+
     def test_caps_overlong_title(self) -> None:
         html = f"<title>{'x' * 500}</title>"
         recovered = _recover_html_title(html)

--- a/tests/unit/test_article_extraction.py
+++ b/tests/unit/test_article_extraction.py
@@ -317,6 +317,10 @@ class TestTitleRecovery:
         html = '<meta name="og:title" content="Via Name Attr">'
         assert _recover_html_title(html) == "Via Name Attr"
 
+    def test_og_title_tolerates_whitespace_around_equals(self) -> None:
+        html = '<meta property = "og:title" content = "Spaced Attrs">'
+        assert _recover_html_title(html) == "Spaced Attrs"
+
     def test_cdata_title_recovered(self) -> None:
         html = "<title><![CDATA[CDATA Title & More]]></title>"
         assert _recover_html_title(html) == "CDATA Title & More"

--- a/tests/unit/test_inbox_builder.py
+++ b/tests/unit/test_inbox_builder.py
@@ -100,8 +100,9 @@ def _failed_archive() -> ArchiveResult:
 
 
 class _Extraction:
-    def __init__(self, text: str) -> None:
+    def __init__(self, text: str, title: str | None = None) -> None:
         self.text = text
+        self.title = title
 
 
 # ── acquire_inbox_bytes ─────────────────────────────────────────────
@@ -319,6 +320,64 @@ def test_build_item_title_falls_back_to_url() -> None:
     )
     assert item is not None
     assert item["title"] == _URL
+
+
+def _acquire_with_title(config: AppConfig, title: str | None) -> object:
+    with (
+        patch(
+            "influx.sources.inbox.download_archive_autodetect",
+            return_value=_ok_html_archive(),
+        ),
+        patch(
+            "influx.sources.inbox.extract_article_from_html",
+            return_value=_Extraction(_LONG_BODY, title=title),
+        ),
+    ):
+        return acquire_inbox_bytes(_URL, config=config)
+
+
+def test_acquire_captures_extracted_title() -> None:
+    """The HTML branch threads the recovered title onto InboxAcquisition (#210)."""
+    acquired = _acquire_with_title(_make_config(), "Recovered Title")
+    assert acquired.extracted_title == "Recovered Title"  # type: ignore[attr-defined]
+
+
+def test_build_item_uses_extracted_title_when_no_hint() -> None:
+    config = _make_config()
+    acquired = _acquire_with_title(config, "Recovered Title")
+    item = build_inbox_note_item(
+        acquired=acquired,  # type: ignore[arg-type]
+        profile_name="ai-robotics",
+        score=8,
+        confidence=0.9,
+        reason="relevant",
+        filter_tags=(),
+        source_tag="inbox",
+        submitted_by="x",
+        title_hint=None,
+        config=config,
+    )
+    assert item is not None
+    assert item["title"] == "Recovered Title"
+
+
+def test_build_item_hint_wins_over_extracted_title() -> None:
+    config = _make_config()
+    acquired = _acquire_with_title(config, "Recovered Title")
+    item = build_inbox_note_item(
+        acquired=acquired,  # type: ignore[arg-type]
+        profile_name="ai-robotics",
+        score=8,
+        confidence=0.9,
+        reason="relevant",
+        filter_tags=(),
+        source_tag="inbox",
+        submitted_by="x",
+        title_hint="Submitter Title",
+        config=config,
+    )
+    assert item is not None
+    assert item["title"] == "Submitter Title"
 
 
 def test_build_item_thin_summary_suppressed() -> None:

--- a/tests/unit/test_inbox_tick.py
+++ b/tests/unit/test_inbox_tick.py
@@ -1006,6 +1006,35 @@ async def test_pdf_happy_path_ingests(tmp_path: Path) -> None:
     assert client.completed[0]["cited_nodes"] == ["note-pdf"]
 
 
+async def test_pdf_relative_local_path_resolves_against_pdf_root(
+    tmp_path: Path,
+) -> None:
+    """Regression #209: a relative local_path resolves under pdf_root, not CWD."""
+    pdf_root = tmp_path / "pdfs"
+    pdf_root.mkdir()
+    pdf = pdf_root / "paper.pdf"
+    pdf.write_bytes(b"%PDF-1.4 body")
+    config = _make_pdf_config(pdf_root, tmp_path / "archive")
+    # Submitter sends a path relative to pdf_root.
+    client = FakeClient(tasks=[_task_pdf(local_path="paper.pdf")], note_id="note-pdf")
+    with (
+        patch(
+            "influx.inbox.acquire_inbox_pdf", return_value=_pdf_acquisition()
+        ) as mock_acquire,
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_returning(8),
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch("influx.inbox.dispatch_profile", return_value=RunOutcome(ingested=1)),
+    ):
+        await _tick(client, config).execute()
+
+    mock_acquire.assert_called_once()
+    assert Path(mock_acquire.call_args.args[0]) == pdf.resolve()
+    assert "ingested into 1 profile(s): alpha" in client.completed[0]["outcome"]
+
+
 async def test_pdf_dedup_cache_hit_no_new_profiles(tmp_path: Path) -> None:
     """A re-submitted PDF whose note already lists the profile is a cache hit.
 


### PR DESCRIPTION
## Summary

Fixes #210. An inbox **URL** item fell back to the raw URL as its title whenever the submitter didn't supply one — `extract_article_from_html` returned only body text, so a successfully fetched HTML article was scored *and* written under a URL string (hurting filter and note quality). The plan (§3.2) says the submitter hint is a fallback "if HTML extraction can't recover one" — extraction now actually recovers one.

## What changed

- `extraction/article.py` — recover a best-effort document title (`<title>` → `og:title` → `<h1>`, whitespace-collapsed, 300-char cap) and return it on `ArticleExtractionResult.title`.
- `sources/inbox.py` — `InboxAcquisition` carries `extracted_title`; the HTML acquire branch captures it; `build_inbox_note_item` title preference is now **hint → extracted title → URL**.
- `inbox.py` — the filter candidate title uses the same preference, so the filter scores a real title, not a URL.

PDF items keep their existing fallback; the RSS path is unaffected (it already has the feed item title).

## Test plan

- `make check` green — **2503 passed**, ruff + pyright clean.
- New tests: `_recover_html_title` (`<title>` preference, og:title fallback, `<h1>` fallback strips inner tags, none-when-absent, 300-char cap); `extract_article_from_html` threads the title; inbox acquire captures `extracted_title`; build-item uses extracted title when no hint and hint-wins-over-extracted.

Closes #210
