### PR TITLE
fix: classify archive 429-with-HTML as http_429, not content_type_mismatch (#227)

### DIFF
--- a/src/influx/http_client.py
+++ b/src/influx/http_client.py
@@ -283,7 +283,14 @@ def guarded_fetch(
             reason=str(exc),
         ) from exc
 
-    if expected_content_type is not None:
+    # The content-type guard is a success-path (2xx/3xx) validation only.
+    # On a non-2xx response the status code is the real signal: an error
+    # body's content-type is meaningless (arXiv serves its HTTP 429
+    # rate-limit page as text/html even when a PDF was requested).
+    # Checking it here would mask the status as a content_type_mismatch
+    # and lose the rate-limit signal — so we skip the check and return
+    # the FetchResult for the caller's status handling (#227).
+    if expected_content_type is not None and status_code < 400:
         _check_content_type(content_type, expected_content_type, final_url)
 
     return FetchResult(

--- a/src/influx/http_client.py
+++ b/src/influx/http_client.py
@@ -283,13 +283,14 @@ def guarded_fetch(
             reason=str(exc),
         ) from exc
 
-    # The content-type guard is a success-path (2xx/3xx) validation only.
-    # On a non-2xx response the status code is the real signal: an error
-    # body's content-type is meaningless (arXiv serves its HTTP 429
-    # rate-limit page as text/html even when a PDF was requested).
-    # Checking it here would mask the status as a content_type_mismatch
-    # and lose the rate-limit signal — so we skip the check and return
-    # the FetchResult for the caller's status handling (#227).
+    # The content-type guard only runs on a non-error response
+    # (status < 400).  On an HTTP error (>= 400) the status code is the
+    # real signal: an error body's content-type is meaningless (arXiv
+    # serves its HTTP 429 rate-limit page as text/html even when a PDF
+    # was requested).  Checking it here would mask the status as a
+    # content_type_mismatch and lose the rate-limit signal — so we skip
+    # the check and return the FetchResult for the caller's status
+    # handling (#227).
     if expected_content_type is not None and status_code < 400:
         _check_content_type(content_type, expected_content_type, final_url)
 

--- a/tests/unit/test_archive_download.py
+++ b/tests/unit/test_archive_download.py
@@ -495,3 +495,42 @@ class TestDownloadArchiveAutodetect:
         ):
             _autodetect(tmp_path, item_id="../../etc/passwd")
         mock_fetch.assert_not_called()
+
+
+class TestArchive429HtmlEndToEnd:
+    """End-to-end via the real guarded_fetch: a 429 PDF request that
+    arXiv answers with an HTML rate-limit page must classify as
+    ``http_429`` (or ``rate_limited`` under policy), NOT
+    ``content_type_mismatch`` (#227).
+    """
+
+    def _fake_getaddrinfo(self, ip: str = "93.184.216.34"):
+        import socket
+
+        def _gai(host: str, *args: object, **kwargs: object):
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0))]
+
+        return _gai
+
+    def test_arxiv_429_html_pdf_classifies_http_429(self, tmp_path: Path) -> None:
+        import httpx
+        import respx
+
+        with respx.mock:
+            respx.get(_URL).mock(
+                return_value=httpx.Response(
+                    429,
+                    content=b"<html><body>rate exceeded</body></html>",
+                    headers={"content-type": "text/html"},
+                )
+            )
+            with patch(
+                "influx.http_client.socket.getaddrinfo",
+                self._fake_getaddrinfo(),
+            ):
+                result = _dl(tmp_path)
+
+        assert result.ok is False
+        assert result.failure_kind == "http_429"
+        # No archive file is written for a rate-limited response.
+        assert not any(tmp_path.rglob("*.pdf"))

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -413,14 +413,15 @@ class TestContentTypeFamilyMismatch:
 
 
 class TestContentTypeCheckIsSuccessPathOnly:
