### PR TITLE
Archive downloader sends no User-Agent → publisher 403/429/anti-bot; ~4/9 stuck notes reco

### DIFF
--- a/src/influx/http_client.py
+++ b/src/influx/http_client.py
@@ -40,6 +40,18 @@ _ALLOWED_SCHEMES = frozenset({"http", "https"})
 
 _MAX_REDIRECTS = 20
 
+# Browser-like User-Agent for outbound archive fetches.  httpx's default
+# ``python-httpx/<version>`` UA trips publisher anti-bot defences, which
+# return 403/429/anti-bot challenge pages instead of the document — the
+# request never had a chance.  Presenting a mainstream browser UA lets a
+# chunk of those "stuck" notes (publisher PDFs/articles) acquire on the
+# next sweep with no other change.  Set on the GET ``httpx.Client`` so it
+# is preserved across every redirect hop.
+_BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
 ContentTypeFamily = Literal["html", "pdf", "xml"]
 
 _CONTENT_TYPE_FAMILIES: dict[ContentTypeFamily, frozenset[str]] = {
@@ -221,7 +233,11 @@ def guarded_fetch(
     current_url = url
 
     try:
-        with httpx.Client(timeout=timeout, follow_redirects=False) as client:
+        with httpx.Client(
+            timeout=timeout,
+            follow_redirects=False,
+            headers={"User-Agent": _BROWSER_USER_AGENT},
+        ) as client:
             for _hop in range(_MAX_REDIRECTS + 1):
                 with client.stream("GET", current_url) as response:
                     if response.is_redirect:

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -178,6 +178,51 @@ class TestFetchResult:
         assert result.final_url == url
 
 
+# ── Browser User-Agent on archive fetches ────────────────────────────
+
+
+class TestBrowserUserAgent:
+    """guarded_fetch presents a browser UA so publisher anti-bot defences
+    don't return 403/429/anti-bot pages instead of the document."""
+
+    @respx.mock
+    def test_sends_browser_user_agent(self) -> None:
+        url = "http://example.com/paper.pdf"
+        route = respx.get(url).mock(
+            return_value=httpx.Response(
+                200,
+                content=b"%PDF-1.7",
+                headers={"content-type": "application/pdf"},
+            )
+        )
+        fake = _fake_getaddrinfo("93.184.216.34")
+        with patch(_PATCH_GAI, fake):
+            guarded_fetch(url, expected_content_type="pdf")
+        sent_ua = route.calls.last.request.headers.get("user-agent", "")
+        assert "Mozilla/5.0" in sent_ua
+        assert "python-httpx" not in sent_ua
+
+    @respx.mock
+    def test_user_agent_preserved_across_redirect(self) -> None:
+        start = "http://example.com/start"
+        final = "http://example.com/final.pdf"
+        respx.get(start).mock(
+            return_value=httpx.Response(302, headers={"location": final}),
+        )
+        final_route = respx.get(final).mock(
+            return_value=httpx.Response(
+                200,
+                content=b"%PDF-1.7",
+                headers={"content-type": "application/pdf"},
+            )
+        )
+        fake = _fake_getaddrinfo("93.184.216.34")
+        with patch(_PATCH_GAI, fake):
+            guarded_fetch(start, expected_content_type="pdf")
+        sent_ua = final_route.calls.last.request.headers.get("user-agent", "")
+        assert "Mozilla/5.0" in sent_ua
+
+
 # ── DNS resolution failure ───────────────────────────────────────────
 
 


### PR DESCRIPTION
## What

Archive downloader sends no User-Agent → publisher 403/429/anti-bot; ~4/9 stuck notes recover from a browser UA alone

Closes #239

## Review

- verdicts: [correctness]=LGTM [security]=LGTM
- rounds: 1
- test gate: GREEN
- agent cost: $2.07
- Lithos task: `a8938fac-2ede-4a39-b16a-8b642765455d`

Per-round commits are intentional (the dialogue history); squash-merge keeps main clean.

🤖 Generated by lithos-loom story-develop