### PR TITLE
refactor(repair): route Tier 3 recovery through the shared Cascade (3a.2)

### DIFF
--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -25,22 +25,30 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 from influx import metrics
 from influx.canonical_note import (
+    FULL_TEXT,
     drop_tier2,
     drop_tier2_and_tier3,
+    extract_section_body,
     graft_user_notes,
+    insert_tier3_sections,
     parse_lenient,
     upsert_archive_path,
 )
+from influx.cascade import Acquired, Cascade
+from influx.config import ProfileThresholds
 from influx.errors import ExtractionError, LCMAError, LithosError
 from influx.notes import merge_tags
 from influx.repair_counters import (
     CountedStage,
     classify_failure,
+    parse_repair_section,
     record_counted_failure,
+    upsert_repair_section,
 )
 from influx.telemetry import current_run_id, get_tracer
 
 if TYPE_CHECKING:
+    from influx.cascade import Tier
     from influx.config import AppConfig
     from influx.lithos_client import LithosClient
 
@@ -56,7 +64,6 @@ __all__ = [
     "SweepWriteError",
     "TextExtractionHook",
     "Tier2EnrichHook",
-    "Tier3ExtractHook",
     "apply_abstract_only_reextraction",
     "compute_clearing",
     "select_stages",
@@ -218,35 +225,6 @@ class Tier2EnrichHook(Protocol):
     def __call__(self, note: dict[str, object]) -> None: ...
 
 
-class Tier3ExtractHook(Protocol):
-    """Callable protocol for Tier 3 deep extraction retry (PRD 06 §4).
-
-    Called by the sweep when a note is missing
-    ``influx:deep-extracted``, the current max profile score meets the
-    threshold, and ``influx:text-terminal`` is absent.
-
-    The implementation performs deep extraction and updates the note
-    accordingly.  On success, the note should carry
-    ``influx:deep-extracted`` after the sweep's rewrite.
-
-    Parameters
-    ----------
-    note:
-        The current note state (as returned by ``lithos_read``).
-
-    Raises
-    ------
-    ExtractionError
-        On extraction failure — the sweep treats this as "stage
-        failed this pass" and keeps ``influx:repair-needed``.
-    LithosError
-        On Lithos API failure — propagated to the sweep's error
-        handling.
-    """
-
-    def __call__(self, note: dict[str, object]) -> None: ...
-
-
 class ArchiveDownloadHook(Protocol):
     """Callable protocol for archive download retry (PRD 04).
 
@@ -321,12 +299,16 @@ class SweepHooks:
     When a hook is ``None``, the corresponding stage is skipped even if
     stage selection would otherwise select it.  PRD 07 wires the real
     implementations; tests inject fakes.
+
+    Tier 3 is no longer a hook: it runs through the shared
+    :class:`~influx.cascade.Cascade` passed to :func:`sweep` (finding 3,
+    3a.2), so an absent cascade skips Tier 3 the same way an absent hook
+    skips its stage.
     """
 
     archive_download: ArchiveDownloadHook | None = None
     re_extract_archive: ReExtractArchiveHook | None = None
     tier2_enrich: Tier2EnrichHook | None = None
-    tier3_extract: Tier3ExtractHook | None = None
     text_extraction: TextExtractionHook | None = None
 
 
@@ -1167,16 +1149,16 @@ def _run_tier_retry(
     *,
     profile: str,
     current_tags: list[str],
-    hook: Tier2EnrichHook | Tier3ExtractHook,
+    hook: Tier2EnrichHook,
     stage: CountedStage,
     log_subject: str,
 ) -> list[str]:
-    """Run a Tier 2 / Tier 3 retry stage.
+    """Run the Tier 2 enrichment retry stage.
 
-    Both tiers share the same shape — counted-failure cap, terminal-tag
-    flip, hook-mutation rollback — so they delegate to a single helper
-    parameterised on *stage* (``"tier2"`` / ``"tier3"``) and the log
-    subject used for the per-stage failure WARN line.
+    Wraps the hook in the counted-failure cap / terminal-tag flip /
+    hook-mutation rollback envelope, parameterised on *stage* and the
+    log subject used for the per-stage failure WARN line.  (Tier 3 now
+    runs through the Cascade — see :func:`_run_tier3_via_cascade`.)
     """
     try:
         with _stage_attempt(
@@ -1208,6 +1190,147 @@ def _run_tier_retry(
         return new_tags
 
 
+# ── Tier 3 recovery via the shared Cascade (finding 3, 3a.2) ────────
+#
+# The sweep re-runs Tier 3 through the same ``Cascade.enrich`` the create
+# path uses instead of a bespoke ``tier3_extract`` hook: reconstruct an
+# ``Acquired`` from the persisted note, run only the Tier-3 stage with the
+# note's ``## Repair`` counters, and apply the outcome surgically via the
+# canonical section ops.  Tier 2 (source-coupled extraction) and Tier 1
+# stay outside the Cascade for now — 3a.3 / 3a.4.
+
+_TIER3_ONLY: frozenset[Tier] = frozenset(("tier3",))
+
+
+def _build_sweep_cascade(config: AppConfig, profile: str) -> Cascade:
+    """Build the profile's enrichment Cascade for the repair sweep.
+
+    Tier-3-only for now (3a.2): ``tier2_extractor`` is left unset because
+    the sweep does not yet route Tier 2 through the Cascade — that stage's
+    source-coupled extractor dispatch is 3a.3.
+    """
+    profile_cfg = next((p for p in config.profiles if p.name == profile), None)
+    return Cascade(
+        config=config,
+        profile_name=profile,
+        profile_summary=profile_cfg.description if profile_cfg else "",
+        thresholds=profile_cfg.thresholds if profile_cfg else ProfileThresholds(),
+    )
+
+
+def _reconstruct_acquired(note: dict[str, Any], *, full_text: str) -> Acquired:
+    """Rebuild the minimal ``Acquired`` the Cascade's Tier 3 needs.
+
+    Tier 3 reads only ``item_id`` / ``title`` / ``extracted_text``; the
+    other fields are filled defensively from the note so the same helper
+    can grow to feed Tier 2 (3a.3) and Tier 1 (3a.4).  ``title`` comes
+    from the note's doc-level title (``read_note`` strips the ``# Title``
+    from ``content``), which is a strictly more reliable source than the
+    old hook's parse of the stripped body.
+    """
+    return Acquired(
+        item_id=str(note.get("id") or ""),
+        source_url=str(note.get("source_url") or ""),
+        title=_doc_title(note),
+        abstract="",
+        extracted_text=full_text,
+    )
+
+
+def _run_tier3_via_cascade(
+    note: dict[str, Any],
+    *,
+    profile: str,
+    current_tags: list[str],
+    cascade: Cascade,
+    max_profile_score: int,
+) -> list[str]:
+    """Re-run Tier 3 through the shared Cascade (finding 3, 3a.2).
+
+    Replaces the bespoke ``tier3_extract`` sweep hook.  On success the
+    four Tier-3 sections are inserted and ``influx:deep-extracted`` is
+    added; on a counted-class failure the advanced ``## Repair`` counters
+    are persisted and ``influx:tier3-terminal`` is applied at the cap
+    (``enrich`` owns the counter lifecycle — 3a.1 Fork 6).  A missing
+    ``## Full Text`` is a counted ``parse`` failure exactly as the old
+    hook raised, so the Tier-3 cap still trips for a note that never
+    gains full text.
+    """
+    content = str(note.get("content") or "")
+    metrics.repair_candidates().add(1, {"profile": profile, "kind": "tier3"})
+
+    full_text = extract_section_body(content, FULL_TEXT)
+    if not full_text:
+        exc = ExtractionError(
+            "No ## Full Text section found in note",
+            stage="parse",
+            detail="Cannot run Tier 3 extraction without full text",
+        )
+        new_tags = _apply_counted_failure(
+            note=note,
+            current_tags=current_tags,
+            exc=exc,
+            profile=profile,
+            stage="tier3",
+            failure_stage="parse",
+        )
+        _log_stage_failure("tier3_extraction", note=note, profile=profile, exc=exc)
+        return new_tags
+
+    counters_before = parse_repair_section(content)
+    acquired = _reconstruct_acquired(note, full_text=full_text)
+
+    tracer = get_tracer()
+    with tracer.span(
+        "influx.repair.tier3",
+        attributes={
+            "influx.note_id": note.get("id", ""),
+            "influx.profile": profile,
+            "influx.run_id": current_run_id.get() or "",
+        },
+    ):
+        sections = cascade.enrich(
+            acquired,
+            max_profile_score,
+            stages=_TIER3_ONLY,
+            counters=counters_before,
+        )
+
+    new_tags = list(current_tags)
+    if sections.tier3 is not None:
+        note["content"] = insert_tier3_sections(content, sections.tier3)
+        if "influx:deep-extracted" not in new_tags:
+            new_tags.append("influx:deep-extracted")
+        note["tags"] = list(new_tags)
+        return new_tags
+
+    # Failure — ``enrich`` already logged the Tier-3 failure and advanced
+    # the counters on a counted-class failure (transient leaves them).
+    if sections.counters != counters_before:
+        note["content"] = upsert_repair_section(content, sections.counters)
+    newly_terminal = [t for t in sections.terminal_flags if t not in current_tags]
+    new_tags.extend(newly_terminal)
+    if "influx:tier3-terminal" in newly_terminal:
+        logger.warning(
+            "sweep: tier3 marked terminal after %d counted failures for %s",
+            sections.counters.tier3_attempts,
+            note.get("id", "?"),
+            extra={
+                "sweep_stage": "tier3_terminal_flip",
+                "note_id": note.get("id"),
+                "profile": profile,
+                "run_id": current_run_id.get() or "",
+                "tier3_attempts": sections.counters.tier3_attempts,
+                # The counted stage that tripped the cap survives in the
+                # ## Repair counters even though ``enrich`` swallowed the
+                # exception, so operators still see *which* stage failed.
+                "stage": sections.counters.tier3_last_stage,
+            },
+        )
+    note["tags"] = list(new_tags)
+    return new_tags
+
+
 def _doc_title(note: dict[str, Any]) -> str:
     """Return the note's doc-level title (top-level, then ``metadata``)."""
     direct = note.get("title")
