### PR TITLE
fix(diagrams): render component diagram on GitHub (subgraph id clash)

### DIFF
--- a/docs/generated/architecture.md
+++ b/docs/generated/architecture.md
@@ -5,7 +5,7 @@
 
 ```mermaid
 graph TD
-  subgraph Core
+  subgraph tier_Core["Core"]
     Enrich
     Feedback
     Filter
@@ -15,12 +15,12 @@ graph TD
     Sources
     Storage
   end
-  subgraph Entrypoints
+  subgraph tier_Entrypoints["Entrypoints"]
     Entrypoint
     HttpApi
     Orchestration
   end
-  subgraph Foundation
+  subgraph tier_Foundation["Foundation"]
     Common
     Config
     Observability

--- a/tests/meta/_diagram_toolkit.py
+++ b/tests/meta/_diagram_toolkit.py
@@ -83,7 +83,13 @@ def render_component_diagram() -> str:
         members = [c for c in sorted(tiers[tier]) if c in components]
         if not members:
             continue
-        lines.append(f"  subgraph {tier}")
+        # Give the subgraph an explicit id distinct from any component node id.
+        # A tier and a component may share a name (e.g. "Entrypoints"); emitting
+        # `subgraph Entrypoints` around a node `Entrypoints` makes Mermaid think
+        # the subgraph contains itself ("would create a cycle") and GitHub fails
+        # to render it. `subgraph tier_X["X"]` keeps the label but avoids the clash.
+        tier_id = "tier_" + re.sub(r"\W+", "_", tier)
+        lines.append(f'  subgraph {tier_id}["{tier}"]')
         for comp in members:
             lines.append(f"    {comp}")
             placed.add(comp)


### PR DESCRIPTION
## What

The merged *diagrams-as-tests* work left `docs/generated/architecture.md` unrenderable on GitHub:

> Unable to render rich display — Setting Entrypoints as parent of Entrypoints would create a cycle

A **tier** and a **component** share the name `Entrypoints`, so the generator emitted `subgraph Entrypoints` wrapping a node `Entrypoints` — Mermaid reads that as a subgraph containing itself.

## Fix

Emit `subgraph tier_<name>["<name>"]` — the subgraph keeps its display label but gets an id (`tier_Entrypoints`) that can't collide with a component node. Regenerated `architecture.md`; validated the output with `mermaid-cli` (renders clean).

Same fix is being applied to the sibling repos that share this diagram toolkit (lithos, lithos-loom, lithos-lens).

## Test plan

- [ ] `docs/generated/architecture.md` renders on GitHub (no "cycle" error)
- [ ] `make diagrams` passes (drift check green)
