### PR TITLE
refactor(repair): route repair_counters placement through canonical ops (PR 5/6)

### DIFF
--- a/src/influx/canonical_note.py
+++ b/src/influx/canonical_note.py
@@ -639,6 +639,12 @@ def upsert_section_text(content: str, heading: str, rendered_section: str) -> st
     place (trimming leading blank lines from the following content so blank
     lines do not accumulate across re-renders); otherwise it is inserted at
     :func:`insertion_point`.
+
+    The touched section is written verbatim from *rendered_section*, i.e. with
+    the LF line endings the Influx renderers emit.  Surrounding bytes are
+    preserved as-is, so on a (non-canonical) CRLF note the replaced/inserted
+    section is LF while the rest of the note keeps its CRLF endings — the ops
+    do not round-trip CRLF for the section they own.
     """
     span = _section_span(content, heading)
     if span is not None:

--- a/src/influx/canonical_note.py
+++ b/src/influx/canonical_note.py
@@ -640,11 +640,13 @@ def upsert_section_text(content: str, heading: str, rendered_section: str) -> st
     lines do not accumulate across re-renders); otherwise it is inserted at
     :func:`insertion_point`.
 
-    The touched section is written verbatim from *rendered_section*, i.e. with
-    the LF line endings the Influx renderers emit.  Surrounding bytes are
-    preserved as-is, so on a (non-canonical) CRLF note the replaced/inserted
-    section is LF while the rest of the note keeps its CRLF endings — the ops
-    do not round-trip CRLF for the section they own.
+    The touched section — and the blank-line separators placed immediately
+    around it — are written with the LF line endings the Influx renderers
+    emit; content *below* the section (e.g. the ``## User Notes`` region) is
+    preserved byte-for-byte.  On a (non-canonical) CRLF note the section and
+    its adjacent separators therefore come out LF — a CRLF blank line just
+    above the section gains a trailing LF — while the region below keeps its
+    CRLF endings.  The ops do not round-trip CRLF for the region they own.
     """
     span = _section_span(content, heading)
     if span is not None:

--- a/src/influx/repair_counters.py
+++ b/src/influx/repair_counters.py
@@ -28,6 +28,7 @@ import re
 from dataclasses import dataclass, replace
 from typing import Any, Literal
 
+from influx.canonical_note import REPAIR, extract_section_body, upsert_section_text
 from influx.errors import ExtractionError, LCMAError
 
 __all__ = [
@@ -124,12 +125,8 @@ class RepairCounters:
 # ── Section parser / serializer ─────────────────────────────────────
 
 
-_REPAIR_HEADING_RE = re.compile(r"^## Repair[ \t]*\n", re.MULTILINE)
 _REPAIR_BULLET_RE = re.compile(r"^[ \t]*-\s*(\w+)\s*:\s*(.*)$")
 _QUOTED_RE = re.compile(r'^"(.*)"$')
-_NEXT_HEADING_RE = re.compile(r"^## ", re.MULTILINE)
-_REPAIR_PROFILE_RELEVANCE_RE = re.compile(r"^## Profile Relevance\b", re.MULTILINE)
-_REPAIR_USER_NOTES_RE = re.compile(r"^## User Notes\b", re.MULTILINE)
 
 
 def _collapse_to_single_line(value: str) -> str:
@@ -143,33 +140,18 @@ def _collapse_to_single_line(value: str) -> str:
     return " ".join(value.replace("\r", " ").split())[:300]
 
 
-def _find_repair_section_span(content: str) -> tuple[int, int] | None:
-    """Return (start, end) of the existing ``## Repair`` section, or None."""
-    m = _REPAIR_HEADING_RE.search(content)
-    if not m:
-        return None
-    body_start = m.end()
-    next_h = _NEXT_HEADING_RE.search(content, body_start)
-    end = next_h.start() if next_h else len(content)
-    return m.start(), end
-
-
 def parse_repair_section(content: str) -> RepairCounters:
     """Parse the ``## Repair`` section of *content* into :class:`RepairCounters`.
 
-    Returns zero-defaults when the section is absent.  Unknown bullets
-    are ignored; malformed integer counts default to zero so a hand-edit
-    cannot break the sweep.
+    The section is located by :func:`canonical_note.extract_section_body`
+    (CRLF-tolerant); only the bullet grammar is owned here.  Returns
+    zero-defaults when the section is absent.  Unknown bullets are ignored;
+    malformed integer counts default to zero so a hand-edit cannot break the
+    sweep.
     """
-    span = _find_repair_section_span(content)
-    if span is None:
+    body = extract_section_body(content, REPAIR)
+    if not body:
         return RepairCounters()
-    start, end = span
-    # Skip past the heading line we already matched.
-    body_start = content.find("\n", start)
-    if body_start < 0 or body_start >= end:
-        return RepairCounters()
-    body = content[body_start + 1 : end]
 
     fields: dict[str, Any] = {}
     int_keys = {"tier2_attempts", "tier3_attempts", "archive_attempts"}
@@ -222,35 +204,13 @@ def render_repair_section(counters: RepairCounters) -> str:
 def upsert_repair_section(content: str, counters: RepairCounters) -> str:
     """Return *content* with the ``## Repair`` section set to *counters*.
 
-    Replaces an existing section in place; otherwise inserts the new
-    section before ``## Profile Relevance`` (canonical placement,
-    matching ``canonical_note.insertion_point``), or before
-    ``## User Notes``, or at end of content when neither is present.
+    Placement is delegated to :func:`canonical_note.upsert_section_text`:
+    an existing section is replaced in place (trimming accumulated blank
+    lines); otherwise the section is inserted at
+    :func:`canonical_note.insertion_point` — before ``## Profile Relevance``,
+    else before ``## User Notes``, else at end of content.
     """
-    rendered = render_repair_section(counters)
-    span = _find_repair_section_span(content)
-    if span is not None:
-        start, end = span
-        # Trim leading whitespace from the post-section so we don't
-        # accumulate blank lines on every re-render.
-        tail = content[end:].lstrip("\n")
-        if tail:
-            tail = "\n" + tail
-        head = content[:start].rstrip("\n")
-        separator = "\n\n" if head.strip() else ""
-        return head + separator + rendered + tail
-
-    pr = _REPAIR_PROFILE_RELEVANCE_RE.search(content)
-    if pr:
-        ins = pr.start()
-        return content[:ins] + rendered + "\n" + content[ins:]
-    un = _REPAIR_USER_NOTES_RE.search(content)
-    if un:
-        ins = un.start()
-        return content[:ins] + rendered + "\n" + content[ins:]
-    if content and not content.endswith("\n"):
-        content += "\n"
-    return content + ("\n" if content else "") + rendered
+    return upsert_section_text(content, REPAIR, render_repair_section(counters))
 
 
 # ── Failure classification ──────────────────────────────────────────

--- a/tests/unit/test_canonical_note.py
+++ b/tests/unit/test_canonical_note.py
@@ -413,19 +413,20 @@ class TestUpsertSectionText:
         )
         assert "\n\n\n" not in result
 
