### PR TITLE
fix: normalise Lithos connection failures to LithosError (#231)

### DIFF
--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -654,9 +654,29 @@ class LithosClient:
                 self._session = session
                 logger.info("Lithos SSE connection established to %s", self._url)
                 return session
-            except Exception:
+            except (LithosError, LCMAError, McpError):
+                # Already-typed errors propagate unchanged.  An McpError
+                # raised during agent-register is normalised to LCMAError
+                # downstream by _call_lcma_tool.
                 await stack.aclose()
                 raise
+            except Exception as exc:
+                # A transport/connection failure (httpx.ConnectError, OSError,
+                # or the anyio TaskGroup's ExceptionGroup wrapping them when
+                # Lithos is unreachable) would otherwise leak raw to callers.
+                # The fire-and-forget inbox tick catches (LithosError,
+                # LCMAError) but not a bare ExceptionGroup, so the exception
+                # escaped as an unretrieved task error (#231).  Normalise it
+                # to a LithosError so every caller handles "Lithos
+                # unreachable" through one typed path.  ``except Exception``
+                # (not BaseException) lets CancelledError / KeyboardInterrupt
+                # propagate untouched.
+                await stack.aclose()
+                raise LithosError(
+                    "connection_failed",
+                    operation="connect",
+                    detail=f"could not connect to Lithos at {self._url}: {exc!r}",
+                ) from exc
 
     async def reconnect(self) -> None:
         """Drop the current SSE connection and re-establish it.

--- a/tests/unit/test_lithos_client.py
+++ b/tests/unit/test_lithos_client.py
@@ -663,3 +663,73 @@ class TestReadNoteEnvelopeNormalisation:
         note["tags"].append("mutated")
 
         assert note["metadata"]["tags"] == ["source:rss"]
+
+
+class TestEnsureConnectedNormalisesConnectionErrors:
+    """A transport/connection failure is normalised to LithosError (#231).
+
+    When Lithos is unreachable the SSE TaskGroup raises an
+    ``ExceptionGroup`` wrapping a connect error.  Left raw, it escaped
+    the fire-and-forget inbox tick (which catches ``LithosError`` /
+    ``LCMAError``) as an unretrieved task exception.  ``_ensure_connected``
+    now wraps it so every caller has one typed failure path.
+    """
+
+    @staticmethod
+    def _boom_cm(exc: BaseException):
+        class _CM:
+            async def __aenter__(self) -> object:
+                raise exc
+
+            async def __aexit__(self, *_a: object) -> bool:
+                return False
+
+        return lambda _url: _CM()
+
+    async def test_exception_group_connect_error_wrapped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = LithosClient(url="http://localhost:1234/sse")
+        eg = ExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [ConnectionError("All connection attempts failed")],
+        )
+        monkeypatch.setattr("influx.lithos_client.sse_client", self._boom_cm(eg))
+        with pytest.raises(LithosError) as ei:
+            await client._ensure_connected()
+        assert ei.value.operation == "connect"
+        assert "could not connect to Lithos" in ei.value.detail
+
+    async def test_bare_connection_error_wrapped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = LithosClient(url="http://localhost:1234/sse")
+        monkeypatch.setattr(
+            "influx.lithos_client.sse_client",
+            self._boom_cm(ConnectionError("connection refused")),
+        )
+        with pytest.raises(LithosError):
+            await client._ensure_connected()
+
+    async def test_already_typed_lithos_error_not_rewrapped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = LithosClient(url="http://localhost:1234/sse")
+        sentinel = LithosError("already_typed", operation="prior")
+        monkeypatch.setattr("influx.lithos_client.sse_client", self._boom_cm(sentinel))
+        with pytest.raises(LithosError) as ei:
+            await client._ensure_connected()
+        assert ei.value is sentinel
+
+    async def test_cancelled_error_propagates(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import asyncio
+
+        client = LithosClient(url="http://localhost:1234/sse")
+        monkeypatch.setattr(
+            "influx.lithos_client.sse_client",
+            self._boom_cm(asyncio.CancelledError()),
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await client._ensure_connected()


### PR DESCRIPTION
## Summary

Fixes #231 — when Lithos/LCMA is unreachable, the inbox tick leaked an unhandled `ExceptionGroup` instead of degrading cleanly.

## Root cause

`LithosClient._ensure_connected` let the raw connection failure propagate: an `httpx.ConnectError` wrapped in the SSE TaskGroup's `ExceptionGroup('unhandled errors in a TaskGroup', …)`. `InboxTick.execute` wraps its `task_list_body` call in `except (LithosError, LCMAError)`, but a bare `ExceptionGroup` is neither — so it escaped the handler and, because the tick runs as a fire-and-forget `asyncio` task, surfaced as a `Task exception was never retrieved` ERROR with a full stack trace. The tick silently died for that cycle.

Observed on staging (2026-06-03 22:45) — the only ERROR-level log line in 24h.

## Fix

Normalise at the client layer (the single connection chokepoint, used by `call_tool`/`list_tools`/`reconnect`):

```python
except (LithosError, LCMAError, McpError):
    await stack.aclose(); raise          # already-typed / McpError → handled downstream
except Exception as exc:                 # ConnectError, OSError, ExceptionGroup[…]
    await stack.aclose()
    raise LithosError("connection_failed", operation="connect",
                      detail=f"could not connect to Lithos at {self._url}: {exc!r}") from exc
```

- Every caller now handles "Lithos unreachable" through one typed path.
- `McpError` (e.g. from agent-register) still propagates → `_call_lcma_tool` normalises it to `LCMAError`.
- `except Exception` (not `BaseException`) lets `CancelledError` / `KeyboardInterrupt` propagate untouched.

With this, the inbox tick's existing `except (LithosError, LCMAError)` catches the failure → clean WARNING + return, no leaked `ExceptionGroup`.

## Acceptance criteria

- [x] A connection failure to LCMA surfaces as `LithosError`, consistently across callers — not a raw `httpx.ConnectError`/`ExceptionGroup`
- [x] The inbox tick logs a clean degraded WARNING and returns (existing `except (LithosError, LCMAError)` path; covered by `test_status_records_task_list_failure`)
- [x] Scheduled-run behaviour unchanged

## Test plan

- [x] `test_lithos_client.py::TestEnsureConnectedNormalisesConnectionErrors` — ExceptionGroup-wrapped connect error and bare `ConnectionError` both wrap to `LithosError(operation="connect")`; an already-typed `LithosError` is not re-wrapped; `CancelledError` propagates
- [x] Existing `test_status_records_task_list_failure` confirms the tick handles `LithosError` from `task_list_body` cleanly
- [x] Full suite **2571 passed**; `make lint` (incl. `ruff format --check`) + `make typecheck` clean

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)
