### PR TITLE
feat: per-item operational logging for inbox tick

### DIFF
--- a/src/influx/inbox.py
+++ b/src/influx/inbox.py
@@ -73,6 +73,17 @@ _DEFAULT_SOURCE_TAG = "inbox"
 _CLAIM_ASPECT = "ingest"
 _ALLOWED_URL_SCHEMES = ("http", "https")
 _REJECTED_TAG_PREFIX = "influx:rejected:"
+# Cap source identifiers in the per-item summary log so a pathological URL
+# can't bloat the line; the full value still rides in the ``extra`` field.
+_LOG_SOURCE_MAX = 200
+
+
+def _log_source(value: object) -> str:
+    """Render a source_url / local_path for a log message, length-capped."""
+    text = str(value)
+    if len(text) <= _LOG_SOURCE_MAX:
+        return text
+    return text[: _LOG_SOURCE_MAX - 1] + "…"
 
 
 def _valid_source_tag(tag: str) -> bool:
@@ -231,6 +242,12 @@ class _ItemOutcome:
     outcome: str
     cited_nodes: list[str]
     inbox_result: dict[str, Any]
+    # The bounded ``inbox_items_processed`` outcome label for this item, reused
+    # for the per-item operational summary log so it matches the metric.
+    metric_outcome: str
+    # Profiles the item was actually ingested into (empty for terminal /
+    # filtered / cache-hit outcomes); surfaced in the per-item summary log.
+    ingested_profiles: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -646,6 +663,7 @@ class InboxTick:
                 outcome=f"error: {reason}",
                 cited_nodes=[],
                 inbox_result={"source_url": source_url, "error": reason},
+                metric_outcome="error",
             )
 
         # ── Cache-hit replay (§6) ─────────────────────────────────────
@@ -680,6 +698,7 @@ class InboxTick:
                         "per_profile": {},
                         "processing_time_ms": int((time.monotonic() - started) * 1000),
                     },
+                    metric_outcome="cache_hit",
                 )
 
         # Acquire once (blocking download/extract → thread); bytes + extracted
@@ -790,8 +809,21 @@ class InboxTick:
 
         if not dispatched and not dispatch_failed:
             # Every clearing profile was busy — skip this tick and let a later
-            # tick retry the whole item (§5.5 / §10); do NOT complete.
+            # tick retry the whole item (§5.5 / §10); do NOT complete.  This
+            # branch never reaches ``_complete``, so log the deferral here so
+            # the item is still visible at INFO (it is left ``open`` for a
+            # later tick).
             metrics.inbox_items_processed().add(1, {"outcome": "profile_busy_skipped"})
+            logger.info(
+                "inbox item deferred: all profiles busy source_url=%s profiles=%s",
+                _log_source(acquired.source_url),
+                busy,
+                extra={
+                    "source_url": acquired.source_url,
+                    "outcome": "profile_busy_skipped",
+                    "profiles": list(busy),
+                },
+            )
             return None
 
         ingested_names = [
@@ -831,6 +863,8 @@ class InboxTick:
                 "per_profile": per_profile,
                 "processing_time_ms": int((time.monotonic() - started) * 1000),
             },