@@ -1228,6 +1351,7 @@ async def _process_sweep_note(
     client: LithosClient,
     config: AppConfig,
     hooks: SweepHooks,
+    cascade: Cascade | None = None,
 ) -> None:
     """Select stages, execute, clear tags, rewrite one note (§5.2-5.4).
 
@@ -1338,15 +1462,14 @@ async def _process_sweep_note(
             log_subject="tier2_enrichment",
         )
 
-    if stages.tier3_retry and hooks.tier3_extract:
+    if stages.tier3_retry and cascade is not None:
         current_tags = await asyncio.to_thread(
-            _run_tier_retry,
+            _run_tier3_via_cascade,
             note,
             profile=profile,
             current_tags=current_tags,
-            hook=hooks.tier3_extract,
-            stage="tier3",
-            log_subject="tier3_extraction",
+            cascade=cascade,
+            max_profile_score=max_profile_score,
         )
 
     # ── Compute and apply clearing ──────────────────────────────
@@ -1380,6 +1503,7 @@ async def sweep(
     client: LithosClient,
     config: AppConfig,
     hooks: SweepHooks | None = None,
+    cascade: Cascade | None = None,
 ) -> list[dict[str, Any]]:
     """Run the repair sweep for *profile* (PRD 06 §5.1 FR-REP-1).
 
