### PR TITLE
refactor(renderer): render_note composes a CanonicalNote via serialize (PR 6/6)

### DIFF
--- a/src/influx/canonical_note.py
+++ b/src/influx/canonical_note.py
@@ -617,17 +617,16 @@ def replace_profile_relevance_section(
     A no-op when the section is absent.  Preserves the blank line before a
     following section.
     """
-    match = _heading_line_re(PROFILE_RELEVANCE).search(content)
-    if match is None:
+    span = _section_span(content, PROFILE_RELEVANCE)
+    if span is None:
         return content
-    pr_idx = match.start()
-    next_h2 = content.find("\n## ", match.end())
+    pr_idx, end = span
 
     pr_body = render_profile_relevance_body(entries)
     marker = f"## {PROFILE_RELEVANCE}"
     replacement = f"{marker}\n{pr_body}\n" if pr_body else f"{marker}\n"
-    if next_h2 != -1:
-        return content[:pr_idx] + replacement + "\n" + content[next_h2 + 1 :]
+    if end < len(content):
+        return content[:pr_idx] + replacement + "\n" + content[end:]
     return content[:pr_idx] + replacement
 
 

--- a/src/influx/renderer.py
+++ b/src/influx/renderer.py
@@ -22,9 +22,19 @@ Public surface:
 from __future__ import annotations
 
 from influx.canonical_note import (
+    ARCHIVE,
+    BUILDS_ON,
+    CLAIMS,
+    DATASETS,
+    FULL_TEXT,
+    OPEN_QUESTIONS,
+    PROFILE_RELEVANCE,
+    SUMMARY,
+    CanonicalNote,
     ProfileRelevanceEntry,
+    Section,
     render_profile_relevance_body,
-    render_tier3_sections,
+    serialize,
 )
 from influx.errors import InfluxError
 from influx.schemas import Tier1Enrichment, Tier3Extraction
@@ -76,9 +86,8 @@ def render_archive_section(archive_path: str | None) -> str:
     str
         The rendered section text starting with ``## Archive\\n``.
     """
-    if archive_path is not None:
-        return f"## Archive\npath: {archive_path}\n"
-    return "## Archive\n"
+    body = _archive_body(archive_path)
+    return f"## {ARCHIVE}\n{body}\n" if body else f"## {ARCHIVE}\n"
 
 
 def validate_archive_tag_invariant(
@@ -108,13 +117,60 @@ def validate_archive_tag_invariant(
         )
 
 
+# ── Section-body builders (compose the CanonicalNote model) ─────────
+
+
+def _archive_body(archive_path: str | None) -> str:
+    """Body of the ``## Archive`` section — the ``path:`` line, or empty."""
+    return f"path: {archive_path}" if archive_path is not None else ""
+
+
+def _summary_body(
+    tier1_enrichment: Tier1Enrichment | None,
+    summary: str,
+    keywords: list[str],
+) -> str | None:
+    """Body of the ``## Summary`` section, or ``None`` to omit it (FR-ENR-6).
+
+    Structured Tier-1 enrichment wins (``### Contributions`` / ``### Method``
+    / ``### Result`` / ``### Relevance``); else the plain *summary* (with a
+    ``Keywords:`` line when present); else the section is omitted.
+    """
+    if tier1_enrichment is not None:
+        parts = ["### Contributions"]
+        parts.extend(f"- {contrib}" for contrib in tier1_enrichment.contributions)
+        parts.append(f"\n### Method\n{tier1_enrichment.method}")
+        parts.append(f"\n### Result\n{tier1_enrichment.result}")
+        parts.append(f"\n### Relevance\n{tier1_enrichment.relevance}")
+        return "\n".join(parts)
+    if summary:
+        body = summary
+        if keywords:
+            body += f"\n\nKeywords: {', '.join(keywords)}"
+        return body
+    return None
+
+
+def _tier3_sections(tier3: Tier3Extraction) -> list[Section]:
+    """The four Tier 3 sections as ``Section`` values (US-012)."""
+
+    def _bullets(items: list[str]) -> str:
+        return "\n".join(f"- {item}" for item in items)
+
+    return [
+        Section(CLAIMS, _bullets(tier3.claims)),
+        Section(DATASETS, _bullets(tier3.datasets)),
+        Section(BUILDS_ON, _bullets(tier3.builds_on)),
+        Section(OPEN_QUESTIONS, _bullets(tier3.open_questions)),
+    ]
+
+
 # ── Full canonical renderer (FR-NOTE-1..8, US-007) ──────────────────
 
 
 def render_note(
     *,
     title: str,
-    source_url: str,
     tags: list[str],
     confidence: float,
     archive_path: str | None,
@@ -132,8 +188,6 @@ def render_note(
     ----------
     title:
         The ``# <Title>`` text (without the ``# `` prefix).
-    source_url:
-        Normalised canonical URL for frontmatter.
     tags:
         The final merged tag list (from ``influx.notes.merge_tags``).
     confidence:
@@ -169,7 +223,16 @@ def render_note(
     Returns
     -------
     str
-        The complete canonical note text.
+        The complete canonical note text.  The note is composed as a
+        :class:`~influx.canonical_note.CanonicalNote` and emitted via
+        :func:`~influx.canonical_note.serialize`, so the output is always in
+        canonical form — single blank-line separators, trailing-stripped
+        section bodies.  This is byte-identical to the historical imperative
+        rendering for section bodies without trailing whitespace; a body that
+        *does* end in whitespace (e.g. a summary / full-text / reason with a
+        trailing newline) has it normalised away rather than emitted as a
+        double blank line.  The ``## User Notes`` region is still appended
+        byte-exactly.
 
     Raises
     ------
@@ -185,63 +248,42 @@ def render_note(
         )
     validate_archive_tag_invariant(archive_path=archive_path, tags=tags)
 
-    archive_section = render_archive_section(archive_path)
+    # Compose the note as a CanonicalNote and serialise it — body-only output
+    # (#178).  Lithos owns the outer YAML frontmatter and persists tags /
+    # source_url / confidence / note_type / namespace as first-class
+    # ``lithos_write`` API parameters (spec §5.1); the renderer never emits a
+    # ``---``-fenced block of its own (LithosClient.write_note enforces this).
+    # The ``# {title}`` H1 is retained as the body's canonical title.
+    sections: list[Section] = [Section(ARCHIVE, _archive_body(archive_path))]
 
-    # Compose note — body-only output (#178).  Lithos owns the outer
-    # YAML frontmatter and persists tags / source_url / confidence /
-    # note_type / namespace as first-class API parameters on
-    # ``lithos_write`` (spec §5.1); the renderer must NOT emit a
-    # ``---``-fenced frontmatter block of its own.  The ``# {title}``
-    # heading is retained — Lithos's ``extract_title_from_content``
-    # strips its own prepended title on read, leaving this one as the
-    # body's canonical H1.  ``LithosClient.write_note`` enforces this
-    # contract via a strict-mode assertion that rejects content
-    # starting with ``---\\n``.
-    output = f"# {title}\n\n"
-    output += archive_section + "\n"
+    summary_body = _summary_body(tier1_enrichment, summary, keywords)
+    if summary_body is not None:
+        sections.append(Section(SUMMARY, summary_body))
 
-    # Summary section: structured Tier1Enrichment → plain summary → omit
-    if tier1_enrichment is not None:
-        output += "## Summary\n"
-        output += "### Contributions\n"
-        for contrib in tier1_enrichment.contributions:
-            output += f"- {contrib}\n"
-        output += f"\n### Method\n{tier1_enrichment.method}\n"
-        output += f"\n### Result\n{tier1_enrichment.result}\n"
-        output += f"\n### Relevance\n{tier1_enrichment.relevance}\n"
-    elif summary:
-        summary_body = summary
-        if keywords:
-            summary_body += f"\n\nKeywords: {', '.join(keywords)}"
-        output += f"## Summary\n{summary_body}\n"
-
-    # Full Text section (Tier 2) — omitted when absent/empty (FR-ENR-6, US-011)
+    # Full Text (Tier 2) — omitted when absent/empty (FR-ENR-6, US-011).
     if full_text:
-        output += f"\n## Full Text\n{full_text}\n"
+        sections.append(Section(FULL_TEXT, full_text))
 
     # Tier 3 sections (US-012) — omitted entirely when absent (FR-ENR-6).
-    # The section block is owned by canonical_note (shared with the repair
-    # sweep); the leading blank-line separator is added here.
     if tier3_extraction is not None:
-        output += "\n" + render_tier3_sections(tier3_extraction)
+        sections.extend(_tier3_sections(tier3_extraction))
 
-    # Profile Relevance section — always emitted to keep the canonical
-    # note shape stable (US-007); body is empty when no entries are given.
-    output += "\n"
-    pr_body = _render_profile_relevance_body(profile_entries)
-    if pr_body:
-        output += f"## Profile Relevance\n{pr_body}\n"
-    else:
-        output += "## Profile Relevance\n"
+    # Profile Relevance — always emitted to keep the shape stable (US-007);
+    # the body is empty when no entries are given.
+    sections.append(
+        Section(PROFILE_RELEVANCE, render_profile_relevance_body(profile_entries))
+    )
 
-    # User Notes — preserved byte-exactly or empty heading appended
-    output += "\n"
-    if user_notes is not None:
-        output += user_notes
-    else:
-        output += "## User Notes\n"
-
-    return output
+    # Trailing-strip every body so serialize() emits canonical single
+    # blank-line separators (see the Returns note on normalisation).  The
+    # ## User Notes region is appended byte-exactly by serialize().
+    note = CanonicalNote(
+        frontmatter_raw="",
+        title=title,
+        sections=tuple(Section(s.heading, s.body.rstrip("\r\n")) for s in sections),
+        user_notes=user_notes,
+    )
+    return serialize(note)
 
 
 # ── High-level facade for source builders ──────────────────────────
@@ -250,7 +292,6 @@ def render_note(
 def render(
     *,
     title: str,
-    source_url: str,
     tags: list[str],
     confidence: float,
     archive_path: str | None,
@@ -274,8 +315,8 @@ def render(
 
     Parameters
     ----------
-    title, source_url, tags, confidence, archive_path, summary,
-    keywords, tier1_enrichment, full_text, tier3_extraction, user_notes:
+    title, tags, confidence, archive_path, summary, keywords,
+    tier1_enrichment, full_text, tier3_extraction, user_notes:
         Forwarded to :func:`render_note`.
     profile_name, score, reason:
         Used to construct a single-entry profile relevance list.
@@ -294,7 +335,6 @@ def render(
     ]
     return render_note(
         title=title,
-        source_url=source_url,
         tags=tags,
         confidence=confidence,
         archive_path=archive_path,

--- a/src/influx/renderer.py
+++ b/src/influx/renderer.py
@@ -226,13 +226,15 @@ def render_note(
         The complete canonical note text.  The note is composed as a
         :class:`~influx.canonical_note.CanonicalNote` and emitted via
         :func:`~influx.canonical_note.serialize`, so the output is always in
-        canonical form — single blank-line separators, trailing-stripped
-        section bodies.  This is byte-identical to the historical imperative
-        rendering for section bodies without trailing whitespace; a body that
-        *does* end in whitespace (e.g. a summary / full-text / reason with a
-        trailing newline) has it normalised away rather than emitted as a
-        double blank line.  The ``## User Notes`` region is still appended
-        byte-exactly.
+        canonical form — single blank-line separators, with section bodies
+        stripped of trailing line endings (``\\r``/``\\n``).  Trailing spaces
+        and tabs are *not* stripped (matching the parser's canonical form, so
+        such bodies still round-trip).  This is byte-identical to the
+        historical imperative rendering for bodies that do not end in a
+        newline; a body that *does* end in one or more newlines (e.g. a
+        summary / full-text / reason with a trailing ``\\n``) has them
+        collapsed rather than emitted as a double blank line.  The
+        ``## User Notes`` region is still appended byte-exactly.
 
     Raises
     ------
@@ -274,9 +276,10 @@ def render_note(
         Section(PROFILE_RELEVANCE, render_profile_relevance_body(profile_entries))
     )
 
-    # Trailing-strip every body so serialize() emits canonical single
-    # blank-line separators (see the Returns note on normalisation).  The
-    # ## User Notes region is appended byte-exactly by serialize().
+    # Strip trailing line endings (\r/\n) from every body — matching the
+    # parser's canonical form — so serialize() emits single blank-line
+    # separators (see the Returns note on normalisation).  Trailing spaces are
+    # preserved; the ## User Notes region is appended byte-exactly.
     note = CanonicalNote(
         frontmatter_raw="",
         title=title,

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -1341,7 +1341,6 @@ def build_arxiv_note_item(
 
     content = render(
         title=item.title,
-        source_url=source_url,
         tags=tags,
         confidence=confidence,
         archive_path=archive_path,

--- a/src/influx/sources/inbox.py
+++ b/src/influx/sources/inbox.py
@@ -340,7 +340,6 @@ def build_inbox_note_item(
 
     content = render(
         title=title,
-        source_url=source_url,
         tags=tags,
         confidence=confidence,
         archive_path=acquired.archive_path,

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -711,7 +711,6 @@ def build_rss_note_item(
 
     content = render(
         title=item.title,
-        source_url=source_url,
         tags=tags,
         confidence=confidence,
         archive_path=archive_path,

--- a/tests/integration/test_multi_profile_shared_source.py
+++ b/tests/integration/test_multi_profile_shared_source.py
@@ -97,7 +97,6 @@ def _render_item_content(
     """Render a minimal canonical note for a profile item."""
     return render_note(
         title=SHARED_TITLE,
-        source_url=SHARED_URL,
         tags=tags,
         confidence=0.8,
         archive_path=None,

--- a/tests/integration/test_profile_rejection_authority.py
+++ b/tests/integration/test_profile_rejection_authority.py
@@ -97,7 +97,6 @@ def _render_item_content(
     """Render a minimal canonical note for a profile item."""
     return render_note(
         title=SHARED_TITLE,
-        source_url=SHARED_URL,
         tags=tags,
         confidence=0.8,
         archive_path=None,
@@ -259,7 +258,6 @@ def _existing_rejected_note_content() -> str:
     """Content for existing note (Profile Relevance for the rejected profile)."""
     return render_note(
         title=SHARED_TITLE,
-        source_url=SHARED_URL,
         tags=_existing_rejected_note_tags(),
         confidence=0.8,
         archive_path=None,

--- a/tests/unit/test_canonical_note.py
+++ b/tests/unit/test_canonical_note.py
@@ -562,6 +562,60 @@ def test_render_profile_relevance_body_empty() -> None:
     assert cn.render_profile_relevance_body([]) == ""
 
 
+class TestReplaceProfileRelevanceSection:
+    """Exact-byte replacement — the section end-boundary was converged onto
+    the shared _section_span helper (PR 6 / #253 review); these pin that the
+    output is byte-identical to the prior find("\\n## ") logic.
+    """
+
+    _ENTRIES = [
+        ProfileRelevanceEntry("a", 8, "r1"),
+        ProfileRelevanceEntry("b", 4, "r2"),
+    ]
+
+    def test_replace_mid_note_before_user_notes(self) -> None:
+        content = (
+            "# T\n\n## Summary\ns\n\n"
+            "## Profile Relevance\n### old\nScore: 1/10\nx\n\n## User Notes\nMINE\n"
+        )
+        assert cn.replace_profile_relevance_section(content, self._ENTRIES) == (
+            "# T\n\n## Summary\ns\n\n## Profile Relevance\n"
+            "### a\nScore: 8/10\nr1\n\n### b\nScore: 4/10\nr2\n\n## User Notes\nMINE\n"
+        )
+
+    def test_replace_followed_by_another_section(self) -> None:
+        content = (
+            "# T\n\n## Profile Relevance\n### old\nScore: 1/10\nx\n\n"
+            "## Repair\n- a: 1\n"
+        )
+        assert cn.replace_profile_relevance_section(content, self._ENTRIES) == (
+            "# T\n\n## Profile Relevance\n"
+            "### a\nScore: 8/10\nr1\n\n### b\nScore: 4/10\nr2\n\n## Repair\n- a: 1\n"
+        )
+
+    def test_replace_last_section_at_eof(self) -> None:
+        content = (
+            "# T\n\n## Summary\ns\n\n## Profile Relevance\n### old\nScore: 1/10\nx\n"
+        )
+        assert cn.replace_profile_relevance_section(content, self._ENTRIES) == (
+            "# T\n\n## Summary\ns\n\n## Profile Relevance\n"
+            "### a\nScore: 8/10\nr1\n\n### b\nScore: 4/10\nr2\n"
+        )
+
+    def test_replace_with_empty_entries_keeps_bare_heading(self) -> None:
+        content = (
+            "# T\n\n## Profile Relevance\n### old\nScore: 1/10\nx\n\n"
+            "## User Notes\nMINE\n"
+        )
+        assert cn.replace_profile_relevance_section(content, []) == (
+            "# T\n\n## Profile Relevance\n\n## User Notes\nMINE\n"
+        )
+
+    def test_noop_when_absent(self) -> None:
+        content = "# T\n\n## Summary\ns\n\n## User Notes\n"
+        assert cn.replace_profile_relevance_section(content, self._ENTRIES) == content
+
+
 def test_constants_are_section_headings() -> None:
     assert ARCHIVE in SECTION_ORDER
     assert FULL_TEXT in SECTION_ORDER

--- a/tests/unit/test_full_text_render.py
+++ b/tests/unit/test_full_text_render.py
@@ -14,7 +14,6 @@ from influx.renderer import render_note
 _BASE_TAGS = ["source:arxiv", "ingested-by:influx", "schema:1"]
 _BASE_KWARGS = {
     "title": "Test Note",
-    "source_url": "https://arxiv.org/abs/2601.00001",
     "tags": _BASE_TAGS,
     "confidence": 0.8,
     "archive_path": None,

--- a/tests/unit/test_inbox_tick.py
+++ b/tests/unit/test_inbox_tick.py
@@ -652,7 +652,6 @@ def _note_content(ingested: list[str]) -> str:
 
     return render_note(
         title="Existing",
-        source_url="https://example.com/article",
         tags=["ingested-by:influx"],
         confidence=1.0,
         archive_path=None,

--- a/tests/unit/test_multi_profile_merge.py
+++ b/tests/unit/test_multi_profile_merge.py
@@ -39,7 +39,6 @@ def _make_note_content(
     """Render a minimal canonical note for testing."""
     return render_note(
         title=title,
-        source_url=source_url,
         tags=tags,
         confidence=0.8,
         archive_path=None,

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -5,7 +5,9 @@ The Renderer module owns the canonical Markdown shape from spec §9.
 it wraps a single-profile :class:`ProfileRelevanceEntry` and delegates
 to :func:`render_note`. These tests cover:
 
-- Frontmatter shape (note_type, namespace, source_url, tags, confidence)
+- Body-only output (no frontmatter fence): Lithos owns note_type /
+  namespace / source_url / tags / confidence as ``lithos_write`` API
+  parameters (#178), so the renderer must not emit them
 - Section ordering: ``## Archive``, ``## Summary``, ``## Full Text``,
   ``## Claims``, ``## Datasets & Benchmarks``, ``## Builds On``,
   ``## Open Questions``, ``## Profile Relevance``, ``## User Notes``
@@ -321,11 +323,13 @@ class TestRenderFacadeParity:
 
 class TestRenderNoteCanonicalNormalization:
     """``render_note`` composes a :class:`CanonicalNote` and ``serialize()``s
-    it, so its output is always canonical — single blank-line separators,
-    trailing-stripped bodies.  Bodies without trailing whitespace are
-    byte-identical to the historical imperative rendering (pinned by the
-    suites above); a body that *does* carry trailing whitespace is normalised
-    rather than emitted as a double blank line.
+    it, so its output is always canonical — single blank-line separators, with
+    bodies stripped of trailing line endings (``\\r``/``\\n``).  Trailing
+    spaces/tabs are preserved (matching the parser's canonical form).  Bodies
+    that do not end in a newline are byte-identical to the historical
+    imperative rendering (pinned by the suites above); a body that *does* end
+    in one or more newlines is normalised rather than emitted as a double
+    blank line.
     """
 
     _BASE = {
@@ -361,9 +365,19 @@ class TestRenderNoteCanonicalNormalization:
             "## Summary\nA summary.\n\n## Profile Relevance\n\n## User Notes\n"
         )
 
-    def test_clean_and_trailing_whitespace_converge_to_same_bytes(self) -> None:
+    def test_clean_and_trailing_newline_converge_to_same_bytes(self) -> None:
         # The normalisation target IS the clean-input rendering: a trailing
-        # newline is collapsed toward the no-trailing-whitespace form.
+        # newline is collapsed toward the no-trailing-newline form.
         assert render_note(**self._BASE, full_text="Body line.") == render_note(
             **self._BASE, full_text="Body line.\n"
         )
+
+    def test_trailing_spaces_on_body_are_preserved(self) -> None:
+        # Only trailing line endings are collapsed — trailing spaces survive
+        # (rstrip("\r\n") matches the parser's canonical body form), so a
+        # space-terminated body still round-trips.
+        out = render_note(**self._BASE, full_text="Body line.  ")
+        assert (
+            "## Full Text\nBody line.  \n\n## Profile Relevance" in out
+        )  # spaces kept, single blank line
+        assert cn.serialize(cn.parse(out)) == out

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -17,6 +17,7 @@ to :func:`render_note`. These tests cover:
 
 from __future__ import annotations
 
+from influx import canonical_note as cn
 from influx.notes import parse_note
 from influx.renderer import (
     ProfileRelevanceEntry,
@@ -34,7 +35,6 @@ def _render_minimal(**overrides: object) -> str:
     """Render a minimal note with sensible defaults; *overrides* override kwargs."""
     kwargs: dict[str, object] = {
         "title": "A Paper About Things",
-        "source_url": "https://arxiv.org/abs/2601.00001",
         "tags": list(_BASE_TAGS),
         "confidence": 0.8,
         "archive_path": "papers/arxiv/2026/01/2601.00001.pdf",
@@ -80,12 +80,6 @@ class TestBodyOnlyOutput:
         text = _render_minimal(tags=["source:arxiv", "ingested-by:influx", "favourite"])
         assert "tags:" not in text
         assert "  - favourite" not in text
-
-    def test_does_not_inline_source_url(self) -> None:
-        text = _render_minimal(source_url="https://arxiv.org/abs/2601.00001")
-        # The URL may appear inside section content (it doesn't here),
-        # but never in a ``source_url: …`` YAML key shape.
-        assert "source_url:" not in text
 
 
 # ── Section ordering ────────────────────────────────────────────────
@@ -301,7 +295,6 @@ class TestRenderFacadeParity:
     def test_render_matches_manual_render_note(self) -> None:
         kwargs = {
             "title": "Parity Paper",
-            "source_url": "https://arxiv.org/abs/2601.00099",
             "tags": list(_BASE_TAGS),
             "confidence": 0.7,
             "archive_path": None,
@@ -313,7 +306,6 @@ class TestRenderFacadeParity:
         via_facade = render(**kwargs)  # type: ignore[arg-type]
         via_render_note = render_note(
             title="Parity Paper",
-            source_url="https://arxiv.org/abs/2601.00099",
             tags=list(_BASE_TAGS),
             confidence=0.7,
             archive_path=None,
@@ -322,3 +314,56 @@ class TestRenderFacadeParity:
             profile_entries=[ProfileRelevanceEntry("research", 7, "Worth a look.")],
         )
         assert via_facade == via_render_note
+
+
+# ── Canonical normalization (PR 6 — render composes via serialize) ──
+
+
+class TestRenderNoteCanonicalNormalization:
+    """``render_note`` composes a :class:`CanonicalNote` and ``serialize()``s
+    it, so its output is always canonical — single blank-line separators,
+    trailing-stripped bodies.  Bodies without trailing whitespace are
+    byte-identical to the historical imperative rendering (pinned by the
+    suites above); a body that *does* carry trailing whitespace is normalised
+    rather than emitted as a double blank line.
+    """
+
+    _BASE = {
+        "title": "T",
+        "tags": ["ingested-by:influx"],
+        "confidence": 0.5,
+        "archive_path": "p/x.pdf",
+        "summary": "",
+        "keywords": [],
+        "profile_entries": [],
+    }
+
+    def test_output_always_roundtrips_through_the_model(self) -> None:
+        # Trailing whitespace on every free-text field still yields canonical
+        # output (``serialize(parse(x)) == x``).
+        out = render_note(
+            **{**self._BASE, "summary": "A summary.\n\n"},
+            full_text="Body.\n",
+        )
+        assert cn.serialize(cn.parse(out)) == out
+
+    def test_trailing_newline_full_text_collapses_double_blank_line(self) -> None:
+        out = render_note(**self._BASE, full_text="Body line.\n")
+        assert out == (
+            "# T\n\n## Archive\npath: p/x.pdf\n\n"
+            "## Full Text\nBody line.\n\n## Profile Relevance\n\n## User Notes\n"
+        )
+
+    def test_trailing_newline_summary_collapses_double_blank_line(self) -> None:
+        out = render_note(**{**self._BASE, "summary": "A summary.\n"})
+        assert out == (
+            "# T\n\n## Archive\npath: p/x.pdf\n\n"
+            "## Summary\nA summary.\n\n## Profile Relevance\n\n## User Notes\n"
+        )
+
+    def test_clean_and_trailing_whitespace_converge_to_same_bytes(self) -> None:
+        # The normalisation target IS the clean-input rendering: a trailing
+        # newline is collapsed toward the no-trailing-whitespace form.
+        assert render_note(**self._BASE, full_text="Body line.") == render_note(
+            **self._BASE, full_text="Body line.\n"
+        )

--- a/tests/unit/test_summary_render.py
+++ b/tests/unit/test_summary_render.py
@@ -15,7 +15,6 @@ from influx.schemas import Tier1Enrichment
 _BASE_TAGS = ["source:arxiv", "ingested-by:influx", "schema:1"]
 _BASE_KWARGS = {
     "title": "Test Note",
-    "source_url": "https://arxiv.org/abs/2601.00001",
     "tags": _BASE_TAGS,
     "confidence": 0.8,
     "archive_path": None,

--- a/tests/unit/test_tier3_render.py
+++ b/tests/unit/test_tier3_render.py
@@ -15,7 +15,6 @@ from influx.schemas import Tier3Extraction
 _BASE_TAGS = ["source:arxiv", "ingested-by:influx", "schema:1"]
 _BASE_KWARGS = {
     "title": "Test Note",
-    "source_url": "https://arxiv.org/abs/2601.00001",
     "tags": _BASE_TAGS,
     "confidence": 0.8,
     "archive_path": None,

--- a/tests/unit/test_user_notes_roundtrip.py
+++ b/tests/unit/test_user_notes_roundtrip.py
@@ -44,7 +44,6 @@ class TestGoldenFileRoundTrip:
     def test_render_matches_golden_file(self, golden_text: str) -> None:
         rendered = render_note(
             title="Attention Is All You Need (Redux)",
-            source_url="https://arxiv.org/abs/2601.12345",
             tags=[
                 "source:arxiv",
                 "arxiv-id:2601.12345",
@@ -91,7 +90,6 @@ class TestGoldenFileRoundTrip:
 
         rendered = render_note(
             title=parsed.title,
-            source_url="https://arxiv.org/abs/2601.12345",
             tags=[
                 "source:arxiv",
                 "arxiv-id:2601.12345",
@@ -172,7 +170,6 @@ class TestUserNotesRoundTrip:
 
         rewritten = render_note(
             title=parsed.title,
-            source_url="https://arxiv.org/abs/2601.99999",
             tags=[
                 "source:arxiv",
                 "arxiv-id:2601.99999",
@@ -202,7 +199,6 @@ class TestUserNotesRoundTrip:
         parsed = parse_note(self.ORIGINAL_NOTE)
         rewritten = render_note(
             title=parsed.title,
-            source_url="https://arxiv.org/abs/2601.99999",
             tags=["source:arxiv", "ingested-by:influx", "schema:1"],
             confidence=0.7,
             archive_path="arxiv/2026/01/2601.99999.pdf",
@@ -219,7 +215,6 @@ class TestUserNotesRoundTrip:
         parsed = parse_note(self.ORIGINAL_NOTE)
         rewritten = render_note(
             title=parsed.title,
-            source_url="https://arxiv.org/abs/2601.99999",
             tags=["source:arxiv", "ingested-by:influx", "schema:1"],
             confidence=0.7,
             archive_path="arxiv/2026/01/2601.99999.pdf",
@@ -236,7 +231,6 @@ class TestUserNotesRoundTrip:
         parsed = parse_note(self.ORIGINAL_NOTE)
         rewritten = render_note(
             title=parsed.title,
-            source_url="https://arxiv.org/abs/2601.99999",
             tags=["source:arxiv", "ingested-by:influx", "schema:1"],
             confidence=0.7,
             archive_path="arxiv/2026/01/2601.99999.pdf",
@@ -254,7 +248,6 @@ class TestUserNotesRoundTrip:
         """When User Notes is absent, renderer appends empty heading."""
         rendered = render_note(
             title="No User Notes Yet",
-            source_url="https://arxiv.org/abs/2601.00001",
             tags=["source:arxiv", "ingested-by:influx", "schema:1"],
             confidence=0.7,
             archive_path=None,
@@ -348,7 +341,6 @@ class TestRejectedProfileNotRefreshed:
         )
         rendered = render_note(
             title="Rejection Test",
-            source_url="https://arxiv.org/abs/2601.00001",
             tags=tags,
             confidence=0.7,
             archive_path=None,
@@ -374,7 +366,6 @@ class TestSectionOrdering:
         """US-007: canonical renderer always emits ``## Profile Relevance``."""
         rendered = render_note(
             title="Empty Profiles",
-            source_url="https://arxiv.org/abs/2601.00001",
             tags=["source:arxiv", "ingested-by:influx", "schema:1"],
             confidence=0.7,
             archive_path=None,
@@ -393,7 +384,6 @@ class TestSectionOrdering:
     def test_archive_before_summary(self) -> None:
         rendered = render_note(
             title="Order Test",
-            source_url="https://arxiv.org/abs/2601.00001",
             tags=["source:arxiv", "ingested-by:influx", "schema:1"],
             confidence=0.8,
             archive_path="arxiv/2026/01/2601.00001.pdf",
@@ -420,7 +410,6 @@ class TestSectionOrdering:
     def test_archive_immediately_after_title(self) -> None:
         rendered = render_note(
             title="Order Test",
-            source_url="https://arxiv.org/abs/2601.00001",
             tags=["source:arxiv", "ingested-by:influx", "schema:1"],
             confidence=0.8,
             archive_path="arxiv/2026/01/2601.00001.pdf",
@@ -446,7 +435,6 @@ class TestRendererArchiveInvariant:
         with pytest.raises(ArchiveInvariantError):
             render_note(
                 title="Invariant Test",
-                source_url="https://arxiv.org/abs/2601.00001",
                 tags=[
                     "source:arxiv",
                     "ingested-by:influx",
@@ -480,7 +468,6 @@ class TestIngestedByTagValidation:
         with pytest.raises(MissingIngestedByTagError):
             render_note(
                 title="FM Test",
-                source_url="https://arxiv.org/abs/2601.00001",
                 tags=["source:arxiv"],
                 confidence=0.7,
                 archive_path=None,
@@ -495,7 +482,6 @@ class TestIngestedByTagValidation:
         with pytest.raises(MissingIngestedByTagError):
             render_note(
                 title="FM Test",
-                source_url="https://arxiv.org/abs/2601.00001",
                 tags=[],
                 confidence=0.7,
                 archive_path=None,
@@ -661,7 +647,6 @@ class TestRejectedProfilePreservedOnCRLF:
         )
         rendered = render_note(
             title=parsed.title,
-            source_url="https://arxiv.org/abs/2601.55555",
             tags=tags,
             confidence=0.7,
             archive_path="arxiv/2026/01/2601.55555.pdf",


### PR DESCRIPTION
**PR 6 of 6 — the capstone** in the CanonicalNote stack (finding 1 / Lithos task `9ae1086e`), on top of #251–#255. With this merged, `influx.canonical_note` is the single owner of note shape: `render_note` no longer hand-builds the note string — it composes a `CanonicalNote` and hands it to `serialize()`, so section ordering, separators, and the byte-exact `## User Notes` invariant all live in one module.

## What changed

### 1. `render_note` composes via `serialize()` (the capstone)
- Builds a `CanonicalNote` from `Section` values and `serialize()`s it. Section-body construction is factored into `_archive_body` / `_summary_body` / `_tier3_sections`; the imperative `output += …` builder and the renderer-owned Tier 3 block are gone.
- **Byte-identical** to the previous rendering for section bodies **without** trailing whitespace — the normal case — pinned by the existing golden / tier3 / full-text / summary / user-notes suites (all unchanged and green).
- **Intended normalization (a small write-path byte change):** a body that carries *trailing* whitespace — a `summary` / `full_text` / `reason` ending in a newline, which extraction and LLM output can produce and which nothing provably strips upstream (`cascade.py` passes `extracted_text` through) — is now trailing-stripped, so `serialize()` emits a canonical **single** blank-line separator instead of the double blank line the old builder emitted. This is whitespace-only, it makes the renderer's output canonical by construction, and it's documented on `render_note` and pinned by new tests. Flagged explicitly because it touches the hot write path.

### 2. Converge `replace_profile_relevance_section`
Its end-boundary now uses the shared `_section_span` helper — removing the last hand-rolled `content.find("\n## ")` in the module (the commitment carried over from the #253 review). **Byte-identical** across the replacement matrix.

### 3. Drop the dead `source_url` param
`render_note` / `render` have been body-only since #178 (Lithos owns frontmatter), so `source_url` was unused. Removed at every call site — including `**kwargs` dicts pyright can't see. `render_archive_section` now delegates to the shared `_archive_body` to avoid duplicating the `path:` format.

## Test plan
- [x] `make check` green — **2680 passed**. The sole failure is the pre-existing `test_cli_http.py::…::test_run_conflict_exit_1` subprocess-timeout flake, **confirmed identical on clean main** (stash + re-run) without this change.
- [x] New `TestRenderNoteCanonicalNormalization` — output always round-trips (`serialize(parse(x)) == x`); trailing-newline `full_text` / `summary` collapse the double blank line to canonical; clean and trailing-whitespace inputs converge to the same bytes.
- [x] New `TestReplaceProfileRelevanceSection` — exact-byte replacement across mid-note / followed-by-section / EOF / empty-entries / absent cases (parity guard for the `_section_span` convergence).
- [x] Existing renderer byte-identity suites pass unchanged — the clean-input gate for change 1.
- [x] pyright + ruff (check + format) clean.

## Notes
- `source_url` normalization / de-dup remains a Lithos-side concern; nothing in Influx needed the param.
- Related-but-distinct: #222 (duplicate `# Title`) is **not** fixed here — this stack positions that fix without performing it.
- Completes finding 1; findings 2–7 remain as separate Lithos tasks (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