+            metric_outcome=metric_outcome,
+            ingested_profiles=tuple(ingested_names),
         )
 
     def _filtered_out_outcome(
@@ -846,12 +880,14 @@ class InboxTick:
         URL is already a note, else a fresh ``filtered out: top score …``.
         """
         if cache_note_id is not None:
-            metrics.inbox_items_processed().add(1, {"outcome": "cache_hit"})
+            metric_outcome = "cache_hit"
+            metrics.inbox_items_processed().add(1, {"outcome": metric_outcome})
             outcome = (
                 f"cache_hit: existing note {cache_note_id}; no new profiles matched"
             )
         else:
-            metrics.inbox_items_processed().add(1, {"outcome": "filtered_out"})
+            metric_outcome = "filtered_out"
+            metrics.inbox_items_processed().add(1, {"outcome": metric_outcome})
             # (score, name, threshold) for every profile the model scored.
             scored = [
                 (ps.scored.score, ps.name, ps.threshold)
@@ -878,6 +914,7 @@ class InboxTick:
                 ),
                 "processing_time_ms": int((time.monotonic() - started) * 1000),
             },
+            metric_outcome=metric_outcome,
         )
 
     async def _lookup_existing(
@@ -890,11 +927,14 @@ class InboxTick:
         """
         try:
             body = await client.cache_lookup_by_url_body(source_url=source_url)
-        except (LithosError, LCMAError):
+        except (LithosError, LCMAError) as exc:
+            # Graceful degradation, not a failure — no stack trace (this fires
+            # once per item during a Lithos blip; the error class + message is
+            # enough to correlate without spamming traces).
             logger.warning(
-                "inbox cache lookup failed for %s; treating as miss",
+                "inbox cache lookup failed for %s; treating as miss: %s",
                 source_url,
-                exc_info=True,
+                exc,
             )
             return None
         return _extract_note_id(body)
@@ -916,18 +956,20 @@ class InboxTick:
             note = await client.read_note(note_id=note_id)
             parsed = parse_note(str(note.get("content") or ""))
             ingested = {e.profile_name for e in parse_profile_relevance(parsed)}
-        except (LithosError, LCMAError):
+        except (LithosError, LCMAError) as exc:
+            # Replay-all fallback is correct-by-design (merge dedupes), so this
+            # is a degradation, not a failure — message + identifier, no trace.
             logger.warning(
-                "inbox read_note failed for %s; replaying all profiles",
+                "inbox read_note failed for %s; replaying all profiles: %s",
                 note_id,
-                exc_info=True,
+                exc,
             )
             return profiles
-        except Exception:  # noqa: BLE001 — parse of a non-canonical note must not poison
+        except Exception as exc:  # noqa: BLE001 — parse of a non-canonical note must not poison
             logger.warning(
-                "inbox could not parse existing note %s; replaying all profiles",
+                "inbox could not parse existing note %s; replaying all profiles: %s",
                 note_id,
-                exc_info=True,
+                exc,
             )
             return profiles
         tags = note.get("tags") or []
@@ -1096,6 +1138,28 @@ class InboxTick:
                 "inbox task_complete failed task_id=%s", task_id, exc_info=True
             )
             metrics.inbox_task_call_failures().add(1, {"phase": "complete"})
