### PR TITLE
fix: reattach doc-level title for repair parse_note input (#220)

### DIFF
--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -1243,9 +1243,15 @@ def _content_for_note_parse(note: dict[str, Any]) -> str:
     ``content`` — prepending the title into the persisted body would
     compound the existing duplicate-``# Title`` shape.
     """
-    content = str(note.get("content", ""))
-    if any(line.startswith("# ") for line in content.splitlines()):
-        return content
+    content = str(note.get("content") or "")
+    # Mirror parse_note / _split_title title detection exactly: strip the
+    # line and exclude ``## `` headings. A bare ``line.startswith("# ")``
+    # would miss an indented H1 that _split_title *would* accept, causing a
+    # second title to be prepended and shifting the parsed title.
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# ") and not stripped.startswith("## "):
+            return content
     title = _doc_title(note)
     if not title:
         return content

--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -1215,6 +1215,43 @@ def _run_tier_retry(
         return new_tags
 
 
+def _doc_title(note: dict[str, Any]) -> str:
+    """Return the note's doc-level title (top-level, then ``metadata``)."""
+    direct = note.get("title")
+    if isinstance(direct, str) and direct:
+        return direct
+    meta = note.get("metadata")
+    if isinstance(meta, dict):
+        nested = meta.get("title")
+        if isinstance(nested, str) and nested:
+            return nested
+    return ""
+
+
+def _content_for_note_parse(note: dict[str, Any]) -> str:
+    """Return note content shaped for :func:`influx.notes.parse_note`.
+
+    ``read_note`` serves note ``content`` with the ``# {title}`` heading
+    stripped — the title is a doc-level metadata field. ``parse_note``
+    requires that heading (``_split_title`` raises ``NoteParseError``
+    without it), even though the archive-path / profile-relevance data
+    the sweep needs live in the body *below* the title. Reattach the
+    doc-level title when the body has no ``# `` heading so parsing
+    succeeds.
+
+    Parse-input only: the rewrite path must keep using the unmodified
+    ``content`` — prepending the title into the persisted body would
+    compound the existing duplicate-``# Title`` shape.
+    """
+    content = str(note.get("content", ""))
+    if any(line.startswith("# ") for line in content.splitlines()):
+        return content
+    title = _doc_title(note)
+    if not title:
+        return content
+    return f"# {title}\n\n{content}"
+
+
 async def _process_sweep_note(
     note: dict[str, Any],
     *,
@@ -1230,13 +1267,14 @@ async def _process_sweep_note(
     from influx.notes import parse_archive_path, parse_note, parse_profile_relevance
 
     tags: list[str] = list(note.get("tags", []))
-    content: str = note.get("content", "")
 
-    # Parse note structure for stage selection inputs.
+    # Parse note structure for stage selection inputs. ``read_note`` strips
+    # the doc-level title from ``content``; reattach it for parsing only so
+    # archive-path / profile-relevance extraction works (#220).
     archive_path: str | None = None
     max_profile_score: int = 0
     try:
-        parsed = parse_note(content)
+        parsed = parse_note(_content_for_note_parse(note))
         archive_path = parse_archive_path(parsed)
         entries = parse_profile_relevance(parsed)
         if entries:

--- a/tests/unit/test_repair_hook_rollback.py
+++ b/tests/unit/test_repair_hook_rollback.py
@@ -348,7 +348,7 @@ class TestTier2EnrichRollback:
                 "content": (
                     "## Archive\npath: a.pdf\n"
                     "## Profile Relevance\n"
-                    "- profile: p, score: 9\n"
+                    "### p\nScore: 9/10\n"
                 ),
                 "tags": [
                     "influx:repair-needed",
@@ -395,7 +395,7 @@ class TestTier3ExtractRollback:
                 "content": (
                     "## Archive\npath: a.pdf\n"
                     "## Profile Relevance\n"
-                    "- profile: p, score: 9\n"
+                    "### p\nScore: 9/10\n"
                 ),
                 "tags": [
                     "influx:repair-needed",

--- a/tests/unit/test_repair_sweep.py
+++ b/tests/unit/test_repair_sweep.py
@@ -1645,3 +1645,33 @@ class TestContentForNoteParse:
         assert _doc_title({"metadata": {"title": "nested"}}) == "nested"
         assert _doc_title({"title": "", "metadata": {"title": "nested"}}) == "nested"
         assert _doc_title({"id": "x"}) == ""
+
+    def test_recognises_indented_h1_like_split_title(self) -> None:
+        # _split_title strips the line, so an indented '# Title' IS a title.
+        # The reattach check must agree and NOT prepend a second one.
+        from influx.repair import _content_for_note_parse
+
+        note: dict[str, Any] = {
+            "id": "rss-x",
+            "title": "Doc Title",
+            "content": "   # Indented Title\n\n## Archive\n",
+        }
+        assert _content_for_note_parse(note) == "   # Indented Title\n\n## Archive\n"
+
+    def test_excludes_h2_when_detecting_title(self) -> None:
+        # A '## ' heading is not a title — reattach should still fire.
+        from influx.repair import _content_for_note_parse
+
+        note: dict[str, Any] = {
+            "id": "rss-x",
+            "title": "Doc Title",
+            "content": "## Archive\n## Summary\n",
+        }
+        assert _content_for_note_parse(note).startswith("# Doc Title\n\n")
+
+    def test_none_content_does_not_become_literal_none(self) -> None:
+        from influx.repair import _content_for_note_parse
+
+        note: dict[str, Any] = {"id": "rss-x", "title": "T", "content": None}
+        # str(None) would yield "None"; must coerce to "" first.
+        assert _content_for_note_parse(note) == "# T\n\n"

--- a/tests/unit/test_repair_sweep.py
+++ b/tests/unit/test_repair_sweep.py
@@ -1583,3 +1583,65 @@ class TestSweepEnvelopeNormalisation:
             "content": args["content"],
         }
         assert infer_note_source(rewritten) == "rss"
+
+
+class TestContentForNoteParse:
+    """#220: ``read_note`` strips the ``# {title}`` heading from ``content``
+    (title is doc-level metadata), but ``parse_note`` requires it. The sweep
+    must reattach the doc-level title for parsing so archive-path /
+    profile-relevance extraction works — without it the archive path (present
+    in the body) is silently lost and stage selection runs blind.
+    """
+
+    def test_reattaches_title_so_archive_path_parses(self) -> None:
+        from influx.notes import parse_archive_path, parse_note
+        from influx.repair import _content_for_note_parse
+
+        # The real read_note body shape: no leading '# Title'.
+        note: dict[str, Any] = {
+            "id": "rss-x",
+            "title": "Some Paper",
+            "content": (
+                "## Archive\npath: arxiv/2026/05/2605.20049.pdf\n\n## Summary\nx\n"
+            ),
+        }
+        parsed = parse_note(_content_for_note_parse(note))
+        assert parsed.title == "Some Paper"
+        assert parse_archive_path(parsed) == "arxiv/2026/05/2605.20049.pdf"
+
+    def test_leaves_content_unchanged_when_title_present(self) -> None:
+        from influx.repair import _content_for_note_parse
+
+        note: dict[str, Any] = {
+            "id": "rss-x",
+            "title": "Doc Title",
+            "content": "# Inner Title\n\n## Archive\n",
+        }
+        # Already has a '# ' heading — must not double-prepend.
+        assert _content_for_note_parse(note) == "# Inner Title\n\n## Archive\n"
+
+    def test_falls_back_to_metadata_title(self) -> None:
+        from influx.repair import _content_for_note_parse
+
+        note: dict[str, Any] = {
+            "id": "rss-x",
+            "metadata": {"title": "Nested Title"},
+            "content": "## Archive\n",
+        }
+        assert _content_for_note_parse(note).startswith("# Nested Title\n\n")
+
+    def test_returns_content_unchanged_when_no_title_available(self) -> None:
+        from influx.repair import _content_for_note_parse
+
+        note: dict[str, Any] = {"id": "rss-x", "content": "## Archive\n"}
+        # No doc-level title to reattach — leave content as-is (caller's
+        # try/except still handles the NoteParseError gracefully).
+        assert _content_for_note_parse(note) == "## Archive\n"
+
+    def test_doc_title_resolution_order(self) -> None:
+        from influx.repair import _doc_title
+
+        assert _doc_title({"title": "top"}) == "top"
+        assert _doc_title({"metadata": {"title": "nested"}}) == "nested"
+        assert _doc_title({"title": "", "metadata": {"title": "nested"}}) == "nested"
+        assert _doc_title({"id": "x"}) == ""


### PR DESCRIPTION
Fixes #220.

## Problem

The repair sweep parses each note with `parse_note(content)` to extract
the archive path and profile-relevance score for stage selection. But
`read_note` serves note `content` with the **`# {title}` heading
stripped** (the title is doc-level metadata), and `parse_note` requires
it — `_split_title` raises `NoteParseError: No title heading found`.

The sweep caught it and continued ("will still rewrite") but with
`archive_path = None` and `max_profile_score = 0`, so **stage selection
ran on incomplete inputs** — even though the archive path was sitting in
the body under `## Archive`. Archive/text repair was silently impaired.

Same family as #218/#219: a repair helper fed the `read_note` envelope
shape but expecting the on-disk shape.

## Fix

`_content_for_note_parse` reattaches the doc-level title (top-level, then
`metadata.title`) when the body has no `# ` heading, used for **parse
input only**. The rewrite path keeps the unmodified `content` —
prepending into the persisted body would compound the existing
duplicate-`# Title` shape.

## Why it stayed latent

~96% of notes (1,409/1,466 on staging) carry a *double* `# Title` (a
separate writer artifact). `read_note` strips one, the duplicate
survives, and `parse_note` works. Only the correctly single-titled notes
expose the mismatch — **23 of 39 `influx:repair-needed`** on staging
(staging-ai ×7, ai-agents ×8, ai-foundations ×3, ai-coding ×3,
robotics ×2). The double-title shape is worth its own follow-up; it is
benign today.

## Verification

- New `TestContentForNoteParse`: reattachment lets `parse_note` +
  `parse_archive_path` recover the archive path; no double-prepend when a
  title is present; `metadata.title` fallback; graceful no-op when no
  doc-level title exists.
- `make typecheck` clean; ruff clean; 130 repair/integration tests pass.
- **Live staging repro** on the stranded notes: before → `NoteParseError`;
  after → parses cleanly with title reattached and
  `archive_path=arxiv/2026/05/2605.20049.pdf` (and `None` for the
  genuinely archive-missing one — correct).
