### PR TITLE
fix: resolve repair archive-download args from read_note envelope (#223)

### DIFF
--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -647,7 +647,7 @@ def _resolve_rss_download_args(
     source_url = _note_source_url(note)
     if not source_url:
         raise ExtractionError(
-            "Cannot retry archive download: no source_url in frontmatter",
+            "Cannot retry archive download: no doc-level source_url on note",
             stage="resolve",
             detail=f"note id={note.get('id', '?')}",
         )
@@ -878,7 +878,7 @@ def _run_rss_text_extraction(note: dict[str, object], config: AppConfig) -> str:
     source_url = _note_source_url(note)
     if not source_url:
         raise ExtractionError(
-            "Cannot retry text extraction: no source_url in frontmatter",
+            "Cannot retry text extraction: no doc-level source_url on note",
             stage="resolve",
             detail=f"note id={note.get('id', '?')}",
         )

--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -42,6 +42,7 @@ from influx.repair import (
 )
 from influx.schemas import Tier3Extraction
 from influx.storage import download_archive
+from influx.urls import url_hash
 
 __all__ = ["DefaultSweepHooks", "make_default_sweep_hooks"]
 
@@ -197,6 +198,12 @@ def _extract_from_archive(
 
 _ARXIV_ID_TAG_PREFIX = "arxiv-id:"
 _SOURCE_TAG_PREFIX = "source:"
+_FEED_SLUG_TAG_PREFIX = "feed-slug:"
+# Modern arxiv ids encode the publication YYMM in their first four digits
+# (e.g. ``2605.10178`` → 2026-05), matching acquisition's published_year/month.
+_ARXIV_ID_YYMM_RE = re.compile(r"^(?P<yy>\d{2})(?P<mm>\d{2})\.")
+# Leading ``YYYY-MM`` of an ISO-8601 ``created_at`` timestamp.
+_ISO_YEAR_MONTH_RE = re.compile(r"^(?P<year>\d{4})-(?P<month>\d{2})")
 _NOTE_PATH_RE = re.compile(
     r"(?:papers|articles)/(?P<source>[^/]+)/(?P<year>\d{4})/(?P<month>\d{2})"
 )
@@ -497,6 +504,58 @@ def _parse_year_month_from_note_path(note_path: str) -> tuple[int, int] | None:
         return None
 
 
+def _year_month_from_arxiv_id(arxiv_id: str) -> tuple[int, int] | None:
+    """Derive ``(year, month)`` from a modern arxiv id's ``YYMM`` prefix."""
+    m = _ARXIV_ID_YYMM_RE.match(arxiv_id)
+    if not m:
+        return None
+    month = int(m.group("mm"))
+    if not 1 <= month <= 12:
+        return None
+    return 2000 + int(m.group("yy")), month
+
+
+def _year_month_from_iso(timestamp: str) -> tuple[int, int] | None:
+    """Derive ``(year, month)`` from the leading ``YYYY-MM`` of an ISO timestamp."""
+    m = _ISO_YEAR_MONTH_RE.match(timestamp)
+    if not m:
+        return None
+    month = int(m.group("month"))
+    if not 1 <= month <= 12:
+        return None
+    return int(m.group("year")), month
+
+
+def _year_month_from_note(
+    note: dict[str, object], *, arxiv_id: str | None = None
+) -> tuple[int, int] | None:
+    """Resolve the archive ``(year, month)`` bucket for a note.
+
+    ``read_note`` does not preserve the Influx note ``path``
+    (``papers|articles/<source>/YYYY/MM``), so the path-based parse fails
+    for every sweep candidate. Fall back to the publication date encoded in
+    the arxiv id (``YYMM``), then to the note's ``created_at``. The retry
+    archive path may differ from the original bucket — that is acceptable
+    (see :func:`_rss_item_id_from_note`); it only needs to be deterministic.
+    """
+    ym = _parse_year_month_from_note_path(str(note.get("path") or ""))
+    if ym is not None:
+        return ym
+    if arxiv_id:
+        ym = _year_month_from_arxiv_id(arxiv_id)
+        if ym is not None:
+            return ym
+    created_at = note.get("created_at")
+    if not isinstance(created_at, str) or not created_at:
+        meta = note.get("metadata")
+        if isinstance(meta, dict):
+            meta_created = meta.get("created_at")
+            created_at = meta_created if isinstance(meta_created, str) else ""
+        else:
+            created_at = ""
+    return _year_month_from_iso(created_at) if created_at else None
+
+
 def _classify_download_kind(error: str) -> str:
     """Return the ``kind`` discriminator from an ``ArchiveResult.error`` string.
 
@@ -553,12 +612,25 @@ def _rss_item_id_from_note(note: dict[str, object]) -> str | None:
     component that is not recoverable from the persisted note); this is
     fine because acquisition failed and no archive currently lives on
     disk for the original path.
+
+    ``read_note`` (the repair sweep's only note source) returns a Lithos
+    UUID as ``id``, not the Influx ``rss-<feed-slug>-<url-hash>`` form, so
+    the prefix strip yields nothing. In that case reconstruct the exact
+    same ``{feed-slug}-{url-hash}`` item_id from the ``feed-slug:`` tag and
+    ``source_url`` — acquisition builds the note id as
+    ``rss-{feed_slug}-{url_hash(url)}`` (``influx.sources.rss``), and
+    ``url_hash`` normalises internally, so this matches byte-for-byte.
     """
     note_id = str(note.get("id", ""))
-    if not note_id.startswith(_RSS_NOTE_ID_PREFIX):
-        return None
-    item_id = note_id[len(_RSS_NOTE_ID_PREFIX) :]
-    return item_id or None
+    if note_id.startswith(_RSS_NOTE_ID_PREFIX):
+        item_id = note_id[len(_RSS_NOTE_ID_PREFIX) :]
+        if item_id:
+            return item_id
+    feed_slug = _find_tag(_note_tags(note), _FEED_SLUG_TAG_PREFIX)
+    source_url = _note_source_url(note)
+    if feed_slug and source_url:
+        return f"{feed_slug}-{url_hash(source_url)}"
+    return None
 
 
 def _resolve_rss_download_args(
@@ -582,17 +654,17 @@ def _resolve_rss_download_args(
     item_id = _rss_item_id_from_note(note)
     if not item_id:
         raise ExtractionError(
-            "Cannot retry archive download: note id missing 'rss-' prefix",
+            "Cannot retry archive download: cannot recover RSS item_id "
+            "(no 'rss-' id, and no feed-slug tag + source_url to reconstruct)",
             stage="resolve",
             detail=f"note id={note.get('id', '?')}",
         )
-    note_path = str(note.get("path", ""))
-    ym = _parse_year_month_from_note_path(note_path)
+    ym = _year_month_from_note(note)
     if ym is None:
         raise ExtractionError(
-            "Cannot retry archive download: note path missing year/month",
+            "Cannot retry archive download: no year/month from path or created_at",
             stage="resolve",
-            detail=f"path={note_path!r}",
+            detail=f"note id={note.get('id', '?')}",
         )
     year, month = ym
     return {
@@ -647,13 +719,13 @@ def _resolve_arxiv_download_args(
             stage="resolve",
             detail=f"note id={note.get('id', '?')}",
         )
-    note_path = str(note.get("path", ""))
-    ym = _parse_year_month_from_note_path(note_path)
+    ym = _year_month_from_note(note, arxiv_id=arxiv_id)
     if ym is None:
         raise ExtractionError(
-            "Cannot retry archive download: note path missing year/month",
+            "Cannot retry archive download: no year/month from path, "
+            "arxiv id, or created_at",
             stage="resolve",
-            detail=f"path={note_path!r}",
+            detail=f"note id={note.get('id', '?')}",
         )
     year, month = ym
     pdf_url = f"https://arxiv.org/pdf/{arxiv_id}.pdf"

--- a/tests/unit/test_repair_hooks_production.py
+++ b/tests/unit/test_repair_hooks_production.py
@@ -707,10 +707,17 @@ class TestArchiveDownloadHookMetadataRecovery:
         assert exc_info.value.stage == "resolve"
         assert classify_failure(exc_info.value) == "transient"
 
-    def test_missing_year_month_in_path_raises_resolve(self, tmp_path: Path) -> None:
+    def test_unresolvable_year_month_raises_resolve(self, tmp_path: Path) -> None:
+        # #223: year/month now falls back to the arxiv id's YYMM, then
+        # created_at. It only raises when NONE resolve: a legacy-format
+        # arxiv id (no YYMM prefix), a path without year/month, and no
+        # created_at on the note.
         config = _make_config(tmp_path)
         hooks = make_default_sweep_hooks(config)
-        note = _make_archive_missing_note(note_path="papers/arxiv/")
+        note = _make_archive_missing_note(
+            arxiv_id="math.GT/0309136", note_path="papers/arxiv/"
+        )
+        note.pop("created_at", None)
 
         assert hooks.archive_download is not None
         with pytest.raises(ExtractionError) as exc_info:
@@ -1075,10 +1082,14 @@ class TestArchiveDownloadHookRssMetadataRecovery:
         assert exc_info.value.stage == "resolve"
         assert classify_failure(exc_info.value) == "transient"
 
-    def test_missing_id_prefix_raises_resolve(self, tmp_path: Path) -> None:
+    def test_unresolvable_item_id_raises_resolve(self, tmp_path: Path) -> None:
+        # #223: a non-``rss-`` id now reconstructs item_id from the
+        # feed-slug tag + source_url. It only raises when reconstruction is
+        # also impossible — here the feed-slug tag is stripped.
         config = _make_config(tmp_path)
         hooks = make_default_sweep_hooks(config)
         note = _make_rss_archive_missing_note(omit_id_prefix=True)
+        note["tags"] = [t for t in note["tags"] if not t.startswith("feed-slug:")]
 
         assert hooks.archive_download is not None
         with pytest.raises(ExtractionError) as exc_info:
@@ -1721,3 +1732,119 @@ class TestArchiveDownloadHookPolicyRegistry:
         # arxiv.org has no built-in policy entry, so it resolves to the
         # no-op ``attempt`` policy.
         assert registry.policy_for("https://arxiv.org/pdf/x.pdf").mode == "attempt"
+
+
+class TestYearMonthResolution:
+    """#223: year/month must resolve when the read_note envelope has no path."""
+
+    def test_year_month_from_arxiv_id(self) -> None:
+        from influx.repair_hooks import _year_month_from_arxiv_id
+
+        assert _year_month_from_arxiv_id("2605.10178") == (2026, 5)
+        assert _year_month_from_arxiv_id("2412.00001") == (2024, 12)
+        assert _year_month_from_arxiv_id("2613.00001") is None  # month 13
+        assert _year_month_from_arxiv_id("not-an-id") is None
+
+    def test_year_month_from_iso(self) -> None:
+        from influx.repair_hooks import _year_month_from_iso
+
+        assert _year_month_from_iso("2026-05-31T09:22:58+00:00") == (2026, 5)
+        assert _year_month_from_iso("2026-13-01") is None  # month 13
+        assert _year_month_from_iso("garbage") is None
+
+    def test_prefers_path_then_arxiv_id_then_created_at(self) -> None:
+        from influx.repair_hooks import _year_month_from_note
+
+        # path wins
+        assert _year_month_from_note(
+            {"path": "papers/arxiv/2024/03", "created_at": "2026-05-01"},
+            arxiv_id="2605.10178",
+        ) == (2024, 3)
+        # no path -> arxiv id YYMM
+        assert _year_month_from_note(
+            {"path": None, "created_at": "2026-01-01"}, arxiv_id="2605.10178"
+        ) == (2026, 5)
+        # no path, no arxiv id -> created_at
+        assert _year_month_from_note(
+            {"path": None, "created_at": "2026-05-31T09:22:58+00:00"}
+        ) == (2026, 5)
+        # created_at nested under metadata
+        assert _year_month_from_note(
+            {"metadata": {"created_at": "2026-04-02T00:00:00+00:00"}}
+        ) == (2026, 4)
+        # nothing -> None
+        assert _year_month_from_note({"id": "x"}) is None
+
+
+class TestRssItemIdReconstruction:
+    """#223: reconstruct the RSS archive item_id from the read_note envelope."""
+
+    def test_strips_rss_prefix_when_present(self) -> None:
+        from influx.repair_hooks import _rss_item_id_from_note
+
+        assert _rss_item_id_from_note({"id": "rss-techcrunch-abc123"}) == (
+            "techcrunch-abc123"
+        )
+
+    def test_reconstructs_from_feed_slug_and_source_url(self) -> None:
+        from influx.repair_hooks import _rss_item_id_from_note
+        from influx.urls import url_hash
+
+        url = "https://www.alignmentforum.org/posts/Cmk/advice"
+        note = {
+            "id": "4c9c8175-605e-41fe-807c-5438ca40d1d7",  # Lithos UUID, no rss-
+            "source_url": url,
+            "tags": ["source:rss", "feed-slug:ai-alignment-forum"],
+        }
+        # Matches acquisition's id == rss-{feed_slug}-{url_hash(url)}.
+        assert _rss_item_id_from_note(note) == f"ai-alignment-forum-{url_hash(url)}"
+
+    def test_none_when_no_prefix_and_no_reconstruction_inputs(self) -> None:
+        from influx.repair_hooks import _rss_item_id_from_note
+
+        # UUID id, no feed-slug tag -> cannot reconstruct.
+        assert _rss_item_id_from_note({"id": "uuid", "tags": ["source:rss"]}) is None
+
+    def test_resolve_rss_args_from_envelope_shape(self, tmp_path: Path) -> None:
+        from influx.repair_hooks import _resolve_rss_download_args
+        from influx.urls import url_hash
+
+        config = _make_config(tmp_path)
+        url = "https://www.alignmentforum.org/posts/Cmk/advice"
+        note = {
+            "id": "4c9c8175-605e-41fe-807c-5438ca40d1d7",
+            "source_url": url,
+            "path": None,
+            "created_at": "2026-05-31T09:22:58+00:00",
+            "tags": [
+                "source:rss",
+                "feed-slug:ai-alignment-forum",
+                "influx:archive-missing",
+                "influx:repair-needed",
+            ],
+        }
+        args = _resolve_rss_download_args(note, config)
+        assert args["url"] == url
+        assert args["item_id"] == f"ai-alignment-forum-{url_hash(url)}"
+        assert args["published_year"] == 2026
+        assert args["published_month"] == 5
+        assert args["ext"] == ".html"
+
+    def test_resolve_arxiv_args_from_envelope_shape(self, tmp_path: Path) -> None:
+        from influx.repair_hooks import _resolve_arxiv_download_args
+
+        config = _make_config(tmp_path)
+        note = {
+            "id": "56868609-29d7-46c2-9325-2dc56fb1f108",
+            "source_url": "https://arxiv.org/abs/2605.10178",
+            "path": None,
+            "created_at": "2026-05-12T02:24:14+00:00",
+            "tags": ["arxiv-id:2605.10178", "source:arxiv", "influx:repair-needed"],
+        }
+        args = _resolve_arxiv_download_args(note, config)
+        assert args["url"] == "https://arxiv.org/pdf/2605.10178.pdf"
+        assert args["item_id"] == "2605.10178"
+        # year/month from the arxiv id's YYMM, since path is absent.
+        assert args["published_year"] == 2026
+        assert args["published_month"] == 5
+        assert args["ext"] == ".pdf"


### PR DESCRIPTION
Fixes #223.

## Problem

After #219/#221 unblocked the repair sweep's read/parse path, archive
**re-download** still failed for `influx:archive-missing` notes because
the resolvers derive args from fields the `read_note` envelope doesn't
preserve:

- **arxiv** → `note path missing year/month` — `path` is `None` in the envelope.
- **RSS** → `note id missing 'rss-' prefix` — `read_note` returns a Lithos UUID.

Same family as #187/#218/#220. Verified on staging: a manual
`ai-foundations` repair run left **0 of 13** notes cleared — text now
extracts (#219) but the archive stays missing, so `repair-needed` never
clears and the notes churn every sweep.

## Fix

Derive from the envelope, keeping existing path/id behaviour first:

- `_year_month_from_note`: note `path` → arxiv id `YYMM`
  (`2605.10178` → 2026-05, matching acquisition's `published_year/month`)
  → `created_at`.
- `_rss_item_id_from_note`: `rss-` prefix → `{feed-slug}-{url_hash(source_url)}`.
  Acquisition builds the note id as `rss-{feed_slug}-{url_hash(url)}`, and
  `url_hash` normalises internally, so this reconstructs it byte-for-byte.

The retry archive path may legitimately differ from the original bucket
(already documented on `_rss_item_id_from_note`) — it only needs to be
deterministic.

## Verification

- **Live staging repro** on the stranded notes:
  - RSS `4c9c8175` → `item_id=ai-alignment-forum-f6b74ef59c`, year=2026 month=5, ext=.html
  - arxiv `56868609` → `item_id=2605.10178`, year=2026 month=5, ext=.pdf

  Both previously raised at `stage="resolve"`.
- New tests: year/month precedence (path → arxiv YYMM → created_at),
  RSS item_id reconstruction, end-to-end resolver coverage for the
  envelope shape. Two existing strict-raise tests repointed to the
  genuinely-unresolvable case.
- `make typecheck` clean, ruff clean, **2540 tests pass**.

## Note

This is the third and (per the corpus audit) likely last bug in the
read_note-envelope family for the repair sweep. Once it lands and staging
rebuilds, the ~39 stranded `repair-needed` notes should start clearing on
the next sweep.