+            return
+
+        # Single per-item operational summary: the happy-path INFO line an
+        # operator greps to see exactly which URL / local PDF was processed and
+        # how it resolved.  Emitted once per completed item (success, filtered,
+        # cache-hit, and validation-terminal all funnel through here); the
+        # busy-skip path logs its own deferral line instead.
+        ir = result.inbox_result
+        source = ir.get("source_url") or ir.get("local_path") or "<unknown>"
+        logger.info(
+            "inbox item done source_url=%s outcome=%s profiles=%s task_id=%s",
+            _log_source(source),
+            result.metric_outcome,
+            list(result.ingested_profiles),
+            task_id,
+            extra={
+                "source_url": source,
+                "outcome": result.metric_outcome,
+                "profiles": list(result.ingested_profiles),
+                "task_id": task_id,
+            },
+        )
 
     async def _complete_terminal(
         self,
@@ -1119,5 +1183,10 @@ class InboxTick:
         await self._complete(
             client,
             task_id,
-            _ItemOutcome(outcome=outcome, cited_nodes=[], inbox_result=inbox_result),
+            _ItemOutcome(
+                outcome=outcome,
+                cited_nodes=[],
+                inbox_result=inbox_result,
+                metric_outcome=metric_outcome,
+            ),
         )

--- a/src/influx/sources/inbox.py
+++ b/src/influx/sources/inbox.py
@@ -135,16 +135,20 @@ def acquire_inbox_bytes(
         elif body is not None:
             # Fetched bytes whose Content-Type is neither HTML nor PDF
             # (e.g. an XML feed URL submitted to the inbox): no extractor
-            # applies, so fall through to the summary hint.  Logged so an
-            # operator can see why a submitted URL produced no body.
-            _log.info(
+            # applies, so fall through to the summary hint.  DEBUG, not INFO:
+            # this is a routine fallback that fires for every feed URL, and
+            # the per-item summary log already records the outcome (#212).
+            _log.debug(
                 "inbox content-type not extractable url=%s family=%r, "
                 "using summary fallback",
                 url,
                 family or archive_result.content_type,
             )
     except (ExtractionError, NetworkError, OSError) as exc:
-        _log.debug("inbox extraction failed for %s, using summary hint: %s", url, exc)
+        # WARNING, not DEBUG: extraction failed and the item proceeds on the
+        # (thinner) summary hint — a content-quality degradation an operator
+        # should see at the default level.
+        _log.warning("inbox extraction failed for %s, using summary hint: %s", url, exc)
 
     return InboxAcquisition(
         source_url=source_url,
@@ -211,7 +215,9 @@ def acquire_inbox_pdf(
         summary = extracted_text
         flavour = "pdf"
     except (ExtractionError, OSError) as exc:
-        _log.debug(
+        # WARNING, not DEBUG: see ``acquire_inbox_bytes`` — a failed PDF
+        # extraction proceeds on the summary hint and is worth surfacing.
+        _log.warning(
             "inbox pdf extraction failed for %s, using summary hint: %s",
             local_path,
             exc,

--- a/tests/unit/test_inbox_builder.py
+++ b/tests/unit/test_inbox_builder.py
@@ -182,7 +182,7 @@ def test_acquire_non_extractable_type_uses_summary_fallback(
             "influx.sources.inbox.download_archive_autodetect",
             return_value=mismatch,
         ),
-        caplog.at_level(logging.INFO, logger="influx.sources.inbox"),  # type: ignore[attr-defined]
+        caplog.at_level(logging.DEBUG, logger="influx.sources.inbox"),  # type: ignore[attr-defined]
     ):
         acquired = acquire_inbox_bytes(_URL, config=config, summary_hint="a hint")
 

--- a/tests/unit/test_inbox_pdf.py
+++ b/tests/unit/test_inbox_pdf.py
@@ -120,13 +120,19 @@ def test_acquire_pdf_same_bytes_two_names_one_identity(tmp_path: Path) -> None:
 
 def test_acquire_pdf_falls_back_to_summary_hint_on_extraction_failure(
     tmp_path: Path,
+    caplog: object,
 ) -> None:
+    import logging
+
     config = _make_config(str(tmp_path / "archive"))
     pdf = _write_pdf(tmp_path)
 
-    with patch(
-        "influx.sources.inbox.extract_pdf",
-        side_effect=ExtractionError("boom", url="x", stage="read", detail="d"),
+    with (
+        patch(
+            "influx.sources.inbox.extract_pdf",
+            side_effect=ExtractionError("boom", url="x", stage="read", detail="d"),
+        ),
+        caplog.at_level(logging.WARNING, logger="influx.sources.inbox"),  # type: ignore[attr-defined]
     ):
         acquired = acquire_inbox_pdf(pdf, config=config, summary_hint="a hint")
 
@@ -135,6 +141,12 @@ def test_acquire_pdf_falls_back_to_summary_hint_on_extraction_failure(
     assert acquired.text_flavour == "summary-fallback"
     # The archive copy still succeeded — bytes were read before extraction.
     assert acquired.archive_missing is False
+    # A failed extraction that proceeds on the (thinner) summary hint is a
+    # content-quality degradation an operator should see at the default level.
+    assert any(
+        "inbox pdf extraction failed" in r.message
+        for r in caplog.records  # type: ignore[attr-defined]
+    )
 
 
 def test_synthetic_url_slug_suffix() -> None:

--- a/tests/unit/test_inbox_tick.py
+++ b/tests/unit/test_inbox_tick.py
@@ -15,6 +15,7 @@ scorer, ``build_filter_prompt``, ``dispatch_profile``):
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -1213,3 +1214,96 @@ async def test_tasks_listed_records_full_backlog_not_slice() -> None:
     )
     assert listed_total == 2
     assert client.claimed == ["a"]  # only the slice was claimed
+
+
+# ── Per-item operational summary log ─────────────────────────────────────
+# One INFO line per item so an operator can grep what was processed and how
+# it resolved without metric-spelunking or reading Lithos task metadata.
+
+
+def _summary_records(caplog: Any) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.message.startswith("inbox item done")]
+
+
+async def test_item_done_summary_logged_for_ingested(caplog: Any) -> None:
+    client = FakeClient(tasks=[_task()], note_id="note-xyz")
+    with (
+        caplog.at_level(logging.INFO, logger="influx.inbox"),
+        patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_returning(8),
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch("influx.inbox.dispatch_profile", return_value=RunOutcome(ingested=1)),
+    ):
+        await _tick(client).execute()
+
+    records = _summary_records(caplog)
+    assert len(records) == 1
+    rec = records[0]
+    assert getattr(rec, "outcome", None) == "ingested"
+    assert getattr(rec, "source_url", None) == "https://example.com/article"
+    assert getattr(rec, "profiles", None) == ["alpha"]
+    assert getattr(rec, "task_id", None) == "task-1"
+
+
+async def test_item_done_summary_logged_for_filtered_out(caplog: Any) -> None:
+    client = FakeClient(tasks=[_task()])
+    with (
+        caplog.at_level(logging.INFO, logger="influx.inbox"),
+        patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+        patch(
+            "influx.inbox.make_default_batch_scorer",
+            return_value=_scorer_returning(3),  # below threshold 7
+        ),
+        patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+        patch("influx.inbox.dispatch_profile"),
+    ):
+        await _tick(client).execute()
+
+    records = _summary_records(caplog)
+    assert len(records) == 1
+    assert getattr(records[0], "outcome", None) == "filtered_out"
+    assert getattr(records[0], "profiles", None) == []  # nothing ingested
+
+
+async def test_item_done_summary_logged_for_invalid_submission(caplog: Any) -> None:
+    client = FakeClient(tasks=[{"id": "t", "metadata": {"kind": "bogus"}}])
+    with caplog.at_level(logging.INFO, logger="influx.inbox"):
+        await _tick(client).execute()
+
+    records = _summary_records(caplog)
+    assert len(records) == 1
+    assert getattr(records[0], "outcome", None) == "invalid_submission"
+
+
+async def test_busy_skip_logs_deferral_with_source(caplog: Any) -> None:
+    """The all-profiles-busy branch never completes, so it logs its own
+    deferral line — otherwise the item would be invisible at INFO."""
+    config = _make_config([("a", 7), ("b", 7)])
+    client = FakeClient(tasks=[_task()])
+    coordinator = Coordinator()
+    tick = InboxTick(
+        config=config,
+        coordinator=coordinator,
+        client_factory=lambda: client,  # type: ignore[arg-type]
+    )
+    async with coordinator.hold("a"), coordinator.hold("b"):
+        with (
+            caplog.at_level(logging.INFO, logger="influx.inbox"),
+            patch("influx.inbox.acquire_inbox_bytes", return_value=_acquisition()),
+            patch(
+                "influx.inbox.make_default_batch_scorer",
+                return_value=_scorer_by_profile({"a": 8, "b": 8}),
+            ),
+            patch("influx.inbox.build_filter_prompt", return_value="prompt"),
+            patch("influx.inbox.dispatch_profile"),
+        ):
+            await tick.execute()
+
+    assert _summary_records(caplog) == []  # no completion → no "item done"
+    deferred = [r for r in caplog.records if "deferred: all profiles busy" in r.message]
+    assert len(deferred) == 1
+    assert getattr(deferred[0], "source_url", None) == "https://example.com/article"
+    assert sorted(getattr(deferred[0], "profiles", [])) == ["a", "b"]


### PR DESCRIPTION
## Context

The inbox tick's failure paths were well logged, but the entire happy path emitted only aggregate metrics. An operator running at the default `INFO` level could **not** tell which URLs or local PDFs had been processed without metric-spelunking or reading Lithos task metadata. This PR closes that gap and right-sizes a few mis-levelled / noisy logs.

## Changes

**Coverage**
- One `INFO` summary line per completed item — `inbox item done source_url=… outcome=… profiles=… task_id=…` — emitted from the single `_complete` choke point, so success / `filtered_out` / `cache_hit` / validation-terminal all log exactly once. The outcome label reuses the bounded `inbox_items_processed` metric label via a new `_ItemOutcome.metric_outcome` field.
- The all-profiles-busy skip branch now logs `inbox item deferred: all profiles busy`. It never reaches `_complete`, so that item was previously invisible at `INFO`.

**Noise**
- `content-type not extractable` `INFO` → `DEBUG` (routine feed-URL fallback; the new summary line records the outcome).
- Dropped `exc_info=True` on the three graceful-degradation warnings (cache-lookup miss, `read_note` / parse replay-all). They recover by design and would otherwise stack-trace once per item during a Lithos blip. Genuine failures (`task_list`/`claim`/`update`/`complete`/crash) keep their traces.
- Promoted the two extraction-fallback logs `DEBUG` → `WARNING`: proceeding on the thinner summary hint is a content-quality degradation worth surfacing.

Identifiers ride in `extra={}` (queryable in JSON/OTEL per SPEC §13.2) **and** in the message text (the text formatter renders only `%(message)s`).

## Test plan

- [x] `make check` green (ruff + pyright + 2519 tests pass)
- [x] New tests: per-item summary for ingested / filtered_out / invalid_submission / busy-skip (`test_inbox_tick.py`)
- [x] PDF extraction-failure now asserts the `WARNING` (`test_inbox_pdf.py`)
- [x] Content-type test updated to `DEBUG` (`test_inbox_builder.py`)
- [ ] Manual: run a tick at `INFLUX_LOG_LEVEL=INFO` with one URL + one local PDF; confirm exactly one `inbox item done` line per item and no stack traces on a simulated cache-lookup blip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