-    """The content-type guard is a 2xx success-path validation (#227).
+    """The content-type guard only runs on non-error responses (#227).
 
-    A non-2xx response (notably arXiv's HTTP 429 rate-limit page, which
-    is served as ``text/html`` even when a PDF was requested) must NOT
-    be reported as ``content_type_mismatch`` — the status code is the
-    real signal.  ``guarded_fetch`` returns the ``FetchResult`` so the
-    caller's status handling (e.g. ``download_archive``) can classify it
-    as ``http_429`` / ``rate_limited``.
+    On an HTTP error (status >= 400) — notably arXiv's HTTP 429
+    rate-limit page, served as ``text/html`` even when a PDF was
+    requested — the content-type must NOT be reported as
+    ``content_type_mismatch``; the status code is the real signal.
+    ``guarded_fetch`` returns the ``FetchResult`` so the caller's status
+    handling (e.g. ``download_archive``) can classify it as ``http_429``
+    / ``rate_limited``.
     """
 
     @respx.mock

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -412,6 +412,70 @@ class TestContentTypeFamilyMismatch:
             assert err.kind == "content_type_mismatch"
 
 
+class TestContentTypeCheckIsSuccessPathOnly:
+    """The content-type guard is a 2xx success-path validation (#227).
+
+    A non-2xx response (notably arXiv's HTTP 429 rate-limit page, which
+    is served as ``text/html`` even when a PDF was requested) must NOT
+    be reported as ``content_type_mismatch`` — the status code is the
+    real signal.  ``guarded_fetch`` returns the ``FetchResult`` so the
+    caller's status handling (e.g. ``download_archive``) can classify it
+    as ``http_429`` / ``rate_limited``.
+    """
+
+    @respx.mock
+    def test_expected_pdf_got_429_html_returns_result(self) -> None:
+        url = "http://export.arxiv.org/pdf/2605.10310.pdf"
+        respx.get(url).mock(
+            return_value=httpx.Response(
+                429,
+                content=b"<html>rate exceeded</html>",
+                headers={"content-type": "text/html"},
+            ),
+        )
+        fake = _fake_getaddrinfo("93.184.216.34")
+        with patch(_PATCH_GAI, fake):
+            result = guarded_fetch(url, expected_content_type="pdf")
+        assert isinstance(result, FetchResult)
+        assert result.status_code == 429
+        assert "text/html" in result.content_type
+
+    @respx.mock
+    def test_expected_pdf_got_503_html_returns_result(self) -> None:
+        url = "http://example.com/file.pdf"
+        respx.get(url).mock(
+            return_value=httpx.Response(
+                503,
+                content=b"<html>unavailable</html>",
+                headers={"content-type": "text/html"},
+            ),
+        )
+        fake = _fake_getaddrinfo("93.184.216.34")
+        with patch(_PATCH_GAI, fake):
+            result = guarded_fetch(url, expected_content_type="pdf")
+        assert result.status_code == 503
+
+    @respx.mock
+    def test_2xx_wrong_content_type_still_raises(self) -> None:
+        # Regression guard: a 200 with the wrong content-type must still
+        # raise content_type_mismatch — the success-path check is intact.
+        url = "http://example.com/file.pdf"
+        respx.get(url).mock(
+            return_value=httpx.Response(
+                200,
+                content=b"<html>",
+                headers={"content-type": "text/html"},
+            ),
+        )
+        fake = _fake_getaddrinfo("93.184.216.34")
+        with (
+            patch(_PATCH_GAI, fake),
+            pytest.raises(NetworkError) as exc_info,
+        ):
+            guarded_fetch(url, expected_content_type="pdf")
+        assert exc_info.value.kind == "content_type_mismatch"
+
+
 # ── Redirect re-validation (US-005) ──────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Fixes #227 — when arXiv answers a PDF archive request with an **HTTP 429 rate-limit page** (served as `text/html`), `guarded_fetch` misclassified it as `content_type_mismatch` and lost the 429 signal.

## Root cause

`guarded_fetch` (`http_client.py`) ran the content-type guard **unconditionally** after reading the body, before the status code was surfaced:

```python
status_code = response.status_code          # 429, captured but never checked
if expected_content_type is not None:
    _check_content_type(...)                # raises content_type_mismatch
return FetchResult(...)                     # unreachable on a 429-HTML response
```

`download_archive` already has correct status handling (`if result.status_code >= 400: ... "HTTP {code}"` at `storage.py:369`, which `classify_failure_kind` maps to `http_429`/`rate_limited`) — but it was **unreachable** because `guarded_fetch` raised first.

## Fix

The content-type guard is a **success-path validation** — an error body's content-type is meaningless. Gate it on `status_code < 400`. On a non-2xx response, `guarded_fetch` returns the `FetchResult` so the caller's existing status handling classifies it. One line of behavior, fully aligned with what the `download_archive` policy tests already assume.

```python
if expected_content_type is not None and status_code < 400:
    _check_content_type(content_type, expected_content_type, final_url)
```

## Impact

- arXiv 429s now classify as `http_429` / `rate_limited` → the `influx:archive-rate-limited` tag and rate-limit policy apply again.
- The repair sweep no longer re-hammers arXiv on a misclassified `content_type_mismatch`.
- The `expected_content_type=None` autodetect path is untouched.

## Acceptance criteria

- [x] `guarded_fetch(expected_content_type="pdf")` on a 429-HTML response returns `FetchResult(status_code=429)`, no raise
- [x] `download_archive` on that response → `failure_kind="http_429"` (end-to-end test, real `guarded_fetch`)
- [x] 2xx with mismatched content-type still raises `content_type_mismatch` (regression guard)
- [x] autodetect path unchanged

## Test plan

- [x] `test_http_client.py::TestContentTypeCheckIsSuccessPathOnly` — 429-HTML and 503-HTML PDF requests return the result; 2xx wrong-type still raises
- [x] `test_archive_download.py::TestArchive429HtmlEndToEnd` — respx-mocked 429-HTML through the real `guarded_fetch` → `http_429`, no file written
- [x] Full suite: **2544 passed**; ruff + pyright clean

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)