-    def test_crlf_note_touched_section_lf_surrounding_preserved(self) -> None:
+    def test_crlf_note_section_and_separators_written_lf(self) -> None:
         # Influx-owned sections are written LF (as upsert_archive_path does for
-        # the path: line). On a CRLF note the replaced ## Repair block is LF
-        # and the surrounding CRLF bytes — incl. the User Notes region — are
-        # preserved rather than round-tripped to CRLF.
+        # the path: line). On a CRLF note the replaced ## Repair block AND its
+        # adjacent separators come out LF — note the extra LF where the
+        # preceding CRLF blank line meets the new "\n\n" separator — while the
+        # trailing ## User Notes region keeps its CRLF bytes verbatim.
         content = (
             "# T\n\n## Repair\n- tier2_attempts: 1\n\n## User Notes\nMINE\n"
         ).replace("\n", "\r\n")
-        result = cn.upsert_section_text(
+        assert cn.upsert_section_text(
             content, REPAIR, "## Repair\n- tier2_attempts: 2\n"
+        ) == (
+            "# T\r\n\r\n\n## Repair\n- tier2_attempts: 2\n\n## User Notes\r\nMINE\r\n"
         )
-        assert "## Repair\n- tier2_attempts: 2\n" in result  # touched section LF
-        assert result.endswith("## User Notes\r\nMINE\r\n")  # CRLF tail preserved
 
 
 # ── Structured immutable ops ────────────────────────────────────────

--- a/tests/unit/test_canonical_note.py
+++ b/tests/unit/test_canonical_note.py
@@ -372,23 +372,60 @@ class TestUpsertArchivePath:
 
 
 class TestUpsertSectionText:
-    def test_inserts_before_profile_relevance(self) -> None:
+    """Exact-byte insert/replace behaviour the repair_counters ## Repair
+    placement (PR 5) delegates to. Pins the insertion-point fallback chain
+    (before Profile Relevance → before User Notes → EOF) and in-place
+    replacement without blank-line accumulation.
+    """
+
+    _RENDERED = "## Repair\n- tier2_attempts: 1\n"
+
+    def test_insert_before_profile_relevance(self) -> None:
         content = (
             "# T\n\n## Summary\ns\n\n"
             "## Profile Relevance\n### p\nScore: 5/10\nr\n\n## User Notes\n"
         )
-        rendered = "## Repair\n- tier2_attempts: 1\n"
-        result = cn.upsert_section_text(content, REPAIR, rendered)
-        # inserted before Profile Relevance, after Summary
-        assert result.index("## Repair") < result.index("## Profile Relevance")
-        assert result.index("## Summary") < result.index("## Repair")
+        assert cn.upsert_section_text(content, REPAIR, self._RENDERED) == (
+            "# T\n\n## Summary\ns\n\n## Repair\n- tier2_attempts: 1\n\n"
+            "## Profile Relevance\n### p\nScore: 5/10\nr\n\n## User Notes\n"
+        )
 
-    def test_replace_does_not_accumulate_blank_lines(self) -> None:
-        content = "# T\n\n## Summary\ns\n\n## User Notes\n"
-        r1 = cn.upsert_section_text(content, REPAIR, "## Repair\n- tier2_attempts: 1\n")
-        r2 = cn.upsert_section_text(r1, REPAIR, "## Repair\n- tier2_attempts: 2\n")
-        assert "- tier2_attempts: 2" in r2
-        assert "\n\n\n" not in r2
+    def test_insert_fallback_before_user_notes(self) -> None:
+        content = "# T\n\n## Summary\ns\n\n## User Notes\nMINE\n"
+        assert cn.upsert_section_text(content, REPAIR, self._RENDERED) == (
+            "# T\n\n## Summary\ns\n\n## Repair\n- tier2_attempts: 1\n\n"
+            "## User Notes\nMINE\n"
+        )
+
+    def test_insert_fallback_at_eof(self) -> None:
+        content = "# T\n\n## Summary\ns\n"
+        assert cn.upsert_section_text(content, REPAIR, self._RENDERED) == (
+            "# T\n\n## Summary\ns\n\n## Repair\n- tier2_attempts: 1\n"
+        )
+
+    def test_replace_in_place_no_blank_line_accumulation(self) -> None:
+        content = "# T\n\n## Repair\n- tier2_attempts: 1\n\n## User Notes\nMINE\n"
+        result = cn.upsert_section_text(
+            content, REPAIR, "## Repair\n- tier2_attempts: 2\n"
+        )
+        assert result == (
+            "# T\n\n## Repair\n- tier2_attempts: 2\n\n## User Notes\nMINE\n"
+        )
+        assert "\n\n\n" not in result
+
+    def test_crlf_note_touched_section_lf_surrounding_preserved(self) -> None:
+        # Influx-owned sections are written LF (as upsert_archive_path does for
+        # the path: line). On a CRLF note the replaced ## Repair block is LF
+        # and the surrounding CRLF bytes — incl. the User Notes region — are
+        # preserved rather than round-tripped to CRLF.
+        content = (
+            "# T\n\n## Repair\n- tier2_attempts: 1\n\n## User Notes\nMINE\n"
+        ).replace("\n", "\r\n")
+        result = cn.upsert_section_text(
+            content, REPAIR, "## Repair\n- tier2_attempts: 2\n"
+        )
+        assert "## Repair\n- tier2_attempts: 2\n" in result  # touched section LF
+        assert result.endswith("## User Notes\r\nMINE\r\n")  # CRLF tail preserved
 
 
 # ── Structured immutable ops ────────────────────────────────────────

--- a/tests/unit/test_canonical_note.py
+++ b/tests/unit/test_canonical_note.py
@@ -531,32 +531,8 @@ def test_constants_are_section_headings() -> None:
     assert SECTION_ORDER[-1] == USER_NOTES
 
 
-# ── Transitional parity with the legacy helpers ─────────────────────
-#
-# The canonical ops that PRs 2-5 swap the existing helpers onto must be
-# byte-identical to those helpers on canonical inputs — that is what makes
-# each migration a no-op for production bytes. These assertions pin that
-# equivalence and are deleted as each legacy helper is removed in its
-# migration PR. NOTE: drop_tier2 / drop_tier2_and_tier3 / upsert_archive_path
-# are deliberately excluded — they intentionally *diverge* from the legacy
-# helpers (byte-exact User Notes; whole-section path: idempotence), a fix
-# that lands with the PR 3/PR 4 migrations.
-
-
-class TestLegacyParityTransitional:
-    def _canonical_note(self) -> str:
-        return _read("golden_lf.md")
-
-    # NOTE: the repair_hooks parity cases (PR 2) and the lithos_client parity
-    # cases — graft_user_notes / replace_profile_relevance (PR 3) — were removed
-    # as those legacy helpers were deleted in favour of the canonical ops.
-
-    def test_upsert_repair_matches_repair_counters(self) -> None:
-        from influx import repair_counters as rc
-
-        note = _read("tier3_full.md")
-        counters = rc.RepairCounters(tier2_attempts=1, tier2_last_stage="parse")
-        rendered = rc.render_repair_section(counters)
-        assert cn.upsert_section_text(
-            note, REPAIR, rendered
-        ) == rc.upsert_repair_section(note, counters)
+# NOTE: the transitional legacy-parity suite (repair_hooks / lithos_client /
+# repair_counters helpers vs the canonical ops) was retired across PRs 2-5 as
+# each legacy helper was deleted in favour of the shared canonical_note op. The
+# per-op byte-exactness those cases guarded is now pinned directly by the
+# canonical-op tests above and each migrated module's own suite.

--- a/tests/unit/test_repair_counters.py
+++ b/tests/unit/test_repair_counters.py
@@ -145,6 +145,34 @@ class TestRecordCountedFailureBelowCap:
         assert "influx:tier2-terminal" in result.new_tags
 
 
+# ── parse_repair_section: section location ─────────────────────────
+
+
+class TestParseRepairSectionLocation:
+    """The read side locates ## Repair via canonical_note.extract_section_body."""
+
+    def test_parses_counters_from_crlf_note(self) -> None:
+        # CRLF regression: the legacy ^## Repair[ \t]*\n heading regex never
+        # matched a "## Repair\r\n" heading and silently returned zero
+        # counters; the canonical anchored matcher is CRLF-tolerant.
+        content = (
+            "# Paper\n\n## Repair\n"
+            "- tier2_attempts: 2\n"
+            '- tier2_last_stage: "parse"\n'
+            "- tier3_attempts: 1\n\n"
+            "## Profile Relevance\n### r\nScore: 9/10\nReason\n\n"
+            "## User Notes\n"
+        ).replace("\n", "\r\n")
+        counters = parse_repair_section(content)
+        assert counters.tier2_attempts == 2
+        assert counters.tier2_last_stage == "parse"
+        assert counters.tier3_attempts == 1
+
+    def test_absent_section_returns_zero_defaults(self) -> None:
+        counters = parse_repair_section(_BASE_NOTE)
+        assert counters == RepairCounters()
+
+
 # ── record_counted_failure: cap-reach and idempotence ──────────────
 
 


### PR DESCRIPTION
## Context

**PR 5 of 6** in the CanonicalNote stack (finding 1 / Lithos task `9ae1086e`), on top of #251–#254. This is the deliberately **hybrid** one: `RepairCounters` keeps the domain knowledge it genuinely owns — the per-stage counter bullet grammar — and hands only the section-*placement* machinery to `influx.canonical_note`.

## What this PR does

- **`parse_repair_section`** — locates and slices the `## Repair` body via `canonical_note.extract_section_body` instead of the local `_find_repair_section_span` + `_REPAIR_HEADING_RE` / `_NEXT_HEADING_RE`. The bullet grammar (`_REPAIR_BULLET_RE`, `_QUOTED_RE`, `_collapse_to_single_line`) stays local — that's the counter domain.
- **`upsert_repair_section`** — collapses to a one-liner delegating to `canonical_note.upsert_section_text(content, REPAIR, render_repair_section(counters))`, deleting the local replace/insert logic and the `_REPAIR_PROFILE_RELEVANCE_RE` / `_REPAIR_USER_NOTES_RE` placement anchors. Byte-identical to the prior implementation (PR 1's parity harness pinned it; the whole `test_repair_counters` suite stays green unchanged).
- Kept entirely local: `RepairCounters` (+ `bump_*`/`attempts_for`), `render_repair_section`, `classify_failure`, `record_counted_failure`, `CountedFailureResult`. Net −41 lines.

## Incidental fix

Same shape as PR 4's archive-CRLF fix: the legacy read regex `^## Repair[ \t]*\n` never matched a `## Repair\r\n` heading, so a CRLF note silently parsed **zero** counters — losing terminal-flip state on the read side. `extract_section_body` is CRLF-tolerant. Added a parse test pinning it.

## Tests

- Added `TestParseRepairSectionLocation` — CRLF parse round-trip + absent-section zero-defaults.
- Retired the **last** transitional legacy-parity case (`test_upsert_repair_matches_repair_counters`): now that `upsert_repair_section` *is* the canonical op, that assertion is a self-comparison. The per-op byte-exactness it guarded is pinned directly by the canonical-op tests and `test_repair_counters`. This clears the whole transitional-parity scaffold the stack has been carrying since PR 1.
- `make check`: lint + pyright clean; whole suite green on CI. Locally the only failure is the pre-existing `test_cli_http.py::test_run_conflict_exit_1` subprocess-timeout flake (passes on CI; reproduces on `main`).

## Follow-up (final PR)

PR 6 (optional) — renderer composes via `serialize` (round-trip identity by construction), drop the dead `source_url` param from `render_note`, and converge `replace_profile_relevance_section`'s end-boundary onto the shared section-span helper (carried over from the #253 review), each with a parity test.
