### PR TITLE
feat: feed-yield diagnostic + operator runbook (weekly review, both envs)

### DIFF
--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -1,29 +1,57 @@
-# Influx Staging Operator Runbook
+# Influx Operator Runbook
 
-**Audience:** anyone diagnosing a failed or partial scheduled run on
-`influx-staging` without reading the source.
+**Audience:** anyone diagnosing a failed or partial scheduled run, or
+running the routine health review, on either `influx-staging` or the
+production `influx` deployment — without reading the source.
 
 **Bar:** find the failure in under ten minutes, decide whether to
 intervene or wait for the next sweep.
 
 **Tooling:** `scripts/influx-diagnose.py` wraps every recipe in this
-document. Run `./scripts/influx-diagnose.py --help` for the full
-subcommand list.
+document. Every subcommand takes `--env staging|prod` (default
+`staging`) and reads `docker/.env.<env>`, so the same recipes work
+against both environments — just pass the right `--env`. Run
+`./scripts/influx-diagnose.py --help` for the full subcommand list.
+
+> **Proactive vs reactive:** §1–§10 are the reactive troubleshooting
+> reference. For the routine sweep once Influx is in production, start at
+> [§11 Weekly operational review](#11-weekly-operational-review).
+
+---
+
+## Quick navigation: symptom → section
+
+| Symptom | Go to |
+| --- | --- |
+| Routine weekly health check | [§11 Weekly operational review](#11-weekly-operational-review) |
+| Promotion gate FAILs | [§8c Promotion gate](#8c-promotion-gate-issue-165) |
+| A run failed / degraded / didn't run | [§2 Decide if there is a problem](#2-decide-if-there-is-a-problem), [§3 Drill into one run](#3-drill-into-one-run) |
+| Unexpected exception / new ERROR in logs | [§4 Common log shapes](#4-common-log-shapes) |
+| A feed produces nothing / a feed went silent | [§8g Feed yield](#8g-feed-yield--per-feed-note-production-issue-233) |
+| arXiv 429 / timeout storms | [§9 Scheduling stagger](#9-scheduling-stagger-issue-87) |
+| Slug-collision squatters / zombie notes | [§8 Cleaning up slug-collision squatters](#8-cleaning-up-slug-collision-squatters) |
+| Notes with empty/invalid source metadata | [§8b Invalid-source notes](#8b-cleaning-up-invalid-source-metadata-notes-issue-162) |
+| Lithos unreachable / inbox-tick errors | [§4 Common log shapes](#4-common-log-shapes) (connection failures surface as `LithosError`) |
 
 ---
 
 ## 1. Environment quick-reference
 
-| Item                  | Where it lives                                                        |
-| --------------------- | --------------------------------------------------------------------- |
-| Container name        | `influx-staging` (set via `INFLUX_CONTAINER_NAME` in `docker/.env.staging`) |
-| Run ledger (history)  | `${INFLUX_STATE_PATH}/runs.jsonl` — append-only JSONL.                |
-| Active runs           | `${INFLUX_STATE_PATH}/active-runs.json` — keyed by `run_id`.          |
-| Admin HTTP API        | `http://${INFLUX_ADMIN_BIND_HOST}:${INFLUX_ADMIN_HOST_PORT}` (default `127.0.0.1:18080`). |
-| Logs                  | `docker logs influx-staging` — JSON-per-line via `InfluxJsonFormatter`. |
+`scripts/influx-diagnose.py` reads `docker/.env.<env>` for every value
+below, so switching environments is just `--env staging` / `--env prod`.
 
-`scripts/influx-diagnose.py` reads `docker/.env.<env>` for these
-values, so substituting environments is `--env dev` / `--env staging`.
+| Item | `--env staging` | `--env prod` |
+| --- | --- | --- |
+| Container (`INFLUX_CONTAINER_NAME`) | `influx-staging` | `influx` |
+| Admin host port (`INFLUX_ADMIN_HOST_PORT`) | `18081` | `18080` |
+| Run ledger (history) | `${INFLUX_STATE_PATH}/runs.jsonl` (append-only JSONL) | ″ (per-env `INFLUX_STATE_PATH`) |
+| Active runs | `${INFLUX_STATE_PATH}/active-runs.json` (keyed by `run_id`) | ″ |
+| Config | `${INFLUX_DATA_PATH}/influx.toml` | ″ |
+| Corpus (notes on disk) | `<knowledge>/articles/**.md` | ″ |
+| Logs | `docker logs influx-staging` (JSON-per-line) | `docker logs influx` |
+
+All commands below show `--env staging`; substitute `--env prod` for the
+production deployment.
 
 ## 2. Decide if there is a problem
 
@@ -725,6 +753,85 @@ one of `--yes <doc-id>`, `--yes-to-all`, or `--id <doc-id>` (the
 explicitly). Idempotent — re-running after `--apply` is a no-op for
 already-fixed docs.
 
+## 8g. Feed yield — per-feed note production (issue #233)
+
+`feed-yield` answers "which RSS feeds are actually earning their place?"
+by joining the configured feed list (`influx.toml`) against the
+`feed-slug:` tag the writer stamps on every note in the corpus. It is
+read-only (corpus + config; no Lithos / docker / HTTP) and is the
+primary tool for ongoing feed curation.
+
+```bash
+# All feeds, dead-weight first (default sort = yield ascending).
+./scripts/influx-diagnose.py --env staging feed-yield
+
+# One profile; 7-day recent window; machine-readable.
+./scripts/influx-diagnose.py --env staging feed-yield \
+    --profile retro-computing --since-days 7 --json
+
+# Most-active first.
+./scripts/influx-diagnose.py --env staging feed-yield --sort recent
+```
+
+Columns: `tot` (all-time notes), `recent` (notes created within
+`--since-days`, default 30), `latest` (most recent note date), `F`
+(forum-feed flag), `profile`, `feed`. A trailing summary counts
+zero-yield and silent feeds, and lists **orphan** slugs (notes from
+feeds no longer in the config — removed/renamed sources).
+
+### Reading the four signals
+
+| Signal | Meaning | Action |
+| --- | --- | --- |
+| **zero-yield** (`tot=0`) | configured but never produced a note | Disambiguate before cutting — see below. |
+| **silent** (`tot>0`, `recent=0`) | produced before, stopped | **Newly broken** — feed went dead/changed, or upstream went quiet. The clearest "something just broke" alarm. |
+| **top producer** | high volume | Sanity-check it is *quality*, not noise — especially forums. High yield ≠ high value. |
+| **orphan** | notes from a feed no longer in config | Informational (historical contributor). |
+
+### zero-yield ≠ broken (the key subtlety)
+
+A feed whose URL works fine but whose items all fail the relevance
+filter also shows `tot=0`. **Always disambiguate before cutting:**
+
+```bash
+# 1. Does the feed URL return a real feed with items?
+curl -sSL -A "Mozilla/5.0" "<feed-url>" | grep -ciE "<item|<entry"
+
+# 2. Is Influx fetching it and dropping every item at the filter?
+./scripts/influx-diagnose.py --env staging warnings \
+  | grep "feed='<Feed Name>'"        # 'article inspected ... decision=drop reason=...'
+```
+
+- URL **404 / anti-bot wall / empty / wrong content-type** → genuinely
+  broken: find a replacement URL (try RSS autodiscovery — fetch the
+  site homepage and grep for `application/rss+xml` / `atom+xml`), else
+  cut the `[[profiles.sources.rss]]` block from `influx.toml`.
+- URL **200 with items, but all `not_returned_by_filter` /
+  `below_relevance`** → not broken: the scorer judges the content
+  not relevant. This is a curation/threshold call, not a fix. Such a
+  feed causes **no degradation** (a fetched-then-filtered feed is not a
+  `source_acquisition` failure) — the only cost is wasted filter calls.
+
+### Forum feeds and the durable-knowledge bar
+
+Forum feeds (flagged `F`) can be top producers but mix genuine signal
+(release announcements, technical write-ups) with chatter (help/support
+threads, opinion polls, "Re:" replies). High yield from a forum is a
+prompt to **sample the content**, not to assume value:
+
+```bash
+# Eyeball recent titles + summaries for one feed-slug.
+grep -rl "feed-slug:<slug>" "<knowledge>/articles" | head -10 | \
+  xargs -I{} sh -c 'echo "== {} =="; sed -n "/^title:/p;/^## Summary/,+3p" {}'
+```
+
+If a forum's notes are mostly chatter, the fix is to tighten the
+profile's scoring `description` (teach the scorer to score chatter low)
+rather than raising the relevance threshold — see the retro-computing
+profile's `DURABLE-KNOWLEDGE BAR` block for the pattern. Re-run
+`feed-yield` over the following cycles to confirm the tuning reduced the
+low-value volume while keeping the substantive notes.
+
 ## 9. Scheduling stagger (issue #87)
 
 Profiles share a single global `[schedule].cron` expression. Within
@@ -821,3 +928,84 @@ next levers are operator-side: raise `arxiv_429_max_retries`, raise
 - Terminal cap rationale and prior incident notes: PR #11 (initial
   data layer), PR #15 (archive cap), PR #25 (archive_download hook),
   PR #26 (text_extraction_retry hook).
+
+## 11. Weekly operational review
+
+A ~15-minute proactive sweep to run once a week while Influx is in
+production (and worth running on staging too). Tiered: top-line health
+first, so you can stop early if everything is green. All steps are local
+reads (ledger + corpus + logs) — run them from the host with
+`--env prod`.
+
+### 1. Top-line health (~5 min, the must-do)
+
+```bash
+./scripts/influx-diagnose.py --env prod promotion-gate
+./scripts/influx-diagnose.py --env prod recent --limit 12
+./scripts/influx-diagnose.py --env prod failures --limit 20
+```
+
+- **Healthy:** gate `PASS`; `unexpected_failure=0`; `expected_lossy`
+  ratio at/under the cap (0.50); every profile ran its scheduled cycle
+  and `status=completed`.
+- **Escalate:** any `unexpected_failure` run. That bucket is real data
+  integrity — `slug_collision`, `content_too_large`, `version_conflict`,
+  `invalid_input` — not tolerated upstream noise. → [§8c](#8c-promotion-gate-issue-165),
+  [§3](#3-drill-into-one-run). Distinguish from `expected_lossy`
+  (arXiv/upstream blips), which is normal.
+
+### 2. Error / exception scan
+
+```bash
+./scripts/influx-diagnose.py --env prod warnings | grep -i error
+```
+
+- **Healthy:** only known-benign lines (empty-HTML-tree extraction, OTEL
+  deprecation warnings).
+- **Escalate:** any **new exception class or traceback** (this is how
+  the inbox-tick `ExceptionGroup`-on-Lithos-unreachable bug, #231, was
+  found). → [§4](#4-common-log-shapes).
+
+### 3. Feed health
+
+```bash
+./scripts/influx-diagnose.py --env prod feed-yield --since-days 7
+```
+
+- **Healthy:** no *newly* silent feeds; the zero-yield set is unchanged
+  from last week.
+- **Escalate:** a previously-producing feed now silent → a feed broke
+  upstream; disambiguate and fix/cut per [§8g](#8g-feed-yield--per-feed-note-production-issue-233).
+- **Monthly:** sample a top forum feed's content to confirm the
+  durable-knowledge bar still holds; tune the profile `description` if
+  chatter is creeping in.
+
+### 4. Corpus hygiene (regression catch)
+
+```bash
+./scripts/influx-diagnose.py --env prod invalid-source          # read-only audit
+./scripts/influx-diagnose.py --env prod slug-collision-backlog
+```
+
+- **Healthy:** counts roughly flat week-over-week (a few/week is the
+  known empty-source trickle).
+- **Escalate:** a spike in either → a writer/ingestion regression. →
+  [§8](#8-cleaning-up-slug-collision-squatters),
+  [§8b](#8b-cleaning-up-invalid-source-metadata-notes-issue-162).
+
+### 5. Volume sanity
+
+From the `recent` output (step 1), eyeball `ingested=` per profile.
+
+- **Healthy:** volumes roughly stable run-over-run.
+- **Escalate:** a cliff (e.g. a profile that usually ingests 5–15
+  dropping to 0) signals a pipeline or upstream breakage even when
+  nothing logged an error — cross-check with feed-yield (step 3).
+
+### Automation
+
+Steps 1–2 are the cheap-and-critical pair and lend themselves to a
+weekly cron that emails/pings only on a regression (the staging
+promotion-gate already runs as a local cron — extend it to bundle the
+error scan and a feed-yield diff). Steps 3–5 benefit from a human eye,
+so keep those manual.

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -31,6 +31,10 @@ Subcommands
                     configurable severity policy (issue #165); exits
                     0 on PASS / 1 on FAIL so a CI promotion step can
                     consume it directly
+    feed-yield      Notes-ingested-per-RSS-feed from the on-disk corpus
+                    (joins influx.toml feeds against feed-slug: note
+                    tags); surfaces dead/broken, silent, and
+                    top-producing feeds for curation (issue #233)
     cancel          Print the curl line for cancelling an in-flight run
                     (this script never sends destructive HTTP itself)
 

--- a/scripts/influx-diagnose.py
+++ b/scripts/influx-diagnose.py
@@ -1969,6 +1969,219 @@ def cmd_strip_embedded_frontmatter(args: argparse.Namespace) -> int:
     return 0 if counts.get(_EMBEDDED_FM_OUTCOME_FAILED, 0) == 0 else 1
 
 
+# ── feed-yield (operational: notes ingested per RSS feed) ────────────
+
+
+def _resolve_config_path(env: dict[str, str]) -> Path:
+    """Resolve the on-disk ``influx.toml`` path.
+
+    ``${INFLUX_DATA_PATH}/influx.toml`` is the convention the env files
+    already use for the ``[lithos] url`` lookup in ``_read_lithos_url``.
+    """
+    data_path = env.get("INFLUX_DATA_PATH")
+    if not data_path:
+        sys.exit(
+            "Cannot resolve influx.toml: set $INFLUX_DATA_PATH in the env "
+            "file (the directory containing influx.toml)."
+        )
+    path = Path(data_path) / "influx.toml"
+    if not path.exists():
+        sys.exit(f"influx.toml not found at {path}")
+    return path
+
+
+_FORUM_FEED_MARKERS = ("forum", "new topics", "latest forum")
+
+
+def _is_forum_feed(name: str, url: str) -> bool:
+    """Heuristic: does this feed publish discussion/forum threads?"""
+    blob = f"{name} {url}".lower()
+    return any(marker in blob for marker in _FORUM_FEED_MARKERS)
+
+
+def _configured_rss_feeds(config: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Map ``feed-slug`` → ``{profile, name, url, forum}`` for every RSS feed.
+
+    The slug is derived from the feed NAME via the same
+    :func:`influx.slugs.slugify_feed_name` the writer tags notes with
+    (``feed-slug:<slug>``), so the result joins directly against the
+    corpus scan.
+    """
+    from influx.slugs import slugify_feed_name
+
+    feeds: dict[str, dict[str, Any]] = {}
+    profiles = config.get("profiles")
+    if not isinstance(profiles, list):
+        return feeds
+    for prof in profiles:
+        if not isinstance(prof, dict):
+            continue
+        pname = str(prof.get("name", "?"))
+        sources = prof.get("sources")
+        rss = (sources or {}).get("rss") if isinstance(sources, dict) else None
+        if not isinstance(rss, list):
+            continue
+        for entry in rss:
+            if not isinstance(entry, dict):
+                continue
+            name = str(entry.get("name", ""))
+            url = str(entry.get("url", ""))
+            slug = slugify_feed_name(name)
+            if not slug:
+                continue
+            feeds[slug] = {
+                "profile": pname,
+                "name": name,
+                "url": url,
+                "forum": _is_forum_feed(name, url),
+            }
+    return feeds
+
+
+def _scan_feed_yield(
+    articles_path: Path, *, since_iso: str | None = None
+) -> dict[str, dict[str, Any]]:
+    """Count notes per ``feed-slug:`` tag across the on-disk corpus.
+
+    Returns ``slug → {count, recent, latest}`` where *count* is the
+    all-time note total, *recent* is the count with ``created_at`` on or
+    after *since_iso* (when provided), and *latest* is the most recent
+    ``created_at`` date (``YYYY-MM-DD``).  Date comparison is on the
+    ``YYYY-MM-DD`` prefix, which is lexicographically ordered.
+    """
+    import yaml
+
+    from influx.notes import NoteParseError, _split_frontmatter
+
+    fs_re = re.compile(r"feed-slug:([a-z0-9-]+)")
+    out: dict[str, dict[str, Any]] = {}
+    if not articles_path.exists():
+        return out
+    for md in articles_path.rglob("*.md"):
+        try:
+            text = md.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        try:
+            fm_raw, _rest = _split_frontmatter(text)
+        except NoteParseError:
+            continue
+        try:
+            meta = yaml.safe_load(fm_raw)
+        except yaml.YAMLError:
+            continue
+        if not isinstance(meta, dict):
+            continue
+        tags = meta.get("tags") or []
+        if not isinstance(tags, list):
+            continue
+        created = str(meta.get("created_at", "") or "")[:10]
+        for tag in tags:
+            match = fs_re.fullmatch(str(tag))
+            if not match:
+                continue
+            slug = match.group(1)
+            rec = out.setdefault(slug, {"count": 0, "recent": 0, "latest": ""})
+            rec["count"] += 1
+            if created > rec["latest"]:
+                rec["latest"] = created
+            if since_iso is not None and created >= since_iso:
+                rec["recent"] += 1
+    return out
+
+
+def cmd_feed_yield(args: argparse.Namespace) -> int:
+    """Report notes-ingested-per-RSS-feed from the on-disk corpus.
+
+    Joins the configured feed list (``influx.toml``) against per-feed
+    note counts (the ``feed-slug:`` tag the writer stamps on every
+    note), so an operator can see which feeds earn their place, which
+    produce nothing (broken/dead), and which have gone silent recently.
+    Pure read of on-disk notes + config — no Lithos / docker / HTTP.
+    """
+    import datetime as _dt
+    import tomllib
+
+    env = _load_env(args.env)
+    cfg_path = _resolve_config_path(env)
+    articles = _resolve_corpus_articles_path(env)
+
+    with cfg_path.open("rb") as fh:
+        config = tomllib.load(fh)
+
+    feeds = _configured_rss_feeds(config)
+    since_days = int(getattr(args, "since_days", 30) or 30)
+    since_iso = (
+        (_dt.datetime.now(_dt.UTC) - _dt.timedelta(days=since_days)).date().isoformat()
+    )
+    yields = _scan_feed_yield(articles, since_iso=since_iso)
+
+    for slug, meta in feeds.items():
+        y = yields.get(slug, {})
+        meta["count"] = int(y.get("count", 0))
+        meta["recent"] = int(y.get("recent", 0))
+        meta["latest"] = str(y.get("latest", "") or "")
+
+    rows = list(feeds.values())
+    profile_filter = getattr(args, "profile", None)
+    if profile_filter:
+        rows = [r for r in rows if r["profile"] == profile_filter]
+
+    sort_key = getattr(args, "sort", "yield")
+    if sort_key == "recent":
+        rows.sort(key=lambda r: (r["recent"], r["count"], r["profile"]))
+    elif sort_key == "name":
+        rows.sort(key=lambda r: (r["profile"], r["name"].lower()))
+    else:  # "yield" — ascending so dead weight surfaces first
+        rows.sort(key=lambda r: (r["count"], r["recent"], r["profile"]))
+
+    orphans = {s: y for s, y in yields.items() if s not in feeds}
+
+    if getattr(args, "json", False):
+        print(
+            json.dumps(
+                {
+                    "since_days": since_days,
+                    "feeds": rows,
+                    "orphans": [
+                        {"slug": s, **y}
+                        for s, y in sorted(
+                            orphans.items(), key=lambda x: -x[1]["count"]
+                        )
+                    ],
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    print(
+        f"Feed yield (notes per RSS feed) — corpus={articles}  "
+        f"recent window={since_days}d\n"
+    )
+    print(f"{'tot':>5} {'recent':>6} {'latest':>10} {'F':1} {'profile':16} feed")
+    print("-" * 86)
+    for r in rows:
+        print(
+            f"{r['count']:>5} {r['recent']:>6} "
+            f"{(r['latest'] or '  never'):>10} "
+            f"{'F' if r['forum'] else ' '} {r['profile']:16} {r['name'][:36]}"
+        )
+
+    zero = [r for r in rows if r["count"] == 0]
+    silent = [r for r in rows if r["count"] > 0 and r["recent"] == 0]
+    print()
+    print(
+        f"Summary: {len(rows)} feeds | zero-yield (never produced): "
+        f"{len(zero)} | silent (no notes in {since_days}d): {len(silent)}"
+    )
+    if orphans:
+        print("\nfeed-slugs in corpus NOT in current config (removed/renamed feeds):")
+        for s, y in sorted(orphans.items(), key=lambda x: -x[1]["count"]):
+            print(f"  {y['count']:>5}  latest {y['latest']}  {s}")
+    return 0
+
+
 async def _fetch_invalid_source_notes(
     *,
     lithos_url: str,
@@ -2553,6 +2766,34 @@ def _build_parser() -> argparse.ArgumentParser:
         help="override LITHOS_URL from the env file.",
     )
     p_strip.set_defaults(func=cmd_strip_embedded_frontmatter)
+
+    p_yield = sub.add_parser(
+        "feed-yield",
+        help=(
+            "notes-ingested-per-RSS-feed from the on-disk corpus — joins "
+            "influx.toml feeds against the feed-slug: note tags to surface "
+            "dead/broken feeds (zero-yield), gone-silent feeds, and the "
+            "real top producers.  Read-only."
+        ),
+    )
+    p_yield.add_argument("--profile", help="filter to a single profile")
+    p_yield.add_argument(
+        "--since-days",
+        type=int,
+        default=30,
+        dest="since_days",
+        help="recent-window size in days for the 'recent' column (default: 30)",
+    )
+    p_yield.add_argument(
+        "--sort",
+        choices=["yield", "recent", "name"],
+        default="yield",
+        help="sort order (default: yield — ascending, dead weight first)",
+    )
+    p_yield.add_argument(
+        "--json", action="store_true", help="emit JSON instead of a table"
+    )
+    p_yield.set_defaults(func=cmd_feed_yield)
 
     p_invalid = sub.add_parser(
         "invalid-source",

--- a/tests/unit/test_diagnose_feed_yield.py
+++ b/tests/unit/test_diagnose_feed_yield.py
@@ -1,0 +1,205 @@
+"""Unit tests for ``./scripts/influx-diagnose.py feed-yield``.
+
+The subcommand joins the configured RSS feed list (influx.toml) against
+per-feed note counts derived from the ``feed-slug:`` tag the writer
+stamps on every note, surfacing dead/broken, silent, and top-producing
+feeds for curation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+
+def _load_script() -> Any:
+    repo_root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "influx_diagnose", repo_root / "scripts" / "influx-diagnose.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_DIAGNOSE = _load_script()
+
+
+def _write_note(articles: Path, rel: str, *, feed_slug: str, created: str) -> None:
+    path = articles / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fm = (
+        "---\n"
+        "author: influx\n"
+        f"created_at: '{created}T00:00:00+00:00'\n"
+        "tags:\n"
+        "- source:rss\n"
+        f"- feed-slug:{feed_slug}\n"
+        "---\n"
+        "# Title\n\n## Summary\nbody\n"
+    )
+    path.write_text(fm, encoding="utf-8")
+
+
+# ── _is_forum_feed ──────────────────────────────────────────────────
+
+
+class TestIsForumFeed:
+    def test_forum_in_name(self) -> None:
+        assert _DIAGNOSE._is_forum_feed("Amiga.org Forum", "https://x/feed")
+
+    def test_new_topics_marker(self) -> None:
+        assert _DIAGNOSE._is_forum_feed("Lemon64 (new topics)", "https://x")
+
+    def test_forum_in_url(self) -> None:
+        assert _DIAGNOSE._is_forum_feed("SGI", "https://forums.sgi.sh/rss")
+
+    def test_plain_blog_is_not_forum(self) -> None:
+        assert not _DIAGNOSE._is_forum_feed(
+            "Simon Willison's Weblog", "https://simonwillison.net/atom"
+        )
+
+
+# ── _configured_rss_feeds ───────────────────────────────────────────
+
+
+class TestConfiguredRssFeeds:
+    def test_maps_slug_to_profile_and_forum_flag(self) -> None:
+        config = {
+            "profiles": [
+                {
+                    "name": "retro",
+                    "sources": {
+                        "rss": [
+                            {"name": "Amiga.org Forum", "url": "https://a/feed"},
+                            {"name": "Amiga-News.de", "url": "https://b/feed"},
+                        ]
+                    },
+                },
+                {
+                    "name": "ai",
+                    "sources": {
+                        "rss": [{"name": "Lilian Weng", "url": "https://l/feed"}]
+                    },
+                },
+            ]
+        }
+        feeds = _DIAGNOSE._configured_rss_feeds(config)
+        assert set(feeds) == {"amiga-org-forum", "amiga-news-de", "lilian-weng"}
+        assert feeds["amiga-org-forum"]["profile"] == "retro"
+        assert feeds["amiga-org-forum"]["forum"] is True
+        assert feeds["amiga-news-de"]["forum"] is False
+        assert feeds["lilian-weng"]["profile"] == "ai"
+
+    def test_tolerates_missing_or_malformed_sections(self) -> None:
+        assert _DIAGNOSE._configured_rss_feeds({}) == {}
+        assert _DIAGNOSE._configured_rss_feeds({"profiles": "nope"}) == {}
+        assert (
+            _DIAGNOSE._configured_rss_feeds(
+                {"profiles": [{"name": "p", "sources": {}}]}
+            )
+            == {}
+        )
+
+
+# ── _scan_feed_yield ────────────────────────────────────────────────
+
+
+class TestScanFeedYield:
+    def test_counts_recent_and_latest(self, tmp_path: Path) -> None:
+        articles = tmp_path / "articles"
+        _write_note(articles, "a.md", feed_slug="foo", created="2026-06-01")
+        _write_note(articles, "b.md", feed_slug="foo", created="2026-04-01")
+        _write_note(articles, "c.md", feed_slug="bar", created="2026-06-05")
+
+        out = _DIAGNOSE._scan_feed_yield(articles, since_iso="2026-05-01")
+        assert out["foo"]["count"] == 2
+        assert out["foo"]["recent"] == 1  # only the 06-01 note is >= 05-01
+        assert out["foo"]["latest"] == "2026-06-01"
+        assert out["bar"]["count"] == 1
+        assert out["bar"]["recent"] == 1
+
+    def test_missing_dir_returns_empty(self, tmp_path: Path) -> None:
+        assert _DIAGNOSE._scan_feed_yield(tmp_path / "nope") == {}
+
+    def test_notes_without_feed_slug_ignored(self, tmp_path: Path) -> None:
+        articles = tmp_path / "articles"
+        path = articles / "x.md"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            "---\nauthor: influx\ntags:\n- source:arxiv\n---\n# T\n",
+            encoding="utf-8",
+        )
+        assert _DIAGNOSE._scan_feed_yield(articles) == {}
+
+
+# ── cmd_feed_yield ──────────────────────────────────────────────────
+
+
+class TestCmdFeedYield:
+    def _config_toml(self) -> str:
+        return (
+            "[[profiles]]\n"
+            'name = "retro"\n'
+            "[[profiles.sources.rss]]\n"
+            'name = "Live Feed"\n'
+            'url = "https://live/feed"\n'
+            "[[profiles.sources.rss]]\n"
+            'name = "Dead Feed"\n'
+            'url = "https://dead/feed"\n'
+        )
+
+    def test_table_flags_zero_yield_and_orphans(
+        self, tmp_path: Path, capsys: Any
+    ) -> None:
+        # Config: Live Feed + Dead Feed. Corpus: notes for live-feed and an
+        # orphan slug not in config.
+        cfg = tmp_path / "influx.toml"
+        cfg.write_text(self._config_toml(), encoding="utf-8")
+        articles = tmp_path / "knowledge" / "articles"
+        _write_note(articles, "a.md", feed_slug="live-feed", created="2026-06-01")
+        _write_note(articles, "b.md", feed_slug="gone-feed", created="2026-05-01")
+
+        args = argparse.Namespace(
+            env="staging", profile=None, since_days=3650, sort="yield", json=False
+        )
+        with patch.multiple(
+            _DIAGNOSE,
+            _load_env=lambda env: {},
+            _resolve_config_path=lambda env: cfg,
+            _resolve_corpus_articles_path=lambda env: articles,
+        ):
+            rc = _DIAGNOSE.cmd_feed_yield(args)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "Live Feed" in out and "Dead Feed" in out
+        assert "zero-yield (never produced): 1" in out  # Dead Feed
+        assert "gone-feed" in out  # orphan section
+
+    def test_json_output(self, tmp_path: Path, capsys: Any) -> None:
+        import json as _json
+
+        cfg = tmp_path / "influx.toml"
+        cfg.write_text(self._config_toml(), encoding="utf-8")
+        articles = tmp_path / "knowledge" / "articles"
+        _write_note(articles, "a.md", feed_slug="live-feed", created="2026-06-01")
+
+        args = argparse.Namespace(
+            env="staging", profile=None, since_days=30, sort="yield", json=True
+        )
+        with patch.multiple(
+            _DIAGNOSE,
+            _load_env=lambda env: {},
+            _resolve_config_path=lambda env: cfg,
+            _resolve_corpus_articles_path=lambda env: articles,
+        ):
+            _DIAGNOSE.cmd_feed_yield(args)
+        payload = _json.loads(capsys.readouterr().out)
+        assert payload["since_days"] == 30
+        slugs = {f["name"]: f for f in payload["feeds"]}
+        assert slugs["Live Feed"]["count"] == 1
+        assert slugs["Dead Feed"]["count"] == 0


### PR DESCRIPTION
## Summary

Adds `influx-diagnose feed-yield` — a read-only operational report of **notes ingested per RSS feed**, so feed curation runs on evidence instead of guesswork. It joins the configured feed list (`influx.toml`) against the `feed-slug:` tag the writer stamps on every note.

Motivated by a staging curation pass: we needed to know which feeds actually produce durable knowledge vs. which are dead weight. The one-off that answered it was useful enough to want continually.

## What it surfaces

- **Zero-yield** feeds — configured but never produced a note (broken URL / dead host / blocked).
- **Silent** feeds — produced before, nothing in the recent window (`--since-days`, default 30).
- **Top producers** — ranked, with a forum-vs-news flag (`F`).
- **Orphan slugs** — notes from feeds no longer in config (removed/renamed).

```
  tot recent     latest F profile          feed
   0      0      never   robotics         Science Robotics       ← broken/blocked
   4      0 2026-05-05   retro-computing  VCF Events             ← gone silent
 102     91 2026-06-06 F retro-computing  Lemon64 Forum (new topics)
 117     98 2026-06-05   retro-computing  Amiga-News.de (English)
Summary: 56 feeds | zero-yield: 10 | silent (no notes in 30d): 3
```

Options: `--profile`, `--since-days N`, `--sort {yield,recent,name}`, `--json`.

## Test plan

- [x] `test_diagnose_feed_yield.py` — 11 tests: `_is_forum_feed` heuristic; `_configured_rss_feeds` slug mapping + malformed-config tolerance; `_scan_feed_yield` count/recent/latest + missing-dir + non-feed notes ignored; `cmd_feed_yield` table (zero-yield + orphan flagging) and `--json`
- [x] `make lint` (incl. `ruff format --check`) + `make typecheck` clean
- [x] Script-only change — no `src/influx` touched; sibling diagnose suites green

## Notes

Read-only (corpus + config; no Lithos/docker/HTTP), consistent with the other diagnose subcommands. Helpers are pure for testability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Added: operator runbook generalization (weekly review + feed-yield docs)

Folds this tool — and the operational knowledge from the production-readiness push — into the runbook:

- **Renamed** `docs/operations/staging-runbook.md` → `runbook.md` and generalized it to serve **both** `influx-staging` and the production `influx` deployment (single codebase; prod = promoted staging). §1 is now a staging-vs-prod env quick-reference; every recipe notes `--env staging|prod`.
- **New "Quick navigation: symptom → section"** index near the top.
- **New §8g — feed-yield how-to:** the four signals (zero-yield / silent / top-producer / orphan), the *zero-yield ≠ broken* disambiguation (fetch URL + check filter logs), and the forum durable-knowledge-bar workflow.
- **New §11 — Weekly operational review:** a tiered ~15-min proactive sweep (gate + recent + failures → error scan → feed-yield → corpus hygiene → volume sanity) with healthy/escalate criteria grounded in the real incidents we hit (`unexpected_failure`, the inbox-tick `ExceptionGroup`, dead feeds, zombie/collision regressions), plus an automation note.
- `influx-diagnose.py`: `feed-yield` now listed in the module subcommand summary.

No external references to the old filename existed, so the rename is clean (git-tracked rename preserves history).
