### PR TITLE
feat: dedicated arXiv API discovery timeout, separate from PDF downloads (#229)

### DIFF
--- a/src/influx/config.py
+++ b/src/influx/config.py
@@ -679,6 +679,16 @@ class ResilienceConfig(BaseModel):
     rss_timeout_cooldown_threshold: int = 3
     rss_timeout_cooldown_seconds: int = 1800
     lithos_write_conflict_max_retries: int = 1
+    # Issue #165 follow-up: dedicated timeout for the arXiv API
+    # *discovery* fetch (``export.arxiv.org/api/query``), independent of
+    # ``storage.download_timeout_seconds`` which governs PDF/archive
+    # downloads.  The arXiv query endpoint is materially slower than a
+    # CDN PDF fetch and was the dominant driver of ``source_acquisition``
+    # timeout degradations at the shared 30s value.  A longer, separate
+    # timeout lets a slow-but-responsive query complete instead of
+    # exhausting the retry budget on read timeouts, without making PDF
+    # downloads wait as long.  Applies to connect+read+write+pool.
+    arxiv_api_timeout_seconds: int = 60
 
     @field_validator(
         "max_retries",
@@ -699,6 +709,15 @@ class ResilienceConfig(BaseModel):
             raise ConfigError(
                 "resilience.* retry and backoff fields must be non-negative"
             )
+        return v
+
+    @field_validator("arxiv_api_timeout_seconds")
+    @classmethod
+    def _positive_timeout(cls, v: int) -> int:
+        # A zero/negative read timeout would make every arXiv discovery
+        # fetch fail instantly — require a real, positive value.
+        if v <= 0:
+            raise ConfigError("resilience.arxiv_api_timeout_seconds must be positive")
         return v
 
 

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -760,8 +760,11 @@ def fetch_arxiv(
         place this tunable lives is config-parsing code (AC-X-1).
     timeout_seconds:
         Connect + read timeout in seconds for the underlying
-        ``guarded_fetch``.  ``None`` resolves to the
-        :class:`~influx.config.StorageConfig` field default (AC-X-1).
+        ``guarded_fetch``.  ``None`` resolves to
+        ``resilience.arxiv_api_timeout_seconds`` — the arXiv query
+        endpoint is slower than a PDF download, so it has a dedicated
+        timeout independent of ``storage.download_timeout_seconds``
+        (#165 follow-up).
 
     Returns
     -------
@@ -816,9 +819,11 @@ def _fetch_with_retry(
     """Fetch *url* with 429 backoff and exponential retry (FR-RES-1/2).
 
     ``max_download_bytes`` and ``timeout_seconds`` default to ``None``;
-    when omitted they are resolved from the pydantic
-    :class:`~influx.config.StorageConfig` field defaults so the only
-    place these tunable defaults live is config-parsing code (AC-X-1).
+    when omitted, ``max_download_bytes`` resolves to the
+    :class:`~influx.config.StorageConfig` default and ``timeout_seconds``
+    to ``resilience.arxiv_api_timeout_seconds`` — the arXiv query
+    endpoint has a dedicated timeout, separate from PDF downloads
+    (#165 follow-up).
 
     Issue #129 hardening:
 
@@ -837,12 +842,13 @@ def _fetch_with_retry(
       so the run ledger surfaces "we hit 429 N times but recovered"
       distinct from the swallowed-error list.
     """
-    if max_download_bytes is None or timeout_seconds is None:
-        _storage_defaults = StorageConfig()
-        if max_download_bytes is None:
-            max_download_bytes = _storage_defaults.max_download_bytes
-        if timeout_seconds is None:
-            timeout_seconds = _storage_defaults.download_timeout_seconds
+    if max_download_bytes is None:
+        max_download_bytes = StorageConfig().max_download_bytes
+    if timeout_seconds is None:
+        # The discovery fetch defaults to the arXiv-API timeout, not the
+        # shared storage download timeout — the query endpoint is slower
+        # than a PDF download (#165 follow-up).
+        timeout_seconds = resilience.arxiv_api_timeout_seconds
 
     max_retries = resilience.max_retries
     backoff_base = resilience.backoff_base_seconds
@@ -1613,7 +1619,7 @@ async def _fetch_arxiv_items(
             resilience=config.resilience,
             backfill_range=backfill_range,
             max_download_bytes=config.storage.max_download_bytes,
-            timeout_seconds=config.storage.download_timeout_seconds,
+            timeout_seconds=config.resilience.arxiv_api_timeout_seconds,
         )
 
     n_categories = max(len(arxiv_cfg.categories), 1)
@@ -1652,7 +1658,7 @@ async def _fetch_arxiv_items(
                 resilience=config.resilience,
                 backfill_range=day_range,
                 max_download_bytes=config.storage.max_download_bytes,
-                timeout_seconds=config.storage.download_timeout_seconds,
+                timeout_seconds=config.resilience.arxiv_api_timeout_seconds,
             )
         except NetworkError:
             _log.warning(

--- a/tests/unit/test_arxiv_fetcher.py
+++ b/tests/unit/test_arxiv_fetcher.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 from influx.config import ArxivSourceConfig, ResilienceConfig
-from influx.errors import NetworkError
+from influx.errors import ConfigError, NetworkError
 from influx.http_client import FetchResult
 from influx.sources.arxiv import (
     ArxivItem,
@@ -537,6 +537,43 @@ class TestFetchRetry:
             )
         assert mock_fetch.call_count == 1
         mock_sleep.assert_not_called()
+
+    def test_arxiv_api_timeout_default_is_60(self) -> None:
+        assert ResilienceConfig().arxiv_api_timeout_seconds == 60
+
+    def test_arxiv_api_timeout_must_be_positive(self) -> None:
+        for bad in (0, -1):
+            with pytest.raises(ConfigError, match="arxiv_api_timeout_seconds"):
+                ResilienceConfig(arxiv_api_timeout_seconds=bad)
+
+    @patch("influx.sources.arxiv.guarded_fetch")
+    def test_timeout_defaults_to_arxiv_api_timeout(self, mock_fetch: MagicMock) -> None:
+        """The discovery fetch uses resilience.arxiv_api_timeout_seconds
+        when no explicit timeout_seconds is passed (#165 follow-up) —
+        NOT the shared storage download timeout."""
+        mock_fetch.return_value = _make_fetch_result(_load_fixture("empty_feed.atom"))
+        resilience = ResilienceConfig(arxiv_api_timeout_seconds=90)
+        fetch_arxiv(
+            arxiv_config=ArxivSourceConfig(categories=["cs.AI"]),
+            resilience=resilience,
+        )
+        _, kwargs = mock_fetch.call_args
+        assert kwargs["timeout_seconds"] == 90
+
+    @patch("influx.sources.arxiv.guarded_fetch")
+    def test_explicit_timeout_seconds_overrides_default(
+        self, mock_fetch: MagicMock
+    ) -> None:
+        """An explicit timeout_seconds still wins over the resilience
+        default (the per-day backfill path passes one explicitly)."""
+        mock_fetch.return_value = _make_fetch_result(_load_fixture("empty_feed.atom"))
+        fetch_arxiv(
+            arxiv_config=ArxivSourceConfig(categories=["cs.AI"]),
+            resilience=ResilienceConfig(arxiv_api_timeout_seconds=90),
+            timeout_seconds=15,
+        )
+        _, kwargs = mock_fetch.call_args
+        assert kwargs["timeout_seconds"] == 15
 
     @patch("influx.sources.arxiv.guarded_fetch")
     def test_content_type_not_passed_to_guarded_fetch(


### PR DESCRIPTION
## Summary

Adds a dedicated, config-driven timeout for the **arXiv API discovery fetch** (`export.arxiv.org/api/query`), independent of `storage.download_timeout_seconds`. Closes #229.

## Why

`guarded_fetch` served both the arXiv API *query* (paper discovery) and *PDF/archive downloads* under a single timeout (`storage.download_timeout_seconds`, 30s). The arXiv query endpoint is materially slower than a CDN PDF fetch, and its read-timeouts were the **dominant driver of `source_acquisition` degradations** in the promotion-gate window (~8 of the last 20 scheduled runs). One exhausted query timeout flags the whole run `expected_lossy`, pushing the gate's lossy ratio over its 0.5 cap. Bumping the shared timeout would also slow every PDF download — hence a separate knob.

## Change

- **`[resilience] arxiv_api_timeout_seconds`** — default **60s**, validated positive (a 0/negative read timeout would make every discovery fetch fail instantly).
- The arXiv discovery path uses it: `fetch_arxiv` → `_fetch_with_retry` default, and both `_fetch_arxiv_items` call sites (main + per-day backfill). PDF/archive downloads keep `storage.download_timeout_seconds`.
- An explicit `timeout_seconds` still overrides (the per-day backfill path passes one).

## Acceptance criteria

- [x] `resilience.arxiv_api_timeout_seconds` exists, defaults to 60, rejects `<= 0`
- [x] Discovery `guarded_fetch` receives the new timeout (not the storage timeout) when no explicit value is passed
- [x] Explicit `timeout_seconds` still overrides
- [x] PDF/archive downloads unaffected (still `storage.download_timeout_seconds`)

## Test plan

- [x] `test_arxiv_fetcher.py`: `test_arxiv_api_timeout_default_is_60`, `test_arxiv_api_timeout_must_be_positive`, `test_timeout_defaults_to_arxiv_api_timeout`, `test_explicit_timeout_seconds_overrides_default`
- [x] Full suite: **2567 passed**; `make lint` (incl. `ruff format --check`) + `make typecheck` clean

## Deployment note

Staging + prod `influx.toml` set `arxiv_api_timeout_seconds = 90` (extra headroom over the 30s that was timing out). Config lives outside this repo; values applied on the staging/prod hosts. Takes effect on the next staging restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
