### PR TITLE
feat: strip-embedded-frontmatter cleanup subcommand (#225)

### DIFF
--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -1625,6 +1625,352 @@ def cmd_rewrite_legacy_notes(args: argparse.Namespace) -> int:
     return 0 if counts.get(_LEGACY_OUTCOME_FAILED, 0) == 0 else 1
 
 
+# ── strip-embedded-frontmatter (#225) ───────────────────────────────
+#
+# Distinct from rewrite-legacy-notes (#176).  Those notes have EMPTY
+# doc-level metadata and recover the values FROM the embedded block.
+# These ~1,241 notes (created 2026-05-01 → 2026-05-24) have VALID
+# doc-level metadata — the embedded block is redundant content bloat.
+# The writer stopped emitting this shape after ~2026-05-24, so the
+# population is fixed.  This job strips the block and leaves doc-level
+# metadata untouched: a pure content rewrite via the Lithos write path.
+
+_EMBEDDED_FM_OUTCOME_PLANNED = "would_strip"
+_EMBEDDED_FM_OUTCOME_SKIPPED_ALREADY_CLEAN = "skipped_already_clean"
+_EMBEDDED_FM_OUTCOME_REFUSED_NON_INFLUX = "refused_non_influx_authored"
+_EMBEDDED_FM_OUTCOME_STRIPPED = "stripped"
+_EMBEDDED_FM_OUTCOME_FAILED = "failed"
+
+
+def strip_embedded_frontmatter_block(content: str) -> str | None:
+    """Strip a leading embedded ``---`` frontmatter block from read_note content.
+
+    Legacy notes (#225) carry — after Lithos strips the one ``# Title``
+    it prepended on save — a content body that *starts* with a redundant
+    ``---``-fenced YAML block duplicating the doc-level metadata,
+    followed by the renderer's ``# Title`` heading and the ``## ``
+    section body::
+
+        ---
+        note_type: summary
+        source_url: ...
+        tags: [...]
+        ---
+        # Title
+
+        ## Archive
+        ...
+
+    Returns the content with that leading fenced block removed (leaving
+    ``# Title\\n\\n## Archive ...`` — byte-identical to a current,
+    post-05-24 note's read shape), or ``None`` when *content* does not
+    start with a frontmatter fence (an already-clean / current-shape
+    note, which the caller skips).
+
+    The fence split delegates to :func:`influx.notes._split_frontmatter`,
+    which is line-anchored: a naive ``content.find("---")`` would match a
+    ``---`` inside a YAML value.  The renderer title heading and every
+    ``## `` section (``## Archive``, ``## Summary``, ``## User Notes``,
+    …) are preserved byte-for-byte.
+    """
+    from influx.notes import NoteParseError, _split_frontmatter
+
+    try:
+        _frontmatter, body = _split_frontmatter(content)
+    except NoteParseError:
+        return None
+    return body.lstrip("\n")
+
+
+def _select_embedded_frontmatter_doc_ids_from_corpus(
+    articles_path: Path,
+) -> list[str]:
+    """Scan the on-disk corpus for Influx-authored docs with an embedded fm block.
+
+    Walks ``articles_path`` recursively and returns the ids of
+    ``author == 'influx'`` docs whose content body — after the single
+    ``# Title`` Lithos prepends on save — begins with a redundant
+    ``---``-fenced frontmatter block (the #225 legacy shape).  The
+    per-doc processor re-validates authoritatively via ``read_note`` +
+    :func:`strip_embedded_frontmatter_block`; this selector only narrows
+    the candidate set so dry-run output isn't dominated by healthy docs.
+
+    Both the outer (doc-level) fence and the inner ``# Title`` heading
+    are split with the line-anchored helpers from :mod:`influx.notes`,
+    so a ``---`` embedded in a frontmatter VALUE is never mistaken for a
+    fence.  Files without an outer fence, parse failures, and
+    non-influx-authored docs are silently skipped — the per-doc guards
+    are the authoritative refusals.
+    """
+    import yaml
+
+    from influx.notes import NoteParseError, _split_frontmatter, _split_title
+
+    ids: list[str] = []
+    seen: set[str] = set()
+    if not articles_path.exists():
+        return ids
+    for md in articles_path.rglob("*.md"):
+        try:
+            text = md.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        try:
+            frontmatter_raw, after_outer = _split_frontmatter(text)
+        except NoteParseError:
+            continue
+        try:
+            meta = yaml.safe_load(frontmatter_raw)
+        except yaml.YAMLError:
+            continue
+        if not isinstance(meta, dict) or meta.get("author") != "influx":
+            continue
+        # Mirror Lithos's read path: it strips the one title it prepended
+        # on save.  An embedded fm block is present iff the body then
+        # begins with a fence.
+        try:
+            _title, body = _split_title(after_outer)
+        except NoteParseError:
+            continue
+        if not body.lstrip("\n").startswith("---"):
+            continue
+        doc_id = meta.get("id")
+        if not isinstance(doc_id, str) or not doc_id or doc_id in seen:
+            continue
+        seen.add(doc_id)
+        ids.append(doc_id)
+    return ids
+
+
+async def _process_one_embedded_frontmatter_doc(
+    *,
+    client: Any,
+    doc_id: str,
+    apply: bool,
+) -> tuple[str, str, dict[str, Any] | None]:
+    """Read one doc, strip its embedded fm block, and rewrite when ``apply=True``.
+
+    Doc-level metadata (tags, source_url, confidence, title, path) is
+    written back unchanged — only ``content`` is rewritten.  Returns
+    ``(outcome, reason, plan)`` where ``plan`` carries the byte delta
+    for the operator line and is ``None`` for skip/refuse outcomes.
+    """
+    try:
+        doc = await client.read_note(note_id=doc_id)
+    except BaseException as exc:  # noqa: BLE001
+        return (
+            _EMBEDDED_FM_OUTCOME_FAILED,
+            f"read failed: {_format_exception_chain(exc)}",
+            None,
+        )
+
+    metadata = doc.get("metadata") or {}
+    author = metadata.get("author") or doc.get("author") or ""
+    if author != "influx":
+        return (
+            _EMBEDDED_FM_OUTCOME_REFUSED_NON_INFLUX,
+            f"doc.author={author!r} — refusing to touch a non-influx-authored doc",
+            None,
+        )
+
+    content = str(doc.get("content") or "")
+    new_content = strip_embedded_frontmatter_block(content)
+    if new_content is None:
+        return (
+            _EMBEDDED_FM_OUTCOME_SKIPPED_ALREADY_CLEAN,
+            "content has no embedded frontmatter block — already current shape",
+            None,
+        )
+
+    plan: dict[str, Any] = {
+        "old_content_len": len(content),
+        "new_content_len": len(new_content),
+    }
+    if not apply:
+        return (
+            _EMBEDDED_FM_OUTCOME_PLANNED,
+            "ready to strip embedded frontmatter",
+            plan,
+        )
+
+    # Content-only rewrite: every doc-level field is read back from the
+    # note envelope unchanged (mirrors influx.repair's proven write
+    # contract — see _build_sweep_write_args).  Only ``content`` differs.
+    conf_raw = doc.get("confidence")
+    if conf_raw is None:
+        conf_raw = metadata.get("confidence", 1.0)
+    try:
+        confidence = float(conf_raw)
+    except (TypeError, ValueError):
+        confidence = 1.0
+
+    write_args: dict[str, Any] = {
+        "id": doc_id,
+        "title": str(doc.get("title") or metadata.get("title") or ""),
+        "content": new_content,
+        "agent": "influx",
+        "path": str(doc.get("path") or metadata.get("path") or ""),
+        "source_url": str(doc.get("source_url") or metadata.get("source_url") or ""),
+        "tags": list(doc.get("tags") or metadata.get("tags") or []),
+        "confidence": confidence,
+        "note_type": str(
+            doc.get("note_type") or metadata.get("note_type") or "summary"
+        ),
+        "namespace": str(
+            doc.get("namespace") or metadata.get("namespace") or "influx"
+        ),
+    }
+    version = doc.get("version")
+    if version is None:
+        version = metadata.get("version")
+    if version is not None:
+        write_args["expected_version"] = version
+
+    try:
+        result = await client.call_tool("lithos_write", write_args)
+    except BaseException as exc:  # noqa: BLE001
+        return (
+            _EMBEDDED_FM_OUTCOME_FAILED,
+            f"write failed: {_format_exception_chain(exc)}",
+            plan,
+        )
+
+    try:
+        body = json.loads(result.content[0].text)
+    except (AttributeError, IndexError, json.JSONDecodeError, TypeError) as exc:
+        return (
+            _EMBEDDED_FM_OUTCOME_FAILED,
+            f"could not decode lithos_write response: {exc!r}",
+            plan,
+        )
+
+    status = body.get("status", "")
+    if status in {"updated", "created"}:
+        return _EMBEDDED_FM_OUTCOME_STRIPPED, f"write status={status}", plan
+    return (
+        _EMBEDDED_FM_OUTCOME_FAILED,
+        f"unexpected write status: {status!r} (body={body!r})",
+        plan,
+    )
+
+
+def cmd_strip_embedded_frontmatter(args: argparse.Namespace) -> int:
+    """Strip redundant embedded frontmatter from legacy note bodies (#225).
+
+    Candidates come from ``--id <doc-id>`` (repeatable) or, by default,
+    a scan of the on-disk Lithos ``articles/`` subtree for
+    Influx-authored docs carrying an embedded frontmatter block.  Each
+    candidate is read via ``lithos_read``; legacy-shape docs have the
+    block stripped and the (unchanged) doc-level metadata written back
+    via ``lithos_write``.  Already-clean and non-influx-authored docs
+    are skipped or refused.  Dry-run by default; ``--apply`` requires an
+    explicit confirmation flag.
+    """
+    env = _load_env(args.env)
+
+    id_list = list(getattr(args, "id", None) or [])
+
+    # Early validation: --apply without confirmation is rejected before
+    # any corpus scan, so the failure mode is obvious to the operator.
+    if args.apply and not id_list and not args.yes and not args.yes_to_all:
+        sys.exit(
+            "--apply requires at least one --yes <doc-id> "
+            "(or --yes-to-all, or --id <doc-id>).  Aborted."
+        )
+
+    # ── Candidate selection ──
+    if id_list:
+        seen: set[str] = set()
+        doc_ids: list[str] = []
+        for doc_id in id_list:
+            if doc_id not in seen:
+                seen.add(doc_id)
+                doc_ids.append(doc_id)
+    else:
+        articles = _resolve_corpus_articles_path(env)
+        doc_ids = _select_embedded_frontmatter_doc_ids_from_corpus(articles)
+
+    limit = getattr(args, "limit", None)
+    if limit is not None and limit >= 0:
+        doc_ids = doc_ids[:limit]
+
+    if not doc_ids:
+        print(
+            "No candidate doc ids — the corpus scan found no Influx-authored "
+            "docs with an embedded frontmatter block."
+        )
+        return 0
+
+    # ── Apply-mode subset narrowing ──
+    if args.apply:
+        if id_list:
+            # --id names the targets explicitly; no extra --yes required.
+            confirmed: set[str] = set(doc_ids)
+        else:
+            confirmed = set(args.yes or [])
+            if args.yes_to_all:
+                confirmed.update(doc_ids)
+            unknown = confirmed - set(doc_ids)
+            if unknown:
+                print(
+                    "Warning: --yes ids not present in the candidate set: "
+                    + ", ".join(sorted(unknown))
+                )
+                confirmed -= unknown
+            if not confirmed:
+                sys.exit("No matching --yes ids; nothing to strip.")
+        doc_ids = [d for d in doc_ids if d in confirmed]
+
+    # ── Re-exec under uv if needed (lithos_client imports mcp) ──
+    _ensure_project_runtime_or_reexec()
+    lithos_url = _read_lithos_url(args, env)
+
+    mode = "Apply" if args.apply else "Dry-run"
+    suffix = "+lithos_write" if args.apply else " (no writes)"
+    print(
+        f"{mode} mode: processing {len(doc_ids)} doc id(s) via "
+        f"lithos_read{suffix} on {lithos_url}\n"
+    )
+
+    import asyncio
+
+    counts: dict[str, int] = {}
+
+    async def _drive() -> None:
+        client = _make_lithos_client(lithos_url)
+        try:
+            for doc_id in doc_ids:
+                outcome, reason, plan = await _process_one_embedded_frontmatter_doc(
+                    client=client,
+                    doc_id=doc_id,
+                    apply=args.apply,
+                )
+                counts[outcome] = counts.get(outcome, 0) + 1
+                line = f"{outcome:>30}  doc_id={doc_id}  {reason}"
+                if plan is not None:
+                    line += (
+                        f"  content_bytes={plan['old_content_len']}"
+                        f"→{plan['new_content_len']}"
+                    )
+                print(line)
+        finally:
+            await client.close()
+
+    asyncio.run(_drive())
+
+    print()
+    print("Summary: " + " ".join(f"{k}={v}" for k, v in sorted(counts.items())))
+    if not args.apply:
+        print(
+            "\nTo strip these docs, re-run with:\n"
+            "    --apply --yes-to-all       (strip every 'would_strip' doc)\n"
+            "    --apply --yes <doc-id>     (strip specific docs, repeatable)\n"
+            "    --apply --id <doc-id>      (skip corpus scan, repeatable)"
+        )
+    # Exit non-zero only on genuine failures.
+    return 0 if counts.get(_EMBEDDED_FM_OUTCOME_FAILED, 0) == 0 else 1
+
+
 async def _fetch_invalid_source_notes(
     *,
     lithos_url: str,
@@ -2155,6 +2501,60 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     p_rewrite.set_defaults(func=cmd_rewrite_legacy_notes)
+
+    p_strip = sub.add_parser(
+        "strip-embedded-frontmatter",
+        help=(
+            "strip the redundant embedded YAML frontmatter block from legacy "
+            "Influx note bodies whose doc-level metadata is already valid "
+            "(issue #225).  Distinct from rewrite-legacy-notes, which recovers "
+            "EMPTY doc-level metadata.  Default mode is read-only / audit; "
+            "--apply rewrites content via lithos_write."
+        ),
+    )
+    p_strip.add_argument(
+        "--apply",
+        action="store_true",
+        help=(
+            "actually strip the embedded block (default: dry-run / audit).  "
+            "Must be combined with --yes <doc-id>, --yes-to-all, or --id."
+        ),
+    )
+    p_strip.add_argument(
+        "--yes",
+        action="append",
+        metavar="DOC_ID",
+        help=(
+            "confirm strip of a specific doc (repeatable).  Required with "
+            "--apply unless --yes-to-all or --id is set."
+        ),
+    )
+    p_strip.add_argument(
+        "--yes-to-all",
+        action="store_true",
+        help="strip every candidate listed in the read-only plan.",
+    )
+    p_strip.add_argument(
+        "--id",
+        action="append",
+        metavar="DOC_ID",
+        help=(
+            "act on a known doc-id directly, bypassing the corpus scan "
+            "(repeatable).  Without --apply, reports a planned strip line; "
+            "with --apply, strips without an extra --yes."
+        ),
+    )
+    p_strip.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="cap the number of candidate docs processed (staged rollout).",
+    )
+    p_strip.add_argument(
+        "--lithos-url",
+        help="override LITHOS_URL from the env file.",
+    )
+    p_strip.set_defaults(func=cmd_strip_embedded_frontmatter)
 
     p_invalid = sub.add_parser(
         "invalid-source",

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -1816,9 +1816,7 @@ async def _process_one_embedded_frontmatter_doc(
         "note_type": str(
             doc.get("note_type") or metadata.get("note_type") or "summary"
         ),
-        "namespace": str(
-            doc.get("namespace") or metadata.get("namespace") or "influx"
-        ),
+        "namespace": str(doc.get("namespace") or metadata.get("namespace") or "influx"),
     }
     version = doc.get("version")
     if version is None:

--- a/tests/unit/test_diagnose_strip_embedded_frontmatter.py
+++ b/tests/unit/test_diagnose_strip_embedded_frontmatter.py
@@ -1,0 +1,499 @@
+"""Unit tests for ``./scripts/influx-diagnose.py strip-embedded-frontmatter``.
+
+The subcommand strips the redundant embedded YAML frontmatter block from
+the ~1,241 legacy Influx notes (created 2026-05-01 → 2026-05-24) whose
+doc-level metadata is already valid.  Unlike ``rewrite-legacy-notes``
+(#176), which recovers EMPTY metadata from the embedded block, this job
+leaves doc-level metadata untouched and rewrites only ``content`` so a
+cleaned note matches the current (post-05-24) shape exactly.
+
+See agent-lore/influx#225.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _load_script() -> Any:
+    """Load ``scripts/influx-diagnose.py`` as a module for direct testing."""
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "influx_diagnose",
+        repo_root / "scripts" / "influx-diagnose.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_DIAGNOSE = _load_script()
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+
+# read_note content shape for a #225 legacy note: Lithos has already
+# stripped the one ``# Title`` it prepended on save, so the body STARTS
+# with the redundant embedded frontmatter fence, then the renderer's
+# title heading, then the section body.
+LEGACY_READ_CONTENT = """---
+note_type: summary
+namespace: influx
+source_url: https://huggingface.co/blog/1b-sentence-embeddings
+tags:
+  - profile:knowledge-systems
+  - source:blog
+  - feed-slug:huggingface-blog
+  - ingested-by:influx
+  - schema:1
+confidence: 1.0
+---
+# Train a Sentence Embedding Model with 1B Training Pairs
+
+## Archive
+path: blog/2021/10/huggingface-blog-2021-10-25-8c9a1e482e.html
+
+## Summary
+### Contributions
+- Developed a sentence embedding model trained on 1 billion pairs
+
+## User Notes
+hand-written note, must survive byte-for-byte
+"""
+
+# What the cleaned content must look like — identical to a current,
+# post-05-24 note's read shape (title heading + sections, no fence).
+CLEANED_READ_CONTENT = """# Train a Sentence Embedding Model with 1B Training Pairs
+
+## Archive
+path: blog/2021/10/huggingface-blog-2021-10-25-8c9a1e482e.html
+
+## Summary
+### Contributions
+- Developed a sentence embedding model trained on 1 billion pairs
+
+## User Notes
+hand-written note, must survive byte-for-byte
+"""
+
+
+def _legacy_doc(doc_id: str = "legacy-225-id") -> dict[str, Any]:
+    """read_note envelope for a legacy note: valid metadata, bloated content."""
+    return {
+        "id": doc_id,
+        "title": "Train a Sentence Embedding Model with 1B Training Pairs",
+        "content": LEGACY_READ_CONTENT,
+        "path": None,
+        "source_url": "https://huggingface.co/blog/1b-sentence-embeddings",
+        "tags": [
+            "profile:knowledge-systems",
+            "source:blog",
+            "feed-slug:huggingface-blog",
+            "ingested-by:influx",
+            "schema:1",
+        ],
+        "confidence": 1.0,
+        "note_type": "summary",
+        "namespace": "influx",
+        "version": 2,
+        "author": "influx",
+        "metadata": {
+            "author": "influx",
+            "title": "Train a Sentence Embedding Model with 1B Training Pairs",
+            "source_url": "https://huggingface.co/blog/1b-sentence-embeddings",
+            "tags": [
+                "profile:knowledge-systems",
+                "source:blog",
+                "feed-slug:huggingface-blog",
+                "ingested-by:influx",
+                "schema:1",
+            ],
+            "confidence": 1.0,
+            "note_type": "summary",
+            "namespace": "influx",
+            "version": 2,
+        },
+    }
+
+
+def _clean_doc(doc_id: str = "clean-id") -> dict[str, Any]:
+    """A current-shape note: content starts with the title heading, no fence."""
+    return {
+        "id": doc_id,
+        "title": "Already Clean",
+        "content": "# Already Clean\n\n## Archive\nClean body.\n\n## User Notes\n",
+        "path": None,
+        "source_url": "https://example.com/clean",
+        "tags": ["profile:ai-foundations", "ingested-by:influx"],
+        "confidence": 1.0,
+        "note_type": "summary",
+        "namespace": "influx",
+        "version": 1,
+        "author": "influx",
+        "metadata": {"author": "influx", "version": 1},
+    }
+
+
+def _make_args(**overrides: Any) -> argparse.Namespace:
+    defaults: dict[str, Any] = {
+        "env": "staging",
+        "apply": False,
+        "yes": None,
+        "yes_to_all": False,
+        "id": None,
+        "limit": None,
+        "lithos_url": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _patch_runtime(client: MagicMock) -> Any:
+    """Context-manager bundle of patches every cmd test needs."""
+    return patch.multiple(
+        _DIAGNOSE,
+        _make_lithos_client=lambda url: client,
+        _load_env=lambda env: {},
+        _read_lithos_url=lambda args, env: "http://stub.lithos/sse",
+        _ensure_project_runtime_or_reexec=lambda: None,
+    )
+
+
+def _write_ok_result() -> MagicMock:
+    """A lithos_write response object decoding to ``status=updated``."""
+    result = MagicMock()
+    result.content = [MagicMock(text='{"status": "updated"}')]
+    return result
+
+
+# ── strip_embedded_frontmatter_block ────────────────────────────────
+
+
+class TestStripEmbeddedFrontmatterBlock:
+    """Pure content transform."""
+
+    def test_strips_block_to_current_shape(self) -> None:
+        assert (
+            _DIAGNOSE.strip_embedded_frontmatter_block(LEGACY_READ_CONTENT)
+            == CLEANED_READ_CONTENT
+        )
+
+    def test_returns_none_when_no_fence(self) -> None:
+        # Current-shape note: starts with the title heading, not a fence.
+        assert (
+            _DIAGNOSE.strip_embedded_frontmatter_block(
+                "# Title\n\n## Archive\nbody\n"
+            )
+            is None
+        )
+
+    def test_idempotent_on_cleaned_content(self) -> None:
+        # Re-running over an already-cleaned note is a no-op (returns None).
+        assert (
+            _DIAGNOSE.strip_embedded_frontmatter_block(CLEANED_READ_CONTENT)
+            is None
+        )
+
+    def test_preserves_user_notes_byte_for_byte(self) -> None:
+        out = _DIAGNOSE.strip_embedded_frontmatter_block(LEGACY_READ_CONTENT)
+        assert out is not None
+        assert out.endswith(
+            "## User Notes\nhand-written note, must survive byte-for-byte\n"
+        )
+
+    def test_line_anchored_not_fooled_by_dashes_in_value(self) -> None:
+        # A frontmatter VALUE containing ``---`` must not truncate the split;
+        # the closing fence is the line-anchored ``---``, not the substring.
+        content = (
+            "---\n"
+            "source_url: https://example.com/a---b\n"
+            "tags:\n"
+            "  - source:blog\n"
+            "---\n"
+            "# Title\n\n## Archive\nbody\n"
+        )
+        out = _DIAGNOSE.strip_embedded_frontmatter_block(content)
+        assert out == "# Title\n\n## Archive\nbody\n"
+
+
+# ── _select_embedded_frontmatter_doc_ids_from_corpus ────────────────
+
+
+def _write_note(
+    articles: Path,
+    rel: str,
+    *,
+    doc_id: str,
+    author: str,
+    body: str,
+) -> None:
+    """Write an on-disk note with an outer doc-level frontmatter block."""
+    path = articles / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    outer = f"---\nid: {doc_id}\nauthor: {author}\ntitle: A Title\n---\n"
+    path.write_text(outer + body, encoding="utf-8")
+
+
+# On disk, Lithos prepends its own title, so the legacy body carries the
+# title heading twice around the embedded fence.
+_LEGACY_DISK_BODY = (
+    "\n\n# A Title\n\n"
+    "---\n"
+    "note_type: summary\n"
+    "source_url: https://example.com/x\n"
+    "tags:\n  - source:blog\n"
+    "---\n"
+    "# A Title\n\n## Archive\nbody\n"
+)
+_CLEAN_DISK_BODY = "\n\n# A Title\n\n# A Title\n\n## Archive\nbody\n"
+
+
+class TestSelectEmbeddedFrontmatterDocIds:
+    def test_selects_influx_legacy_skips_clean_and_non_influx(
+        self, tmp_path: Path
+    ) -> None:
+        articles = tmp_path / "articles"
+        _write_note(
+            articles, "a.md", doc_id="legacy-1", author="influx",
+            body=_LEGACY_DISK_BODY,
+        )
+        _write_note(
+            articles, "b.md", doc_id="clean-1", author="influx",
+            body=_CLEAN_DISK_BODY,
+        )
+        _write_note(
+            articles, "c.md", doc_id="other-1", author="someone-else",
+            body=_LEGACY_DISK_BODY,
+        )
+        ids = _DIAGNOSE._select_embedded_frontmatter_doc_ids_from_corpus(articles)
+        assert ids == ["legacy-1"]
+
+    def test_missing_articles_dir_returns_empty(self, tmp_path: Path) -> None:
+        ids = _DIAGNOSE._select_embedded_frontmatter_doc_ids_from_corpus(
+            tmp_path / "does-not-exist"
+        )
+        assert ids == []
+
+    def test_deduplicates_repeated_ids(self, tmp_path: Path) -> None:
+        articles = tmp_path / "articles"
+        _write_note(
+            articles, "a.md", doc_id="dup", author="influx",
+            body=_LEGACY_DISK_BODY,
+        )
+        _write_note(
+            articles, "nested/a.md", doc_id="dup", author="influx",
+            body=_LEGACY_DISK_BODY,
+        )
+        ids = _DIAGNOSE._select_embedded_frontmatter_doc_ids_from_corpus(articles)
+        assert ids == ["dup"]
+
+
+# ── _process_one_embedded_frontmatter_doc ───────────────────────────
+
+
+class TestProcessOneEmbeddedFrontmatterDoc:
+    @pytest.mark.asyncio
+    async def test_dry_run_plans_strip(self) -> None:
+        client = MagicMock()
+        client.read_note = AsyncMock(return_value=_legacy_doc())
+        client.call_tool = AsyncMock()
+
+        outcome, _reason, plan = (
+            await _DIAGNOSE._process_one_embedded_frontmatter_doc(
+                client=client, doc_id="legacy-225-id", apply=False
+            )
+        )
+        assert outcome == _DIAGNOSE._EMBEDDED_FM_OUTCOME_PLANNED
+        assert plan is not None
+        assert plan["new_content_len"] < plan["old_content_len"]
+        client.call_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_apply_writes_cleaned_content_and_preserves_metadata(
+        self,
+    ) -> None:
+        client = MagicMock()
+        client.read_note = AsyncMock(return_value=_legacy_doc())
+        client.call_tool = AsyncMock(return_value=_write_ok_result())
+
+        outcome, _reason, _plan = (
+            await _DIAGNOSE._process_one_embedded_frontmatter_doc(
+                client=client, doc_id="legacy-225-id", apply=True
+            )
+        )
+        assert outcome == _DIAGNOSE._EMBEDDED_FM_OUTCOME_STRIPPED
+
+        client.call_tool.assert_awaited_once()
+        tool_name, write_args = client.call_tool.await_args.args
+        assert tool_name == "lithos_write"
+        # Content rewritten to the current shape — no embedded fence.
+        assert write_args["content"] == CLEANED_READ_CONTENT
+        assert "\n---\n" not in write_args["content"]
+        # Doc-level metadata preserved byte-for-byte.
+        assert write_args["source_url"] == (
+            "https://huggingface.co/blog/1b-sentence-embeddings"
+        )
+        assert write_args["tags"] == [
+            "profile:knowledge-systems",
+            "source:blog",
+            "feed-slug:huggingface-blog",
+            "ingested-by:influx",
+            "schema:1",
+        ]
+        assert write_args["confidence"] == 1.0
+        assert write_args["expected_version"] == 2
+
+    @pytest.mark.asyncio
+    async def test_skips_already_clean_note(self) -> None:
+        client = MagicMock()
+        client.read_note = AsyncMock(return_value=_clean_doc())
+        client.call_tool = AsyncMock()
+
+        outcome, _reason, plan = (
+            await _DIAGNOSE._process_one_embedded_frontmatter_doc(
+                client=client, doc_id="clean-id", apply=True
+            )
+        )
+        assert outcome == _DIAGNOSE._EMBEDDED_FM_OUTCOME_SKIPPED_ALREADY_CLEAN
+        assert plan is None
+        client.call_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_refuses_non_influx_authored(self) -> None:
+        doc = _legacy_doc()
+        doc["author"] = "someone-else"
+        doc["metadata"]["author"] = "someone-else"
+        client = MagicMock()
+        client.read_note = AsyncMock(return_value=doc)
+        client.call_tool = AsyncMock()
+
+        outcome, _reason, _plan = (
+            await _DIAGNOSE._process_one_embedded_frontmatter_doc(
+                client=client, doc_id="legacy-225-id", apply=True
+            )
+        )
+        assert outcome == _DIAGNOSE._EMBEDDED_FM_OUTCOME_REFUSED_NON_INFLUX
+        client.call_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_read_failure_is_reported(self) -> None:
+        client = MagicMock()
+        client.read_note = AsyncMock(side_effect=RuntimeError("boom"))
+        outcome, reason, _plan = (
+            await _DIAGNOSE._process_one_embedded_frontmatter_doc(
+                client=client, doc_id="legacy-225-id", apply=True
+            )
+        )
+        assert outcome == _DIAGNOSE._EMBEDDED_FM_OUTCOME_FAILED
+        assert "read failed" in reason
+
+    @pytest.mark.asyncio
+    async def test_unexpected_write_status_is_failure(self) -> None:
+        result = MagicMock()
+        result.content = [MagicMock(text='{"status": "rejected"}')]
+        client = MagicMock()
+        client.read_note = AsyncMock(return_value=_legacy_doc())
+        client.call_tool = AsyncMock(return_value=result)
+
+        outcome, reason, _plan = (
+            await _DIAGNOSE._process_one_embedded_frontmatter_doc(
+                client=client, doc_id="legacy-225-id", apply=True
+            )
+        )
+        assert outcome == _DIAGNOSE._EMBEDDED_FM_OUTCOME_FAILED
+        assert "rejected" in reason
+
+
+# ── cmd_strip_embedded_frontmatter ──────────────────────────────────
+
+
+class TestCmdStripEmbeddedFrontmatter:
+    def test_apply_without_confirmation_aborts(self) -> None:
+        with (
+            patch.object(_DIAGNOSE, "_load_env", lambda env: {}),
+            pytest.raises(SystemExit),
+        ):
+            _DIAGNOSE.cmd_strip_embedded_frontmatter(_make_args(apply=True))
+
+    def test_dry_run_audit_lists_and_counts(self, capsys: Any) -> None:
+        client = MagicMock()
+        client.read_note = AsyncMock(return_value=_legacy_doc())
+        client.call_tool = AsyncMock()
+        client.close = AsyncMock()
+
+        with _patch_runtime(client):
+            rc = _DIAGNOSE.cmd_strip_embedded_frontmatter(
+                _make_args(id=["legacy-225-id"])
+            )
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "would_strip" in out
+        assert "Summary:" in out
+        client.call_tool.assert_not_called()
+
+    def test_apply_with_id_strips_without_yes(self) -> None:
+        client = MagicMock()
+        client.read_note = AsyncMock(return_value=_legacy_doc())
+        client.call_tool = AsyncMock(return_value=_write_ok_result())
+        client.close = AsyncMock()
+
+        with _patch_runtime(client):
+            rc = _DIAGNOSE.cmd_strip_embedded_frontmatter(
+                _make_args(apply=True, id=["legacy-225-id"])
+            )
+        assert rc == 0
+        client.call_tool.assert_awaited_once()
+
+    def test_apply_yes_to_all_over_corpus_scan(self) -> None:
+        client = MagicMock()
+        client.read_note = AsyncMock(return_value=_legacy_doc())
+        client.call_tool = AsyncMock(return_value=_write_ok_result())
+        client.close = AsyncMock()
+
+        patches = patch.multiple(
+            _DIAGNOSE,
+            _make_lithos_client=lambda url: client,
+            _load_env=lambda env: {},
+            _read_lithos_url=lambda args, env: "http://stub.lithos/sse",
+            _ensure_project_runtime_or_reexec=lambda: None,
+            _resolve_corpus_articles_path=lambda env: Path("/unused"),
+            _select_embedded_frontmatter_doc_ids_from_corpus=(
+                lambda p: ["legacy-225-id"]
+            ),
+        )
+        with patches:
+            rc = _DIAGNOSE.cmd_strip_embedded_frontmatter(
+                _make_args(apply=True, yes_to_all=True)
+            )
+        assert rc == 0
+        client.call_tool.assert_awaited_once()
+
+    def test_limit_caps_candidate_set(self) -> None:
+        client = MagicMock()
+        client.read_note = AsyncMock(return_value=_legacy_doc())
+        client.call_tool = AsyncMock()
+        client.close = AsyncMock()
+
+        patches = patch.multiple(
+            _DIAGNOSE,
+            _make_lithos_client=lambda url: client,
+            _load_env=lambda env: {},
+            _read_lithos_url=lambda args, env: "http://stub.lithos/sse",
+            _ensure_project_runtime_or_reexec=lambda: None,
+            _resolve_corpus_articles_path=lambda env: Path("/unused"),
+            _select_embedded_frontmatter_doc_ids_from_corpus=(
+                lambda p: ["a", "b", "c", "d"]
+            ),
+        )
+        with patches:
+            _DIAGNOSE.cmd_strip_embedded_frontmatter(_make_args(limit=2))
+        # Only the first two candidates are read.
+        assert client.read_note.await_count == 2

--- a/tests/unit/test_diagnose_strip_embedded_frontmatter.py
+++ b/tests/unit/test_diagnose_strip_embedded_frontmatter.py
@@ -189,18 +189,13 @@ class TestStripEmbeddedFrontmatterBlock:
     def test_returns_none_when_no_fence(self) -> None:
         # Current-shape note: starts with the title heading, not a fence.
         assert (
-            _DIAGNOSE.strip_embedded_frontmatter_block(
-                "# Title\n\n## Archive\nbody\n"
-            )
+            _DIAGNOSE.strip_embedded_frontmatter_block("# Title\n\n## Archive\nbody\n")
             is None
         )
 
     def test_idempotent_on_cleaned_content(self) -> None:
         # Re-running over an already-cleaned note is a no-op (returns None).
-        assert (
-            _DIAGNOSE.strip_embedded_frontmatter_block(CLEANED_READ_CONTENT)
-            is None
-        )
+        assert _DIAGNOSE.strip_embedded_frontmatter_block(CLEANED_READ_CONTENT) is None
 
     def test_preserves_user_notes_byte_for_byte(self) -> None:
         out = _DIAGNOSE.strip_embedded_frontmatter_block(LEGACY_READ_CONTENT)
@@ -262,15 +257,24 @@ class TestSelectEmbeddedFrontmatterDocIds:
     ) -> None:
         articles = tmp_path / "articles"
         _write_note(
-            articles, "a.md", doc_id="legacy-1", author="influx",
+            articles,
+            "a.md",
+            doc_id="legacy-1",
+            author="influx",
             body=_LEGACY_DISK_BODY,
         )
         _write_note(
-            articles, "b.md", doc_id="clean-1", author="influx",
+            articles,
+            "b.md",
+            doc_id="clean-1",
+            author="influx",
             body=_CLEAN_DISK_BODY,
         )
         _write_note(
-            articles, "c.md", doc_id="other-1", author="someone-else",
+            articles,
+            "c.md",
+            doc_id="other-1",
+            author="someone-else",
             body=_LEGACY_DISK_BODY,
         )
         ids = _DIAGNOSE._select_embedded_frontmatter_doc_ids_from_corpus(articles)
@@ -285,11 +289,17 @@ class TestSelectEmbeddedFrontmatterDocIds:
     def test_deduplicates_repeated_ids(self, tmp_path: Path) -> None:
         articles = tmp_path / "articles"
         _write_note(
-            articles, "a.md", doc_id="dup", author="influx",
+            articles,
+            "a.md",
+            doc_id="dup",
+            author="influx",
             body=_LEGACY_DISK_BODY,
         )
         _write_note(
-            articles, "nested/a.md", doc_id="dup", author="influx",
+            articles,
+            "nested/a.md",
+            doc_id="dup",
+            author="influx",
             body=_LEGACY_DISK_BODY,
         )
         ids = _DIAGNOSE._select_embedded_frontmatter_doc_ids_from_corpus(articles)
@@ -306,10 +316,8 @@ class TestProcessOneEmbeddedFrontmatterDoc:
         client.read_note = AsyncMock(return_value=_legacy_doc())
         client.call_tool = AsyncMock()
 
-        outcome, _reason, plan = (
-            await _DIAGNOSE._process_one_embedded_frontmatter_doc(
-                client=client, doc_id="legacy-225-id", apply=False
-            )
+        outcome, _reason, plan = await _DIAGNOSE._process_one_embedded_frontmatter_doc(
+            client=client, doc_id="legacy-225-id", apply=False
         )
         assert outcome == _DIAGNOSE._EMBEDDED_FM_OUTCOME_PLANNED
         assert plan is not None
@@ -324,10 +332,8 @@ class TestProcessOneEmbeddedFrontmatterDoc:
         client.read_note = AsyncMock(return_value=_legacy_doc())
         client.call_tool = AsyncMock(return_value=_write_ok_result())
 
-        outcome, _reason, _plan = (
-            await _DIAGNOSE._process_one_embedded_frontmatter_doc(
-                client=client, doc_id="legacy-225-id", apply=True
-            )
+        outcome, _reason, _plan = await _DIAGNOSE._process_one_embedded_frontmatter_doc(
+            client=client, doc_id="legacy-225-id", apply=True
         )
         assert outcome == _DIAGNOSE._EMBEDDED_FM_OUTCOME_STRIPPED
 
@@ -357,10 +363,8 @@ class TestProcessOneEmbeddedFrontmatterDoc:
         client.read_note = AsyncMock(return_value=_clean_doc())
         client.call_tool = AsyncMock()
 
-        outcome, _reason, plan = (
-            await _DIAGNOSE._process_one_embedded_frontmatter_doc(
-                client=client, doc_id="clean-id", apply=True
-            )
+        outcome, _reason, plan = await _DIAGNOSE._process_one_embedded_frontmatter_doc(
+            client=client, doc_id="clean-id", apply=True
         )
         assert outcome == _DIAGNOSE._EMBEDDED_FM_OUTCOME_SKIPPED_ALREADY_CLEAN
         assert plan is None
@@ -375,10 +379,8 @@ class TestProcessOneEmbeddedFrontmatterDoc:
         client.read_note = AsyncMock(return_value=doc)
         client.call_tool = AsyncMock()
 
-        outcome, _reason, _plan = (
-            await _DIAGNOSE._process_one_embedded_frontmatter_doc(
-                client=client, doc_id="legacy-225-id", apply=True
-            )
+        outcome, _reason, _plan = await _DIAGNOSE._process_one_embedded_frontmatter_doc(
+            client=client, doc_id="legacy-225-id", apply=True
         )
         assert outcome == _DIAGNOSE._EMBEDDED_FM_OUTCOME_REFUSED_NON_INFLUX
         client.call_tool.assert_not_called()
@@ -387,10 +389,8 @@ class TestProcessOneEmbeddedFrontmatterDoc:
     async def test_read_failure_is_reported(self) -> None:
         client = MagicMock()
         client.read_note = AsyncMock(side_effect=RuntimeError("boom"))
-        outcome, reason, _plan = (
-            await _DIAGNOSE._process_one_embedded_frontmatter_doc(
-                client=client, doc_id="legacy-225-id", apply=True
-            )
+        outcome, reason, _plan = await _DIAGNOSE._process_one_embedded_frontmatter_doc(
+            client=client, doc_id="legacy-225-id", apply=True
         )
         assert outcome == _DIAGNOSE._EMBEDDED_FM_OUTCOME_FAILED
         assert "read failed" in reason
@@ -403,10 +403,8 @@ class TestProcessOneEmbeddedFrontmatterDoc:
         client.read_note = AsyncMock(return_value=_legacy_doc())
         client.call_tool = AsyncMock(return_value=result)
 
-        outcome, reason, _plan = (
-            await _DIAGNOSE._process_one_embedded_frontmatter_doc(
-                client=client, doc_id="legacy-225-id", apply=True
-            )
+        outcome, reason, _plan = await _DIAGNOSE._process_one_embedded_frontmatter_doc(
+            client=client, doc_id="legacy-225-id", apply=True
         )
         assert outcome == _DIAGNOSE._EMBEDDED_FM_OUTCOME_FAILED
         assert "rejected" in reason


### PR DESCRIPTION
## Summary

Adds the `influx-diagnose strip-embedded-frontmatter` subcommand to resolve #225 — a one-shot cleanup of the ~1,241 legacy Influx notes (created 2026-05-01 → 2026-05-24) whose content body embeds a redundant `---`-fenced YAML block duplicating the doc-level metadata. The writer stopped emitting this shape after ~2026-05-24, so the population is fixed.

This is **distinct from `rewrite-legacy-notes` (#176)**: those notes have *empty* doc-level metadata recovered *from* the embedded block. The #225 notes have *valid* doc-level metadata — the embedded block is pure content bloat. The new job leaves doc-level metadata untouched and rewrites **only `content`**, so a cleaned note matches the current (post-05-24) shape exactly.

## How it works

- **`strip_embedded_frontmatter_block`** — strips the leading embedded fence from the `read_note` content (after Lithos has stripped the one `# Title` it prepends on save, the legacy body *starts* with the fence). Delegates to the line-anchored `notes._split_frontmatter`, so a `---` inside a YAML value can't fool it. Preserves the renderer title heading and every `## ` section (`## Archive`, `## Summary`, `## User Notes`, …) byte-for-byte. Returns `None` for already-clean content → idempotent.
- **`_select_embedded_frontmatter_doc_ids_from_corpus`** — enumerates candidates from the on-disk `articles/` subtree, mirroring Lithos's read-path title strip; the per-doc `read_note` check is authoritative.
- **Content-only write** mirrors `influx.repair`'s proven envelope contract: every doc-level field is read back unchanged, only `content` differs.
- **Safety**: dry-run / audit by default; `--apply` requires `--yes <id>`, `--yes-to-all`, or `--id <id>`. `--limit` supports a staged rollout.

## Acceptance criteria (all verified on staging)

- [x] Read-only audit lists every Influx-authored note with an embedded block + a count (**1018** candidates on staging, zero false positives)
- [x] Apply removes the embedded block, preserving every `## ` section, the title heading(s), and all doc-level metadata
- [x] Result matches the current post-05-24 shape — confirmed on disk (`# Title` ×2 + sections, no fence) and via `read_note`
- [x] Idempotent — re-running an applied doc reports `skipped_already_clean`
- [x] Dry-run by default; apply requires explicit confirmation
- [x] Notes without the embedded shape are left untouched
- [x] The duplicate `# Title` heading (the by-design #222 behavior) is **not** changed

## Live verification

```
$ influx-diagnose strip-embedded-frontmatter            # audit
Summary: would_strip=1018

$ influx-diagnose strip-embedded-frontmatter --apply --id 4889eea7-…
stripped  write status=updated  content_bytes=950→677
# re-read: content now starts with "# Title\n\n## Archive…", source_url/tags/confidence preserved
$ influx-diagnose strip-embedded-frontmatter --apply --id 4889eea7-…   # re-run
skipped_already_clean
```

## Test plan

- [x] `tests/unit/test_diagnose_strip_embedded_frontmatter.py` — 19 tests: pure transform (incl. line-anchored / dashes-in-value, idempotency, User Notes preservation), corpus selector (legacy vs clean vs non-influx, dedup, missing dir), per-doc processor (dry-run, apply preserves metadata, skip-clean, refuse-non-influx, read/write failures), and the command (confirmation gate, audit, `--id`, `--yes-to-all`, `--limit`)
- [x] `ruff check` + `pyright` clean
- [x] No regression in `test_diagnose_rewrite_legacy_notes.py`

## Rollout note

Staging is the only Influx corpus (no production deployment exists). It has been fully cleaned — see the update below.

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update — staging fully cleaned.** Ran `--apply --yes-to-all` over staging: **1018/1018 notes stripped, 0 failures**. Re-audit reports **0 candidates remaining**. An independent on-disk scan flagged 3 notes containing a `---` line, but all 3 are legitimate mid-body content (thematic breaks after a table; an article quoting a `.md` file's frontmatter) — the leading-fence selector correctly leaves them untouched. Staging is the only Influx corpus (no production deployment), so this completes the #225 cleanup end-to-end.
