### PR TITLE
refactor(repair): migrate archive splice + note parse onto canonical ops (PR 4/6)

### DIFF
--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -28,6 +28,8 @@ from influx.canonical_note import (
     drop_tier2,
     drop_tier2_and_tier3,
     graft_user_notes,
+    parse_lenient,
+    upsert_archive_path,
 )
 from influx.errors import ExtractionError, LCMAError, LithosError
 from influx.notes import merge_tags
@@ -1018,20 +1020,13 @@ def _run_archive_retry(
             span_name="influx.repair.archive",
         ):
             downloaded_path = hook(note)
-        # Patch ## Archive with the freshly downloaded path (idempotent —
-        # only inserts when no path: line is already present).
-        content = str(note.get("content", ""))
-        marker = "## Archive\n"
-        idx = content.find(marker)
-        if idx >= 0:
-            insert_pos = idx + len(marker)
-            rest = content[insert_pos:]
-            if not rest.startswith("path:"):
-                note["content"] = (
-                    content[:insert_pos]
-                    + f"path: {downloaded_path}\n"
-                    + content[insert_pos:]
-                )
+        # Patch ## Archive with the freshly downloaded path. Idempotent,
+        # CRLF-tolerant, and scans the whole section for an existing
+        # ``path:`` line — canonical_note owns the splice (a no-op when the
+        # section is absent or already carries a path).
+        note["content"] = upsert_archive_path(
+            str(note.get("content", "")), downloaded_path
+        )
         return current_tags, downloaded_path, True
     except (ExtractionError, LithosError) as exc:
         failure_stage = (
@@ -1226,36 +1221,6 @@ def _doc_title(note: dict[str, Any]) -> str:
     return ""
 
 
-def _content_for_note_parse(note: dict[str, Any]) -> str:
-    """Return note content shaped for :func:`influx.notes.parse_note`.
-
-    ``read_note`` serves note ``content`` with the ``# {title}`` heading
-    stripped — the title is a doc-level metadata field. ``parse_note``
-    requires that heading (``_split_title`` raises ``NoteParseError``
-    without it), even though the archive-path / profile-relevance data
-    the sweep needs live in the body *below* the title. Reattach the
-    doc-level title when the body has no ``# `` heading so parsing
-    succeeds.
-
-    Parse-input only: the rewrite path must keep using the unmodified
-    ``content`` — prepending the title into the persisted body would
-    compound the existing duplicate-``# Title`` shape.
-    """
-    content = str(note.get("content") or "")
-    # Mirror parse_note / _split_title title detection exactly: strip the
-    # line and exclude ``## `` headings. A bare ``line.startswith("# ")``
-    # would miss an indented H1 that _split_title *would* accept, causing a
-    # second title to be prepended and shifting the parsed title.
-    for line in content.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("# ") and not stripped.startswith("## "):
-            return content
-    title = _doc_title(note)
-    if not title:
-        return content
-    return f"# {title}\n\n{content}"
-
-
 async def _process_sweep_note(
     note: dict[str, Any],
     *,
@@ -1268,7 +1233,7 @@ async def _process_sweep_note(
 
     Raises :class:`SweepWriteError` on terminal write failure.
     """
-    from influx.notes import parse_archive_path, parse_note, parse_profile_relevance
+    from influx.notes import parse_archive_path, parse_profile_relevance
 
     tags: list[str] = list(note.get("tags", []))
 
@@ -1278,7 +1243,9 @@ async def _process_sweep_note(
     archive_path: str | None = None
     max_profile_score: int = 0
     try:
-        parsed = parse_note(_content_for_note_parse(note))
+        parsed = parse_lenient(
+            str(note.get("content") or ""), fallback_title=_doc_title(note)
+        )
         archive_path = parse_archive_path(parsed)
         entries = parse_profile_relevance(parsed)
         if entries:

--- a/tests/integration/test_repair_sweep_archive_only.py
+++ b/tests/integration/test_repair_sweep_archive_only.py
@@ -302,6 +302,77 @@ class TestArchiveOnlyRepairFlow:
             # Path spliced directly below the CRLF ## Archive heading (the
             # inserted line itself is LF-terminated, matching the canonical op).
             assert f"## Archive\r\npath: {_ARCHIVE_PATH}\n" in written_content
+            # archive-missing clears now that a path is stored (as for LF).
+            assert "influx:archive-missing" not in write_calls[0][1]["tags"]
+        finally:
+            await client.close()
+
+    async def test_title_stripped_note_parses_archive_path_and_clears_tag(
+        self,
+        fake_lithos: FakeLithosServer,
+        fake_lithos_url: str,
+    ) -> None:
+        """The sweep parse composition extracts a body archive path.
+
+        ``read_note`` strips the ``# {title}`` heading, so the sweep must
+        parse via ``parse_lenient(..., fallback_title=_doc_title(note))`` to
+        see the archive ``path:`` living in the body. With no archive-download
+        hook the archive stage is skipped, so ``influx:archive-missing`` is
+        dropped *only* because ``compute_clearing`` saw the parsed
+        (non-``None``) archive path. Pins the *caller* composition: dropping
+        ``_doc_title`` (or calling ``parse`` directly) would make the parse
+        raise, leave ``archive_path`` ``None``, and keep the tag set.
+        """
+        stored_path = "papers/arxiv/2026/04/already-here.pdf"
+        # Real read_note body shape: NO leading '# Title'; path in the body.
+        content = (
+            "## Archive\n"
+            f"path: {stored_path}\n\n"
+            "## Summary\nA summary.\n\n"
+            "## Profile Relevance\n### ai-robotics\nScore: 5/10\nRelevant.\n\n"
+            "## User Notes\n"
+        )
+        note: dict[str, Any] = {
+            "id": "note-title-stripped",
+            "title": "Doc Title",  # doc-level title _doc_title() must supply
+            "content": content,
+            "tags": [
+                "profile:ai-robotics",
+                "influx:repair-needed",
+                "influx:archive-missing",
+                "ingested-by:influx",
+                "source:arxiv",
+                "text:html",
+            ],
+            "version": 1,
+            "source_url": "https://arxiv.org/abs/2601.00099",
+            "path": "papers/arxiv/2026/04",
+            "confidence": 0.9,
+            "note_type": "summary",
+            "namespace": "influx",
+        }
+        _queue_single_note(fake_lithos, note)
+
+        config = _make_config(lithos_url=fake_lithos_url)
+        # No archive_download hook: the archive stage is skipped, so the only
+        # way influx:archive-missing clears is via the parsed body path.
+        hooks = SweepHooks()
+
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            await sweep(
+                "ai-robotics",
+                client=client,
+                config=config,
+                hooks=hooks,
+            )
+            write_calls = [c for c in fake_lithos.calls if c[0] == "lithos_write"]
+            assert len(write_calls) == 1
+            payload = write_calls[0][1]
+            # Parsed body path ⇒ archive-missing cleared (composition works).
+            assert "influx:archive-missing" not in payload["tags"]
+            # Body path preserved verbatim (no duplicate splice).
+            assert payload["content"].count(f"path: {stored_path}") == 1
         finally:
             await client.close()
 

--- a/tests/integration/test_repair_sweep_archive_only.py
+++ b/tests/integration/test_repair_sweep_archive_only.py
@@ -259,6 +259,52 @@ class TestArchiveOnlyRepairFlow:
         finally:
             await client.close()
 
+    async def test_archive_download_splices_path_into_crlf_note(
+        self,
+        fake_lithos: FakeLithosServer,
+        fake_lithos_url: str,
+    ) -> None:
+        """A CRLF-shaped ``## Archive`` heading still receives the path.
+
+        PR 4 routed the splice through ``canonical_note.upsert_archive_path``,
+        whose anchored matcher is CRLF-tolerant. The legacy
+        ``find("## Archive\\n")`` never matched a ``## Archive\\r\\n`` heading,
+        so a CRLF note's freshly downloaded archive path was silently dropped.
+        """
+        tags = [
+            "profile:ai-robotics",
+            "influx:repair-needed",
+            "influx:archive-missing",
+            "ingested-by:influx",
+            "source:arxiv",
+            "text:html",
+        ]
+        note = _make_note_dict(tags=tags)
+        # Rewrite the body with CRLF line endings — the shape legacy missed.
+        note["content"] = note["content"].replace("\n", "\r\n")
+        assert "## Archive\r\n" in note["content"]
+        _queue_single_note(fake_lithos, note)
+
+        config = _make_config(lithos_url=fake_lithos_url)
+        hooks = SweepHooks(archive_download=_fake_archive_download)
+
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            await sweep(
+                "ai-robotics",
+                client=client,
+                config=config,
+                hooks=hooks,
+            )
+            write_calls = [c for c in fake_lithos.calls if c[0] == "lithos_write"]
+            assert len(write_calls) == 1
+            written_content = write_calls[0][1]["content"]
+            # Path spliced directly below the CRLF ## Archive heading (the
+            # inserted line itself is LF-terminated, matching the canonical op).
+            assert f"## Archive\r\npath: {_ARCHIVE_PATH}\n" in written_content
+        finally:
+            await client.close()
+
     async def test_archive_repair_with_text_html_does_not_select_text_stage(
         self,
         fake_lithos: FakeLithosServer,

--- a/tests/unit/test_canonical_note.py
+++ b/tests/unit/test_canonical_note.py
@@ -153,6 +153,20 @@ class TestParse:
         with pytest.raises(NoteParseError):
             cn.parse_lenient("## Archive\npath: x\n")
 
+    def test_has_title_heading_recognises_indented_h1(self) -> None:
+        # _split_title strips the line, so an indented "# Title" IS a title;
+        # the lenient detector must agree and not reattach a second one.
+        assert cn._has_title_heading("   # Indented Title\n\n## Archive\n")
+        body = "   # Indented Title\n\n## Archive\npath: p\n"
+        note = cn.parse_lenient(body, fallback_title="Doc Title")
+        assert note.title == "Indented Title"
+
+    def test_has_title_heading_excludes_h2(self) -> None:
+        # A "## " heading is not a title — the fallback must still fire.
+        assert not cn._has_title_heading("## Archive\n## Summary\n")
+        note = cn.parse_lenient("## Archive\n## Summary\n", fallback_title="Doc")
+        assert note.title == "Doc"
+
 
 # ── User Notes matcher semantics (§3 divergence matrix) ─────────────
 

--- a/tests/unit/test_repair_sweep.py
+++ b/tests/unit/test_repair_sweep.py
@@ -1585,17 +1585,23 @@ class TestSweepEnvelopeNormalisation:
         assert infer_note_source(rewritten) == "rss"
 
 
-class TestContentForNoteParse:
+class TestSweepNoteParse:
     """#220: ``read_note`` strips the ``# {title}`` heading from ``content``
-    (title is doc-level metadata), but ``parse_note`` requires it. The sweep
-    must reattach the doc-level title for parsing so archive-path /
-    profile-relevance extraction works — without it the archive path (present
-    in the body) is silently lost and stage selection runs blind.
+    (title is doc-level metadata), but the parser requires it. The sweep parses
+    via ``canonical_note.parse_lenient`` with ``_doc_title(note)`` as the
+    fallback so archive-path / profile-relevance extraction still works —
+    without it the archive path (present in the body) is silently lost and
+    stage selection runs blind.
+
+    The granular title-detection nuances (indented H1, H2 exclusion) now live
+    in ``canonical_note`` and are covered by test_canonical_note.py; this class
+    pins the repair-side composition (``parse_lenient`` + ``_doc_title``).
     """
 
     def test_reattaches_title_so_archive_path_parses(self) -> None:
-        from influx.notes import parse_archive_path, parse_note
-        from influx.repair import _content_for_note_parse
+        from influx.canonical_note import parse_lenient
+        from influx.notes import parse_archive_path
+        from influx.repair import _doc_title
 
         # The real read_note body shape: no leading '# Title'.
         note: dict[str, Any] = {
@@ -1605,38 +1611,11 @@ class TestContentForNoteParse:
                 "## Archive\npath: arxiv/2026/05/2605.20049.pdf\n\n## Summary\nx\n"
             ),
         }
-        parsed = parse_note(_content_for_note_parse(note))
+        parsed = parse_lenient(
+            str(note.get("content") or ""), fallback_title=_doc_title(note)
+        )
         assert parsed.title == "Some Paper"
         assert parse_archive_path(parsed) == "arxiv/2026/05/2605.20049.pdf"
-
-    def test_leaves_content_unchanged_when_title_present(self) -> None:
-        from influx.repair import _content_for_note_parse
-
-        note: dict[str, Any] = {
-            "id": "rss-x",
-            "title": "Doc Title",
-            "content": "# Inner Title\n\n## Archive\n",
-        }
-        # Already has a '# ' heading — must not double-prepend.
-        assert _content_for_note_parse(note) == "# Inner Title\n\n## Archive\n"
-
-    def test_falls_back_to_metadata_title(self) -> None:
-        from influx.repair import _content_for_note_parse
-
-        note: dict[str, Any] = {
-            "id": "rss-x",
-            "metadata": {"title": "Nested Title"},
-            "content": "## Archive\n",
-        }
-        assert _content_for_note_parse(note).startswith("# Nested Title\n\n")
-
-    def test_returns_content_unchanged_when_no_title_available(self) -> None:
-        from influx.repair import _content_for_note_parse
-
-        note: dict[str, Any] = {"id": "rss-x", "content": "## Archive\n"}
-        # No doc-level title to reattach — leave content as-is (caller's
-        # try/except still handles the NoteParseError gracefully).
-        assert _content_for_note_parse(note) == "## Archive\n"
 
     def test_doc_title_resolution_order(self) -> None:
         from influx.repair import _doc_title
@@ -1646,32 +1625,13 @@ class TestContentForNoteParse:
         assert _doc_title({"title": "", "metadata": {"title": "nested"}}) == "nested"
         assert _doc_title({"id": "x"}) == ""
 
-    def test_recognises_indented_h1_like_split_title(self) -> None:
-        # _split_title strips the line, so an indented '# Title' IS a title.
-        # The reattach check must agree and NOT prepend a second one.
-        from influx.repair import _content_for_note_parse
+    def test_none_content_parses_gracefully(self) -> None:
+        from influx.canonical_note import parse_lenient
+        from influx.repair import _doc_title
 
-        note: dict[str, Any] = {
-            "id": "rss-x",
-            "title": "Doc Title",
-            "content": "   # Indented Title\n\n## Archive\n",
-        }
-        assert _content_for_note_parse(note) == "   # Indented Title\n\n## Archive\n"
-
-    def test_excludes_h2_when_detecting_title(self) -> None:
-        # A '## ' heading is not a title — reattach should still fire.
-        from influx.repair import _content_for_note_parse
-
-        note: dict[str, Any] = {
-            "id": "rss-x",
-            "title": "Doc Title",
-            "content": "## Archive\n## Summary\n",
-        }
-        assert _content_for_note_parse(note).startswith("# Doc Title\n\n")
-
-    def test_none_content_does_not_become_literal_none(self) -> None:
-        from influx.repair import _content_for_note_parse
-
+        # str(None) would yield "None"; the caller coerces via `or ""`.
         note: dict[str, Any] = {"id": "rss-x", "title": "T", "content": None}
-        # str(None) would yield "None"; must coerce to "" first.
-        assert _content_for_note_parse(note) == "# T\n\n"
+        parsed = parse_lenient(
+            str(note.get("content") or ""), fallback_title=_doc_title(note)
+        )
+        assert parsed.title == "T"


### PR DESCRIPTION
## Context

**PR 4 of 6** in the CanonicalNote stack (finding 1 / Lithos task `9ae1086e`), on top of #251–#253. Migrates `repair.py`'s two remaining pieces of hand-rolled note-structure code onto `influx.canonical_note`.

## What this PR does

- **`_run_archive_retry`** — the raw `## Archive` splice (`find("## Archive\n")` + `startswith("path:")` insert) becomes `canonical_note.upsert_archive_path`. On canonical LF notes this is byte-identical, but it fixes two latent bugs on the archive-download retry path:
  - **CRLF** — the legacy literal `find("## Archive\n")` never matches a `## Archive\r\n` heading, so a CRLF note's freshly downloaded archive path was silently dropped. The anchored matcher is CRLF-tolerant.
  - **Idempotence** — the legacy check only inspected the byte immediately after the heading, so a `path:` line preceded by a blank line or indented would be duplicated. `upsert_archive_path` scans the whole `## Archive` section.
- **`_process_sweep_note`** — `parse_note(_content_for_note_parse(note))` becomes `parse_lenient(str(note.get("content") or ""), fallback_title=_doc_title(note))`. `_content_for_note_parse` re-implemented the parser's title detection to reattach the doc-level title that `read_note` strips; `parse_lenient` owns that now via `_has_title_heading`, which mirrors the real parser's `_split_title` (the removed local copy used `str.splitlines`, subtly divergent on form-feed characters). `_doc_title` stays in `repair.py` — note-dict title resolution is repair-domain, not note-shape.

## Tests

- **Added** `test_archive_download_splices_path_into_crlf_note` — drives an archive-download sweep on a CRLF-shaped note and asserts the path is spliced below the `## Archive\r\n` heading at the production boundary (the exact case the legacy `find` missed; the inserted line is LF-terminated, matching the canonical op).
- **Added** `_has_title_heading` indented-H1 / H2-exclusion cases to `test_canonical_note` — the title-detection nuance that moved out of `repair.py`.
- Replaced `repair.py`'s `TestContentForNoteParse` with `TestSweepNoteParse`, covering the `parse_lenient` + `_doc_title` composition and the `None`-content coercion; the granular byte-shape cases now live with `parse_lenient` in `test_canonical_note`.
- `upsert_archive_path`'s own idempotence/CRLF behaviour was already unit-tested in `test_canonical_note` (PR 1).
- `make check`: lint + pyright clean; whole suite green on CI. Locally the only failure is the pre-existing `test_cli_http.py::test_run_conflict_exit_1` subprocess-timeout flake (passes on CI; reproduces on `main`).

## Follow-ups (this stack)

PR 5 `repair_counters` placement onto `insertion_point` / `upsert_section_text` · PR 6 (optional) renderer composes via `serialize`, drop the dead `source_url` param, and converge `replace_profile_relevance_section`'s end-boundary onto the shared section-span helper (carried over from the #253 review).
