### PR TITLE
refactor(repair): migrate repair_hooks + renderer onto shared canonical ops (PR 2/6)

### DIFF
--- a/docs/generated/architecture.md
+++ b/docs/generated/architecture.md
@@ -77,7 +77,6 @@ graph TD
   Repair --> Enrich
   Repair --> LithosBridge
   Repair --> Observability
-  Repair --> Schemas
   Repair --> Sources
   Repair --> Storage
   Sources --> Common

--- a/src/influx/renderer.py
+++ b/src/influx/renderer.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from influx.canonical_note import (
     ProfileRelevanceEntry,
     render_profile_relevance_body,
+    render_tier3_sections,
 )
 from influx.errors import InfluxError
 from influx.schemas import Tier1Enrichment, Tier3Extraction
@@ -218,20 +219,11 @@ def render_note(
     if full_text:
         output += f"\n## Full Text\n{full_text}\n"
 
-    # Tier 3 sections (US-012) — omitted entirely when absent (FR-ENR-6)
+    # Tier 3 sections (US-012) — omitted entirely when absent (FR-ENR-6).
+    # The section block is owned by canonical_note (shared with the repair
+    # sweep); the leading blank-line separator is added here.
     if tier3_extraction is not None:
-        output += "\n## Claims\n"
-        for claim in tier3_extraction.claims:
-            output += f"- {claim}\n"
-        output += "\n## Datasets & Benchmarks\n"
-        for ds in tier3_extraction.datasets:
-            output += f"- {ds}\n"
-        output += "\n## Builds On\n"
-        for item in tier3_extraction.builds_on:
-            output += f"- {item}\n"
-        output += "\n## Open Questions\n"
-        for q in tier3_extraction.open_questions:
-            output += f"- {q}\n"
+        output += "\n" + render_tier3_sections(tier3_extraction)
 
     # Profile Relevance section — always emitted to keep the canonical
     # note shape stable (US-007); body is empty when no entries are given.

--- a/src/influx/repair_counters.py
+++ b/src/influx/repair_counters.py
@@ -224,7 +224,7 @@ def upsert_repair_section(content: str, counters: RepairCounters) -> str:
 
     Replaces an existing section in place; otherwise inserts the new
     section before ``## Profile Relevance`` (canonical placement,
-    matching ``repair_hooks._find_insertion_point``), or before
+    matching ``canonical_note.insertion_point``), or before
     ``## User Notes``, or at end of content when neither is present.
     """
     rendered = render_repair_section(counters)

--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -22,6 +22,12 @@ import trafilatura
 from influx.archive_policy import (
     registry_from_config as _archive_policy_registry_from_config,
 )
+from influx.canonical_note import (
+    FULL_TEXT,
+    extract_section_body,
+    insert_full_text_section,
+    insert_tier3_sections,
+)
 from influx.config import AppConfig
 from influx.enrich import tier3_extract as _tier3_extract
 from influx.errors import ExtractionError, LCMAError, NetworkError
@@ -40,7 +46,6 @@ from influx.repair import (
     Tier2EnrichHook,
     Tier3ExtractHook,
 )
-from influx.schemas import Tier3Extraction
 from influx.storage import download_archive
 from influx.urls import url_hash
 
@@ -49,77 +54,13 @@ __all__ = ["DefaultSweepHooks", "make_default_sweep_hooks"]
 _log = logging.getLogger(__name__)
 
 # ── Content manipulation helpers ────────────────────────────────────
+#
+# The section-shape ops (insert Full Text / Tier 3, find the insertion point,
+# extract a section body) are owned by :mod:`influx.canonical_note` and
+# imported above.  Only ``_extract_title`` — a title locator with no canonical
+# equivalent — remains local.
 
-_PROFILE_RELEVANCE_RE = re.compile(r"^## Profile Relevance\b", re.MULTILINE)
-_USER_NOTES_RE = re.compile(r"^## User Notes\b", re.MULTILINE)
-_FULL_TEXT_HEADING_RE = re.compile(r"^## Full Text[ \t]*$", re.MULTILINE)
-_NEXT_H2_RE = re.compile(r"^## ", re.MULTILINE)
 _TITLE_RE = re.compile(r"^# ([^\r\n]+)", re.MULTILINE)
-
-
-def _find_insertion_point(content: str) -> int:
-    """Find the position to insert new sections before Profile Relevance.
-
-    Falls back to before ``## User Notes`` or end-of-string.
-    """
-    m = _PROFILE_RELEVANCE_RE.search(content)
-    if m:
-        return m.start()
-    m = _USER_NOTES_RE.search(content)
-    if m:
-        return m.start()
-    return len(content)
-
-
-def _insert_full_text_section(content: str, full_text: str) -> str:
-    """Insert ``## Full Text`` section at the canonical position."""
-    pos = _find_insertion_point(content)
-    section = f"\n## Full Text\n{full_text}\n"
-    return content[:pos] + section + "\n" + content[pos:]
-
-
-def _render_tier3_sections(tier3: Tier3Extraction) -> str:
-    """Render the four Tier 3 sections as markdown."""
-    parts: list[str] = []
-
-    parts.append("## Claims")
-    for claim in tier3.claims:
-        parts.append(f"- {claim}")
-
-    parts.append("\n## Datasets & Benchmarks")
-    for ds in tier3.datasets:
-        parts.append(f"- {ds}")
-
-    parts.append("\n## Builds On")
-    for item in tier3.builds_on:
-        parts.append(f"- {item}")
-
-    parts.append("\n## Open Questions")
-    for q in tier3.open_questions:
-        parts.append(f"- {q}")
-
-    return "\n".join(parts) + "\n"
-
-
-def _insert_tier3_sections(content: str, tier3: Tier3Extraction) -> str:
-    """Insert Tier 3 sections at the canonical position."""
-    pos = _find_insertion_point(content)
-    section_text = "\n" + _render_tier3_sections(tier3)
-    return content[:pos] + section_text + "\n" + content[pos:]
-
-
-def _extract_full_text_body(content: str) -> str:
-    """Extract the ``## Full Text`` section body from note content."""
-    start_match = _FULL_TEXT_HEADING_RE.search(content)
-    if not start_match:
-        return ""
-    body_start = start_match.end()
-    if body_start < len(content) and content[body_start] == "\n":
-        body_start += 1
-    next_match = _NEXT_H2_RE.search(content, body_start)
-    if next_match:
-        return content[body_start : next_match.start()].rstrip()
-    return content[body_start:].rstrip()
 
 
 def _extract_title(content: str) -> str:
@@ -1061,7 +1002,7 @@ def _make_tier2_enrich_hook(config: AppConfig) -> Tier2EnrichHook:
         )
 
         # Insert ## Full Text section into content.
-        note["content"] = _insert_full_text_section(content, extracted_text)
+        note["content"] = insert_full_text_section(content, extracted_text)
 
         # Add full-text tag.
         if "full-text" not in tags:
@@ -1084,7 +1025,7 @@ def _make_tier3_extract_hook(config: AppConfig) -> Tier3ExtractHook:
         tags: list[str] = _note_tags(note)
 
         # Extract full text from note content.
-        full_text = _extract_full_text_body(content)
+        full_text = extract_section_body(content, FULL_TEXT)
         if not full_text:
             raise ExtractionError(
                 "No ## Full Text section found in note",
@@ -1105,7 +1046,7 @@ def _make_tier3_extract_hook(config: AppConfig) -> Tier3ExtractHook:
             raise  # Propagate — the sweep treats LCMAError as stage failure.
 
         # Insert Tier 3 sections into content.
-        note["content"] = _insert_tier3_sections(content, tier3_result)
+        note["content"] = insert_tier3_sections(content, tier3_result)
 
         # Add influx:deep-extracted tag.
         if "influx:deep-extracted" not in tags:

--- a/tests/unit/test_canonical_note.py
+++ b/tests/unit/test_canonical_note.py
@@ -414,7 +414,7 @@ class TestStructuredOps:
         assert headings == ["Archive", "Full Text", "Profile Relevance"]
 
 
-# ── render_tier3_sections ───────────────────────────────────────────
+# ── render_tier3_sections / section inserts ─────────────────────────
 
 
 def test_render_tier3_sections_shape() -> None:
@@ -423,6 +423,29 @@ def test_render_tier3_sections_shape() -> None:
     assert "## Datasets & Benchmarks\n- d1\n" in rendered
     assert "## Builds On\n- b1\n" in rendered
     assert rendered.endswith("## Open Questions\n- q1\n")
+
+
+def test_render_tier3_sections_emits_all_four_headings_when_lists_empty() -> None:
+    rendered = cn.render_tier3_sections(Tier3Extraction(claims=["c1"]))
+    for heading in (
+        "## Claims",
+        "## Datasets & Benchmarks",
+        "## Builds On",
+        "## Open Questions",
+    ):
+        assert heading in rendered
+
+
+def test_insert_full_text_before_profile_relevance() -> None:
+    content = "# T\n\n## Summary\ns\n\n## Profile Relevance\npr\n\n## User Notes\n"
+    result = cn.insert_full_text_section(content, "extracted")
+    assert result.index("## Full Text") < result.index("## Profile Relevance")
+
+
+def test_insert_tier3_before_profile_relevance() -> None:
+    content = "# T\n\n## Full Text\ntext\n\n## Profile Relevance\npr\n\n## User Notes\n"
+    result = cn.insert_tier3_sections(content, TIER3)
+    assert result.index("## Claims") < result.index("## Profile Relevance")
 
 
 # ── ProfileRelevanceEntry identity across modules ───────────────────
@@ -463,32 +486,9 @@ class TestLegacyParityTransitional:
     def _canonical_note(self) -> str:
         return _read("golden_lf.md")
 
-    def test_render_tier3_matches_repair_hooks(self) -> None:
-        from influx import repair_hooks as rh
-
-        assert cn.render_tier3_sections(TIER3) == rh._render_tier3_sections(TIER3)
-
-    def test_insert_full_text_matches_repair_hooks(self) -> None:
-        from influx import repair_hooks as rh
-
-        note = _read("tier3_full.md")
-        assert cn.insert_full_text_section(note, "ft") == rh._insert_full_text_section(
-            note, "ft"
-        )
-
-    def test_insert_tier3_matches_repair_hooks(self) -> None:
-        from influx import repair_hooks as rh
-
-        note = _read("no_user_notes.md")
-        assert cn.insert_tier3_sections(note, TIER3) == rh._insert_tier3_sections(
-            note, TIER3
-        )
-
-    def test_insertion_point_matches_repair_hooks(self) -> None:
-        from influx import repair_hooks as rh
-
-        note = self._canonical_note()
-        assert cn.insertion_point(note) == rh._find_insertion_point(note)
+    # NOTE: the repair_hooks parity cases (render_tier3 / insert_full_text /
+    # insert_tier3 / insertion_point) were removed in PR 2 when those helpers
+    # were deleted in favour of the canonical ops.
 
     def test_graft_user_notes_matches_lithos_client(self) -> None:
         from influx import lithos_client as lc

--- a/tests/unit/test_canonical_note.py
+++ b/tests/unit/test_canonical_note.py
@@ -436,16 +436,63 @@ def test_render_tier3_sections_emits_all_four_headings_when_lists_empty() -> Non
         assert heading in rendered
 
 
-def test_insert_full_text_before_profile_relevance() -> None:
-    content = "# T\n\n## Summary\ns\n\n## Profile Relevance\npr\n\n## User Notes\n"
-    result = cn.insert_full_text_section(content, "extracted")
-    assert result.index("## Full Text") < result.index("## Profile Relevance")
+class TestSectionInsertBytes:
+    """Exact-byte splice behaviour for the section-insert ops.
 
+    Pins the precise inserted bytes and blank-line shape (byte-identical to
+    the legacy repair_hooks helpers PR 2 replaced), the insertion-point
+    fallback chain (before Profile Relevance → before User Notes → EOF), and
+    byte-exact preservation of the surrounding note incl. ``## User Notes``.
+    """
 
-def test_insert_tier3_before_profile_relevance() -> None:
-    content = "# T\n\n## Full Text\ntext\n\n## Profile Relevance\npr\n\n## User Notes\n"
-    result = cn.insert_tier3_sections(content, TIER3)
-    assert result.index("## Claims") < result.index("## Profile Relevance")
+    def test_insert_full_text_before_profile_relevance(self) -> None:
+        content = (
+            "# T\n\n## Summary\ns\n\n## Profile Relevance\npr\n\n## User Notes\nMINE\n"
+        )
+        assert cn.insert_full_text_section(content, "FT") == (
+            "# T\n\n## Summary\ns\n\n\n## Full Text\nFT\n\n"
+            "## Profile Relevance\npr\n\n## User Notes\nMINE\n"
+        )
+
+    def test_insert_full_text_fallback_before_user_notes(self) -> None:
+        content = "# T\n\n## Summary\ns\n\n## User Notes\nMINE\n"
+        result = cn.insert_full_text_section(content, "FT")
+        assert result == (
+            "# T\n\n## Summary\ns\n\n\n## Full Text\nFT\n\n## User Notes\nMINE\n"
+        )
+        # User Notes region preserved byte-exactly.
+        idx = cn.find_user_notes_start(result)
+        assert result[idx:] == "## User Notes\nMINE\n"
+
+    def test_insert_full_text_fallback_eof(self) -> None:
+        content = "# T\n\n## Summary\ns\n"
+        assert cn.insert_full_text_section(content, "FT") == (
+            "# T\n\n## Summary\ns\n\n## Full Text\nFT\n\n"
+        )
+
+    def test_insert_tier3_before_profile_relevance(self) -> None:
+        content = (
+            "# T\n\n## Full Text\ntext\n\n"
+            "## Profile Relevance\npr\n\n## User Notes\nMINE\n"
+        )
+        tier3 = Tier3Extraction(
+            claims=["C1"], datasets=["D1"], builds_on=["B1"], open_questions=["Q1"]
+        )
+        assert cn.insert_tier3_sections(content, tier3) == (
+            "# T\n\n## Full Text\ntext\n\n\n"
+            "## Claims\n- C1\n\n## Datasets & Benchmarks\n- D1\n\n"
+            "## Builds On\n- B1\n\n## Open Questions\n- Q1\n\n"
+            "## Profile Relevance\npr\n\n## User Notes\nMINE\n"
+        )
+
+    def test_insert_tier3_preserves_user_notes_region(self) -> None:
+        content = (
+            "# T\n\n## Full Text\ntext\n\n## Profile Relevance\npr\n\n"
+            "## User Notes\nMINE  \n\n\n"
+        )
+        result = cn.insert_tier3_sections(content, TIER3)
+        idx = cn.find_user_notes_start(result)
+        assert result[idx:] == "## User Notes\nMINE  \n\n\n"
 
 
 # ── ProfileRelevanceEntry identity across modules ───────────────────

--- a/tests/unit/test_repair_hooks_production.py
+++ b/tests/unit/test_repair_hooks_production.py
@@ -28,11 +28,7 @@ from influx.repair import (
 )
 from influx.repair_hooks import (
     DefaultSweepHooks,
-    _extract_full_text_body,
     _extract_title,
-    _insert_full_text_section,
-    _insert_tier3_sections,
-    _render_tier3_sections,
     make_default_sweep_hooks,
 )
 from influx.schemas import Tier3Extraction
@@ -464,72 +460,10 @@ class TestExtractTitle:
         assert _extract_title("no title here") == ""
 
 
-class TestExtractFullTextBody:
-    def test_extracts_body(self) -> None:
-        content = (
-            "## Summary\nsum\n\n"
-            "## Full Text\nThe full text body.\n\n"
-            "## Profile Relevance\n"
-        )
-        assert _extract_full_text_body(content) == "The full text body."
-
-    def test_returns_empty_on_no_section(self) -> None:
-        content = "## Summary\nsum\n\n## Profile Relevance\n"
-        assert _extract_full_text_body(content) == ""
-
-
-class TestInsertFullTextSection:
-    def test_inserts_before_profile_relevance(self) -> None:
-        content = "## Summary\nsum\n\n## Profile Relevance\npr\n"
-        result = _insert_full_text_section(content, "Extracted text.")
-        assert "## Full Text" in result
-        ft_pos = result.find("## Full Text")
-        pr_pos = result.find("## Profile Relevance")
-        assert ft_pos < pr_pos
-
-
-class TestInsertTier3Sections:
-    def test_inserts_before_profile_relevance(self) -> None:
-        content = "## Full Text\ntext\n\n## Profile Relevance\npr\n"
-        tier3 = Tier3Extraction(
-            claims=["C1"],
-            datasets=["D1"],
-            builds_on=["B1"],
-            open_questions=["Q1"],
-        )
-        result = _insert_tier3_sections(content, tier3)
-        assert "## Claims" in result
-        claims_pos = result.find("## Claims")
-        pr_pos = result.find("## Profile Relevance")
-        assert claims_pos < pr_pos
-
-
-class TestRenderTier3Sections:
-    def test_renders_all_four_sections(self) -> None:
-        tier3 = Tier3Extraction(
-            claims=["C1", "C2"],
-            datasets=["D1"],
-            builds_on=["B1"],
-            open_questions=["Q1"],
-        )
-        rendered = _render_tier3_sections(tier3)
-        assert "## Claims" in rendered
-        assert "- C1" in rendered
-        assert "- C2" in rendered
-        assert "## Datasets & Benchmarks" in rendered
-        assert "- D1" in rendered
-        assert "## Builds On" in rendered
-        assert "- B1" in rendered
-        assert "## Open Questions" in rendered
-        assert "- Q1" in rendered
-
-    def test_empty_optional_lists(self) -> None:
-        tier3 = Tier3Extraction(claims=["C1"])
-        rendered = _render_tier3_sections(tier3)
-        assert "## Claims" in rendered
-        assert "## Datasets & Benchmarks" in rendered
-        assert "## Builds On" in rendered
-        assert "## Open Questions" in rendered
+# NOTE: the ## Full Text / Tier 3 section-shape helpers moved to
+# influx.canonical_note in PR 2; their behaviour is covered by
+# tests/unit/test_canonical_note.py (extract_section_body, insert_full_text_
+# section, insert_tier3_sections, render_tier3_sections).
 
 
 # ── Sweep hooks injection seam preserved ─────────────────────────────


### PR DESCRIPTION
## Context

**PR 2 of 6** in the CanonicalNote stack (finding 1 / Lithos task `9ae1086e`), on top of #251. PR 1 introduced `influx.canonical_note` as the single owner of the note shape but migrated no call sites. This PR migrates the first two: the **repair sweep** and the **renderer**, eliminating the byte-for-byte Tier 3 duplication the review flagged.

## What this PR does

- **`repair_hooks.py`** — deletes the local section-shape helpers (`_find_insertion_point`, `_insert_full_text_section`, `_render_tier3_sections`, `_insert_tier3_sections`, `_extract_full_text_body`) and their now-unused regexes, routing the Tier 2 / Tier 3 hooks through `canonical_note.insert_full_text_section` / `insert_tier3_sections` / `extract_section_body`. `_extract_title` stays local (no canonical equivalent). Net −~70 lines of duplicated splice logic.
- **`renderer.py`** — the Tier 3 block (`## Claims` / `## Datasets & Benchmarks` / `## Builds On` / `## Open Questions`) now calls `canonical_note.render_tier3_sections`, the single definition it previously duplicated **byte-for-byte** with `repair_hooks._render_tier3_sections`.
- **Diagram** — `repair_hooks` was the only Repair-tier module importing `influx.schemas` (`Tier3Extraction`); dropping that import removes the `Repair → Schemas` edge. Regenerated diagram committed so the `diagrams` gate stays green.

## Byte-identity

The renderer output is byte-identical (verified incl. the empty-Tier-3-list edge via golden-fixture round-trip; `test_tier3_render` and `test_user_notes_roundtrip` pin the exact bytes). The repair sweep's `SweepHooks` test-injection seam is untouched — the repair-sweep integration tests drive the same public `sweep()` and pass unchanged.

## Tests

- The Tier 3 / full-text section-op coverage that lived in `test_repair_hooks_production` (extract/insert/render) moves to `test_canonical_note`, where the ops now live; added empty-list and insert-ordering cases.
- Removed the four `repair_hooks` entries from the transitional legacy-parity suite now that those helpers are gone (the `lithos_client` / `repair_counters` parity cases remain for PRs 3/5).
- `make check`: lint + pyright clean; whole suite green on CI. Locally the only failure is the pre-existing `test_cli_http.py::test_run_conflict_exit_1` subprocess-timeout flake (passes on CI; reproduces on `main`).

## Follow-ups (this stack)

PR 3 migrate `lithos_client` merge/trim (the User Notes matcher + drop-op bytes change) · PR 4 `repair.py` archive splice (`upsert_archive_path`) + `parse_lenient` · PR 5 `repair_counters` placement · PR 6 (optional) renderer composes via `serialize` + drop dead `source_url` param.
