### PR TITLE
refactor(lithos): migrate merge/trim onto shared canonical ops (PR 3/6)

### DIFF
--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -25,6 +25,12 @@ from mcp.client.session import ClientSession
 from mcp.client.sse import sse_client
 from mcp.shared.exceptions import McpError
 
+from influx.canonical_note import (
+    drop_tier2,
+    drop_tier2_and_tier3,
+    graft_user_notes,
+    replace_profile_relevance_section,
+)
 from influx.dedup import compose_dedup_query
 from influx.errors import ConfigError, LCMAError, LithosError
 from influx.notes import (
@@ -36,11 +42,7 @@ from influx.notes import (
     merge_tags as _canonical_merge_tags,
 )
 from influx.renderer import (
-    ProfileRelevanceEntry,
     merge_profile_relevance_union,
-)
-from influx.renderer import (
-    _render_profile_relevance_body as _render_pr_body,
 )
 from influx.urls import normalise_url
 
@@ -435,29 +437,6 @@ def _merge_tags(existing_tags: list[str], new_tags: list[str]) -> list[str]:
     return _canonical_merge_tags(existing_tags=existing_tags, new_tags=new_tags)
 
 
-_USER_NOTES_MARKER = "## User Notes"
-
-
-def _preserve_user_notes(existing_content: str, new_content: str) -> str:
-    """Merge content, preserving ``## User Notes`` from the existing note.
-
-    The ``## User Notes`` section and everything beneath it in
-    *existing_content* replaces any ``## User Notes`` already present
-    in *new_content* (AC-05-E).
-    """
-    idx = existing_content.find(_USER_NOTES_MARKER)
-    if idx == -1:
-        return new_content
-    user_notes_block = existing_content[idx:]
-
-    new_idx = new_content.find(_USER_NOTES_MARKER)
-    base = new_content[:new_idx].rstrip() if new_idx != -1 else new_content.rstrip()
-    return base + "\n\n" + user_notes_block
-
-
-_PROFILE_RELEVANCE_MARKER = "## Profile Relevance"
-
-
 def _merge_profile_relevance_in_content(
     existing_content: str,
     new_content: str,
@@ -492,88 +471,7 @@ def _merge_profile_relevance_in_content(
     )
 
     # Replace the ## Profile Relevance section in new_content
-    return _replace_profile_relevance_section(new_content, merged_entries)
-
-
-def _replace_profile_relevance_section(
-    content: str,
-    entries: list[ProfileRelevanceEntry],
-) -> str:
-    """Replace the ``## Profile Relevance`` section body in *content*."""
-    pr_idx = content.find(_PROFILE_RELEVANCE_MARKER)
-    if pr_idx == -1:
-        return content
-
-    # Find the end of the Profile Relevance section: the next ## heading
-    after_heading = pr_idx + len(_PROFILE_RELEVANCE_MARKER)
-    next_h2 = content.find("\n## ", after_heading)
-
-    pr_body = _render_pr_body(entries)
-    marker = _PROFILE_RELEVANCE_MARKER
-    replacement = f"{marker}\n{pr_body}\n" if pr_body else f"{marker}\n"
-
-    if next_h2 != -1:
-        # Replace up to but not including the next ## heading's newline
-        return content[:pr_idx] + replacement + "\n" + content[next_h2 + 1 :]
-    else:
-        # Profile Relevance is the last section — replace to end
-        return content[:pr_idx] + replacement
-
-
-_TIER2_MARKER = "## Full Text"
-
-# Tier 3 section headings (master PRD §7.3).
-_TIER3_MARKERS = (
-    "## Claims",
-    "## Datasets & Benchmarks",
-    "## Builds On",
-    "## Open Questions",
-)
-
-
-def _drop_tier2(content: str) -> str:
-    """Remove the ``## Full Text`` (Tier 2) section from *content*.
-
-    Keeps Tier 1 and Tier 3 sections intact (master PRD §9.7 step 1).
-    The Tier 2 section spans from ``## Full Text`` to the next ``##``
-    heading (exclusive) or the ``## User Notes`` marker or end-of-string.
-    """
-    idx = content.find(_TIER2_MARKER)
-    if idx == -1:
-        return content
-    before = content[:idx].rstrip()
-    # Find the next ## heading after Tier 2.
-    rest = content[idx + len(_TIER2_MARKER) :]
-    next_heading = re.search(r"^## ", rest, re.MULTILINE)
-    if next_heading is not None:
-        after = rest[next_heading.start() :]
-        return (before + "\n\n" + after).rstrip()
-    return before
-
-
-def _drop_tier2_and_tier3(content: str) -> str:
-    """Remove Tier 2 (``## Full Text``) AND Tier 3 sections from *content*.
-
-    Keeps only Tier 1 sections + ``## User Notes`` (master PRD §9.7
-    repair path).  Tier 3 headings: ``## Claims``,
-    ``## Datasets & Benchmarks``, ``## Builds On``, ``## Open Questions``.
-    """
-    # First drop Tier 2.
-    result = _drop_tier2(content)
-    # Then drop each Tier 3 section.
-    for marker in _TIER3_MARKERS:
-        idx = result.find(marker)
-        if idx == -1:
-            continue
-        before = result[:idx].rstrip()
-        rest = result[idx + len(marker) :]
-        next_heading = re.search(r"^## ", rest, re.MULTILINE)
-        if next_heading is not None:
-            after = rest[next_heading.start() :]
-            result = (before + "\n\n" + after).rstrip()
-        else:
-            result = before
-    return result
+    return replace_profile_relevance_section(new_content, merged_entries)
 
 
 logger = logging.getLogger(__name__)
@@ -1232,7 +1130,7 @@ class LithosClient:
         existing_tags: list[str] = existing.get("tags", [])
         merged_tags = _merge_tags(existing_tags, original_tags)
         existing_content: str = existing.get("content", "")
-        merged_content = _preserve_user_notes(existing_content, args["content"])
+        merged_content = graft_user_notes(existing_content, args["content"])
         # Multi-profile merge: union-merge Profile Relevance entries (FR-NOTE-6)
         merged_content = _merge_profile_relevance_in_content(
             existing_content, merged_content, merged_tags
@@ -1289,7 +1187,7 @@ class LithosClient:
         - **Repair path** (existing note): handled by US-011.
         """
         # Step 1: drop Tier 2 and retry.
-        trimmed = _drop_tier2(args["content"])
+        trimmed = drop_tier2(args["content"])
         retry_args = {**args, "content": trimmed}
         result = await self.call_tool("lithos_write", retry_args)
         parsed = self._parse_write_response(result, source_url=source_url)
@@ -1332,7 +1230,7 @@ class LithosClient:
         once.  If that also fails: leave existing note untouched, count +
         log, no abort, no ``updated_at`` advance.
         """
-        tier1_content = _drop_tier2_and_tier3(args["content"])
+        tier1_content = drop_tier2_and_tier3(args["content"])
         existing_tags: list[str] = existing.get("tags", [])
         merged_tags = _merge_tags(
             existing_tags, [*original_tags, "influx:repair-needed"]

--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -24,6 +24,11 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
 from influx import metrics
+from influx.canonical_note import (
+    drop_tier2,
+    drop_tier2_and_tier3,
+    graft_user_notes,
+)
 from influx.errors import ExtractionError, LCMAError, LithosError
 from influx.notes import merge_tags
 from influx.repair_counters import (
@@ -812,10 +817,6 @@ async def _sweep_resolve_version_conflict(
     Returns the retry's response ``status``.  Raises
     :class:`SweepWriteError` on unresolved conflict or transport failure.
     """
-    # Late import to avoid circular dependency (lithos_client → repair
-    # is unidirectional, but the sweep needs lithos_client's helpers).
-    from influx.lithos_client import _preserve_user_notes
-
     logger.info(
         "sweep rewrite version_conflict for note %s; re-reading and retrying once",
         note_id,
@@ -841,7 +842,7 @@ async def _sweep_resolve_version_conflict(
     # the refreshed note — never overwrite pending edits with refreshed
     # body content.
     pending_content: str = args.get("content", "")
-    merged_content = _preserve_user_notes(refreshed_content, pending_content)
+    merged_content = graft_user_notes(refreshed_content, pending_content)
 
     retry_args = {
         **args,
@@ -926,9 +927,6 @@ async def _rewrite_sweep_note(
         only) returned ``content_too_large`` — the chronic-oversize
         repair-path exemption (§5.4 failure mode 2, AC-X-8).
     """
-    # Late import to avoid circular dependency.
-    from influx.lithos_client import _drop_tier2, _drop_tier2_and_tier3
-
     note_id: str = note.get("id", "")
     base_args: dict[str, Any] = {
         "id": note_id,
@@ -954,7 +952,7 @@ async def _rewrite_sweep_note(
         return
 
     # Attempt 2: drop ## Full Text (Tier 2) and retry.
-    tier2_args = {**base_args, "content": _drop_tier2(base_args["content"])}
+    tier2_args = {**base_args, "content": drop_tier2(base_args["content"])}
     status = await _attempt_sweep_write(
         client, tier2_args, pending_tags=list(tags), note_id=note_id
     )
@@ -968,7 +966,7 @@ async def _rewrite_sweep_note(
         repair_tags.append("influx:repair-needed")
     tier1_args = {
         **base_args,
-        "content": _drop_tier2_and_tier3(base_args["content"]),
+        "content": drop_tier2_and_tier3(base_args["content"]),
         "tags": repair_tags,
     }
     status = await _attempt_sweep_write(

--- a/tests/contract/test_lithos_client.py
+++ b/tests/contract/test_lithos_client.py
@@ -2155,6 +2155,52 @@ class TestWriteEnvelopeContentTooLarge:
         finally:
             await client.close()
 
+    async def test_first_retry_preserves_user_notes_bytes(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+    ) -> None:
+        """Tier-2 trim preserves the ``## User Notes`` region byte-exactly.
+
+        PR 3 routed the oversize trim through ``canonical_note.drop_tier2``,
+        which drops the legacy whole-document ``rstrip()``. Trailing spaces
+        and blank lines in User Notes now survive the retry (the byte-exact
+        User Notes invariant now holds on the trim path, not just on write).
+        """
+        content = (
+            "# Summary\nTransformer paper.\n\n"
+            "## Full Text\n\nbody text\n\n"
+            "## Claims\n- Claim 1\n\n"
+            "## User Notes\nKeep this.  \n\n"
+        )
+        fake_lithos_server.write_responses.extend(
+            [
+                '{"status": "content_too_large"}',
+                '{"status": "created"}',
+            ]
+        )
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            await client.write_note(
+                title="Big Paper",
+                content=content,
+                path="papers/arxiv/2026/03",
+                source_url="https://arxiv.org/abs/2601.50002",
+                tags=["profile:ml-research"],
+                confidence=0.9,
+            )
+            write_calls = [
+                c for c in fake_lithos_server.calls if c[0] == "lithos_write"
+            ]
+            retry_content = write_calls[1][1]["content"]
+            assert "## Full Text" not in retry_content
+            # Trailing spaces + blank lines preserved verbatim (legacy rstrip
+            # would have truncated to "Keep this.").
+            assert retry_content.endswith("## User Notes\nKeep this.  \n\n")
+        finally:
+            await client.close()
+
     async def test_create_path_skip_on_second_content_too_large(
         self,
         fake_lithos_url: str,

--- a/tests/contract/test_lithos_client.py
+++ b/tests/contract/test_lithos_client.py
@@ -2010,6 +2010,65 @@ class TestWriteEnvelopeVersionConflict:
         finally:
             await client.close()
 
+    async def test_version_conflict_locator_ignores_midline_user_notes(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+    ) -> None:
+        """Conflict merge is protected against an impostor ``## User Notes``.
+
+        PR 3 grafts User Notes via ``canonical_note.graft_user_notes``, whose
+        line-anchored matcher (vs the legacy unanchored ``str.find``) means a
+        mid-line ``## User Notes`` literal in the incoming body no longer
+        truncates the note, and the existing region is grafted byte-exactly
+        including trailing whitespace.
+        """
+        import json as _json
+
+        fake_lithos_server.write_responses.extend(
+            [
+                '{"status": "version_conflict", "note_id": "note-046"}',
+                '{"status": "updated"}',
+            ]
+        )
+        # Existing note's User Notes carry trailing spaces + blank lines.
+        existing_region = "## User Notes\nKeep verbatim.  \n\n\n"
+        fake_lithos_server.read_responses.append(
+            _json.dumps(
+                {
+                    "id": "note-046",
+                    "content": f"# Summary\nOld.\n\n{existing_region}",
+                    "tags": ["profile:ml-research"],
+                    "version": 7,
+                }
+            )
+        )
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            # Incoming body mentions "## User Notes" mid-sentence, before the
+            # real heading — the legacy str.find would truncate here.
+            await client.write_note(
+                title="Paper Y",
+                content=(
+                    "# Summary\nSee the ## User Notes section below.\n\n## User Notes\n"
+                ),
+                path="papers/arxiv/2026/03",
+                source_url="https://arxiv.org/abs/2601.33333",
+                tags=["profile:ml-research"],
+                confidence=0.8,
+            )
+            write_calls = [
+                c for c in fake_lithos_server.calls if c[0] == "lithos_write"
+            ]
+            retry_content = write_calls[1][1]["content"]
+            # Mid-line literal survived (not truncated at the impostor).
+            assert "See the ## User Notes section below." in retry_content
+            # Existing region grafted byte-exactly, trailing whitespace intact.
+            assert retry_content.endswith(existing_region)
+        finally:
+            await client.close()
+
     async def test_second_version_conflict_skips(
         self,
         fake_lithos_url: str,

--- a/tests/integration/test_multi_profile_shared_source.py
+++ b/tests/integration/test_multi_profile_shared_source.py
@@ -456,15 +456,15 @@ class TestPreservationOnSingleProfileRun:
             tags=both_tags,
         )
         # Manually fix: add Profile B's entry too
-        from influx.lithos_client import (
-            _replace_profile_relevance_section,
+        from influx.canonical_note import (
+            replace_profile_relevance_section,
         )
         from influx.notes import (
             parse_note,
             parse_profile_relevance,
         )
 
-        existing_content = _replace_profile_relevance_section(
+        existing_content = replace_profile_relevance_section(
             existing_content,
             [
                 ProfileRelevanceEntry(PROFILE_A, 8, "AI robotics."),

--- a/tests/integration/test_repair_sweep_chronic_oversize.py
+++ b/tests/integration/test_repair_sweep_chronic_oversize.py
@@ -506,3 +506,84 @@ class TestChronicOversizeExemption:
             assert "influx:repair-needed" not in normal_write[0][1]["tags"]
         finally:
             await client.close()
+
+    async def test_trim_retries_preserve_user_notes_bytes(
+        self,
+        fake_lithos: FakeLithosServer,
+        fake_lithos_url: str,
+    ) -> None:
+        """Sweep Tier-2 and Tier-1-only trims preserve ``## User Notes`` bytes.
+
+        Regression guard for the PR 3 migration: ``_rewrite_sweep_note`` now
+        trims via ``canonical_note.drop_tier2`` / ``drop_tier2_and_tier3``,
+        which (unlike the legacy whole-document ``rstrip()``) keep trailing
+        whitespace and blank lines in the final ``## User Notes`` section. With
+        default ``SweepHooks()`` no stage mutates the content, so the trim runs
+        on the note's content verbatim.
+        """
+        user_notes_tail = "## User Notes\nKeep verbatim.  \n\n\n"
+        content = (
+            "---\n"
+            "note_type: summary\n"
+            "namespace: influx\n"
+            "source_url: https://arxiv.org/abs/2601.chronic-un\n"
+            "tags:\n"
+            "  - profile:ai-robotics\n"
+            "  - ingested-by:influx\n"
+            "  - source:arxiv\n"
+            "confidence: 0.9\n"
+            "---\n"
+            "# Test Paper chronic-un\n\n"
+            "## Archive\n"
+            f"path: {_ARCHIVE_PATH}\n\n"
+            "## Summary\nA summary.\n\n"
+            "## Full Text\nBig body text.\n\n"
+            "## Claims\n- A claim.\n\n"
+            "## Profile Relevance\n### ai-robotics\nScore: 5/10\nRelevant.\n\n"
+            f"{user_notes_tail}"
+        )
+        chronic: dict[str, Any] = {
+            "id": "chronic-un",
+            "title": "Test Paper chronic-un",
+            "content": content,
+            "tags": list(_CHRONIC_TAGS),
+            "version": 1,
+            "source_url": "https://arxiv.org/abs/2601.chronic-un",
+            "path": "papers/arxiv/2026/04",
+            "confidence": 0.9,
+            "note_type": "summary",
+            "namespace": "influx",
+        }
+        fake_lithos.list_responses.append(
+            json.dumps({"items": [{"id": chronic["id"], "title": chronic["title"]}]})
+        )
+        fake_lithos.read_responses.append(json.dumps(chronic))
+        for _ in range(_CHRONIC_TRIM_ATTEMPTS):
+            fake_lithos.write_responses.append('{"status": "content_too_large"}')
+
+        config = _make_config(lithos_url=fake_lithos_url, max_items=10)
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            await sweep(
+                "ai-robotics",
+                client=client,
+                config=config,
+                hooks=SweepHooks(),
+            )
+
+            write_calls = [c for c in fake_lithos.calls if c[0] == "lithos_write"]
+            assert len(write_calls) == _CHRONIC_TRIM_ATTEMPTS
+
+            # Attempt 2: Tier 2 dropped, Tier 3 kept, User Notes byte-exact.
+            tier2_dropped = write_calls[1][1]["content"]
+            assert "## Full Text" not in tier2_dropped
+            assert "## Claims" in tier2_dropped
+            assert tier2_dropped.endswith(user_notes_tail)
+
+            # Attempt 3: Tier 2 + Tier 3 dropped, User Notes still byte-exact.
+            tier1_only = write_calls[2][1]["content"]
+            assert "## Full Text" not in tier1_only
+            assert "## Claims" not in tier1_only
+            assert tier1_only.endswith(user_notes_tail)
+        finally:
+            await client.close()

--- a/tests/unit/test_canonical_note.py
+++ b/tests/unit/test_canonical_note.py
@@ -533,30 +533,9 @@ class TestLegacyParityTransitional:
     def _canonical_note(self) -> str:
         return _read("golden_lf.md")
 
-    # NOTE: the repair_hooks parity cases (render_tier3 / insert_full_text /
-    # insert_tier3 / insertion_point) were removed in PR 2 when those helpers
-    # were deleted in favour of the canonical ops.
-
-    def test_graft_user_notes_matches_lithos_client(self) -> None:
-        from influx import lithos_client as lc
-
-        existing = self._canonical_note()
-        new = _read("tier3_full.md")
-        assert cn.graft_user_notes(existing, new) == lc._preserve_user_notes(
-            existing, new
-        )
-
-    def test_replace_profile_relevance_matches_lithos_client(self) -> None:
-        from influx import lithos_client as lc
-
-        note = self._canonical_note()
-        entries = [
-            ProfileRelevanceEntry("a", 8, "r1"),
-            ProfileRelevanceEntry("b", 4, "r2"),
-        ]
-        assert cn.replace_profile_relevance_section(
-            note, entries
-        ) == lc._replace_profile_relevance_section(note, entries)
+    # NOTE: the repair_hooks parity cases (PR 2) and the lithos_client parity
+    # cases — graft_user_notes / replace_profile_relevance (PR 3) — were removed
+    # as those legacy helpers were deleted in favour of the canonical ops.
 
     def test_upsert_repair_matches_repair_counters(self) -> None:
         from influx import repair_counters as rc

--- a/tests/unit/test_multi_profile_merge.py
+++ b/tests/unit/test_multi_profile_merge.py
@@ -8,9 +8,9 @@ helper correctly replaces the ``## Profile Relevance`` section.
 
 from __future__ import annotations
 
+from influx.canonical_note import replace_profile_relevance_section
 from influx.lithos_client import (
     _merge_profile_relevance_in_content,
-    _replace_profile_relevance_section,
 )
 from influx.notes import (
     merge_tags,
@@ -419,11 +419,11 @@ class TestContentLevelProfileRelevanceMerge:
         assert merged == new_content
 
 
-# ── _replace_profile_relevance_section ───────────────────────────────
+# ── replace_profile_relevance_section (canonical_note) ───────────────
 
 
 class TestReplaceProfileRelevanceSection:
-    """_replace_profile_relevance_section() correctly replaces the section body."""
+    """replace_profile_relevance_section() correctly replaces the section body."""
 
     def test_replaces_single_entry_with_two(self) -> None:
         """Replace one entry with two merged entries."""
@@ -457,7 +457,7 @@ class TestReplaceProfileRelevanceSection:
             ),
         ]
 
-        result = _replace_profile_relevance_section(original, merged_entries)
+        result = replace_profile_relevance_section(original, merged_entries)
 
         parsed = parse_note(result)
         entries = parse_profile_relevance(parsed)


### PR DESCRIPTION
## Context

**PR 3 of 6** in the CanonicalNote stack (finding 1 / Lithos task `9ae1086e`), on top of #251 and #252. This is the step the plan flagged as **riskiest and deliberately isolated**: it deletes `lithos_client`'s hand-rolled section splicers and routes the write-retry paths through `influx.canonical_note` — which is where the section-locator tightening and the byte-exact `## User Notes` invariant finally reach production.

## What this PR does

- **`lithos_client.py`** — deletes `_preserve_user_notes`, `_replace_profile_relevance_section`, `_drop_tier2`, `_drop_tier2_and_tier3` and their heading-literal constants (~140 lines). The version-conflict merge now grafts User Notes via `canonical_note.graft_user_notes`; the oversize-trim retries call `canonical_note.drop_tier2` / `drop_tier2_and_tier3`; the Profile Relevance merge routes through `canonical_note.replace_profile_relevance_section`. Drops the private `renderer._render_profile_relevance_body` import.
- **`repair.py`** — the two late "avoid circular dependency" imports of `lithos_client` internals (the sweep's version-conflict and chronic-oversize paths) collapse into a single top-level `canonical_note` import. `canonical_note` imports only Foundation, so there's no cycle to dodge; `Repair → LithosBridge` already existed via `notes`, so no diagram change.

## ⚠️ Intended behaviour change (this is the one PR in the stack that changes production bytes)

Both changes were introduced and unit-tested in `canonical_note` back in PR 1; PR 3 is where they go live.

1. **Trim byte-exactness.** The legacy `_drop_tier2` / `_drop_tier2_and_tier3` ended with a whole-document `.rstrip()`, so an oversize retry silently stripped trailing whitespace and blank lines from the final `## User Notes` section. The canonical drop ops preserve the tail byte-exactly — the User Notes invariant now holds on the *trim* path, not just on first write.
2. **Locator tightening.** `graft` / `replace` / `drop` use line-anchored heading matchers (`^## Heading[ \t]*(?=\r?\n|$)`) instead of unanchored `str.find`. On canonical notes they resolve to identical positions (verified by PR 1's parity checks). On *pathological* input they are strictly protective: a mid-line `## User Notes` literal, or a `### User Notes` sub-heading in the incoming content, can no longer be mistaken for the section boundary and truncate the note during merge.

Neither case affects a normally-rendered note; both are documented in `canonical_note`'s module docstring.

## Tests

- The contract suite (merge + trim vs `FakeLithosServer`) stays green unchanged — its assertions are substring/structural, so the trailing-whitespace fix doesn't perturb them.
- **Added** a contract test (`test_first_retry_preserves_user_notes_bytes`) pinning byte-exact `## User Notes` preservation through the Tier-2 trim retry — the clearest proof the fix reaches the write path (legacy would have truncated `Keep this.  \n\n` to `Keep this.`).
- Repointed the `_replace_profile_relevance_section` unit + integration tests to `canonical_note.replace_profile_relevance_section`.
- Removed the two now-obsolete `lithos_client` legacy-parity cases from `test_canonical_note` (helpers gone); the `repair_counters` parity case remains for PR 5.
- `make check`: lint + pyright clean; whole suite green on CI. Locally the only failure is the pre-existing `test_cli_http.py::test_run_conflict_exit_1` subprocess-timeout flake (passes on CI; reproduces on `main`).

## Follow-ups (this stack)

PR 4 `repair.py` archive splice (`upsert_archive_path`) + `parse_lenient` · PR 5 `repair_counters` placement onto `insertion_point`/`upsert_section_text` · PR 6 (optional) renderer composes via `serialize` + drop dead `source_url` param.