@@ -1399,8 +1523,16 @@ async def sweep(
     ----------
     hooks:
         Optional hook callables for stage execution.  When ``None``,
-        a default empty :class:`SweepHooks` is used (stages that
-        require hooks are skipped, but notes are still rewritten).
+        the production defaults are wired (and, unless *cascade* is
+        given, the production :class:`~influx.cascade.Cascade` too).
+        When supplied explicitly (tests), only the given hooks/cascade
+        are used — stages whose hook (or, for Tier 3, the cascade) is
+        absent are skipped, but notes are still rewritten.
+    cascade:
+        Optional enrichment Cascade for the Tier-3 recovery stage
+        (finding 3, 3a.2).  ``None`` skips Tier 3 exactly as an absent
+        hook skips its stage; the production path builds one when
+        *hooks* is ``None``.
 
     Returns
     -------
@@ -1416,10 +1548,14 @@ async def sweep(
     """
     if hooks is not None:
         effective_hooks = hooks
+        effective_cascade = cascade
     else:
         from influx.repair_hooks import make_default_sweep_hooks
 
         effective_hooks = make_default_sweep_hooks(config).to_sweep_hooks()
+        effective_cascade = (
+            cascade if cascade is not None else _build_sweep_cascade(config, profile)
+        )
 
     limit = config.repair.max_items_per_run
     body = await client.list_notes_body(
@@ -1461,6 +1597,7 @@ async def sweep(
                 client=client,
                 config=config,
                 hooks=effective_hooks,
+                cascade=effective_cascade,
             )
         except ContentTooLargeSkipped:
             # §5.4 failure mode 2: chronic content_too_large on repair

--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -6,9 +6,12 @@ oldest-``updated_at``-first, independently selecting retry stages
 Tier 2, Tier 3) based on the current tag set, and rewriting every
 visited note so ``updated_at`` advances (retry-order advancement).
 
-Worker hooks (``re_extract_archive``, ``tier2_enrich``,
-``tier3_extract``) are test-injectable callables whose real
-implementations ship with PRD 07.
+Worker hooks (``archive_download``, ``re_extract_archive``,
+``tier2_enrich``, ``text_extraction``) are test-injectable callables
+whose real implementations ship with PRD 07.  Tier 3 recovery is no
+longer a hook: it runs through the shared
+:class:`~influx.cascade.Cascade` passed to :func:`sweep` (finding 3,
+3a.2), which the isolation tests inject the same way they inject hooks.
 """
 
 from __future__ import annotations

--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -1,9 +1,10 @@
 """Production-default repair hooks (PRD 07 US-016).
 
 Bridges the PRD 06 hook signatures (``ReExtractArchiveHook``,
-``Tier2EnrichHook``, ``Tier3ExtractHook``) to the lower-level
-extraction and enrichment helpers from PRD 07 (``extraction.html``,
-``extraction.pdf``, ``enrich.tier3_extract``).
+``Tier2EnrichHook``) to the lower-level extraction helpers from PRD 07
+(``extraction.html``, ``extraction.pdf``).  Tier 3 recovery is no longer
+a hook — the sweep runs it through the shared
+:class:`~influx.cascade.Cascade` (finding 3, 3a.2).
 
 The ``SweepHooks`` test-injection seam is preserved unchanged: these
 defaults are only wired in when ``sweep()`` is called without explicit
@@ -23,14 +24,10 @@ from influx.archive_policy import (
     registry_from_config as _archive_policy_registry_from_config,
 )
 from influx.canonical_note import (
-    FULL_TEXT,
-    extract_section_body,
     insert_full_text_section,
-    insert_tier3_sections,
 )
 from influx.config import AppConfig
-from influx.enrich import tier3_extract as _tier3_extract
-from influx.errors import ExtractionError, LCMAError, NetworkError
+from influx.errors import ExtractionError, NetworkError
 from influx.extraction.article import extract_article
 from influx.extraction.html import _clean_html_fragments, _strip_tags
 from influx.extraction.pdf import extract_pdf
@@ -44,7 +41,6 @@ from influx.repair import (
     SweepHooks,
     TextExtractionHook,
     Tier2EnrichHook,
-    Tier3ExtractHook,
 )
 from influx.storage import download_archive
 from influx.urls import url_hash
@@ -55,18 +51,8 @@ _log = logging.getLogger(__name__)
 
 # ── Content manipulation helpers ────────────────────────────────────
 #
-# The section-shape ops (insert Full Text / Tier 3, find the insertion point,
-# extract a section body) are owned by :mod:`influx.canonical_note` and
-# imported above.  Only ``_extract_title`` — a title locator with no canonical
-# equivalent — remains local.
-
-_TITLE_RE = re.compile(r"^# ([^\r\n]+)", re.MULTILINE)
-
-
-def _extract_title(content: str) -> str:
-    """Extract the ``# Title`` from note content."""
-    m = _TITLE_RE.search(content)
-    return m.group(1) if m else ""
+# The section-shape ops (insert Full Text, find the insertion point) are
+# owned by :mod:`influx.canonical_note` and imported above.
 
 
 # ── Archive file reading ────────────────────────────────────────────
@@ -1012,50 +998,6 @@ def _make_tier2_enrich_hook(config: AppConfig) -> Tier2EnrichHook:
     return hook
 
 
-def _make_tier3_extract_hook(config: AppConfig) -> Tier3ExtractHook:
-    """Create the production ``tier3_extract`` hook.
-
-    Reads the ``## Full Text`` body from the note, calls
-    ``enrich.tier3_extract``, inserts the four Tier 3 sections,
-    and adds the ``influx:deep-extracted`` tag.
-    """
-
-    def hook(note: dict[str, object]) -> None:
-        content: str = str(note.get("content", ""))
-        tags: list[str] = _note_tags(note)
-
-        # Extract full text from note content.
-        full_text = extract_section_body(content, FULL_TEXT)
-        if not full_text:
-            raise ExtractionError(
-                "No ## Full Text section found in note",
-                stage="parse",
-                detail="Cannot run Tier 3 extraction without full text",
-            )
-
-        title = _extract_title(content)
-
-        # Call the Tier 3 extraction model.
-        try:
-            tier3_result = _tier3_extract(
-                title=title,
-                full_text=full_text,
-                config=config,
-            )
-        except LCMAError:
-            raise  # Propagate — the sweep treats LCMAError as stage failure.
-
-        # Insert Tier 3 sections into content.
-        note["content"] = insert_tier3_sections(content, tier3_result)
-
-        # Add influx:deep-extracted tag.
-        if "influx:deep-extracted" not in tags:
-            tags.append("influx:deep-extracted")
-            note["tags"] = tags
-
-    return hook
-
-
 # ── Public factory ──────────────────────────────────────────────────
 
 
@@ -1063,10 +1005,11 @@ def _make_tier3_extract_hook(config: AppConfig) -> Tier3ExtractHook:
 class DefaultSweepHooks:
     """Production-default sweep hook wiring with non-optional callables.
 
-    Holds the five production hooks with non-``Optional`` types so
+    Holds the four production hooks with non-``Optional`` types so
     pyright can statically know they are wired, while the parent
     :class:`~influx.repair.SweepHooks` keeps them ``| None`` to preserve
-    the test-injection seam.
+    the test-injection seam.  (Tier 3 recovery is not a hook — the sweep
+    runs it through the shared Cascade; finding 3, 3a.2.)
 
     Use :meth:`to_sweep_hooks` to obtain a ``SweepHooks`` instance for
     passing into :func:`influx.repair.sweep`.
@@ -1075,7 +1018,6 @@ class DefaultSweepHooks:
     archive_download: ArchiveDownloadHook
     re_extract_archive: ReExtractArchiveHook
     tier2_enrich: Tier2EnrichHook
-    tier3_extract: Tier3ExtractHook
     text_extraction: TextExtractionHook
 
     def to_sweep_hooks(self) -> SweepHooks:
@@ -1084,7 +1026,6 @@ class DefaultSweepHooks:
             archive_download=self.archive_download,
             re_extract_archive=self.re_extract_archive,
             tier2_enrich=self.tier2_enrich,
-            tier3_extract=self.tier3_extract,
             text_extraction=self.text_extraction,
         )
 
@@ -1104,6 +1045,5 @@ def make_default_sweep_hooks(config: AppConfig) -> DefaultSweepHooks:
         archive_download=_make_archive_download_hook(config),
         re_extract_archive=_make_re_extract_archive_hook(config),
         tier2_enrich=_make_tier2_enrich_hook(config),
-        tier3_extract=_make_tier3_extract_hook(config),
         text_extraction=_make_text_extraction_hook(config),
     )

--- a/tests/integration/_cascade_fakes.py
+++ b/tests/integration/_cascade_fakes.py
@@ -1,0 +1,59 @@
+"""Fake enrichment Cascades for repair-sweep integration tests (3a.2).
+
+The sweep runs Tier 3 through a :class:`~influx.cascade.Cascade` passed via
+``sweep(cascade=...)``.  These fakes let the zero-monkeypatch integration
+suite drive the Tier-3 recovery outcome — success or not-attempted spy —
+without an LLM, exactly the way ``SweepHooks`` fakes drive the other
+stages.  Inject with ``# type: ignore[arg-type]`` (as the hook fakes do),
+since a fake is structurally-but-not-nominally a ``Cascade``.
+"""
+
+from __future__ import annotations
+
+from influx.cascade import Acquired, EnrichedSections
+from influx.repair_counters import RepairCounters
+from influx.schemas import Tier3Extraction
+
+
+class Tier3SuccessCascade:
+    """``enrich`` returns a canned Tier-3 extraction (deep-extract succeeds)."""
+
+    def __init__(self, tier3: Tier3Extraction | None = None) -> None:
+        self.tier3 = tier3 or Tier3Extraction(claims=["A recovered claim."])
+        self.calls = 0
+
+    def enrich(
+        self,
+        acquired: Acquired,
+        score: int,
+        *,
+        stages: object = None,
+        counters: RepairCounters | None = None,
+    ) -> EnrichedSections:
+        del acquired, score, stages
+        self.calls += 1
+        return EnrichedSections(tier3=self.tier3, counters=counters or RepairCounters())
+
+
+class SpyCascade:
+    """``enrich`` records that it was called and returns an empty result.
+
+    Used by tests that assert Tier 3 is *not* attempted (e.g. a terminal
+    note): a non-zero ``calls`` count means the sweep reached the Cascade
+    when it should have skipped the stage.
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def enrich(
+        self,
+        acquired: Acquired,
+        score: int,
+        *,
+        stages: object = None,
+        counters: RepairCounters | None = None,
+    ) -> EnrichedSections:
+        del acquired, score, stages
+        self.calls += 1
+        return EnrichedSections(counters=counters or RepairCounters())

--- a/tests/integration/test_repair_sweep_high_score_terminal.py
+++ b/tests/integration/test_repair_sweep_high_score_terminal.py
@@ -32,6 +32,7 @@ from influx.config import (
 from influx.lithos_client import LithosClient
 from influx.repair import SweepHooks, sweep
 from tests.contract.test_lithos_client import FakeLithosServer
+from tests.integration._cascade_fakes import SpyCascade
 
 # ── Fixtures ───────────────────────────────────────────────────────
 
@@ -341,15 +342,10 @@ class TestHighScoreTerminalClearing:
     ) -> None:
         """Terminal exemption waives Tier 2 and Tier 3 at high score."""
         tier2_calls = 0
-        tier3_calls = 0
 
         def _tier2_spy(note: dict[str, object]) -> None:
             nonlocal tier2_calls
             tier2_calls += 1
-
-        def _tier3_spy(note: dict[str, object]) -> None:
-            nonlocal tier3_calls
-            tier3_calls += 1
 
         tags = [
             "profile:ai-robotics",
@@ -367,9 +363,9 @@ class TestHighScoreTerminalClearing:
         _queue_single_note(fake_lithos, note)
 
         config = _make_config(lithos_url=fake_lithos_url)
+        tier3_cascade = SpyCascade()
         hooks = SweepHooks(
             tier2_enrich=_tier2_spy,  # type: ignore[arg-type]
-            tier3_extract=_tier3_spy,  # type: ignore[arg-type]
         )
 
         client = LithosClient(url=fake_lithos_url)
@@ -379,13 +375,14 @@ class TestHighScoreTerminalClearing:
                 client=client,
                 config=config,
                 hooks=hooks,
+                cascade=tier3_cascade,  # type: ignore[arg-type]
             )
             assert len(visited) == 1
 
             # Terminal note skips Tier 2 and Tier 3 (influx:text-terminal
             # suppresses both stages in stage selection).
             assert tier2_calls == 0
-            assert tier3_calls == 0
+            assert tier3_cascade.calls == 0
 
             # And influx:repair-needed is still cleared.
             write_calls = [c for c in fake_lithos.calls if c[0] == "lithos_write"]

--- a/tests/integration/test_repair_sweep_rss_archive_recovery.py
+++ b/tests/integration/test_repair_sweep_rss_archive_recovery.py
@@ -13,8 +13,8 @@ The flow exercised here:
   ``## Archive`` populated with ``path:``.
 - Pass 2: feed run-1 written note back → ``re_extract_archive`` returns
   ``UPGRADE`` → ``text:abstract-only`` replaced by ``text:html`` →
-  ``tier2_enrich`` adds ``full-text`` → ``tier3_extract`` adds
-  ``influx:deep-extracted`` → ``influx:repair-needed`` cleared.
+  ``tier2_enrich`` adds ``full-text`` → the shared Cascade's Tier 3
+  adds ``influx:deep-extracted`` → ``influx:repair-needed`` cleared.
 """
 
 from __future__ import annotations
@@ -25,6 +25,7 @@ from typing import Any
 
 import pytest
 
+from influx.canonical_note import insert_full_text_section
 from influx.config import (
     AppConfig,
     FeedbackConfig,
@@ -45,6 +46,7 @@ from influx.repair import (
     sweep,
 )
 from tests.contract.test_lithos_client import FakeLithosServer
+from tests.integration._cascade_fakes import Tier3SuccessCascade
 
 # ── Fixtures ───────────────────────────────────────────────────────
 
@@ -221,11 +223,11 @@ def _add_tag_in_place(note: dict[str, object], tag: str) -> None:
 
 
 def _tier2_enrich_adds_full_text(note: dict[str, object]) -> None:
+    # Mirror the production Tier 2 hook: insert the ``## Full Text`` section
+    # (not just the tag) so the Cascade's Tier-3 stage has body to read.
+    content = str(note.get("content", ""))
+    note["content"] = insert_full_text_section(content, "Recovered full text body.")
     _add_tag_in_place(note, "full-text")
-
-
-def _tier3_extract_adds_deep_extracted(note: dict[str, object]) -> None:
-    _add_tag_in_place(note, "influx:deep-extracted")
 
 
 # ── Tests ──────────────────────────────────────────────────────────
@@ -323,13 +325,13 @@ class TestRssArchiveRecoveryFlow:
             hooks_p2 = SweepHooks(
                 re_extract_archive=_re_extract_upgrade_html,
                 tier2_enrich=_tier2_enrich_adds_full_text,
-                tier3_extract=_tier3_extract_adds_deep_extracted,
             )
             await sweep(
                 "ai-robotics",
                 client=client,
                 config=config,
                 hooks=hooks_p2,
+                cascade=Tier3SuccessCascade(),  # type: ignore[arg-type]
             )
 
             write_calls_p2 = [c for c in fake_lithos.calls if c[0] == "lithos_write"]

--- a/tests/integration/test_repair_sweep_rss_archive_recovery.py
+++ b/tests/integration/test_repair_sweep_rss_archive_recovery.py
@@ -343,6 +343,12 @@ class TestRssArchiveRecoveryFlow:
             assert "full-text" in p2_payload["tags"]
             assert "influx:deep-extracted" in p2_payload["tags"]
 
+            # Tier 3 wrote its sections into the note content, not just the
+            # tag — Tier3SuccessCascade returns claims=["A recovered claim."],
+            # so the Cascade output is inserted via insert_tier3_sections.
+            assert "## Claims" in p2_payload["content"]
+            assert "A recovered claim." in p2_payload["content"]
+
             assert "influx:repair-needed" not in p2_payload["tags"]
 
             assert f"source:rss-{_FEED_SLUG}" in p2_payload["tags"]

--- a/tests/unit/test_repair_hook_rollback.py
+++ b/tests/unit/test_repair_hook_rollback.py
@@ -1,10 +1,15 @@
 """Unit tests for hook-mutation rollback (finding #1).
 
-Hooks (``archive_download``, ``re_extract_archive``, ``tier2_enrich``,
-``tier3_extract``) receive the live mutable note dict.  When a hook
-raises ``ExtractionError`` / ``LithosError`` the sweep MUST treat that
-as "stage failed this pass" (per US-003 / US-013) and MUST NOT persist
-any partial in-place mutations the hook applied before raising.
+Hooks (``archive_download``, ``re_extract_archive``, ``tier2_enrich``)
+receive the live mutable note dict.  When a hook raises
+``ExtractionError`` / ``LithosError`` the sweep MUST treat that as
+"stage failed this pass" (per US-003 / US-013) and MUST NOT persist any
+partial in-place mutations the hook applied before raising.
+
+(Tier 3 is no longer a hook — it runs through the shared Cascade, which
+returns a value rather than mutating the note in place, so there is no
+partial-mutation to roll back.  The failing-Tier-3 invariant lives in
+``test_repair_sweep.py``.)
 
 Each test below provides a fake hook that mutates ``note["tags"]`` (and
 sometimes ``note["content"]``) and then raises; the sweep is expected
@@ -374,52 +379,4 @@ class TestTier2EnrichRollback:
         # full-text mutation from the failing hook MUST NOT survive.
         assert "full-text" not in args["tags"]
         # Stage failed so influx:repair-needed must remain.
-        assert "influx:repair-needed" in args["tags"]
-
-
-# ── tier3_extract rollback ──────────────────────────────────────────
-
-
-class TestTier3ExtractRollback:
-    """A failing tier3 hook must not leak ``influx:deep-extracted``."""
-
-    async def test_tier3_hook_appends_deep_extracted_then_raises(
-        self,
-    ) -> None:
-        items = [{"id": "n1", "title": "Paper"}]
-        # Score 9 ≥ default deep_extract threshold (9) so tier3 selects.
-        read_notes = [
-            {
-                "id": "n1",
-                "title": "Paper",
-                "content": (
-                    "## Archive\npath: a.pdf\n"
-                    "## Profile Relevance\n"
-                    "### p\nScore: 9/10\n"
-                ),
-                "tags": [
-                    "influx:repair-needed",
-                    "text:html",
-                    "full-text",
-                    "profile:p",
-                ],
-            }
-        ]
-
-        def bad_tier3(note: dict[str, object]) -> None:
-            tags = list(note.get("tags", []))  # type: ignore[arg-type]
-            tags.append("influx:deep-extracted")
-            note["tags"] = tags
-            raise ExtractionError("tier3 failed", stage="deep-extract")
-
-        config = _make_config()
-        client = _make_client(list_items=items, read_responses=read_notes)
-        hooks = SweepHooks(tier3_extract=bad_tier3)
-
-        await sweep("p", client=client, config=config, hooks=hooks)
-
-        args = _last_write_args(client)
-        # influx:deep-extracted from the failing hook MUST NOT survive.
-        assert "influx:deep-extracted" not in args["tags"]
-        # Stage failed, so influx:repair-needed must remain.
         assert "influx:repair-needed" in args["tags"]

--- a/tests/unit/test_repair_hooks.py
+++ b/tests/unit/test_repair_hooks.py
@@ -16,7 +16,6 @@ from influx.repair import (
     ReExtractArchiveHook,
     ReExtractionResult,
     Tier2EnrichHook,
-    Tier3ExtractHook,
 )
 
 # ── Fake hook implementations for substitution tests ─────────────────
@@ -81,17 +80,6 @@ def _fake_tier2_raises(note: dict[str, object]) -> None:
     raise ExtractionError(
         "tier2 failed",
         stage="full-text",
-    )
-
-
-def _fake_tier3(note: dict[str, object]) -> None:
-    pass
-
-
-def _fake_tier3_raises(note: dict[str, object]) -> None:
-    raise ExtractionError(
-        "tier3 failed",
-        stage="deep-extract",
     )
 
 
@@ -176,17 +164,6 @@ class TestTier2EnrichHookSubstitution:
 
     def test_raises_extraction_error(self) -> None:
         hook: Tier2EnrichHook = _fake_tier2_raises
-        with pytest.raises(ExtractionError):
-            hook({"id": "n1"})
-
-
-class TestTier3ExtractHookSubstitution:
-    def test_success_callable(self) -> None:
-        hook: Tier3ExtractHook = _fake_tier3
-        hook({"id": "n1"})  # should not raise
-
-    def test_raises_extraction_error(self) -> None:
-        hook: Tier3ExtractHook = _fake_tier3_raises
         with pytest.raises(ExtractionError):
             hook({"id": "n1"})
 

--- a/tests/unit/test_repair_hooks_production.py
+++ b/tests/unit/test_repair_hooks_production.py
@@ -3,7 +3,9 @@
 Verifies that ``make_default_sweep_hooks`` creates hooks conforming to
 the PRD 06 signatures, that the ``re_extract_archive`` hook returns
 the correct ``ReExtractionResult`` variants, and that ``tier2_enrich``
-and ``tier3_extract`` mutate the note dict correctly.
+mutates the note dict correctly.  (Tier 3 recovery is no longer a
+production hook — it runs through the shared Cascade; its behaviour is
+covered by ``test_repair_sweep.py`` and ``test_cascade.py``.)
 """
 
 from __future__ import annotations
@@ -20,7 +22,7 @@ from influx.config import (
     ExtractionConfig,
     StorageConfig,
 )
-from influx.errors import ExtractionError, LCMAError
+from influx.errors import ExtractionError
 from influx.repair import (
     ExtractionOutcome,
     ReExtractionResult,
@@ -28,10 +30,8 @@ from influx.repair import (
 )
 from influx.repair_hooks import (
     DefaultSweepHooks,
-    _extract_title,
     make_default_sweep_hooks,
 )
-from influx.schemas import Tier3Extraction
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -144,7 +144,6 @@ class TestMakeDefaultSweepHooks:
         assert sweep_hooks.archive_download is not None
         assert sweep_hooks.re_extract_archive is not None
         assert sweep_hooks.tier2_enrich is not None
-        assert sweep_hooks.tier3_extract is not None
         assert sweep_hooks.text_extraction is not None
 
     def test_archive_download_wired(self, tmp_path: Path) -> None:
@@ -345,121 +344,6 @@ class TestTier2EnrichFailure:
             hooks.tier2_enrich(note)
 
 
-# ── tier3_extract hook ───────────────────────────────────────────────
-
-
-class TestTier3ExtractSuccess:
-    """Production tier3_extract inserts Tier 3 sections and tag."""
-
-    def test_inserts_tier3_sections(self, tmp_path: Path) -> None:
-        config = _make_config(tmp_path)
-        hooks = make_default_sweep_hooks(config)
-        note = _make_note_dict(full_text="This is the full extracted text.")
-
-        with patch("influx.repair_hooks._tier3_extract") as mock_t3:
-            mock_t3.return_value = Tier3Extraction(
-                claims=["Claim A", "Claim B"],
-                datasets=["Dataset 1"],
-                builds_on=["Ref 1"],
-                open_questions=["Question 1"],
-                potential_connections=["Connection 1"],
-            )
-            hooks.tier3_extract(note)
-
-        content: str = str(note["content"])
-        assert "## Claims" in content
-        assert "- Claim A" in content
-        assert "- Claim B" in content
-        assert "## Datasets & Benchmarks" in content
-        assert "- Dataset 1" in content
-        assert "## Builds On" in content
-        assert "- Ref 1" in content
-        assert "## Open Questions" in content
-        assert "- Question 1" in content
-
-    def test_adds_deep_extracted_tag(self, tmp_path: Path) -> None:
-        config = _make_config(tmp_path)
-        hooks = make_default_sweep_hooks(config)
-        note = _make_note_dict(full_text="Full text here.")
-
-        with patch("influx.repair_hooks._tier3_extract") as mock_t3:
-            mock_t3.return_value = Tier3Extraction(
-                claims=["Claim"],
-            )
-            hooks.tier3_extract(note)
-
-        tags: list[str] = list(note.get("tags", []))
-        assert "influx:deep-extracted" in tags
-
-    def test_does_not_duplicate_deep_extracted_tag(self, tmp_path: Path) -> None:
-        config = _make_config(tmp_path)
-        hooks = make_default_sweep_hooks(config)
-        note = _make_note_dict(full_text="Full text here.")
-        note["tags"] = list(note["tags"]) + ["influx:deep-extracted"]
-
-        with patch("influx.repair_hooks._tier3_extract") as mock_t3:
-            mock_t3.return_value = Tier3Extraction(claims=["Claim"])
-            hooks.tier3_extract(note)
-
-        tags: list[str] = list(note.get("tags", []))
-        assert tags.count("influx:deep-extracted") == 1
-
-    def test_tier3_sections_before_profile_relevance(self, tmp_path: Path) -> None:
-        config = _make_config(tmp_path)
-        hooks = make_default_sweep_hooks(config)
-        note = _make_note_dict(full_text="Full text content.")
-
-        with patch("influx.repair_hooks._tier3_extract") as mock_t3:
-            mock_t3.return_value = Tier3Extraction(
-                claims=["Claim"],
-                datasets=["DS"],
-                builds_on=["Ref"],
-                open_questions=["Q"],
-            )
-            hooks.tier3_extract(note)
-
-        content: str = str(note["content"])
-        claims_pos = content.find("## Claims")
-        profile_pos = content.find("## Profile Relevance")
-        user_notes_pos = content.find("## User Notes")
-        assert claims_pos < profile_pos
-        assert claims_pos < user_notes_pos
-
-
-class TestTier3ExtractFailure:
-    """tier3_extract raises on failure."""
-
-    def test_raises_on_no_full_text(self, tmp_path: Path) -> None:
-        config = _make_config(tmp_path)
-        hooks = make_default_sweep_hooks(config)
-        note = _make_note_dict(full_text=None)
-
-        with pytest.raises(ExtractionError, match="No ## Full Text"):
-            hooks.tier3_extract(note)
-
-    def test_propagates_lcma_error(self, tmp_path: Path) -> None:
-        config = _make_config(tmp_path)
-        hooks = make_default_sweep_hooks(config)
-        note = _make_note_dict(full_text="Full text content here.")
-
-        with patch("influx.repair_hooks._tier3_extract") as mock_t3:
-            mock_t3.side_effect = LCMAError("model failed", model="extract")
-            with pytest.raises(LCMAError):
-                hooks.tier3_extract(note)
-
-
-# ── Content manipulation helpers ─────────────────────────────────────
-
-
-class TestExtractTitle:
-    def test_extracts_title(self) -> None:
-        content = "---\nfm\n---\n# My Paper Title\n\nbody"
-        assert _extract_title(content) == "My Paper Title"
-
-    def test_returns_empty_on_no_title(self) -> None:
-        assert _extract_title("no title here") == ""
-
-
 # NOTE: the ## Full Text / Tier 3 section-shape helpers moved to
 # influx.canonical_note in PR 2; their behaviour is covered by
 # tests/unit/test_canonical_note.py (extract_section_body, insert_full_text_
@@ -476,22 +360,21 @@ class TestSweepHooksInjectionSeam:
         """Test injection via SweepHooks still works."""
         call_count = 0
 
-        def fake_tier3(note: dict[str, object]) -> None:
+        def fake_tier2(note: dict[str, object]) -> None:
             nonlocal call_count
             call_count += 1
 
-        hooks = SweepHooks(tier3_extract=fake_tier3)
+        hooks = SweepHooks(tier2_enrich=fake_tier2)
         # Narrow the optional callable; this is the test-injection seam,
         # not the production-default factory.
-        assert hooks.tier3_extract is not None
-        hooks.tier3_extract({"id": "n1"})
+        assert hooks.tier2_enrich is not None
+        hooks.tier2_enrich({"id": "n1"})
         assert call_count == 1
 
     def test_empty_sweep_hooks_has_none_hooks(self) -> None:
         hooks = SweepHooks()
         assert hooks.re_extract_archive is None
         assert hooks.tier2_enrich is None
-        assert hooks.tier3_extract is None
         assert hooks.archive_download is None
         assert hooks.text_extraction is None
 

--- a/tests/unit/test_repair_sweep.py
+++ b/tests/unit/test_repair_sweep.py
@@ -18,7 +18,13 @@ import pytest
 
 from influx.config import AppConfig, RepairConfig
 from influx.errors import ExtractionError, LCMAError, LithosError
-from influx.repair import ContentTooLargeSkipped, SweepHooks, SweepWriteError, sweep
+from influx.repair import (
+    ContentTooLargeSkipped,
+    SweepHooks,
+    SweepWriteError,
+    _build_sweep_cascade,
+    sweep,
+)
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -55,6 +61,16 @@ def _make_client(
         client.read_note = AsyncMock(return_value={"id": "", "content": "", "tags": []})
     client.call_tool = AsyncMock(return_value=_make_write_result(write_status))
     return client
+
+
+def _sweep_cascade(config: Any) -> Any:
+    """Real sweep Cascade so Tier 3 routes through ``enrich`` (3a.2).
+
+    Tier 3's model call (``influx.cascade.tier3_extract``) is monkeypatched
+    per test, so this drives the real counter/terminal lifecycle without an
+    LLM — the same seam the create path uses.
+    """
+    return _build_sweep_cascade(config, "ai-robotics")
 
 
 # ── lithos_list called with correct parameters ──────────────────────
@@ -314,7 +330,9 @@ class TestSweepRewriteInvariant:
         assert args["confidence"] == 0.7
         assert args["expected_version"] == 5
 
-    async def test_tier3_lcma_error_is_per_note_failure_not_abort(self) -> None:
+    async def test_tier3_lcma_error_is_per_note_failure_not_abort(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Tier-3 model validation errors should not abort the whole sweep."""
         items = [{"id": "n1", "title": "Paper"}]
         note = {
@@ -344,10 +362,11 @@ class TestSweepRewriteInvariant:
             "confidence": 0.9,
         }
 
-        def failing_tier3(note: dict[str, object]) -> None:
-            del note
+        def failing_tier3(*, title: str, full_text: str, config: object) -> None:
+            del title, full_text, config
             raise LCMAError("validation failed", stage="validate")
 
+        monkeypatch.setattr("influx.cascade.tier3_extract", failing_tier3)
         config = _make_config()
         client = _make_client(list_items=items, read_responses=[note])
 
@@ -355,7 +374,8 @@ class TestSweepRewriteInvariant:
             "ai-robotics",
             client=client,
             config=config,
-            hooks=SweepHooks(tier3_extract=failing_tier3),
+            hooks=SweepHooks(),
+            cascade=_sweep_cascade(config),
         )
 
         assert len(result) == 1
@@ -783,17 +803,23 @@ class TestStageFailureLogging:
             "confidence": 0.9,
         }
 
-    async def test_tier3_failure_logs_warning_with_extra_and_exc_info(
+    async def test_tier3_failure_logs_warning_via_cascade(
         self,
+        monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
+        """The sweep now runs Tier 3 through the shared Cascade (3a.2), so a
+        Tier-3 failure is logged by ``enrich``.  The sweep re-runs Tier 3
+        without Tier 1, so the fallback is *materially degraded* — a WARNING
+        with the #151 structured fields — and the counted stage survives in
+        the persisted ``## Repair`` counters."""
         import logging
 
         items = [{"id": "n1", "title": "Paper"}]
         note = self._note("n1")
 
-        def failing(note: dict[str, object]) -> None:
-            del note
+        def failing(*, title: str, full_text: str, config: object) -> None:
+            del title, full_text, config
             raise LCMAError(
                 "Tier 3 extraction response failed validation",
                 model="extract",
@@ -801,36 +827,41 @@ class TestStageFailureLogging:
                 detail="missing 'contributions' field",
             )
 
+        monkeypatch.setattr("influx.cascade.tier3_extract", failing)
         config = _make_config()
         client = _make_client(list_items=items, read_responses=[note])
 
-        with caplog.at_level(logging.WARNING, logger="influx.repair"):
+        with caplog.at_level(logging.WARNING, logger="influx.cascade"):
             await sweep(
                 "ai-robotics",
                 client=client,
                 config=config,
-                hooks=SweepHooks(tier3_extract=failing),
+                hooks=SweepHooks(),
+                cascade=_sweep_cascade(config),
             )
 
         matching = [
             r
             for r in caplog.records
             if r.levelname == "WARNING"
-            and getattr(r, "sweep_stage", None) == "tier3_extraction"
+            and getattr(r, "tier3_failure_kind", None) == "lcma_error"
         ]
         assert matching, [
-            (r.levelname, r.getMessage(), getattr(r, "sweep_stage", None))
+            (r.levelname, r.getMessage(), getattr(r, "tier3_failure_kind", None))
             for r in caplog.records
         ]
         rec = matching[0]
-        assert getattr(rec, "note_id", None) == "n1"
+        assert getattr(rec, "item_id", None) == "n1"
         assert getattr(rec, "profile", None) == "ai-robotics"
-        assert getattr(rec, "exc_type", None) == "LCMAError"
-        assert getattr(rec, "model", None) == "extract"
-        assert getattr(rec, "stage", None) == "validate"
-        assert getattr(rec, "detail", None) == "missing 'contributions' field"
-        # ``exc_info`` must be populated so the JSON formatter renders the traceback.
-        assert rec.exc_info is not None
+        assert getattr(rec, "tier", None) == "3"
+        # No Tier 1 in the sweep → materially degraded (not harmless).
+        assert getattr(rec, "effective_extraction_tier", None) == "tier2"
+
+        # The structured failure stage is durably persisted in ## Repair.
+        write_calls = [
+            c for c in client.call_tool.call_args_list if c.args[0] == "lithos_write"
+        ]
+        assert 'tier3_last_stage: "validate"' in write_calls[-1].args[1]["content"]
 
     async def test_tier2_failure_logs_warning_with_extra(
         self,
@@ -919,15 +950,18 @@ class TestSweepCapCounterAndTerminalFlip:
         args = write_calls[-1].args[1]
         return dict(args)
 
-    async def test_validate_failure_bumps_counter_in_repair_section(self) -> None:
+    async def test_validate_failure_bumps_counter_in_repair_section(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """A single counted failure increments tier3_attempts in ## Repair."""
         items = [{"id": "n1", "title": "Paper"}]
         note = self._note_for_tier3("n1")
 
-        def failing(note: dict[str, object]) -> None:
-            del note
+        def failing(*, title: str, full_text: str, config: object) -> None:
+            del title, full_text, config
             raise LCMAError("validation failed", model="extract", stage="validate")
 
+        monkeypatch.setattr("influx.cascade.tier3_extract", failing)
         config = _make_config()
         client = _make_client(list_items=items, read_responses=[note])
 
@@ -935,7 +969,8 @@ class TestSweepCapCounterAndTerminalFlip:
             "ai-robotics",
             client=client,
             config=config,
-            hooks=SweepHooks(tier3_extract=failing),
+            hooks=SweepHooks(),
+            cascade=_sweep_cascade(config),
         )
 
         rewritten = self._last_write_args(client)
@@ -946,15 +981,18 @@ class TestSweepCapCounterAndTerminalFlip:
         # Terminal not yet flipped.
         assert "influx:tier3-terminal" not in rewritten["tags"]
 
-    async def test_http_failure_does_not_bump_counter(self) -> None:
+    async def test_http_failure_does_not_bump_counter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Transient (HTTP) failures must NOT advance the cap counter."""
         items = [{"id": "n1", "title": "Paper"}]
         note = self._note_for_tier3("n1")
 
-        def failing(note: dict[str, object]) -> None:
-            del note
+        def failing(*, title: str, full_text: str, config: object) -> None:
+            del title, full_text, config
             raise LCMAError("connect timeout", model="extract", stage="http")
 
+        monkeypatch.setattr("influx.cascade.tier3_extract", failing)
         config = _make_config()
         client = _make_client(list_items=items, read_responses=[note])
 
@@ -962,7 +1000,8 @@ class TestSweepCapCounterAndTerminalFlip:
             "ai-robotics",
             client=client,
             config=config,
-            hooks=SweepHooks(tier3_extract=failing),
+            hooks=SweepHooks(),
+            cascade=_sweep_cascade(config),
         )
 
         rewritten = self._last_write_args(client)
@@ -974,6 +1013,7 @@ class TestSweepCapCounterAndTerminalFlip:
 
     async def test_third_counted_failure_flips_tier3_terminal(
         self,
+        monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """At cap=3, ``influx:tier3-terminal`` is added and a WARNING is logged."""
@@ -996,10 +1036,11 @@ class TestSweepCapCounterAndTerminalFlip:
             ),
         )
 
-        def failing(note: dict[str, object]) -> None:
-            del note
+        def failing(*, title: str, full_text: str, config: object) -> None:
+            del title, full_text, config
             raise LCMAError("schema mismatch", model="extract", stage="validate")
 
+        monkeypatch.setattr("influx.cascade.tier3_extract", failing)
         config = _make_config()
         client = _make_client(list_items=items, read_responses=[note])
 
@@ -1008,7 +1049,8 @@ class TestSweepCapCounterAndTerminalFlip:
                 "ai-robotics",
                 client=client,
                 config=config,
-                hooks=SweepHooks(tier3_extract=failing),
+                hooks=SweepHooks(),
+                cascade=_sweep_cascade(config),
             )
 
         rewritten = self._last_write_args(client)
@@ -1025,19 +1067,22 @@ class TestSweepCapCounterAndTerminalFlip:
         assert getattr(rec, "tier3_attempts", None) == 3
         assert getattr(rec, "stage", None) == "validate"
 
-    async def test_tier3_terminal_present_skips_tier3(self) -> None:
-        """Once ``influx:tier3-terminal`` is set, the hook is not called."""
+    async def test_tier3_terminal_present_skips_tier3(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Once ``influx:tier3-terminal`` is set, Tier 3 is not attempted."""
         items = [{"id": "n1", "title": "Paper"}]
         note = self._note_for_tier3("n1")
         note["tags"] = list(note["tags"]) + ["influx:tier3-terminal"]
 
         call_count = 0
 
-        def spy(note: dict[str, object]) -> None:
+        def spy(*, title: str, full_text: str, config: object) -> None:
             nonlocal call_count
-            del note
+            del title, full_text, config
             call_count += 1
 
+        monkeypatch.setattr("influx.cascade.tier3_extract", spy)
         config = _make_config()
         client = _make_client(list_items=items, read_responses=[note])
 
@@ -1045,7 +1090,8 @@ class TestSweepCapCounterAndTerminalFlip:
             "ai-robotics",
             client=client,
             config=config,
-            hooks=SweepHooks(tier3_extract=spy),
+            hooks=SweepHooks(),
+            cascade=_sweep_cascade(config),
         )
 
         assert call_count == 0


### PR DESCRIPTION
**PR 2 of the finding-3a stack** (repair sweep reuses the Cascade — Lithos task `62aa58f4`, design in finding `6cea71c7`). Follows #257 (3a.1). This routes the sweep's **Tier 3** recovery through the shared `Cascade.enrich` instead of the bespoke `tier3_extract` hook, deleting the enrichment/rendering duplication in `repair_hooks`.

Scoped to **Tier 3 only** (source-agnostic — a pure model call on the note's existing `## Full Text`). Tier 2 (source-coupled re-extraction) is 3a.3; Tier 1 recovery is 3a.4.

## What changed

### Sweep runs Tier 3 through the Cascade
`_run_tier3_via_cascade` reconstructs an `Acquired` from the persisted note (`## Full Text` → `extracted_text`, doc-title, id) and runs `enrich(acquired, score, stages={"tier3"}, counters=parse(## Repair))`. On success it inserts the four Tier-3 sections + `influx:deep-extracted`; on a counted failure it persists the advanced counters and flips `influx:tier3-terminal` at the cap — **`enrich` owns the counter lifecycle** (3a.1 Fork 6). A missing `## Full Text` stays a counted `parse` failure exactly as the old hook raised, so the Tier-3 cap still trips for a note that never gains full text.

### `cascade` is an injected dependency mirroring `hooks`
`sweep(profile, *, client, config, hooks=None, cascade=None)`: when `hooks is None` (production) the real Cascade is built alongside the default hooks; when `hooks` is supplied (tests) an **absent `cascade` skips Tier 3 exactly as an absent hook skips its stage**. This keeps every isolation test (`SweepHooks()`, high-score-terminal, advancement/fairness) unchanged and preserves the "drive public `sweep()`, inject via params" seam.

### Deleted the tier3 hook
`SweepHooks.tier3_extract`, the `Tier3ExtractHook` protocol, `repair_hooks._make_tier3_extract_hook` (+ the now-dead `_extract_title`), and the `DefaultSweepHooks` / `to_sweep_hooks` / `make_default_sweep_hooks` wiring.

## Observability note (behaviour change, called out)
Tier-3 failures now log via `enrich`'s #151-classified WARNING (consistent with the create path) instead of the sweep's `_log_stage_failure`. The structured failure **stage + error survive durably in the note's `## Repair` counters** (`tier3_last_stage` / `tier3_last_error`) rather than only in an ephemeral log line — arguably better than the prior behaviour. The old sweep-level LCMAError `exc_info` traceback is dropped for Tier 3 (validation failures where the structured stage/detail matter more).

## Test migration
- **Unit** sweep tests (AsyncMock style) drive Tier 3 via a real Cascade + monkeypatched `influx.cascade.tier3_extract`, so the counter/terminal assertions stay **verbatim** against the real lifecycle (validate→bump, http→no-bump, 3rd→terminal, terminal→skip).
- **Integration** sweep tests (zero-monkeypatch) inject fake Cascades (`tests/integration/_cascade_fakes.py`) via `sweep(cascade=...)` — the seam stays "public `sweep()` + injected params, no reaching into internals". The RSS recovery test's Tier-2 fake now inserts a real `## Full Text` section (mirroring production) so the Cascade's Tier 3 has body to read.
- Removed the obsolete tier3-hook production/rollback tests (their premise — a hook mutating-then-raising — no longer exists; coverage lives in `test_cascade.py` + `test_repair_sweep.py`).

## Test plan
- [x] `make check` green — **2681 passed**; only the pre-existing `test_run_conflict_exit_1` subprocess-timeout flake fails (confirmed identical on clean `main`).
- [x] All 199 repair unit + integration sweep tests pass.
- [x] No `docs/generated/` drift — the `Repair → Enrich` component edge already existed (via `repair_hooks → enrich`), now realised via `repair → cascade`.
- [x] pyright + ruff (check + format) clean.

## Next in the stack
3a.3 routes **Tier 2** through the Cascade (the source-coupled extractor dispatch, reusing the create-path factories — dovetails toward finding-2's Source seam). Then 3a.4 (Tier-1 recovery), 3a.5 (cleanup + drop the `_(proposed)_` markers).
