### PR TITLE
fix: repair sweep reads doc-level source_url, not content body (#218)

### DIFF
--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -204,7 +204,6 @@ _NOTE_PATH_SOURCE_RE = re.compile(r"(?:^|/)(?:papers|articles)/(?P<source>[^/]+)
 _RSS_NOTE_ID_PREFIX = "rss-"
 _ARXIV_NOTE_ID_PREFIX = "arxiv-"
 _ARXIV_HOSTNAMES: frozenset[str] = frozenset({"arxiv.org", "www.arxiv.org"})
-_SOURCE_URL_FRONTMATTER_KEY = "source_url:"
 
 
 def _find_tag(tags: list[str], prefix: str) -> str | None:
@@ -410,7 +409,7 @@ def infer_note_source(note: dict[str, object]) -> str | None:
     if resolved is not None:
         return resolved
 
-    source_url = _parse_source_url_from_note(note) or ""
+    source_url = _note_source_url(note) or ""
     inferred = _infer_source_from_url(source_url)
     if inferred is not None:
         return inferred
@@ -513,22 +512,31 @@ def _classify_download_kind(error: str) -> str:
     return head or "archive_failed"
 
 
-def _parse_source_url_from_note(note: dict[str, object]) -> str | None:
-    """Return the ``source_url`` value from the note's YAML frontmatter, if any.
+def _note_source_url(note: dict[str, object]) -> str | None:
+    """Return the note's doc-level ``source_url`` (top-level or ``metadata``).
 
-    Reuses :func:`influx.notes.parse_note` so the sweep does not carry
-    its own YAML parser.  Returns ``None`` when the note cannot be
-    parsed or the field is absent.
+    The repair sweep operates on the ``lithos_read`` envelope, where
+    ``source_url`` is a structured doc-level field — hoisted to the top
+    level by the #187 read-envelope normalisation, with ``metadata`` as
+    the fallback location.  Mirrors
+    :func:`influx.lithos_client._doc_source_url`.
+
+    This deliberately does NOT parse a ``source_url:`` line out of the
+    content body.  That was the pre-fix legacy shape (empty doc-level
+    metadata, populated content-body frontmatter); those notes have been
+    cleaned up and the writer no longer produces them, so reading the
+    content body would only reintroduce a dependency on a removed shape.
+    Returns ``None`` when no doc-level source_url is present — callers
+    treat that as a transient "needs operator hand-fix" signal.
     """
-    content = str(note.get("content", ""))
-    try:
-        parsed = parse_note(content)
-    except Exception:
-        return None
-    for line in parsed.frontmatter_raw.splitlines():
-        stripped = line.strip()
-        if stripped.startswith(_SOURCE_URL_FRONTMATTER_KEY):
-            return stripped[len(_SOURCE_URL_FRONTMATTER_KEY) :].strip() or None
+    direct = note.get("source_url")
+    if isinstance(direct, str) and direct:
+        return direct
+    meta = note.get("metadata")
+    if isinstance(meta, dict):
+        nested = meta.get("source_url")
+        if isinstance(nested, str) and nested:
+            return nested
     return None
 
 
@@ -564,7 +572,7 @@ def _resolve_rss_download_args(
     transient so an operator hand-fix lands the next pass.
     """
     source = _note_source_tag(note)
-    source_url = _parse_source_url_from_note(note)
+    source_url = _note_source_url(note)
     if not source_url:
         raise ExtractionError(
             "Cannot retry archive download: no source_url in frontmatter",
@@ -795,7 +803,7 @@ def _run_rss_text_extraction(note: dict[str, object], config: AppConfig) -> str:
     fix can repair, and it should keep surfacing through the sweep's
     failure-logging path until corrected.
     """
-    source_url = _parse_source_url_from_note(note)
+    source_url = _note_source_url(note)
     if not source_url:
         raise ExtractionError(
             "Cannot retry text extraction: no source_url in frontmatter",

--- a/tests/unit/test_repair_hooks.py
+++ b/tests/unit/test_repair_hooks.py
@@ -189,3 +189,61 @@ class TestTier3ExtractHookSubstitution:
         hook: Tier3ExtractHook = _fake_tier3_raises
         with pytest.raises(ExtractionError):
             hook({"id": "n1"})
+
+
+class TestNoteSourceUrlResolution:
+    """Regression for #218.
+
+    The repair sweep must read ``source_url`` from the doc-level
+    ``lithos_read`` envelope (top-level, or nested under ``metadata``),
+    NOT from a ``source_url:`` line embedded in the content body. The
+    content-body shape was the pre-fix legacy zombie shape; reading it
+    stranded every correctly-written ``influx:archive-missing`` note
+    with ``ExtractionError: no source_url in frontmatter`` even though
+    the URL was present at the doc level.
+    """
+
+    def test_reads_top_level_source_url(self) -> None:
+        from influx.repair_hooks import _note_source_url
+
+        note: dict[str, object] = {
+            "id": "rss-some-item",
+            "source_url": "https://example.com/article",
+            "content": "# Title\n\n## Archive\n",  # no embedded frontmatter
+        }
+        assert _note_source_url(note) == "https://example.com/article"
+
+    def test_falls_back_to_metadata_nested_source_url(self) -> None:
+        from influx.repair_hooks import _note_source_url
+
+        note: dict[str, object] = {
+            "id": "rss-some-item",
+            "metadata": {"source_url": "https://example.com/nested"},
+            "content": "# Title\n\n## Archive\n",
+        }
+        assert _note_source_url(note) == "https://example.com/nested"
+
+    def test_does_not_read_content_body_frontmatter(self) -> None:
+        # The removed legacy shape: source_url ONLY in the content body.
+        # The sweep must NOT resurrect it — doc-level is the only source.
+        from influx.repair_hooks import _note_source_url
+
+        note: dict[str, object] = {
+            "id": "rss-some-item",
+            "content": ("---\nsource_url: https://example.com/in-body\n---\n# Title\n"),
+        }
+        assert _note_source_url(note) is None
+
+    def test_returns_none_when_absent_everywhere(self) -> None:
+        from influx.repair_hooks import _note_source_url
+
+        note: dict[str, object] = {"id": "rss-x", "content": "# Title\n"}
+        assert _note_source_url(note) is None
+
+    def test_ignores_non_string_source_url(self) -> None:
+        from influx.repair_hooks import _note_source_url
+
+        none_url: dict[str, object] = {"id": "rss-x", "source_url": None}
+        empty_url: dict[str, object] = {"id": "rss-x", "source_url": ""}
+        assert _note_source_url(none_url) is None
+        assert _note_source_url(empty_url) is None

--- a/tests/unit/test_repair_hooks_production.py
+++ b/tests/unit/test_repair_hooks_production.py
@@ -966,25 +966,14 @@ def _make_rss_archive_missing_note(
     note_id = (
         f"{feed_slug}-{url_hash}" if omit_id_prefix else f"rss-{feed_slug}-{url_hash}"
     )
-    fm_url = "" if omit_source_url else source_url
-    content = _rss_note_content(
-        source_url=fm_url if fm_url else "https://example.com/article-42"
-    )
-    if omit_source_url:
-        # Strip the source_url frontmatter line so the resolver hits the
-        # missing-field branch.
-        content = (
-            "\n".join(
-                line
-                for line in content.splitlines()
-                if not line.startswith("source_url:")
-            )
-            + "\n"
-        )
+    content = _rss_note_content(source_url=source_url)
+    # The repair sweep reads source_url from the doc-level field (#218), so
+    # ``omit_source_url`` clears that field to exercise the resolve-raise
+    # branch. The content body is irrelevant to resolution and is left intact.
     return {
         "id": note_id,
         "title": "RSS Article Title",
-        "source_url": source_url,
+        "source_url": "" if omit_source_url else source_url,
         "path": note_path,
         "content": content,
         "tags": [
@@ -1261,7 +1250,11 @@ class TestInferNoteSource:
         }
         assert infer_note_source(note) == "hackernews"
 
-    def test_infers_arxiv_from_source_url_when_tag_missing(self) -> None:
+    def test_does_not_infer_from_content_body_source_url(self) -> None:
+        """#218: a ``source_url:`` line in the content body is the removed
+        legacy shape; inference must NOT read it. Doc-level inference is
+        covered by ``test_infers_arxiv_from_top_level_source_url_*``.
+        """
         from influx.repair_hooks import infer_note_source
 
         body = (
@@ -1273,11 +1266,12 @@ class TestInferNoteSource:
         )
         note = {
             "tags": [],
-            "content": body,
+            "content": body,  # source_url only in the body — must be ignored
             "path": "",
             "id": "",
         }
-        assert infer_note_source(note) == "arxiv"
+        # No doc-level source_url and no tag/path/id signal -> cannot infer.
+        assert infer_note_source(note) is None
 
     def test_infers_arxiv_from_canonical_path(self) -> None:
         from influx.repair_hooks import infer_note_source
@@ -1353,10 +1347,10 @@ class TestInferNoteSource:
     def test_returns_none_when_url_is_non_arxiv_and_other_signals_empty(self) -> None:
         from influx.repair_hooks import infer_note_source
 
-        body = "---\nsource_url: https://example.com/something\ntags: []\n---\n"
         note = {
             "tags": [],
-            "content": body,
+            "content": "# Paper\n\nBody text only.\n",
+            "source_url": "https://example.com/something",  # doc-level, non-arxiv
             "path": "",
             "id": "",
         }


### PR DESCRIPTION
Fixes #218.

## Problem

The repair sweep could not read the `source_url` of correctly-written
notes, so **every `influx:archive-missing` note queued for repair failed
its retry and eventually terminal-flipped** — despite having a valid
doc-level `source_url`.

`_parse_source_url_from_note` (`repair_hooks.py`) read `source_url` only
from the note's **content-body embedded frontmatter**. Correctly-written
notes store `source_url` at the **doc level** and carry no embedded
content frontmatter, so the helper returned `None` and its three callers
(archive-download retry, text-extraction retry, source inference) failed
with `ExtractionError: no source_url in frontmatter`.

This is the **inverse of the legacy zombie shape** (empty doc-level
metadata, populated content frontmatter) and a straggler from #187 —
which already established that the sweep reads doc-level fields hoisted
to the note top-level (`lithos_client._doc_source_url`,
`_READ_ENVELOPE_FIELD_TYPES`). It stayed latent while zombies existed and
surfaced once the writer was fixed and the ~245 zombies were cleaned up.

## Fix

- Rename `_parse_source_url_from_note` → `_note_source_url`; read the
  **doc-level** field only (top-level, then `metadata.source_url`),
  mirroring `_doc_source_url`.
- **No content-body fallback.** That shape no longer exists in the corpus
  (cleanup emptied it) and the writer no longer produces it, so a
  fallback would only re-couple the sweep to removed functionality.
- Remove the now-dead `_SOURCE_URL_FRONTMATTER_KEY`.

## Verification

- New `TestNoteSourceUrlResolution` regression: doc-level top-level +
  `metadata` fallback, and an explicit assertion that content-body
  frontmatter is **not** read.
- Updated RSS fixtures so `omit_source_url` clears the doc-level field
  the code now reads; repointed source-inference tests off the
  content-body shape.
- `make typecheck` clean; ruff clean; 145 repair tests pass.
- **Live staging repro** against the real stranded note
  (`657092a8…`, created 2026-06-01): before → `None` (raised); after →
  `https://standupforme.app/blog/...`.

## Blast radius (staging)

15 notes tagged `influx:archive-missing` + `influx:repair-needed`, all
with a valid doc-level source_url, were stranded and burning failed
tier2/tier3 calls each sweep. They become repairable again after this
lands.
