### PR TITLE
feat: identity-mounted inbox PDF root volume for local-PDF intake

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -14,6 +14,13 @@ INFLUX_STATE_PATH=./state
 # Container name — must be unique per environment so stacks can coexist.
 INFLUX_CONTAINER_NAME=influx-dev
 
+# Inbox local-PDF intake root (docs/plans/inbox.md §16). Identity-mounted:
+# host and container see this dir at the SAME absolute path, because the
+# submit script sends an absolute local_path the container opens as-is.
+# Must match [inbox] pdf_root in influx.toml. Leave [inbox] pdf_root unset
+# to disable local-PDF intake (URL intake is unaffected).
+# INFLUX_INBOX_PDF_ROOT=/tmp/staging-pdf-inbox
+
 # Optional overrides.
 # INFLUX_IMAGE=influx:dev
 # INFLUX_UID=1000

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,6 +13,14 @@ services:
       - ${INFLUX_DATA_PATH:-./data}:/data
       - ${INFLUX_ARCHIVE_PATH:-./archive}:/archive
       - ${INFLUX_STATE_PATH:-./state}:/state
+      # Inbox PDF intake (docs/plans/inbox.md §16.3): the host submit script
+      # stages PDFs here and sends an absolute local_path that the container
+      # opens as-is, so submitter and Influx MUST share this directory at the
+      # SAME absolute path. This is an identity mount (host path == container
+      # path), not a remap like the volumes above. Override per environment
+      # via INFLUX_INBOX_PDF_ROOT; leave [inbox] pdf_root unset to disable
+      # local-PDF intake entirely (the mount is then harmless/unused).
+      - ${INFLUX_INBOX_PDF_ROOT:-/tmp/staging-pdf-inbox}:${INFLUX_INBOX_PDF_ROOT:-/tmp/staging-pdf-inbox}
     ports:
       - "${INFLUX_ADMIN_HOST_PORT:-8080}:${INFLUX_ADMIN_PORT:-8080}"
     extra_hosts:


### PR DESCRIPTION
## Summary

Local-PDF inbox intake (`docs/plans/inbox.md` §16) requires the host submit
script and the container to share `[inbox] pdf_root` at the **same absolute
path**: the script stages a PDF and sends an absolute `local_path` the
container opens as-is, with a §16.3 containment check against the
container-side `pdf_root`.

The existing volumes remap host paths to fixed container mountpoints
(`…/config`→`/data`, `…/archive`→`/archive`, `…/state`→`/state`), so **no
host path resolves identically inside the container**. Setting `[inbox]
pdf_root` to a host path therefore hard-fails config load at startup:

```
ConfigError - inbox.pdf_root is not a directory: '/home/…/inbox-pdfs'
```

This adds an **identity bind mount** (host path == container path) driven by
`INFLUX_INBOX_PDF_ROOT`, so the same absolute path is valid for both the
submit script and the container.

## Changes

- `docker/docker-compose.yml`: identity mount
  `${INFLUX_INBOX_PDF_ROOT:-/tmp/staging-pdf-inbox}` → same path, with an
  explanatory comment.
- `docker/.env.example`: documents the new `INFLUX_INBOX_PDF_ROOT` var.

Per-environment value lives in the (gitignored) `docker/.env.<env>` and must
match `[inbox] pdf_root` in that env's `influx.toml`. Leaving `[inbox]
pdf_root` unset disables local-PDF intake and the mount is unused/harmless;
URL intake is unaffected either way.

## Test plan

- [x] `docker compose config` renders the mount with `source == target`.
- [x] Staging config parses (`load_config`): `inbox.pdf_root=/tmp/staging-pdf-inbox`.
- [x] Recreated staging stack: container `ok`/`ready`, 0 WARNING/ERROR/CRITICAL
      at startup, mount attached identity-style, dir visible in-container as
      `influx:influx`.
- [x] `/status` reports `inbox.enabled=true`; run ledger and schedule preserved
      across the recreate.
- [ ] End-to-end: submit a PDF via `scripts/influx-inbox-submit.py` and confirm
      the inbox tick ingests it (manual, post-merge on staging).
