### PR TITLE
fix: surface Lithos cache_lookup error detail + degrade per-candidate instead of aborting the run

### DIFF
--- a/src/influx/errors.py
+++ b/src/influx/errors.py
@@ -85,6 +85,46 @@ class LCMAError(InfluxError):
         self.detail = detail
 
 
+#: Cap on the ``detail`` fragment in ledger-bound error strings.  The
+#: per-item telemetry lists truncate to 300 (``influx.telemetry``); the
+#: single run-level error string can afford a little more without
+#: bloating ``runs.jsonl``.
+_LEDGER_DETAIL_MAX_CHARS = 500
+
+
+def format_exception_for_ledger(exc: BaseException) -> str:
+    """Render an exception for the run-failure log and ledger ``error`` field.
+
+    ``str(exc)`` is only the message; structured errors in this module
+    (``LithosError``, ``LCMAError``, ``ExtractionError``) carry the
+    server-supplied failure text in a ``detail`` attribute that was
+    previously dropped (#234) — diagnosing a Lithos-side crash required
+    reading the Lithos container logs.  Appends any non-empty
+    ``operation``/``status_code``/``detail`` context, truncating
+    ``detail`` to :data:`_LEDGER_DETAIL_MAX_CHARS`.
+
+    Deliberately NOT ``LithosError.__str__``: callers parse raw
+    ``.detail`` strings (slug-collision recovery) and tests match exact
+    messages, so the message itself must stay untouched.
+    """
+    base = f"{type(exc).__name__}: {exc}"
+    parts: list[str] = []
+    operation = getattr(exc, "operation", "")
+    if operation:
+        parts.append(f"operation={operation}")
+    status_code = getattr(exc, "status_code", None)
+    if status_code is not None:
+        parts.append(f"status={status_code}")
+    detail = getattr(exc, "detail", "")
+    if detail:
+        if len(detail) > _LEDGER_DETAIL_MAX_CHARS:
+            detail = detail[:_LEDGER_DETAIL_MAX_CHARS] + "…"
+        parts.append(f"detail={detail}")
+    if not parts:
+        return base
+    return f"{base} ({', '.join(parts)})"
+
+
 class ExtractionError(InfluxError):
     """Raised when content extraction from a fetched document fails.
 

--- a/src/influx/metrics.py
+++ b/src/influx/metrics.py
@@ -45,6 +45,7 @@ __all__ = [
     "cache_hits",
     "cache_hits_via_url_fallback",
     "candidates_fetched",
+    "dedup_lookup_errors",
     "lithos_writes",
     "llm_validation_failures",
     "repair_candidates",
@@ -663,6 +664,25 @@ def source_acquisition_errors() -> Any:
     return get_meter().counter(
         "influx_source_acquisition_errors_total",
         description="Swallowed source-acquisition errors per run.",
+    )
+
+
+def dedup_lookup_errors() -> Any:
+    """Counter of swallowed pre-acquire ``cache_lookup`` failures (#234).
+
+    Mirrors the ledger's ``dedup_cache_lookup`` degraded reason: every
+    increment corresponds to one entry written through
+    :func:`~influx.telemetry.record_dedup_lookup_error`.  Distinct from
+    :func:`source_acquisition_errors` because the failed call is
+    Influx→Lithos (the lookup tool errored server-side), not
+    Influx→upstream — operators should look at Lithos health, not the
+    feed.
+
+    Labels: ``profile``, ``source``.
+    """
+    return get_meter().counter(
+        "influx_dedup_lookup_errors_total",
+        description="Swallowed pre-acquire cache_lookup failures per run.",
     )
 
 

--- a/src/influx/run.py
+++ b/src/influx/run.py
@@ -422,10 +422,12 @@ async def _run_acquire_stage(
             skip_cache_hits=plan.skip_cache_hits,
         )
         logger.info(
-            "pre-acquire dedup completed profile=%s to_acquire=%d hits_skipped=%d",
+            "pre-acquire dedup completed profile=%s to_acquire=%d hits_skipped=%d "
+            "lookup_errors=%d",
             plan.profile,
             len(outcome.to_acquire),
             len(outcome.hits_to_skip),
+            outcome.lookup_errors,
         )
 
         items: list[ProfileItem] = []

--- a/src/influx/run_dedup.py
+++ b/src/influx/run_dedup.py
@@ -20,6 +20,17 @@ log line for each hit it decides — those signals move out of the Ingest
 stage with the lookup itself.  The defensive source-URL fallback (#128)
 stays in Ingest and only fires when ``cache_hit=False`` reaches the write
 path.
+
+Error handling (#234): a per-candidate :class:`~influx.errors.LithosError`
+from the lookup is caught — the candidate is skipped this run (recorded
+via :func:`~influx.telemetry.record_dedup_lookup_error`, surfaced as the
+``dedup_cache_lookup`` degraded reason) and the rest of the batch
+processes.  Skipping is recoverable: scheduled runs re-fetch the same
+lookback window, so the candidate is re-checked next run.  If *every*
+attempted lookup fails the helper raises instead (Lithos fully down —
+post-#232 connection failures arrive as ``LithosError`` too, and a
+silently-empty "degraded" run would be indistinguishable from a quiet
+feed window).  Non-Lithos exceptions always propagate.
 """
 
 from __future__ import annotations
@@ -30,8 +41,10 @@ from dataclasses import dataclass
 from typing import Any
 
 from influx import metrics
+from influx.errors import LithosError
 from influx.lithos_client import LithosClient
 from influx.source import BoundScoredCandidate
+from influx.telemetry import record_dedup_lookup_error
 
 __all__ = [
     "DedupDecision",
@@ -78,10 +91,16 @@ class DedupDecision:
 
 @dataclass(frozen=True, slots=True)
 class DedupOutcome:
-    """Partitioned dedup result for a batch of scored candidates."""
+    """Partitioned dedup result for a batch of scored candidates.
+
+    ``lookup_errors`` counts candidates skipped because their
+    ``cache_lookup`` raised :class:`~influx.errors.LithosError` (#234)
+    — those candidates land in *neither* partition.
+    """
 
     to_acquire: tuple[DedupDecision, ...]
     hits_to_skip: tuple[DedupDecision, ...]
+    lookup_errors: int = 0
 
 
 async def dedup_scored_candidates(
@@ -97,20 +116,56 @@ async def dedup_scored_candidates(
     candidate, classifies each result per the matrix in this module's
     docstring, and returns a :class:`DedupOutcome`.
 
-    Errors from ``cache_lookup_for_item_body`` propagate — matching the
-    pre-#125 Ingest behaviour, which had no surrounding try/except.
+    A per-candidate :class:`LithosError` is caught and the candidate
+    skipped this run (#234) — recorded via
+    :func:`record_dedup_lookup_error` so the ledger fires the
+    ``dedup_cache_lookup`` degraded reason.  Deliberately *not* treated
+    as a cache miss: acquiring on an unverified lookup risks exactly the
+    duplicate-note / duplicate-cost harm dedup exists to prevent.  If
+    every attempted lookup fails, raises :class:`LithosError` (Lithos
+    fully down must still fail the run).  Non-Lithos exceptions
+    propagate — matching the pre-#125 Ingest behaviour.
     """
     to_acquire: list[DedupDecision] = []
     hits_to_skip: list[DedupDecision] = []
+    lookup_errors = 0
+    last_lookup_error: LithosError | None = None
 
     for bound in bounds:
         candidate = bound.scored.candidate
         abstract = candidate.abstract or None
-        body = await client.cache_lookup_for_item_body(
-            title=candidate.title,
-            source_url=candidate.source_url,
-            abstract_or_summary=abstract,
-        )
+        try:
+            body = await client.cache_lookup_for_item_body(
+                title=candidate.title,
+                source_url=candidate.source_url,
+                abstract_or_summary=abstract,
+            )
+        except LithosError as exc:
+            # #234: one poisoned candidate must not abort the whole
+            # run.  Skip it (re-checked next scheduled run), record the
+            # Lithos-side detail, and keep processing the batch.
+            lookup_errors += 1
+            last_lookup_error = exc
+            logger.warning(
+                "dedup cache_lookup failed profile=%s source_url=%s "
+                "title=%r operation=%s detail=%s source=%s "
+                "— skipping candidate this run",
+                profile,
+                candidate.source_url,
+                candidate.title,
+                exc.operation or "cache_lookup",
+                exc.detail or str(exc),
+                bound.source_label,
+            )
+            record_dedup_lookup_error(
+                source=_metric_source(bound.source_label),
+                kind=exc.operation or "cache_lookup",
+                detail=exc.detail or str(exc),
+            )
+            metrics.dedup_lookup_errors().add(
+                1, {"profile": profile, "source": _metric_source(bound.source_label)}
+            )
+            continue
         hit = bool(body.get("hit"))
 
         if hit:
@@ -147,7 +202,21 @@ async def dedup_scored_candidates(
                 )
             )
 
+    # #234 safeguard: every attempted lookup failing means Lithos is
+    # effectively down (post-#232 connection failures are LithosError
+    # too) — fail the run rather than emit a silently-empty "degraded"
+    # outcome indistinguishable from a quiet feed window.
+    attempted = len(bounds)
+    if attempted > 0 and lookup_errors == attempted:
+        assert last_lookup_error is not None
+        raise LithosError(
+            f"cache_lookup failed for all {attempted} candidates",
+            operation="cache_lookup",
+            detail=last_lookup_error.detail or str(last_lookup_error),
+        ) from last_lookup_error
+
     return DedupOutcome(
         to_acquire=tuple(to_acquire),
         hits_to_skip=tuple(hits_to_skip),
+        lookup_errors=lookup_errors,
     )

--- a/src/influx/run_dedup.py
+++ b/src/influx/run_dedup.py
@@ -30,7 +30,10 @@ lookback window, so the candidate is re-checked next run.  If *every*
 attempted lookup fails the helper raises instead (Lithos fully down —
 post-#232 connection failures arrive as ``LithosError`` too, and a
 silently-empty "degraded" run would be indistinguishable from a quiet
-feed window).  Non-Lithos exceptions always propagate.
+feed window); in that case no skip-and-degrade signals are emitted —
+they are buffered during the loop and flushed only when the batch
+partially succeeded, so a total outage doesn't overcount swallowed
+skips.  Non-Lithos exceptions always propagate.
 """
 
 from __future__ import annotations
@@ -53,6 +56,11 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
+
+#: Cap on the ``detail`` fragment in the per-candidate skip WARNING —
+#: matches the 300-char bound :func:`record_dedup_lookup_error` applies
+#: to the persisted telemetry record.
+_DETAIL_LOG_MAX_CHARS = 300
 
 
 def _metric_source(source_label: str) -> str:
@@ -123,13 +131,17 @@ async def dedup_scored_candidates(
     as a cache miss: acquiring on an unverified lookup risks exactly the
     duplicate-note / duplicate-cost harm dedup exists to prevent.  If
     every attempted lookup fails, raises :class:`LithosError` (Lithos
-    fully down must still fail the run).  Non-Lithos exceptions
-    propagate — matching the pre-#125 Ingest behaviour.
+    fully down must still fail the run) — in that case the per-candidate
+    failures are NOT recorded as swallowed degradations: the
+    skip-and-degrade telemetry/metrics/warnings are buffered during the
+    loop and flushed only once the batch is known to have partially
+    succeeded, so a total outage produces one failed run, not a failed
+    run plus N misleading "skipped candidate" signals.  Non-Lithos
+    exceptions propagate — matching the pre-#125 Ingest behaviour.
     """
     to_acquire: list[DedupDecision] = []
     hits_to_skip: list[DedupDecision] = []
-    lookup_errors = 0
-    last_lookup_error: LithosError | None = None
+    failed: list[tuple[BoundScoredCandidate, LithosError]] = []
 
     for bound in bounds:
         candidate = bound.scored.candidate
@@ -142,29 +154,12 @@ async def dedup_scored_candidates(
             )
         except LithosError as exc:
             # #234: one poisoned candidate must not abort the whole
-            # run.  Skip it (re-checked next scheduled run), record the
-            # Lithos-side detail, and keep processing the batch.
-            lookup_errors += 1
-            last_lookup_error = exc
-            logger.warning(
-                "dedup cache_lookup failed profile=%s source_url=%s "
-                "title=%r operation=%s detail=%s source=%s "
-                "— skipping candidate this run",
-                profile,
-                candidate.source_url,
-                candidate.title,
-                exc.operation or "cache_lookup",
-                exc.detail or str(exc),
-                bound.source_label,
-            )
-            record_dedup_lookup_error(
-                source=_metric_source(bound.source_label),
-                kind=exc.operation or "cache_lookup",
-                detail=exc.detail or str(exc),
-            )
-            metrics.dedup_lookup_errors().add(
-                1, {"profile": profile, "source": _metric_source(bound.source_label)}
-            )
+            # run.  Buffer the failure and keep processing the batch —
+            # the skip-and-degrade signals are flushed after the loop,
+            # and only in the partial-failure case (a total outage
+            # raises instead, and recording "swallowed" degradations
+            # for a run that then fails would overcount).
+            failed.append((bound, exc))
             continue
         hit = bool(body.get("hit"))
 
@@ -205,18 +200,52 @@ async def dedup_scored_candidates(
     # #234 safeguard: every attempted lookup failing means Lithos is
     # effectively down (post-#232 connection failures are LithosError
     # too) — fail the run rather than emit a silently-empty "degraded"
-    # outcome indistinguishable from a quiet feed window.
+    # outcome indistinguishable from a quiet feed window.  Raised
+    # *before* the buffered skip-and-degrade signals are flushed: a
+    # total outage must not record per-candidate "swallowed" telemetry
+    # or metrics for failures that were not, in fact, swallowed.
     attempted = len(bounds)
-    if attempted > 0 and lookup_errors == attempted:
-        assert last_lookup_error is not None
+    if attempted > 0 and len(failed) == attempted:
+        _, last_lookup_error = failed[-1]
         raise LithosError(
             f"cache_lookup failed for all {attempted} candidates",
-            operation="cache_lookup",
+            # Propagate the underlying operation (e.g. "connect" when
+            # Lithos was unreachable) so the formatted ledger error
+            # points operators at what actually failed.
+            operation=last_lookup_error.operation or "cache_lookup",
             detail=last_lookup_error.detail or str(last_lookup_error),
         ) from last_lookup_error
+
+    # Partial failure (or none): the run continues, so each buffered
+    # failure really is a swallowed skip — emit the WARNING, the
+    # run-ledger telemetry record, and the metric tick now.
+    for bound, exc in failed:
+        candidate = bound.scored.candidate
+        detail = exc.detail or str(exc)
+        logger.warning(
+            "dedup lookup failed profile=%s source_url=%s "
+            "title=%r operation=%s detail=%s source=%s "
+            "— skipping candidate this run",
+            profile,
+            candidate.source_url,
+            candidate.title,
+            exc.operation or "cache_lookup",
+            # Bound the logged detail like the persisted telemetry —
+            # Lithos tool error payloads can carry stack traces.
+            detail[:_DETAIL_LOG_MAX_CHARS],
+            bound.source_label,
+        )
+        record_dedup_lookup_error(
+            source=_metric_source(bound.source_label),
+            kind=exc.operation or "cache_lookup",
+            detail=detail,
+        )
+        metrics.dedup_lookup_errors().add(
+            1, {"profile": profile, "source": _metric_source(bound.source_label)}
+        )
 
     return DedupOutcome(
         to_acquire=tuple(to_acquire),
         hits_to_skip=tuple(hits_to_skip),
-        lookup_errors=lookup_errors,
+        lookup_errors=len(failed),
     )

--- a/src/influx/run_ledger.py
+++ b/src/influx/run_ledger.py
@@ -81,6 +81,13 @@ _UNEXPECTED_FAILURE_REASONS: frozenset[str] = frozenset(
         "fetch_stall",
         "filter_stall",
         "filter_error",
+        # #234: the pre-acquire dedup helper swallowed at least one
+        # per-candidate ``cache_lookup`` LithosError.  Unexpected like
+        # ``filter_error`` — pipeline-infrastructure execution failed
+        # (Lithos-side tool error), not expected upstream lossiness —
+        # and immediately actionable: check Lithos health / server
+        # logs, not the feed.
+        "dedup_cache_lookup",
     }
 )
 
@@ -292,6 +299,7 @@ def build_degradation_summary(
     invalid_url_rejections_total: int | None,
     cache_hits_total: int | None,
     write_outcomes: WriteOutcomeCounts | None = None,
+    dedup_lookup_errors: list[dict[str, str]] | None = None,
     top_n: int = _DEGRADATION_SUMMARY_TOP_N,
 ) -> dict[str, Any]:
     """Build the bounded ``degradation_summary`` block for one run (#152).
@@ -374,6 +382,7 @@ def build_degradation_summary(
     archive = archive_failures or []
     retries = source_retry_counts or {}
     writes = write_outcomes or {}
+    lookup_errors = dedup_lookup_errors or []
 
     archive_by_kind: dict[str, int] = {}
     archive_by_domain: dict[str, int] = {}
@@ -391,6 +400,14 @@ def build_degradation_summary(
         source_by_kind[kind] = source_by_kind.get(kind, 0) + 1
         source = str(err.get("source") or "unknown")
         source_by_source[source] = source_by_source.get(source, 0) + 1
+
+    # #234: swallowed pre-acquire cache_lookup failures, bucketed by the
+    # bounded source label.  Kept out of ``source_acquisition.*`` so the
+    # Lithos-side failure mode never masquerades as an upstream one.
+    dedup_lookup_by_source: dict[str, int] = {}
+    for err in lookup_errors:
+        source = str(err.get("source") or "unknown")
+        dedup_lookup_by_source[source] = dedup_lookup_by_source.get(source, 0) + 1
 
     retries_by_kind: dict[str, int] = {}
     retries_by_source: dict[str, int] = {}
@@ -448,6 +465,8 @@ def build_degradation_summary(
             # degraded-reasons list.
             "writes": writes_total,
             "invalid_note_state": invalid_note_state_total,
+            # #234: swallowed pre-acquire cache_lookup failures.
+            "dedup_lookup_errors": len(lookup_errors),
         },
         "archive": {
             "by_kind": _renamed(_top_n_by_count(archive_by_kind, n=top_n), "kind"),
@@ -485,6 +504,14 @@ def build_degradation_summary(
             ),
             "by_source": _renamed(
                 _top_n_by_count(invalid_note_state_by_source, n=top_n), "source"
+            ),
+        },
+        # #234: swallowed pre-acquire cache_lookup failures, by bounded
+        # source label.  When the total is non-zero, the caller appends
+        # ``dedup_cache_lookup`` to the degraded reasons.
+        "dedup_lookup": {
+            "by_source": _renamed(
+                _top_n_by_count(dedup_lookup_by_source, n=top_n), "source"
             ),
         },
     }
@@ -610,6 +637,7 @@ class RunLedger:
         empty_source_writes_total: int | None = None,
         source_acquisition_errors: list[dict[str, str]] | None = None,
         source_cooldown_skips: list[dict[str, str]] | None = None,
+        dedup_lookup_errors: list[dict[str, str]] | None = None,
         source_retry_counts: dict[str, dict[str, int]] | None = None,
         tier3_fallbacks: dict[str, int] | None = None,
         archive_failures: list[ArchiveFailureRecord] | None = None,
@@ -630,6 +658,13 @@ class RunLedger:
           call upstream rather than tried and lost.  Single-run
           signal — like ``filter_error`` — so operators see the skip
           immediately even on the first cooldown-suppressed run.
+        - ``"dedup_cache_lookup"`` (issue #234) — the pre-acquire
+          dedup helper swallowed at least one per-candidate
+          ``cache_lookup`` :class:`~influx.errors.LithosError` and
+          skipped that candidate for this run.  Single-run signal —
+          like ``filter_error`` — because a Lithos-side tool failure
+          is immediately actionable (check Lithos health / server
+          logs, not the upstream feed).
         - ``"filter_error"`` (issue #85 review) — the LLM filter
           scorer raised :class:`FilterScorerError` (transport, parse,
           or provider failure) at least once during this run.  Single-
@@ -708,6 +743,7 @@ class RunLedger:
         """
         errors = list(source_acquisition_errors or [])
         cooldown_skips = list(source_cooldown_skips or [])
+        lookup_errors = list(dedup_lookup_errors or [])
         reasons: list[str] = []
         if errors:
             reasons.append("source_acquisition")
@@ -718,6 +754,13 @@ class RunLedger:
         # network failure) — the run-level summary surfaces both.
         if cooldown_skips:
             reasons.append("source_cooldown_skip")
+        # #234: at least one pre-acquire ``cache_lookup`` LithosError
+        # was swallowed (candidate skipped this run).  Separate reason
+        # from ``source_acquisition`` because the failed call is
+        # Influx→Lithos, not Influx→upstream — operators should check
+        # Lithos health, not the feed.
+        if lookup_errors:
+            reasons.append("dedup_cache_lookup")
 
         # #85 review: filter_error fires immediately on any
         # FilterScorerError catch, regardless of run kind.  Operators
@@ -899,6 +942,7 @@ class RunLedger:
             invalid_url_rejections_total=invalid_url_rejections_total,
             cache_hits_total=cache_hits_total,
             write_outcomes=write_outcomes,
+            dedup_lookup_errors=lookup_errors,
         )
 
         self._finish(
@@ -916,6 +960,7 @@ class RunLedger:
             degraded=bool(reasons),
             source_acquisition_errors=errors,
             source_cooldown_skips=cooldown_skips,
+            dedup_lookup_errors=lookup_errors,
             degraded_reasons=reasons,
             source_retry_counts=source_retry_counts,
             tier3_fallbacks=tier3_fallbacks,
@@ -1274,6 +1319,7 @@ class RunLedger:
         degraded: bool = False,
         source_acquisition_errors: list[dict[str, str]] | None = None,
         source_cooldown_skips: list[dict[str, str]] | None = None,
+        dedup_lookup_errors: list[dict[str, str]] | None = None,
         degraded_reasons: list[str] | None = None,
         source_retry_counts: dict[str, dict[str, int]] | None = None,
         tier3_fallbacks: dict[str, int] | None = None,
@@ -1334,6 +1380,10 @@ class RunLedger:
                     # ``source_acquisition_errors`` so the same JSONL
                     # consumers can read both lists with the same shape.
                     "source_cooldown_skips": list(source_cooldown_skips or []),
+                    # #234: persist swallowed pre-acquire cache_lookup
+                    # failures with the same source/kind/detail shape so
+                    # JSONL consumers can scan a uniform schema.
+                    "dedup_lookup_errors": list(dedup_lookup_errors or []),
                     # #129: deep-copy the per-source retry-count dict so
                     # later mutations of the contextvar bucket do not
                     # leak into the persisted ledger entry.

--- a/src/influx/run_service.py
+++ b/src/influx/run_service.py
@@ -47,6 +47,7 @@ from influx.run import (
 from influx.run_ledger import RunLedger
 from influx.telemetry import (
     current_cache_hits,
+    current_dedup_lookup_errors,
     current_empty_source_writes,
     current_fetched_total,
     current_filter_errors,
@@ -170,6 +171,13 @@ async def ledger_lifecycle(
     # upstream failure — the run-ledger entry tags it as
     # ``source_cooldown_skip`` so operators can tell the two apart.
     source_cooldown_skips_token = current_source_cooldown_skips.set([])
+    # #234: per-run list of swallowed pre-acquire cache_lookup failures.
+    # Distinct from ``current_source_acquisition_errors`` because the
+    # failed call is Influx→Lithos (the lookup tool errored server-side),
+    # not Influx→upstream — the run-ledger entry tags it as
+    # ``dedup_cache_lookup`` so operators check Lithos health, not the
+    # feed.
+    dedup_lookup_errors_token = current_dedup_lookup_errors.set([])
     # #85: per-run pre-filter fetched-count.  A list-of-ints so source
     # adapters increment a shared mutable container; reads at run-end
     # land the value into the run-ledger entry for the
@@ -281,6 +289,7 @@ async def ledger_lifecycle(
         elapsed = (datetime.now(UTC) - started_at).total_seconds()
         source_errors = current_source_acquisition_errors.get() or []
         source_cooldown_skips = current_source_cooldown_skips.get() or []
+        dedup_lookup_errors = current_dedup_lookup_errors.get() or []
 
         if session.skip_reason is not None:
             ledger.skip(run_id=run_id, reason=session.skip_reason)
@@ -384,6 +393,10 @@ async def ledger_lifecycle(
             # from swallowed acquisition errors — the ledger fires the
             # ``source_cooldown_skip`` reason on a non-empty list.
             source_cooldown_skips=source_cooldown_skips,
+            # #234: swallowed pre-acquire cache_lookup failures — the
+            # ledger fires the ``dedup_cache_lookup`` reason on a
+            # non-empty list.
+            dedup_lookup_errors=dedup_lookup_errors,
             # #129: surface recovered retry counts so the ledger entry
             # carries "we hit arXiv 429 twice but recovered" alongside
             # the swallowed-error list, letting an operator distinguish
@@ -484,6 +497,28 @@ async def ledger_lifecycle(
                 plan.kind.value,
                 run_id,
                 filter_errors_total,
+            )
+        if "dedup_cache_lookup" in degraded_reasons:
+            # #234: at least one pre-acquire cache_lookup LithosError
+            # was swallowed and the candidate skipped for this run.
+            # The failed call is Influx→Lithos, so operators triaging
+            # this reason check Lithos health and the Lithos server
+            # logs for cache_lookup tool errors — NOT the upstream
+            # feed.  Skipped candidates are re-checked next scheduled
+            # run.
+            if run_outcome == "success":
+                run_outcome = "degraded"
+            logger.warning(
+                "run flagged dedup_cache_lookup profile=%s kind=%s run_id=%s "
+                "lookup_errors=%d "
+                "(Lithos cache_lookup failed for these candidates; they were "
+                "skipped pre-acquire and will be re-checked next run — "
+                "check Lithos health / cache_lookup server errors, not "
+                "the upstream feed)",
+                profile,
+                plan.kind.value,
+                run_id,
+                len(dedup_lookup_errors),
             )
         if "archive_acquisition" in degraded_reasons:
             if run_outcome == "success":
@@ -749,6 +784,7 @@ async def ledger_lifecycle(
         current_run_id.reset(run_id_token)
         current_source_acquisition_errors.reset(source_errors_token)
         current_source_cooldown_skips.reset(source_cooldown_skips_token)
+        current_dedup_lookup_errors.reset(dedup_lookup_errors_token)
         current_fetched_total.reset(fetched_total_token)
         current_filter_errors.reset(filter_errors_token)
         current_invalid_url_rejections.reset(invalid_url_rejections_token)

--- a/src/influx/run_service.py
+++ b/src/influx/run_service.py
@@ -34,6 +34,7 @@ from typing import Any
 
 from influx import metrics
 from influx.config import AppConfig
+from influx.errors import format_exception_for_ledger
 from influx.notifications import ProfileRunResult
 from influx.run import (
     ItemProvider,
@@ -711,16 +712,22 @@ async def ledger_lifecycle(
         # The body raised — finalise as failure.
         elapsed = (datetime.now(UTC) - started_at).total_seconds()
         exc = session.error
+        # #234: format via the structured-error helper so the Lithos
+        # ``detail`` (the actual server-side failure text) reaches both
+        # the log line and the ledger ``error`` field instead of being
+        # collapsed into a bare "<operation> failed".
+        error_text = format_exception_for_ledger(exc) if exc is not None else "unknown"
         logger.exception(
-            "run failed profile=%s kind=%s run_id=%s duration=%.1fs",
+            "run failed profile=%s kind=%s run_id=%s duration=%.1fs error=%s",
             profile,
             plan.kind.value,
             run_id,
             elapsed,
+            error_text,
         )
         ledger.fail(
             run_id=run_id,
-            error=f"{type(exc).__name__}: {exc}" if exc is not None else "unknown",
+            error=error_text,
         )
         metrics.run_duration().record(elapsed, metric_attrs)
         # Issue #164 review: failure path also carries the ``severity``

--- a/src/influx/telemetry.py
+++ b/src/influx/telemetry.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "DedupLookupError",
     "InfluxMeter",
     "InfluxTracer",
     "SourceAcquisitionError",
@@ -36,6 +37,7 @@ __all__ = [
     "WriteOutcomeCounts",
     "current_archive_terminal_arxiv_ids",
     "current_cache_hits",
+    "current_dedup_lookup_errors",
     "current_empty_source_writes",
     "current_fetched_total",
     "current_filter_errors",
@@ -50,6 +52,7 @@ __all__ = [
     "get_meter",
     "get_tracer",
     "record_cache_hit",
+    "record_dedup_lookup_error",
     "record_empty_source_write",
     "record_fetched_items",
     "record_filter_error",
@@ -164,6 +167,52 @@ def record_source_cooldown_skip(
         return
     skips.append(
         SourceCooldownSkip(
+            {
+                "source": source,
+                "kind": kind,
+                "detail": detail[:300],
+            }
+        )
+    )
+
+
+# Issue #234: a per-candidate ``cache_lookup`` failure swallowed by the
+# pre-acquire dedup helper is recorded *separately* from the
+# source-acquisition path: the failure is Lithos-side (server error on
+# the lookup tool), not an upstream-feed problem, so the run ledger
+# marks the run degraded with ``dedup_cache_lookup`` and operators are
+# pointed at Lithos health rather than the feed.  Same shape as
+# :data:`SourceAcquisitionError` (source / kind / detail dicts) so
+# existing JSONL consumers can scan a uniform schema.
+DedupLookupError = dict[str, str]
+
+
+current_dedup_lookup_errors: ContextVar[list[DedupLookupError] | None] = ContextVar(
+    "current_dedup_lookup_errors",
+    default=None,
+)
+
+
+def record_dedup_lookup_error(
+    *,
+    source: str,
+    kind: str,
+    detail: str,
+) -> None:
+    """Append a swallowed pre-acquire ``cache_lookup`` failure (#234).
+
+    Distinct from :func:`record_source_acquisition_error`: the failed
+    call is Influx→Lithos, not Influx→upstream — the candidate is
+    skipped this run (re-checked next scheduled run) and the ledger
+    fires the dedicated ``dedup_cache_lookup`` degraded reason.  Safe
+    to call outside a run context — silently no-ops when
+    :data:`current_dedup_lookup_errors` is unset.
+    """
+    errors = current_dedup_lookup_errors.get()
+    if errors is None:
+        return
+    errors.append(
+        DedupLookupError(
             {
                 "source": source,
                 "kind": kind,

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -133,7 +133,10 @@ class TestFormatExceptionForLedger:
         err = LithosError(
             "cache_lookup failed",
             operation="cache_lookup",
-            detail="TypeError: '<' not supported between instances of 'NoneType' and 'float'",
+            detail=(
+                "TypeError: '<' not supported between instances "
+                "of 'NoneType' and 'float'"
+            ),
         )
         text = format_exception_for_ledger(err)
         assert text.startswith("LithosError: cache_lookup failed")
@@ -147,7 +150,8 @@ class TestFormatExceptionForLedger:
         assert "status=409" in text
 
     def test_lithos_error_without_context_is_plain(self) -> None:
-        assert format_exception_for_ledger(LithosError("generic")) == "LithosError: generic"
+        text = format_exception_for_ledger(LithosError("generic"))
+        assert text == "LithosError: generic"
 
     def test_detail_truncated(self) -> None:
         err = LithosError("op failed", detail="x" * 2000)

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -10,6 +10,7 @@ from influx.errors import (
     LCMAError,
     LithosError,
     NetworkError,
+    format_exception_for_ledger,
 )
 
 
@@ -114,6 +115,49 @@ class TestExtractionError:
         assert err.url == ""
         assert err.stage == ""
         assert err.detail == ""
+
+
+class TestFormatExceptionForLedger:
+    """format_exception_for_ledger surfaces structured error context (#234).
+
+    ``str(LithosError)`` is only the message — the server-supplied
+    ``detail`` (the actual Lithos-side failure) was dropped from the
+    "run failed" log and the run-ledger ``error`` field, forcing
+    operators to read the Lithos container logs to diagnose failures.
+    """
+
+    def test_plain_exception_unchanged(self) -> None:
+        assert format_exception_for_ledger(RuntimeError("boom")) == "RuntimeError: boom"
+
+    def test_lithos_error_includes_operation_and_detail(self) -> None:
+        err = LithosError(
+            "cache_lookup failed",
+            operation="cache_lookup",
+            detail="TypeError: '<' not supported between instances of 'NoneType' and 'float'",
+        )
+        text = format_exception_for_ledger(err)
+        assert text.startswith("LithosError: cache_lookup failed")
+        assert "operation=cache_lookup" in text
+        assert "'<' not supported" in text
+
+    def test_lithos_error_includes_status_code(self) -> None:
+        err = LithosError("write conflict", operation="lithos_write", status_code=409)
+        text = format_exception_for_ledger(err)
+        assert "operation=lithos_write" in text
+        assert "status=409" in text
+
+    def test_lithos_error_without_context_is_plain(self) -> None:
+        assert format_exception_for_ledger(LithosError("generic")) == "LithosError: generic"
+
+    def test_detail_truncated(self) -> None:
+        err = LithosError("op failed", detail="x" * 2000)
+        text = format_exception_for_ledger(err)
+        assert len(text) < 700
+        assert text.endswith("…)")
+
+    def test_lcma_error_detail_surfaced(self) -> None:
+        err = LCMAError("rate limited", detail="429 Too Many Requests")
+        assert "429 Too Many Requests" in format_exception_for_ledger(err)
 
 
 class TestAllSubclassesCatchable:

--- a/tests/unit/test_run_dedup.py
+++ b/tests/unit/test_run_dedup.py
@@ -371,6 +371,65 @@ async def test_all_lookups_failed_raises() -> None:
 
 
 @pytest.mark.asyncio
+async def test_all_lookups_failed_emits_no_swallowed_signals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A total outage raises WITHOUT recording skip-and-degrade signals.
+
+    The telemetry record / metric / per-candidate warning all describe a
+    *swallowed* skip; when the helper aborts the run instead, emitting
+    them would overcount degradations that were never recovered from.
+    """
+    counter = MagicMock()
+    monkeypatch.setattr("influx.metrics.dedup_lookup_errors", lambda: counter)
+    errors: list[dict[str, str]] = []
+    token = current_dedup_lookup_errors.set(errors)
+    try:
+        bounds = [_make_bound(item_id="a"), _make_bound(item_id="b")]
+        client = MagicMock()
+        client.cache_lookup_for_item_body = AsyncMock(
+            side_effect=[_lithos_error("first"), _lithos_error("second")]
+        )
+
+        with pytest.raises(LithosError, match="all 2 candidates"):
+            await dedup_scored_candidates(
+                bounds,
+                client=client,
+                profile="p1",
+                skip_cache_hits=False,
+            )
+    finally:
+        current_dedup_lookup_errors.reset(token)
+
+    assert errors == []
+    counter.add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_all_lookups_failed_propagates_underlying_operation() -> None:
+    """The all-failed summary error carries the underlying operation —
+    e.g. ``connect`` when Lithos was unreachable (#232) — so the
+    formatted ledger error points operators at what actually failed."""
+    bound = _make_bound()
+    client = MagicMock()
+    client.cache_lookup_for_item_body = AsyncMock(
+        side_effect=LithosError(
+            "connection_failed", operation="connect", detail="refused"
+        )
+    )
+
+    with pytest.raises(LithosError, match="all 1 candidates") as excinfo:
+        await dedup_scored_candidates(
+            [bound],
+            client=client,
+            profile="p1",
+            skip_cache_hits=False,
+        )
+    assert excinfo.value.operation == "connect"
+    assert excinfo.value.detail == "refused"
+
+
+@pytest.mark.asyncio
 async def test_metric_incremented_per_hit(monkeypatch: pytest.MonkeyPatch) -> None:
     """``metrics.cache_hits()`` is incremented exactly once per cache hit
     (skip path and merge path both count)."""

--- a/tests/unit/test_run_dedup.py
+++ b/tests/unit/test_run_dedup.py
@@ -20,11 +20,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from influx.errors import LithosError
 from influx.run_dedup import (
     DedupOutcome,
     dedup_scored_candidates,
 )
 from influx.source import BoundScoredCandidate, Candidate, ScoredCandidate
+from influx.telemetry import current_dedup_lookup_errors
 
 
 def _make_bound(
@@ -235,8 +237,10 @@ async def test_mixed_batch_partitions_correctly() -> None:
 
 
 @pytest.mark.asyncio
-async def test_client_error_propagates() -> None:
-    """Lookup errors propagate — helper does not swallow exceptions."""
+async def test_non_lithos_error_propagates() -> None:
+    """Non-Lithos lookup errors propagate — only ``LithosError`` is
+    treated as a recoverable per-candidate failure (#234).  Anything
+    else (e.g. a bug in our own partition code) must surface."""
     bound = _make_bound()
     client = MagicMock()
     client.cache_lookup_for_item_body = AsyncMock(side_effect=RuntimeError("boom"))
@@ -248,6 +252,122 @@ async def test_client_error_propagates() -> None:
             profile="p1",
             skip_cache_hits=False,
         )
+
+
+# ── #234: per-candidate LithosError degrades instead of aborting ───
+
+
+def _lithos_error(detail: str = "TypeError: '<' not supported") -> LithosError:
+    return LithosError("cache_lookup failed", operation="cache_lookup", detail=detail)
+
+
+@pytest.mark.asyncio
+async def test_lithos_error_skips_candidate_and_continues() -> None:
+    """One candidate's LithosError no longer aborts the batch (#234).
+
+    The errored candidate lands in *neither* partition (recoverable —
+    re-checked next scheduled run); the rest of the batch processes.
+    """
+    bounds = [
+        _make_bound(item_id="ok-1", title="First"),
+        _make_bound(item_id="poisoned", title="Poisoned"),
+        _make_bound(item_id="ok-2", title="Third"),
+    ]
+    client = MagicMock()
+    client.cache_lookup_for_item_body = AsyncMock(
+        side_effect=[{"hit": False}, _lithos_error(), {"hit": False}]
+    )
+
+    outcome = await dedup_scored_candidates(
+        bounds,
+        client=client,
+        profile="p1",
+        skip_cache_hits=False,
+    )
+
+    assert [d.bound.scored.candidate.item_id for d in outcome.to_acquire] == [
+        "ok-1",
+        "ok-2",
+    ]
+    assert outcome.hits_to_skip == ()
+    assert outcome.lookup_errors == 1
+    assert client.cache_lookup_for_item_body.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_lithos_error_records_dedup_lookup_error() -> None:
+    """The skipped candidate is recorded on the run's telemetry list
+    with the bounded source label and the Lithos ``detail`` text."""
+    errors: list[dict[str, str]] = []
+    token = current_dedup_lookup_errors.set(errors)
+    try:
+        bound = _make_bound(source_label="rss:Mozilla Hacks")
+        ok_bound = _make_bound(item_id="ok", source_label="arxiv")
+        client = MagicMock()
+        client.cache_lookup_for_item_body = AsyncMock(
+            side_effect=[_lithos_error("server exploded"), {"hit": False}]
+        )
+
+        await dedup_scored_candidates(
+            [bound, ok_bound],
+            client=client,
+            profile="p1",
+            skip_cache_hits=False,
+        )
+    finally:
+        current_dedup_lookup_errors.reset(token)
+
+    assert errors == [
+        {"source": "rss", "kind": "cache_lookup", "detail": "server exploded"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_lithos_error_increments_metric(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``metrics.dedup_lookup_errors()`` ticks once per skipped candidate
+    with bounded labels."""
+    counter = MagicMock()
+    monkeypatch.setattr("influx.metrics.dedup_lookup_errors", lambda: counter)
+
+    bounds = [_make_bound(item_id="bad", source_label="rss:Feed"), _make_bound()]
+    client = MagicMock()
+    client.cache_lookup_for_item_body = AsyncMock(
+        side_effect=[_lithos_error(), {"hit": False}]
+    )
+
+    await dedup_scored_candidates(
+        bounds,
+        client=client,
+        profile="p1",
+        skip_cache_hits=False,
+    )
+
+    counter.add.assert_called_once_with(1, {"profile": "p1", "source": "rss"})
+
+
+@pytest.mark.asyncio
+async def test_all_lookups_failed_raises() -> None:
+    """Total failure still fails the run (#234 safeguard).
+
+    Post-#232 connection failures are normalised to ``LithosError``, so
+    a fully-down Lithos would otherwise produce a silently-empty
+    "degraded" run indistinguishable from a quiet feed window.
+    """
+    bounds = [_make_bound(item_id="a"), _make_bound(item_id="b")]
+    client = MagicMock()
+    client.cache_lookup_for_item_body = AsyncMock(
+        side_effect=[_lithos_error("first"), _lithos_error("second")]
+    )
+
+    with pytest.raises(LithosError, match="all 2 candidates") as excinfo:
+        await dedup_scored_candidates(
+            bounds,
+            client=client,
+            profile="p1",
+            skip_cache_hits=False,
+        )
+    assert isinstance(excinfo.value.__cause__, LithosError)
+    assert excinfo.value.detail == "second"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_run_ledger.py
+++ b/tests/unit/test_run_ledger.py
@@ -181,6 +181,70 @@ class TestLedgerEntrySeverityField:
         assert entry["degradation_severity"] == "unexpected_failure"
 
 
+class TestDedupCacheLookupReason:
+    """#234: swallowed pre-acquire cache_lookup failures degrade the run."""
+
+    def test_dedup_lookup_errors_fire_reason(self, tmp_path: Path) -> None:
+        ledger = RunLedger(tmp_path / "state")
+        ledger.start(run_id="r-1", profile="p", kind="scheduled", run_range=None)
+        reasons = ledger.complete(
+            run_id="r-1",
+            sources_checked=3,
+            ingested=2,
+            fetched_total=3,
+            dedup_lookup_errors=[
+                {"source": "rss", "kind": "cache_lookup", "detail": "server exploded"},
+            ],
+        )
+        assert reasons == ["dedup_cache_lookup"]
+        entry = ledger.recent()[0]
+        assert entry["degraded"] is True
+        assert entry["degraded_reasons"] == ["dedup_cache_lookup"]
+        assert entry["dedup_lookup_errors"] == [
+            {"source": "rss", "kind": "cache_lookup", "detail": "server exploded"},
+        ]
+
+    def test_severity_is_unexpected_failure(self) -> None:
+        # Lithos-side tool failure is pipeline infrastructure breaking,
+        # like filter_error — not expected upstream lossiness.
+        assert (
+            classify_degradation_severity(["dedup_cache_lookup"])
+            == "unexpected_failure"
+        )
+
+    def test_summary_by_source_populated(self, tmp_path: Path) -> None:
+        ledger = RunLedger(tmp_path / "state")
+        ledger.start(run_id="r-1", profile="p", kind="scheduled", run_range=None)
+        ledger.complete(
+            run_id="r-1",
+            sources_checked=3,
+            ingested=2,
+            fetched_total=3,
+            dedup_lookup_errors=[
+                {"source": "rss", "kind": "cache_lookup", "detail": "a"},
+                {"source": "rss", "kind": "cache_lookup", "detail": "b"},
+                {"source": "arxiv", "kind": "cache_lookup", "detail": "c"},
+            ],
+        )
+        summary = ledger.recent()[0]["degradation_summary"]
+        assert summary["totals"]["dedup_lookup_errors"] == 3
+        assert summary["dedup_lookup"]["by_source"] == [
+            {"source": "rss", "count": 2},
+            {"source": "arxiv", "count": 1},
+        ]
+
+    def test_clean_run_defaults_empty(self, tmp_path: Path) -> None:
+        ledger = RunLedger(tmp_path / "state")
+        ledger.start(run_id="r-1", profile="p", kind="scheduled", run_range=None)
+        reasons = ledger.complete(
+            run_id="r-1", sources_checked=3, ingested=2, fetched_total=3
+        )
+        assert "dedup_cache_lookup" not in reasons
+        entry = ledger.recent()[0]
+        assert entry["dedup_lookup_errors"] == []
+        assert entry["degradation_summary"]["dedup_lookup"]["by_source"] == []
+
+
 def test_run_ledger_records_completed_run(tmp_path: Path) -> None:
     ledger = RunLedger(tmp_path / "state")
 
@@ -1953,6 +2017,9 @@ def test_degradation_summary_distinguishes_all_failure_classes(
         # downstream consumers don't need to defend against absence.
         "writes": 0,
         "invalid_note_state": 0,
+        # #234: no dedup lookup failures in this run — key present so
+        # downstream consumers don't need to defend against absence.
+        "dedup_lookup_errors": 0,
     }
 
 

--- a/tests/unit/test_run_service.py
+++ b/tests/unit/test_run_service.py
@@ -34,6 +34,7 @@ from influx.config import (
     ScheduleConfig,
 )
 from influx.coordinator import RunKind
+from influx.errors import LithosError
 from influx.run import RunOutcome, RunPlan
 from influx.run_ledger import RunLedger
 from influx.run_service import RunService, run_via_service
@@ -226,6 +227,44 @@ async def test_body_exception_marks_ledger_failed_and_propagates(
     entry = ledger.recent()[0]
     assert entry["status"] == "failed"
     assert "RuntimeError" in entry["error"]
+
+
+async def test_failed_run_ledger_error_carries_lithos_detail(
+    tmp_path: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """#234: LithosError ``detail`` reaches the ledger error and log line.
+
+    Previously only ``str(exc)`` ("cache_lookup failed") was recorded,
+    so diagnosing the underlying Lithos-side crash required reading the
+    Lithos container logs.
+    """
+    config = _make_config()
+    ledger = RunLedger(tmp_path)
+    service = RunService(config=config, ledger=ledger)
+
+    async def boom(*args: Any, **kwargs: Any) -> RunOutcome:
+        raise LithosError(
+            "cache_lookup failed",
+            operation="cache_lookup",
+            detail="TypeError: '<' not supported between instances of 'NoneType' and 'float'",
+        )
+
+    with (
+        patch("influx.run.Run.execute", side_effect=boom),
+        caplog.at_level(logging.ERROR, logger="influx.run_service"),
+        pytest.raises(LithosError, match="cache_lookup failed"),
+    ):
+        await service.execute(_scheduled_plan())
+
+    entry = ledger.recent()[0]
+    assert entry["status"] == "failed"
+    assert "operation=cache_lookup" in entry["error"]
+    assert "'<' not supported" in entry["error"]
+
+    failed_records = [r for r in caplog.records if "run failed" in r.getMessage()]
+    assert failed_records, "expected a 'run failed' ERROR record"
+    assert "'<' not supported" in failed_records[0].getMessage()
 
 
 # ── run_via_service: kind → RunPlan flag mapping ───────────────────

--- a/tests/unit/test_run_service.py
+++ b/tests/unit/test_run_service.py
@@ -42,6 +42,7 @@ from influx.telemetry import (
     current_fetched_total,
     current_filter_errors,
     current_source_acquisition_errors,
+    record_dedup_lookup_error,
     record_tier3_fallback,
 )
 
@@ -229,6 +230,71 @@ async def test_body_exception_marks_ledger_failed_and_propagates(
     assert "RuntimeError" in entry["error"]
 
 
+async def test_dedup_lookup_errors_propagate_to_ledger_entry(
+    tmp_path: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A run body that records dedup lookup errors lands them on the
+    ledger entry and degrades the run with ``dedup_cache_lookup`` (#234).
+
+    Uses :func:`record_dedup_lookup_error` from inside the patched body
+    so we exercise the real contextvar wiring inside
+    ``ledger_lifecycle`` rather than mocking the bucket directly.
+    """
+    config = _make_config()
+    ledger = RunLedger(tmp_path)
+    service = RunService(config=config, ledger=ledger)
+
+    async def body_with_lookup_errors(*args: Any, **kwargs: Any) -> RunOutcome:
+        record_dedup_lookup_error(
+            source="rss",
+            kind="cache_lookup",
+            detail="TypeError: '<' not supported",
+        )
+        return RunOutcome(sources_checked=4, ingested=4)
+
+    with (
+        patch("influx.run.Run.execute", new=body_with_lookup_errors),
+        caplog.at_level(logging.WARNING, logger="influx.run_service"),
+    ):
+        await service.execute(_scheduled_plan())
+
+    entry = ledger.recent()[0]
+    assert entry["degraded"] is True
+    assert entry["degraded_reasons"] == ["dedup_cache_lookup"]
+    assert entry["degradation_severity"] == "unexpected_failure"
+    assert entry["dedup_lookup_errors"] == [
+        {
+            "source": "rss",
+            "kind": "cache_lookup",
+            "detail": "TypeError: '<' not supported",
+        },
+    ]
+    flagged = [
+        r for r in caplog.records if "run flagged dedup_cache_lookup" in r.getMessage()
+    ]
+    assert flagged, "expected a 'run flagged dedup_cache_lookup' WARNING"
+    assert "lookup_errors=1" in flagged[0].getMessage()
+
+
+async def test_dedup_lookup_errors_default_empty(tmp_path: Any) -> None:
+    """A clean run lands ``dedup_lookup_errors == []`` on the entry."""
+    config = _make_config()
+    ledger = RunLedger(tmp_path)
+    service = RunService(config=config, ledger=ledger)
+
+    with patch(
+        "influx.run.Run.execute",
+        new_callable=AsyncMock,
+        return_value=RunOutcome(sources_checked=1, ingested=1),
+    ):
+        await service.execute(_scheduled_plan())
+
+    entry = ledger.recent()[0]
+    assert entry["dedup_lookup_errors"] == []
+    assert "dedup_cache_lookup" not in entry["degraded_reasons"]
+
+
 async def test_failed_run_ledger_error_carries_lithos_detail(
     tmp_path: Any,
     caplog: pytest.LogCaptureFixture,
@@ -247,7 +313,10 @@ async def test_failed_run_ledger_error_carries_lithos_detail(
         raise LithosError(
             "cache_lookup failed",
             operation="cache_lookup",
-            detail="TypeError: '<' not supported between instances of 'NoneType' and 'float'",
+            detail=(
+                "TypeError: '<' not supported between instances "
+                "of 'NoneType' and 'float'"
+            ),
         )
 
     with (


### PR DESCRIPTION
## Summary

First prod run (2026-06-07) lost 4/5 profiles to a single Lithos-side `cache_lookup` TypeError, surfaced in influx only as a bare `LithosError: cache_lookup failed`. This PR fixes both influx-side weaknesses (the Lithos crash itself is agent-lore/lithos#312):

### 1. Surface the dropped error detail (observability)

- New `errors.format_exception_for_ledger(exc)` appends any non-empty `operation` / `status_code` / `detail` to the rendered exception (detail truncated to 500 chars).
- The `run failed` ERROR log line and the runs.jsonl `error` field now carry the actual Lithos-side failure text instead of just the message — no more docker-logs archaeology.
- Deliberately **not** `LithosError.__str__`: slug-collision recovery parses raw `.detail` and existing tests match exact messages.

### 2. Degrade per-candidate instead of aborting the run (resilience)

- `dedup_scored_candidates` now catches `LithosError` per candidate, skips that candidate for this run, and continues the batch. Skipped candidates are re-checked next scheduled run.
- **Not** treated as a cache miss — acquiring on an unverified lookup risks exactly the duplicate-note/cost harm dedup exists to prevent.
- **Total-failure safeguard:** if *every* attempted lookup fails (Lithos fully down — post-#232 connection failures arrive as `LithosError` too), the helper raises, so a dead Lithos still fails the run instead of producing a silently-empty "degraded" outcome.
- Non-Lithos exceptions still propagate (programming bugs must surface).

### Ledger / telemetry plumbing (mirrors #146 / #85 precedents)

- New degraded reason **`dedup_cache_lookup`**, classified `unexpected_failure` (like `filter_error` — pipeline-infra breakage, immediately actionable: check Lithos health, not the feed).
- Per-run `dedup_lookup_errors` list (source/kind/detail, same shape as `source_acquisition_errors`) persisted on the ledger entry; `totals.dedup_lookup_errors` + `dedup_lookup.by_source` in the degradation summary.
- Operator warning `run flagged dedup_cache_lookup …` pointing at Lithos rather than the upstream feed.
- New bounded metric `influx_dedup_lookup_errors_total{profile,source}`.
- `DedupOutcome.lookup_errors` count + `lookup_errors=` in the pre-acquire dedup log line.

## Test plan

- [x] `tests/unit/test_errors.py` — formatter includes operation/status/detail, truncates, leaves plain exceptions and context-free LithosErrors untouched
- [x] `tests/unit/test_run_service.py` — ledger `error` + `run failed` log carry LithosError detail; recorded dedup errors degrade the run with reason/severity/list/warning; clean-run default empty
- [x] `tests/unit/test_run_dedup.py` — middle-of-batch LithosError skips only that candidate (`lookup_errors==1`, rest processed); telemetry record carries bounded source + detail; metric ticks; all-lookups-failed raises with `__cause__` chained; non-Lithos errors still propagate (repurposed `test_client_error_propagates`)
- [x] `tests/unit/test_run_ledger.py` — `complete(dedup_lookup_errors=[…])` fires the reason; severity `unexpected_failure`; summary populated and empty-default; existing meta-test covers the new reason literal
- [x] `make check` green locally (ruff, pyright, 2599 tests)

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)
