### PR TITLE
refactor(repair): route Tier 2 recovery through the shared Cascade (3a.3)

### DIFF
--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -7,11 +7,12 @@ Tier 2, Tier 3) based on the current tag set, and rewriting every
 visited note so ``updated_at`` advances (retry-order advancement).
 
 Worker hooks (``archive_download``, ``re_extract_archive``,
-``tier2_enrich``, ``text_extraction``) are test-injectable callables
-whose real implementations ship with PRD 07.  Tier 3 recovery is no
-longer a hook: it runs through the shared
+``text_extraction``) are test-injectable callables whose real
+implementations ship with PRD 07.  Tier 2 and Tier 3 recovery are no
+longer hooks: they run through the shared
 :class:`~influx.cascade.Cascade` passed to :func:`sweep` (finding 3,
-3a.2), which the isolation tests inject the same way they inject hooks.
+3a.2 / 3a.3), which the isolation tests inject the same way they
+inject hooks.
 """
 
 from __future__ import annotations
@@ -24,7 +25,7 @@ import json
 import logging
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 from influx import metrics
 from influx.canonical_note import (
@@ -33,6 +34,7 @@ from influx.canonical_note import (
     drop_tier2_and_tier3,
     extract_section_body,
     graft_user_notes,
+    insert_full_text_section,
     insert_tier3_sections,
     parse_lenient,
     upsert_archive_path,
@@ -43,6 +45,7 @@ from influx.errors import ExtractionError, LCMAError, LithosError
 from influx.notes import merge_tags
 from influx.repair_counters import (
     CountedStage,
+    RepairCounters,
     classify_failure,
     parse_repair_section,
     record_counted_failure,
@@ -51,7 +54,7 @@ from influx.repair_counters import (
 from influx.telemetry import current_run_id, get_tracer
 
 if TYPE_CHECKING:
-    from influx.cascade import Tier
+    from influx.cascade import EnrichedSections, Tier, Tier2Extractor
     from influx.config import AppConfig
     from influx.lithos_client import LithosClient
 
@@ -66,7 +69,6 @@ __all__ = [
     "SweepHooks",
     "SweepWriteError",
     "TextExtractionHook",
-    "Tier2EnrichHook",
     "apply_abstract_only_reextraction",
     "compute_clearing",
     "select_stages",
@@ -199,35 +201,6 @@ class ReExtractArchiveHook(Protocol):
     ) -> ReExtractionResult: ...
 
 
-class Tier2EnrichHook(Protocol):
-    """Callable protocol for Tier 2 enrichment retry (PRD 06 §4).
-
-    Called by the sweep when a note is missing ``full-text``, the
-    current max profile score meets the threshold, and
-    ``influx:text-terminal`` is absent.
-
-    The implementation performs full-text enrichment and updates the
-    note accordingly.  On success, the note should carry ``full-text``
-    after the sweep's rewrite.
-
-    Parameters
-    ----------
-    note:
-        The current note state (as returned by ``lithos_read``).
-
-    Raises
-    ------
-    ExtractionError
-        On enrichment failure — the sweep treats this as "stage
-        failed this pass" and keeps ``influx:repair-needed``.
-    LithosError
-        On Lithos API failure — propagated to the sweep's error
-        handling.
-    """
-
-    def __call__(self, note: dict[str, object]) -> None: ...
-
-
 class ArchiveDownloadHook(Protocol):
     """Callable protocol for archive download retry (PRD 04).
 
@@ -303,15 +276,14 @@ class SweepHooks:
     stage selection would otherwise select it.  PRD 07 wires the real
     implementations; tests inject fakes.
 
-    Tier 3 is no longer a hook: it runs through the shared
+    Tier 2 and Tier 3 are no longer hooks: they run through the shared
     :class:`~influx.cascade.Cascade` passed to :func:`sweep` (finding 3,
-    3a.2), so an absent cascade skips Tier 3 the same way an absent hook
-    skips its stage.
+    3a.2 / 3a.3), so an absent cascade skips both tiers the same way an
+    absent hook skips its stage.
     """
 
     archive_download: ArchiveDownloadHook | None = None
     re_extract_archive: ReExtractArchiveHook | None = None
-    tier2_enrich: Tier2EnrichHook | None = None
     text_extraction: TextExtractionHook | None = None
 
 
@@ -424,8 +396,8 @@ def select_stages(
 def _snapshot_note(note: dict[str, Any]) -> dict[str, Any]:
     """Deep-copy mutable note state for hook-call rollback.
 
-    Hooks (``archive_download``, ``re_extract_archive``, ``tier2_enrich``,
-    ``tier3_extract``) receive the live mutable note dict.  When a hook
+    Hooks (``archive_download``, ``re_extract_archive``,
+    ``text_extraction``) receive the live mutable note dict.  When a hook
     raises ``ExtractionError`` / ``LithosError`` the sweep treats that
     as "stage failed this pass" (per US-003 / US-013) and must NOT
     persist any partial in-place mutations the hook applied before
@@ -1147,70 +1119,31 @@ def _run_text_extraction_retry(
         return new_tags
 
 
-def _run_tier_retry(
-    note: dict[str, Any],
-    *,
-    profile: str,
-    current_tags: list[str],
-    hook: Tier2EnrichHook,
-    stage: CountedStage,
-    log_subject: str,
-) -> list[str]:
-    """Run the Tier 2 enrichment retry stage.
-
-    Wraps the hook in the counted-failure cap / terminal-tag flip /
-    hook-mutation rollback envelope, parameterised on *stage* and the
-    log subject used for the per-stage failure WARN line.  (Tier 3 now
-    runs through the Cascade — see :func:`_run_tier3_via_cascade`.)
-    """
-    try:
-        with _stage_attempt(
-            note,
-            profile=profile,
-            kind=stage,
-            span_name=f"influx.repair.{stage}",
-            sync_tags=current_tags,
-        ):
-            hook(note)
-        # Sync any tag/content mutations the hook applied to the note
-        # dict back into the working tag set.
-        return list(note.get("tags", current_tags))
-    except (ExtractionError, LCMAError, LithosError) as exc:
-        new_tags = _apply_counted_failure(
-            note=note,
-            current_tags=current_tags,
-            exc=exc,
-            profile=profile,
-            stage=stage,
-            failure_stage=getattr(exc, "stage", "") or "",
-        )
-        _log_stage_failure(
-            log_subject,
-            note=note,
-            profile=profile,
-            exc=exc,
-        )
-        return new_tags
-
-
-# ── Tier 3 recovery via the shared Cascade (finding 3, 3a.2) ────────
+# ── Tier 2 / Tier 3 recovery via the shared Cascade (finding 3) ─────
 #
-# The sweep re-runs Tier 3 through the same ``Cascade.enrich`` the create
-# path uses instead of a bespoke ``tier3_extract`` hook: reconstruct an
-# ``Acquired`` from the persisted note, run only the Tier-3 stage with the
-# note's ``## Repair`` counters, and apply the outcome surgically via the
-# canonical section ops.  Tier 2 (source-coupled extraction) and Tier 1
-# stay outside the Cascade for now — 3a.3 / 3a.4.
+# The sweep re-runs Tier 2 and Tier 3 through the same ``Cascade.enrich``
+# the create path uses instead of bespoke ``tier2_enrich`` / ``tier3_extract``
+# hooks: reconstruct an ``Acquired`` from the persisted note, run only the
+# stage being retried with the note's ``## Repair`` counters, and apply the
+# outcome surgically via the canonical section ops.  Tier 1 recovery stays
+# outside the Cascade for now — 3a.4.
 
+_TIER2_ONLY: frozenset[Tier] = frozenset(("tier2",))
 _TIER3_ONLY: frozenset[Tier] = frozenset(("tier3",))
 
 
-def _build_sweep_cascade(config: AppConfig, profile: str) -> Cascade:
+def _build_sweep_cascade(
+    config: AppConfig,
+    profile: str,
+    *,
+    tier2_extractor: Tier2Extractor | None = None,
+) -> Cascade:
     """Build the profile's enrichment Cascade for the repair sweep.
 
-    Tier-3-only for now (3a.2): ``tier2_extractor`` is left unset because
-    the sweep does not yet route Tier 2 through the Cascade — that stage's
-    source-coupled extractor dispatch is 3a.3.
+    ``tier2_extractor`` re-extracts a note's full text from its stored
+    archive (3a.3); the production sweep wires the archive extractor while
+    tests inject a fake or leave it unset to skip Tier 2.  Tier 3 needs no
+    extractor — it runs on the note's existing ``## Full Text``.
     """
     profile_cfg = next((p for p in config.profiles if p.name == profile), None)
     return Cascade(
@@ -1218,25 +1151,142 @@ def _build_sweep_cascade(config: AppConfig, profile: str) -> Cascade:
         profile_name=profile,
         profile_summary=profile_cfg.description if profile_cfg else "",
         thresholds=profile_cfg.thresholds if profile_cfg else ProfileThresholds(),
+        tier2_extractor=tier2_extractor,
     )
 
 
-def _reconstruct_acquired(note: dict[str, Any], *, full_text: str) -> Acquired:
-    """Rebuild the minimal ``Acquired`` the Cascade's Tier 3 needs.
+def _reconstruct_acquired(
+    note: dict[str, Any],
+    *,
+    extracted_text: str | None = None,
+    archive_path: str | None = None,
+) -> Acquired:
+    """Rebuild the minimal ``Acquired`` a Cascade recovery stage needs.
 
-    Tier 3 reads only ``item_id`` / ``title`` / ``extracted_text``; the
-    other fields are filled defensively from the note so the same helper
-    can grow to feed Tier 2 (3a.3) and Tier 1 (3a.4).  ``title`` comes
-    from the note's doc-level title (``read_note`` strips the ``# Title``
-    from ``content``), which is a strictly more reliable source than the
-    old hook's parse of the stripped body.
+    Tier 2 reads ``archive_path`` (its extractor re-reads the stored
+    archive) with ``extracted_text=None`` so the Tier-2 gate fires; Tier 3
+    reads ``extracted_text`` (the note's existing full text).  ``title``
+    comes from the note's doc-level title (``read_note`` strips the
+    ``# Title`` from ``content``), a strictly more reliable source than the
+    old hooks' parse of the stripped body.  Tier 1 (3a.4) will add
+    ``abstract``.
     """
     return Acquired(
         item_id=str(note.get("id") or ""),
         source_url=str(note.get("source_url") or ""),
         title=_doc_title(note),
         abstract="",
-        extracted_text=full_text,
+        extracted_text=extracted_text,
+        archive_path=archive_path,
+    )
+
+
+def _apply_enrich_recovery_failure(
+    *,
+    note: dict[str, Any],
+    content: str,
+    current_tags: list[str],
+    sections: EnrichedSections,
+    counters_before: RepairCounters,
+    stage: Literal["tier2", "tier3"],
+    profile: str,
+) -> list[str]:
+    """Persist a cascade recovery stage's counted-failure outcome.
+
+    Shared by the Tier-2 and Tier-3 sweep handlers: when ``enrich`` advanced
+    the ``## Repair`` counters (a counted-class failure) persist them, apply
+    any newly-tripped ``influx:<stage>-terminal`` flag, and emit the
+    terminal-flip WARNING.  Transient failures leave counters and tags
+    untouched — only ``influx:repair-needed`` stays, which the clearing step
+    preserves.
+    """
+    new_tags = list(current_tags)
+    if sections.counters != counters_before:
+        note["content"] = upsert_repair_section(content, sections.counters)
+    newly_terminal = [t for t in sections.terminal_flags if t not in current_tags]
+    new_tags.extend(newly_terminal)
+    if f"influx:{stage}-terminal" in newly_terminal:
+        attempts = getattr(sections.counters, f"{stage}_attempts")
+        logger.warning(
+            "sweep: %s marked terminal after %d counted failures for %s",
+            stage,
+            attempts,
+            note.get("id", "?"),
+            extra={
+                "sweep_stage": f"{stage}_terminal_flip",
+                "note_id": note.get("id"),
+                "profile": profile,
+                "run_id": current_run_id.get() or "",
+                f"{stage}_attempts": attempts,
+                # The counted stage that tripped the cap survives in the
+                # ## Repair counters even though ``enrich`` swallowed the
+                # exception, so operators still see *which* stage failed.
+                "stage": getattr(sections.counters, f"{stage}_last_stage"),
+            },
+        )
+    note["tags"] = list(new_tags)
+    return new_tags
+
+
+def _run_tier2_via_cascade(
+    note: dict[str, Any],
+    *,
+    profile: str,
+    current_tags: list[str],
+    cascade: Cascade,
+    archive_path: str | None,
+    max_profile_score: int,
+) -> list[str]:
+    """Re-run Tier 2 (full-text enrichment) through the shared Cascade (3a.3).
+
+    Replaces the bespoke ``tier2_enrich`` sweep hook.  The Cascade's
+    ``tier2_extractor`` re-extracts full text from the note's stored archive
+    (``archive_path``); on success the ``## Full Text`` section is inserted and
+    the ``full-text`` tag added.  On a counted-class failure the advanced
+    counters + ``influx:tier2-terminal`` are persisted — notably a missing
+    archive path, which the extractor raises as ``parse`` so ``enrich`` advances
+    the Tier-2 counter, exactly as the old hook did.
+    """
+    content = str(note.get("content") or "")
+    metrics.repair_candidates().add(1, {"profile": profile, "kind": "tier2"})
+
+    counters_before = parse_repair_section(content)
+    acquired = _reconstruct_acquired(note, archive_path=archive_path)
+
+    tracer = get_tracer()
+    with tracer.span(
+        "influx.repair.tier2",
+        attributes={
+            "influx.note_id": note.get("id", ""),
+            "influx.profile": profile,
+            "influx.run_id": current_run_id.get() or "",
+        },
+    ):
+        sections = cascade.enrich(
+            acquired,
+            max_profile_score,
+            stages=_TIER2_ONLY,
+            counters=counters_before,
+        )
+
+    if sections.full_text is not None:
+        new_tags = list(current_tags)
+        note["content"] = insert_full_text_section(content, sections.full_text)
+        if "full-text" not in new_tags:
+            new_tags.append("full-text")
+        note["tags"] = list(new_tags)
+        return new_tags
+
+    # Failure — ``enrich`` advanced the counters on a counted-class failure
+    # (transient leaves them); ``influx:repair-needed`` stays for next pass.
+    return _apply_enrich_recovery_failure(
+        note=note,
+        content=content,
+        current_tags=current_tags,
+        sections=sections,
+        counters_before=counters_before,
+        stage="tier2",
+        profile=profile,
     )
 
 
@@ -1281,7 +1331,7 @@ def _run_tier3_via_cascade(
         return new_tags
 
     counters_before = parse_repair_section(content)
-    acquired = _reconstruct_acquired(note, full_text=full_text)
+    acquired = _reconstruct_acquired(note, extracted_text=full_text)
 
     tracer = get_tracer()
     with tracer.span(
@@ -1299,8 +1349,8 @@ def _run_tier3_via_cascade(
             counters=counters_before,
         )
 
-    new_tags = list(current_tags)
     if sections.tier3 is not None:
+        new_tags = list(current_tags)
         note["content"] = insert_tier3_sections(content, sections.tier3)
         if "influx:deep-extracted" not in new_tags:
             new_tags.append("influx:deep-extracted")
@@ -1309,29 +1359,15 @@ def _run_tier3_via_cascade(
 
     # Failure — ``enrich`` already logged the Tier-3 failure and advanced
     # the counters on a counted-class failure (transient leaves them).
-    if sections.counters != counters_before:
-        note["content"] = upsert_repair_section(content, sections.counters)
-    newly_terminal = [t for t in sections.terminal_flags if t not in current_tags]
-    new_tags.extend(newly_terminal)
-    if "influx:tier3-terminal" in newly_terminal:
-        logger.warning(
-            "sweep: tier3 marked terminal after %d counted failures for %s",
-            sections.counters.tier3_attempts,
-            note.get("id", "?"),
-            extra={
-                "sweep_stage": "tier3_terminal_flip",
-                "note_id": note.get("id"),
-                "profile": profile,
-                "run_id": current_run_id.get() or "",
-                "tier3_attempts": sections.counters.tier3_attempts,
-                # The counted stage that tripped the cap survives in the
-                # ## Repair counters even though ``enrich`` swallowed the
-                # exception, so operators still see *which* stage failed.
-                "stage": sections.counters.tier3_last_stage,
-            },
-        )
-    note["tags"] = list(new_tags)
-    return new_tags
+    return _apply_enrich_recovery_failure(
+        note=note,
+        content=content,
+        current_tags=current_tags,
+        sections=sections,
+        counters_before=counters_before,
+        stage="tier3",
+        profile=profile,
+    )
 
 
 def _doc_title(note: dict[str, Any]) -> str:
@@ -1454,15 +1490,15 @@ async def _process_sweep_note(
             hook=hooks.re_extract_archive,
         )
 
-    if stages.tier2_retry and hooks.tier2_enrich:
+    if stages.tier2_retry and cascade is not None:
         current_tags = await asyncio.to_thread(
-            _run_tier_retry,
+            _run_tier2_via_cascade,
             note,
             profile=profile,
             current_tags=current_tags,
-            hook=hooks.tier2_enrich,
-            stage="tier2",
-            log_subject="tier2_enrichment",
+            cascade=cascade,
+            archive_path=archive_path,
+            max_profile_score=max_profile_score,
         )
 
     if stages.tier3_retry and cascade is not None:
@@ -1553,11 +1589,20 @@ async def sweep(
         effective_hooks = hooks
         effective_cascade = cascade
     else:
-        from influx.repair_hooks import make_default_sweep_hooks
+        from influx.repair_hooks import (
+            make_default_sweep_hooks,
+            make_sweep_tier2_extractor,
+        )
 
         effective_hooks = make_default_sweep_hooks(config).to_sweep_hooks()
         effective_cascade = (
-            cascade if cascade is not None else _build_sweep_cascade(config, profile)
+            cascade
+            if cascade is not None
+            else _build_sweep_cascade(
+                config,
+                profile,
+                tier2_extractor=make_sweep_tier2_extractor(config),
+            )
         )
 
     limit = config.repair.max_items_per_run

--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -1565,13 +1565,14 @@ async def sweep(
         the production defaults are wired (and, unless *cascade* is
         given, the production :class:`~influx.cascade.Cascade` too).
         When supplied explicitly (tests), only the given hooks/cascade
-        are used — stages whose hook (or, for Tier 3, the cascade) is
-        absent are skipped, but notes are still rewritten.
+        are used — stages whose hook (or, for Tier 2 / Tier 3, the
+        cascade) is absent are skipped, but notes are still rewritten.
     cascade:
-        Optional enrichment Cascade for the Tier-3 recovery stage
-        (finding 3, 3a.2).  ``None`` skips Tier 3 exactly as an absent
-        hook skips its stage; the production path builds one when
-        *hooks* is ``None``.
+        Optional enrichment Cascade driving the Tier-2 and Tier-3
+        recovery stages (finding 3, 3a.2 / 3a.3).  ``None`` skips both
+        tiers exactly as an absent hook skips its stage; the production
+        path builds one (with the archive Tier-2 extractor) when *hooks*
+        is ``None``.
 
     Returns
     -------

--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -1,10 +1,12 @@
 """Production-default repair hooks (PRD 07 US-016).
 
 Bridges the PRD 06 hook signatures (``ReExtractArchiveHook``,
-``Tier2EnrichHook``) to the lower-level extraction helpers from PRD 07
-(``extraction.html``, ``extraction.pdf``).  Tier 3 recovery is no longer
-a hook — the sweep runs it through the shared
-:class:`~influx.cascade.Cascade` (finding 3, 3a.2).
+``TextExtractionHook``) to the lower-level extraction helpers from PRD
+07 (``extraction.html``, ``extraction.pdf``).  Tier 2 and Tier 3
+recovery are no longer hooks — the sweep runs them through the shared
+:class:`~influx.cascade.Cascade` (finding 3, 3a.2 / 3a.3); this module
+supplies the sweep's archive-reading :data:`~influx.cascade.Tier2Extractor`
+via :func:`make_sweep_tier2_extractor`.
 
 The ``SweepHooks`` test-injection seam is preserved unchanged: these
 defaults are only wired in when ``sweep()`` is called without explicit
@@ -23,16 +25,13 @@ import trafilatura
 from influx.archive_policy import (
     registry_from_config as _archive_policy_registry_from_config,
 )
-from influx.canonical_note import (
-    insert_full_text_section,
-)
+from influx.cascade import Acquired, TextFlavour, Tier2Extractor, Tier2Result
 from influx.config import AppConfig
 from influx.errors import ExtractionError, NetworkError
 from influx.extraction.article import extract_article
 from influx.extraction.html import _clean_html_fragments, _strip_tags
 from influx.extraction.pdf import extract_pdf
 from influx.extraction.pipeline import extract_arxiv_text
-from influx.notes import parse_archive_path, parse_note
 from influx.repair import (
     ArchiveDownloadHook,
     ExtractionOutcome,
@@ -40,12 +39,15 @@ from influx.repair import (
     ReExtractionResult,
     SweepHooks,
     TextExtractionHook,
-    Tier2EnrichHook,
 )
 from influx.storage import download_archive
 from influx.urls import url_hash
 
-__all__ = ["DefaultSweepHooks", "make_default_sweep_hooks"]
+__all__ = [
+    "DefaultSweepHooks",
+    "make_default_sweep_hooks",
+    "make_sweep_tier2_extractor",
+]
 
 _log = logging.getLogger(__name__)
 
@@ -952,50 +954,39 @@ def _make_re_extract_archive_hook(
     return hook
 
 
-def _make_tier2_enrich_hook(config: AppConfig) -> Tier2EnrichHook:
-    """Create the production ``tier2_enrich`` hook.
+def make_sweep_tier2_extractor(config: AppConfig) -> Tier2Extractor:
+    """Create the sweep's Tier 2 extractor for :class:`~influx.cascade.Cascade`.
 
-    Reads the stored archive, extracts text, inserts ``## Full Text``
-    into the note content, and adds the ``full-text`` tag.
+    Re-extracts full text from the note's already-downloaded archive
+    file — the source-agnostic recovery path.  The Cascade owns the
+    counter lifecycle and section rendering; this extractor only turns
+    an :class:`~influx.cascade.Acquired` into a
+    :class:`~influx.cascade.Tier2Result`.
+
+    A missing archive path raises a counted ``parse`` failure (exactly
+    as the old ``tier2_enrich`` hook did), so the Tier-2 cap still trips
+    for a note that never gains an archive.  Archive-read and extraction
+    failures raise transient stages (``archive_read`` / ``extract`` /
+    ``min_length``) that keep ``influx:repair-needed`` without advancing
+    the counter.
     """
 
-    def hook(note: dict[str, object]) -> None:
-        content: str = str(note.get("content", ""))
-        tags: list[str] = _note_tags(note)
-
-        # Find archive path from note content.
-        try:
-            parsed = parse_note(content)
-            archive_path = parse_archive_path(parsed)
-        except Exception as exc:
-            raise ExtractionError(
-                "Cannot parse archive path from note",
-                stage="parse",
-                detail=str(exc),
-            ) from exc
-
-        if archive_path is None:
+    def extractor(acquired: Acquired) -> Tier2Result:
+        if not acquired.archive_path:
             raise ExtractionError(
                 "No archive path found in note",
                 stage="parse",
                 detail="## Archive section missing or empty",
             )
 
-        # Read and extract from archive.
-        file_bytes = _read_archive_file(config, archive_path)
-        extracted_text, _source_tag = _extract_from_archive(
-            file_bytes, archive_path, config
+        file_bytes = _read_archive_file(config, acquired.archive_path)
+        text, text_tag = _extract_from_archive(
+            file_bytes, acquired.archive_path, config
         )
+        flavour: TextFlavour = "pdf" if text_tag == "text:pdf" else "html"
+        return Tier2Result(text=text, flavour=flavour, text_tag=text_tag)
 
-        # Insert ## Full Text section into content.
-        note["content"] = insert_full_text_section(content, extracted_text)
-
-        # Add full-text tag.
-        if "full-text" not in tags:
-            tags.append("full-text")
-            note["tags"] = tags
-
-    return hook
+    return extractor
 
 
 # ── Public factory ──────────────────────────────────────────────────
@@ -1005,11 +996,12 @@ def _make_tier2_enrich_hook(config: AppConfig) -> Tier2EnrichHook:
 class DefaultSweepHooks:
     """Production-default sweep hook wiring with non-optional callables.
 
-    Holds the four production hooks with non-``Optional`` types so
+    Holds the three production hooks with non-``Optional`` types so
     pyright can statically know they are wired, while the parent
     :class:`~influx.repair.SweepHooks` keeps them ``| None`` to preserve
-    the test-injection seam.  (Tier 3 recovery is not a hook — the sweep
-    runs it through the shared Cascade; finding 3, 3a.2.)
+    the test-injection seam.  (Tier 2 and Tier 3 recovery are not hooks
+    — the sweep runs them through the shared Cascade; finding 3,
+    3a.2 / 3a.3.)
 
     Use :meth:`to_sweep_hooks` to obtain a ``SweepHooks`` instance for
     passing into :func:`influx.repair.sweep`.
@@ -1017,7 +1009,6 @@ class DefaultSweepHooks:
 
     archive_download: ArchiveDownloadHook
     re_extract_archive: ReExtractArchiveHook
-    tier2_enrich: Tier2EnrichHook
     text_extraction: TextExtractionHook
 
     def to_sweep_hooks(self) -> SweepHooks:
@@ -1025,7 +1016,6 @@ class DefaultSweepHooks:
         return SweepHooks(
             archive_download=self.archive_download,
             re_extract_archive=self.re_extract_archive,
-            tier2_enrich=self.tier2_enrich,
             text_extraction=self.text_extraction,
         )
 
@@ -1044,6 +1034,5 @@ def make_default_sweep_hooks(config: AppConfig) -> DefaultSweepHooks:
     return DefaultSweepHooks(
         archive_download=_make_archive_download_hook(config),
         re_extract_archive=_make_re_extract_archive_hook(config),
-        tier2_enrich=_make_tier2_enrich_hook(config),
         text_extraction=_make_text_extraction_hook(config),
     )

--- a/tests/integration/_cascade_fakes.py
+++ b/tests/integration/_cascade_fakes.py
@@ -1,11 +1,12 @@
-"""Fake enrichment Cascades for repair-sweep integration tests (3a.2).
+"""Fake enrichment Cascades for repair-sweep integration tests (3a.2 / 3a.3).
 
-The sweep runs Tier 3 through a :class:`~influx.cascade.Cascade` passed via
-``sweep(cascade=...)``.  These fakes let the zero-monkeypatch integration
-suite drive the Tier-3 recovery outcome — success or not-attempted spy —
-without an LLM, exactly the way ``SweepHooks`` fakes drive the other
-stages.  Inject with ``# type: ignore[arg-type]`` (as the hook fakes do),
-since a fake is structurally-but-not-nominally a ``Cascade``.
+The sweep runs Tier 2 and Tier 3 through a :class:`~influx.cascade.Cascade`
+passed via ``sweep(cascade=...)``.  These fakes let the zero-monkeypatch
+integration suite drive the recovery outcome — success or not-attempted
+spy — without an LLM or archive I/O, exactly the way ``SweepHooks`` fakes
+drive the other stages.  Inject with ``# type: ignore[arg-type]`` (as the
+hook fakes do), since a fake is structurally-but-not-nominally a
+``Cascade``.
 """
 
 from __future__ import annotations
@@ -15,10 +16,23 @@ from influx.repair_counters import RepairCounters
 from influx.schemas import Tier3Extraction
 
 
-class Tier3SuccessCascade:
-    """``enrich`` returns a canned Tier-3 extraction (deep-extract succeeds)."""
+class Tier2Tier3SuccessCascade:
+    """``enrich`` succeeds for whichever stage the sweep requests.
 
-    def __init__(self, tier3: Tier3Extraction | None = None) -> None:
+    Dispatches on ``stages`` so one injected fake drives both the sweep's
+    Tier-2 (full text) and Tier-3 (claims) recovery in a single end-to-end
+    pass, without archive I/O or an LLM.  The sweep applies ``full_text``
+    via ``insert_full_text_section`` (adding the ``full-text`` tag) and
+    ``tier3`` via ``insert_tier3_sections`` (adding ``influx:deep-extracted``).
+    """
+
+    def __init__(
+        self,
+        *,
+        full_text: str = "Recovered full text body.",
+        tier3: Tier3Extraction | None = None,
+    ) -> None:
+        self.full_text = full_text
         self.tier3 = tier3 or Tier3Extraction(claims=["A recovered claim."])
         self.calls = 0
 
@@ -27,20 +41,26 @@ class Tier3SuccessCascade:
         acquired: Acquired,
         score: int,
         *,
-        stages: object = None,
+        stages: frozenset[str] | None = None,
         counters: RepairCounters | None = None,
     ) -> EnrichedSections:
-        del acquired, score, stages
+        del acquired, score
         self.calls += 1
-        return EnrichedSections(tier3=self.tier3, counters=counters or RepairCounters())
+        stage_set = stages or frozenset()
+        result_counters = counters or RepairCounters()
+        if "tier2" in stage_set:
+            return EnrichedSections(full_text=self.full_text, counters=result_counters)
+        if "tier3" in stage_set:
+            return EnrichedSections(tier3=self.tier3, counters=result_counters)
+        return EnrichedSections(counters=result_counters)
 
 
 class SpyCascade:
     """``enrich`` records that it was called and returns an empty result.
 
-    Used by tests that assert Tier 3 is *not* attempted (e.g. a terminal
-    note): a non-zero ``calls`` count means the sweep reached the Cascade
-    when it should have skipped the stage.
+    Used by tests that assert Tier 2 / Tier 3 are *not* attempted (e.g. a
+    terminal note): a non-zero ``calls`` count means the sweep reached the
+    Cascade when it should have skipped both stages.
     """
 
     def __init__(self) -> None:

--- a/tests/integration/test_event_loop_responsiveness.py
+++ b/tests/integration/test_event_loop_responsiveness.py
@@ -240,11 +240,11 @@ async def test_admin_endpoints_responsive_during_repair_sweep(
 ) -> None:
     """Repair sweep stage hooks must not starve the admin event loop.
 
-    Stage 1 of every Run is the repair sweep, which calls per-stage
-    sync hooks (``archive_download``, ``re_extract_archive``,
-    ``tier2_enrich``, ``tier3_extract``, ``text_extraction``) that do
-    blocking HTTP / extraction / model work — exactly the same class
-    of bug as the acquire/filter starvation.
+    Stage 1 of every Run is the repair sweep, which runs per-stage
+    sync work (the ``archive_download`` / ``re_extract_archive`` /
+    ``text_extraction`` hooks plus the shared Cascade's Tier 2 / Tier 3
+    recovery) that does blocking HTTP / extraction / model work — exactly
+    the same class of bug as the acquire/filter starvation.
 
     This test drives :func:`influx.repair._process_sweep_note`
     directly with a hook that hangs on a ``threading.Event``, so the

--- a/tests/integration/test_repair_sweep_high_score_terminal.py
+++ b/tests/integration/test_repair_sweep_high_score_terminal.py
@@ -341,12 +341,6 @@ class TestHighScoreTerminalClearing:
         fake_lithos_url: str,
     ) -> None:
         """Terminal exemption waives Tier 2 and Tier 3 at high score."""
-        tier2_calls = 0
-
-        def _tier2_spy(note: dict[str, object]) -> None:
-            nonlocal tier2_calls
-            tier2_calls += 1
-
         tags = [
             "profile:ai-robotics",
             "influx:repair-needed",
@@ -363,10 +357,9 @@ class TestHighScoreTerminalClearing:
         _queue_single_note(fake_lithos, note)
 
         config = _make_config(lithos_url=fake_lithos_url)
-        tier3_cascade = SpyCascade()
-        hooks = SweepHooks(
-            tier2_enrich=_tier2_spy,  # type: ignore[arg-type]
-        )
+        # Both Tier 2 and Tier 3 now route through the injected Cascade, so a
+        # single spy proves neither stage was attempted (3a.3).
+        spy_cascade = SpyCascade()
 
         client = LithosClient(url=fake_lithos_url)
         try:
@@ -374,15 +367,14 @@ class TestHighScoreTerminalClearing:
                 "ai-robotics",
                 client=client,
                 config=config,
-                hooks=hooks,
-                cascade=tier3_cascade,  # type: ignore[arg-type]
+                hooks=SweepHooks(),
+                cascade=spy_cascade,  # type: ignore[arg-type]
             )
             assert len(visited) == 1
 
             # Terminal note skips Tier 2 and Tier 3 (influx:text-terminal
             # suppresses both stages in stage selection).
-            assert tier2_calls == 0
-            assert tier3_cascade.calls == 0
+            assert spy_cascade.calls == 0
 
             # And influx:repair-needed is still cleared.
             write_calls = [c for c in fake_lithos.calls if c[0] == "lithos_write"]

--- a/tests/integration/test_repair_sweep_rss_archive_recovery.py
+++ b/tests/integration/test_repair_sweep_rss_archive_recovery.py
@@ -12,9 +12,9 @@ The flow exercised here:
   ``archive_download`` succeeds → ``archive-missing`` cleared,
   ``## Archive`` populated with ``path:``.
 - Pass 2: feed run-1 written note back → ``re_extract_archive`` returns
-  ``UPGRADE`` → ``text:abstract-only`` replaced by ``text:html`` →
-  ``tier2_enrich`` adds ``full-text`` → the shared Cascade's Tier 3
-  adds ``influx:deep-extracted`` → ``influx:repair-needed`` cleared.
+  ``UPGRADE`` → ``text:abstract-only`` replaced by ``text:html`` → the
+  shared Cascade's Tier 2 adds ``full-text`` and its Tier 3 adds
+  ``influx:deep-extracted`` → ``influx:repair-needed`` cleared.
 """
 
 from __future__ import annotations
@@ -25,7 +25,6 @@ from typing import Any
 
 import pytest
 
-from influx.canonical_note import insert_full_text_section
 from influx.config import (
     AppConfig,
     FeedbackConfig,
@@ -46,7 +45,7 @@ from influx.repair import (
     sweep,
 )
 from tests.contract.test_lithos_client import FakeLithosServer
-from tests.integration._cascade_fakes import Tier3SuccessCascade
+from tests.integration._cascade_fakes import Tier2Tier3SuccessCascade
 
 # ── Fixtures ───────────────────────────────────────────────────────
 
@@ -214,22 +213,6 @@ def _re_extract_upgrade_html(
     )
 
 
-def _add_tag_in_place(note: dict[str, object], tag: str) -> None:
-    raw = note.get("tags") or []
-    tags = list(raw) if isinstance(raw, list) else []
-    if tag not in tags:
-        tags.append(tag)
-    note["tags"] = tags
-
-
-def _tier2_enrich_adds_full_text(note: dict[str, object]) -> None:
-    # Mirror the production Tier 2 hook: insert the ``## Full Text`` section
-    # (not just the tag) so the Cascade's Tier-3 stage has body to read.
-    content = str(note.get("content", ""))
-    note["content"] = insert_full_text_section(content, "Recovered full text body.")
-    _add_tag_in_place(note, "full-text")
-
-
 # ── Tests ──────────────────────────────────────────────────────────
 
 
@@ -324,14 +307,14 @@ class TestRssArchiveRecoveryFlow:
 
             hooks_p2 = SweepHooks(
                 re_extract_archive=_re_extract_upgrade_html,
-                tier2_enrich=_tier2_enrich_adds_full_text,
             )
             await sweep(
                 "ai-robotics",
                 client=client,
                 config=config,
                 hooks=hooks_p2,
-                cascade=Tier3SuccessCascade(),  # type: ignore[arg-type]
+                # One fake drives both Tier 2 (full text) and Tier 3 (claims).
+                cascade=Tier2Tier3SuccessCascade(),  # type: ignore[arg-type]
             )
 
             write_calls_p2 = [c for c in fake_lithos.calls if c[0] == "lithos_write"]
@@ -344,8 +327,8 @@ class TestRssArchiveRecoveryFlow:
             assert "influx:deep-extracted" in p2_payload["tags"]
 
             # Tier 3 wrote its sections into the note content, not just the
-            # tag — Tier3SuccessCascade returns claims=["A recovered claim."],
-            # so the Cascade output is inserted via insert_tier3_sections.
+            # tag — Tier2Tier3SuccessCascade returns claims=["A recovered
+            # claim."], inserted via insert_tier3_sections.
             assert "## Claims" in p2_payload["content"]
             assert "A recovered claim." in p2_payload["content"]
 

--- a/tests/meta/test_no_stubs.py
+++ b/tests/meta/test_no_stubs.py
@@ -152,8 +152,10 @@ class TestNoStubMarkers:
 #     in src/influx/lithos_client.py.
 #
 # PRD 06 (Repair Sweep + text-terminal + Retry-Order):
-#   - Seam: Hooks for re_extract_archive, tier2_enrich, tier3_extract are
-#     test-injectable callables that PRD 07 wires to real implementations.
+#   - Seam: Hooks for re_extract_archive and text_extraction are
+#     test-injectable callables that PRD 07 wires to real implementations
+#     (Tier 2 / Tier 3 recovery moved onto the shared Cascade in finding 3,
+#     3a.2 / 3a.3).
 #   - Resolution: PRD 07 (Extraction + Enrichment) replaced all hook stubs
 #     with real extraction/enrichment logic.  Confirmed: no stub hooks
 #     remain in src/influx/repair_hooks.py or src/influx/repair.py.

--- a/tests/unit/test_repair_hook_rollback.py
+++ b/tests/unit/test_repair_hook_rollback.py
@@ -1,15 +1,15 @@
 """Unit tests for hook-mutation rollback (finding #1).
 
-Hooks (``archive_download``, ``re_extract_archive``, ``tier2_enrich``)
+Hooks (``archive_download``, ``re_extract_archive``, ``text_extraction``)
 receive the live mutable note dict.  When a hook raises
 ``ExtractionError`` / ``LithosError`` the sweep MUST treat that as
 "stage failed this pass" (per US-003 / US-013) and MUST NOT persist any
 partial in-place mutations the hook applied before raising.
 
-(Tier 3 is no longer a hook — it runs through the shared Cascade, which
-returns a value rather than mutating the note in place, so there is no
-partial-mutation to roll back.  The failing-Tier-3 invariant lives in
-``test_repair_sweep.py``.)
+(Tier 2 and Tier 3 are no longer hooks — they run through the shared
+Cascade, which returns a value rather than mutating the note in place,
+so there is no partial-mutation to roll back.  The failing-tier
+invariants live in ``test_repair_sweep.py``.)
 
 Each test below provides a fake hook that mutates ``note["tags"]`` (and
 sometimes ``note["content"]``) and then raises; the sweep is expected
@@ -335,48 +335,3 @@ class TestReExtractArchiveRollback:
 
         assert "influx:text-terminal" in result
         assert "text:abstract-only" in result
-
-
-# ── tier2_enrich rollback ───────────────────────────────────────────
-
-
-class TestTier2EnrichRollback:
-    """A failing tier2 hook must not leak ``full-text`` into the rewrite."""
-
-    async def test_tier2_hook_appends_full_text_then_raises(self) -> None:
-        items = [{"id": "n1", "title": "Paper"}]
-        # Score 9 ≥ default full_text threshold (8) so tier2 is selected.
-        read_notes = [
-            {
-                "id": "n1",
-                "title": "Paper",
-                "content": (
-                    "## Archive\npath: a.pdf\n"
-                    "## Profile Relevance\n"
-                    "### p\nScore: 9/10\n"
-                ),
-                "tags": [
-                    "influx:repair-needed",
-                    "text:html",
-                    "profile:p",
-                ],
-            }
-        ]
-
-        def bad_tier2(note: dict[str, object]) -> None:
-            tags = list(note.get("tags", []))  # type: ignore[arg-type]
-            tags.append("full-text")
-            note["tags"] = tags
-            raise ExtractionError("tier2 failed", stage="full-text")
-
-        config = _make_config()
-        client = _make_client(list_items=items, read_responses=read_notes)
-        hooks = SweepHooks(tier2_enrich=bad_tier2)
-
-        await sweep("p", client=client, config=config, hooks=hooks)
-
-        args = _last_write_args(client)
-        # full-text mutation from the failing hook MUST NOT survive.
-        assert "full-text" not in args["tags"]
-        # Stage failed so influx:repair-needed must remain.
-        assert "influx:repair-needed" in args["tags"]

--- a/tests/unit/test_repair_hooks.py
+++ b/tests/unit/test_repair_hooks.py
@@ -15,7 +15,6 @@ from influx.repair import (
     ExtractionOutcome,
     ReExtractArchiveHook,
     ReExtractionResult,
-    Tier2EnrichHook,
 )
 
 # ── Fake hook implementations for substitution tests ─────────────────
@@ -69,17 +68,6 @@ def _fake_re_extract_raises_lithos_error(
         "lithos write failed",
         operation="write_note",
         detail="version_conflict",
-    )
-
-
-def _fake_tier2(note: dict[str, object]) -> None:
-    pass
-
-
-def _fake_tier2_raises(note: dict[str, object]) -> None:
-    raise ExtractionError(
-        "tier2 failed",
-        stage="full-text",
     )
 
 
@@ -155,17 +143,6 @@ class TestReExtractArchiveHookSubstitution:
         hook: ReExtractArchiveHook = _fake_re_extract_raises_lithos_error
         with pytest.raises(LithosError):
             hook({"id": "n1"}, "arxiv/2025/01/123.pdf")
-
-
-class TestTier2EnrichHookSubstitution:
-    def test_success_callable(self) -> None:
-        hook: Tier2EnrichHook = _fake_tier2
-        hook({"id": "n1"})  # should not raise
-
-    def test_raises_extraction_error(self) -> None:
-        hook: Tier2EnrichHook = _fake_tier2_raises
-        with pytest.raises(ExtractionError):
-            hook({"id": "n1"})
 
 
 class TestNoteSourceUrlResolution:

--- a/tests/unit/test_repair_hooks_production.py
+++ b/tests/unit/test_repair_hooks_production.py
@@ -2,10 +2,12 @@
 
 Verifies that ``make_default_sweep_hooks`` creates hooks conforming to
 the PRD 06 signatures, that the ``re_extract_archive`` hook returns
-the correct ``ReExtractionResult`` variants, and that ``tier2_enrich``
-mutates the note dict correctly.  (Tier 3 recovery is no longer a
-production hook — it runs through the shared Cascade; its behaviour is
-covered by ``test_repair_sweep.py`` and ``test_cascade.py``.)
+the correct ``ReExtractionResult`` variants, and that
+``make_sweep_tier2_extractor`` turns an ``Acquired`` into a
+``Tier2Result`` (or raises the right counted/transient stage).  (Tier 2
+and Tier 3 recovery are no longer production hooks — they run through
+the shared Cascade; the sweep-level behaviour is covered by
+``test_repair_sweep.py`` and ``test_cascade.py``.)
 """
 
 from __future__ import annotations
@@ -16,6 +18,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from influx.cascade import Acquired, Tier2Result
 from influx.config import (
     AppConfig,
     ArchivePolicyConfig,
@@ -31,6 +34,7 @@ from influx.repair import (
 from influx.repair_hooks import (
     DefaultSweepHooks,
     make_default_sweep_hooks,
+    make_sweep_tier2_extractor,
 )
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -127,6 +131,17 @@ def _make_note_dict(
     }
 
 
+def _acquired(*, archive_path: str | None) -> Acquired:
+    """Build the minimal ``Acquired`` the sweep's Tier 2 extractor reads."""
+    return Acquired(
+        item_id="note-001",
+        source_url="https://arxiv.org/abs/2601.00001",
+        title="Test Paper Title",
+        abstract="",
+        archive_path=archive_path,
+    )
+
+
 # ── make_default_sweep_hooks ─────────────────────────────────────────
 
 
@@ -143,7 +158,6 @@ class TestMakeDefaultSweepHooks:
         assert isinstance(sweep_hooks, SweepHooks)
         assert sweep_hooks.archive_download is not None
         assert sweep_hooks.re_extract_archive is not None
-        assert sweep_hooks.tier2_enrich is not None
         assert sweep_hooks.text_extraction is not None
 
     def test_archive_download_wired(self, tmp_path: Path) -> None:
@@ -268,13 +282,18 @@ class TestReExtractArchiveReturnsReExtractionResult:
         assert isinstance(result, ReExtractionResult)
 
 
-# ── tier2_enrich hook ────────────────────────────────────────────────
+# ── make_sweep_tier2_extractor ───────────────────────────────────────
 
 
-class TestTier2EnrichSuccess:
-    """Production tier2_enrich inserts ## Full Text and full-text tag."""
+class TestSweepTier2ExtractorSuccess:
+    """The sweep's Tier 2 extractor re-extracts full text from the archive.
 
-    def test_inserts_full_text_section(self, tmp_path: Path) -> None:
+    Section insertion + the ``full-text`` tag are the Cascade's / sweep's
+    job now (covered by ``test_repair_sweep.py`` + ``test_canonical_note``);
+    the extractor only produces the ``Tier2Result``.
+    """
+
+    def test_extracts_pdf(self, tmp_path: Path) -> None:
         config = _make_config(tmp_path)
         archive_dir = Path(config.storage.archive_dir)
         (archive_dir / "papers").mkdir(parents=True)
@@ -282,66 +301,54 @@ class TestTier2EnrichSuccess:
         fixture_path = Path("tests/fixtures/extraction/sample.pdf")
         (archive_dir / pdf_path).write_bytes(fixture_path.read_bytes())
 
-        hooks = make_default_sweep_hooks(config)
-        note = _make_note_dict(archive_path=pdf_path)
+        extractor = make_sweep_tier2_extractor(config)
+        result = extractor(_acquired(archive_path=pdf_path))
 
-        hooks.tier2_enrich(note)
+        assert isinstance(result, Tier2Result)
+        assert result.text
+        assert result.flavour == "pdf"
+        assert result.text_tag == "text:pdf"
 
-        content: str = str(note["content"])
-        assert "## Full Text" in content
-
-    def test_adds_full_text_tag(self, tmp_path: Path) -> None:
-        config = _make_config(tmp_path)
+    def test_extracts_html(self, tmp_path: Path) -> None:
+        config = _make_config(tmp_path, min_html_chars=10)
         archive_dir = Path(config.storage.archive_dir)
-        (archive_dir / "papers").mkdir(parents=True)
-        pdf_path = "papers/test.pdf"
-        fixture_path = Path("tests/fixtures/extraction/sample.pdf")
-        (archive_dir / pdf_path).write_bytes(fixture_path.read_bytes())
+        (archive_dir / "pages").mkdir(parents=True)
+        html_path = "pages/article.html"
+        fixture_path = Path("tests/fixtures/extraction/good_article.html")
+        (archive_dir / html_path).write_bytes(fixture_path.read_bytes())
 
-        hooks = make_default_sweep_hooks(config)
-        note = _make_note_dict(archive_path=pdf_path)
+        extractor = make_sweep_tier2_extractor(config)
+        result = extractor(_acquired(archive_path=html_path))
 
-        hooks.tier2_enrich(note)
+        assert result.text
+        assert result.flavour == "html"
+        assert result.text_tag == "text:html"
 
-        tags: list[str] = list(note.get("tags", []))
-        assert "full-text" in tags
 
-    def test_does_not_duplicate_full_text_tag(self, tmp_path: Path) -> None:
+class TestSweepTier2ExtractorFailure:
+    """The extractor raises ``ExtractionError`` so the Cascade can classify it."""
+
+    def test_raises_counted_parse_on_no_archive_path(self, tmp_path: Path) -> None:
         config = _make_config(tmp_path)
-        archive_dir = Path(config.storage.archive_dir)
-        (archive_dir / "papers").mkdir(parents=True)
-        pdf_path = "papers/test.pdf"
-        fixture_path = Path("tests/fixtures/extraction/sample.pdf")
-        (archive_dir / pdf_path).write_bytes(fixture_path.read_bytes())
+        extractor = make_sweep_tier2_extractor(config)
 
-        hooks = make_default_sweep_hooks(config)
-        note = _make_note_dict(archive_path=pdf_path)
-        note["tags"] = list(note["tags"]) + ["full-text"]
+        with pytest.raises(ExtractionError) as exc_info:
+            extractor(_acquired(archive_path=None))
 
-        hooks.tier2_enrich(note)
+        # Counted stage: a note that never gains an archive still trips
+        # the Tier-2 cap, exactly as the old hook raised.
+        assert exc_info.value.stage == "parse"
 
-        tags: list[str] = list(note.get("tags", []))
-        assert tags.count("full-text") == 1
-
-
-class TestTier2EnrichFailure:
-    """tier2_enrich raises ExtractionError on failure."""
-
-    def test_raises_on_missing_archive(self, tmp_path: Path) -> None:
+    def test_raises_transient_read_on_missing_file(self, tmp_path: Path) -> None:
         config = _make_config(tmp_path)
-        hooks = make_default_sweep_hooks(config)
-        note = _make_note_dict(archive_path="papers/missing.pdf")
+        extractor = make_sweep_tier2_extractor(config)
 
-        with pytest.raises(ExtractionError):
-            hooks.tier2_enrich(note)
+        with pytest.raises(ExtractionError) as exc_info:
+            extractor(_acquired(archive_path="papers/missing.pdf"))
 
-    def test_raises_on_no_archive_path(self, tmp_path: Path) -> None:
-        config = _make_config(tmp_path)
-        hooks = make_default_sweep_hooks(config)
-        note = _make_note_dict(archive_path=None)
-
-        with pytest.raises(ExtractionError):
-            hooks.tier2_enrich(note)
+        # Transient: the archive file is expected but temporarily unreadable,
+        # so the counter must not advance.
+        assert exc_info.value.stage == "archive_read"
 
 
 # NOTE: the ## Full Text / Tier 3 section-shape helpers moved to
@@ -360,21 +367,21 @@ class TestSweepHooksInjectionSeam:
         """Test injection via SweepHooks still works."""
         call_count = 0
 
-        def fake_tier2(note: dict[str, object]) -> None:
+        def fake_text_extraction(note: dict[str, object]) -> str:
             nonlocal call_count
             call_count += 1
+            return "text:html"
 
-        hooks = SweepHooks(tier2_enrich=fake_tier2)
+        hooks = SweepHooks(text_extraction=fake_text_extraction)
         # Narrow the optional callable; this is the test-injection seam,
         # not the production-default factory.
-        assert hooks.tier2_enrich is not None
-        hooks.tier2_enrich({"id": "n1"})
+        assert hooks.text_extraction is not None
+        assert hooks.text_extraction({"id": "n1"}) == "text:html"
         assert call_count == 1
 
     def test_empty_sweep_hooks_has_none_hooks(self) -> None:
         hooks = SweepHooks()
         assert hooks.re_extract_archive is None
-        assert hooks.tier2_enrich is None
         assert hooks.archive_download is None
         assert hooks.text_extraction is None
 

--- a/tests/unit/test_repair_sweep.py
+++ b/tests/unit/test_repair_sweep.py
@@ -936,6 +936,161 @@ class TestStageFailureLogging:
         assert "influx:tier2-terminal" not in rewritten["tags"]
 
 
+# ── Tier 2 recovery via the shared Cascade (3a.3) ────────────────────
+
+
+class TestSweepTier2RecoveryViaCascade:
+    """Tier 2 recovery runs through the injected Cascade (3a.3): the sweep
+    reconstructs an ``Acquired`` from the persisted note, hands its archive
+    path to the Cascade's extractor, and persists the outcome (full text on
+    success; advanced ``## Repair`` counters + ``influx:tier2-terminal`` at
+    the cap).  These prove the sweep-level handoff/persistence that the
+    permissive fake-Cascade integration test cannot.
+    """
+
+    @staticmethod
+    def _note_for_tier2(
+        note_id: str, *, score: int = 8, repair_section: str = ""
+    ) -> dict[str, Any]:
+        # No ## Full Text so tier2 is selected; score 8 keeps tier3 (needs
+        # >= 9) out, isolating the Tier-2 path in a single-cascade sweep.
+        body = (
+            "---\n"
+            f"source_url: https://example.com/{note_id}\n"
+            "tags: []\n"
+            "confidence: 0.9\n"
+            "---\n"
+            "# Paper\n\n"
+            "## Archive\n"
+            "path: arxiv/2026/04/paper.pdf\n\n"
+            "## Summary\nSummary\n\n"
+            f"{repair_section}"
+            "## Profile Relevance\n"
+            f"### ai-robotics\nScore: {score}/10\nRelevant\n\n"
+            "## User Notes\n"
+        )
+        return {
+            "id": note_id,
+            "title": "Paper",
+            "content": body,
+            "tags": ["influx:repair-needed", "text:html"],
+            "source_url": f"https://example.com/{note_id}",
+            "confidence": 0.9,
+        }
+
+    @staticmethod
+    def _last_write_args(client: AsyncMock) -> dict[str, Any]:
+        write_calls = [
+            c for c in client.call_tool.call_args_list if c.args[0] == "lithos_write"
+        ]
+        assert write_calls, "expected lithos_write call"
+        return dict(write_calls[-1].args[1])
+
+    async def test_tier2_success_recovers_full_text_and_clears_repair_needed(
+        self,
+    ) -> None:
+        """Real Cascade + archive-reading extractor: the reconstructed
+        ``Acquired`` carries the note's persisted archive path, the recovered
+        text lands as ``## Full Text`` + ``full-text``, and — Tier 3 not
+        required at score 8 — ``influx:repair-needed`` clears."""
+        items = [{"id": "n1", "title": "Paper"}]
+        note = self._note_for_tier2("n1", score=8)
+
+        seen: list[str | None] = []
+
+        def extractor(acquired: Acquired) -> Tier2Result:
+            # Prove the persisted ## Archive path reached the extractor —
+            # a bug reconstructing archive_path (e.g. None) fails here.
+            seen.append(acquired.archive_path)
+            return Tier2Result(
+                text="Recovered full text body.",
+                flavour="html",
+                text_tag="text:html",
+            )
+
+        config = _make_config()
+        client = _make_client(list_items=items, read_responses=[note])
+
+        await sweep(
+            "ai-robotics",
+            client=client,
+            config=config,
+            hooks=SweepHooks(),
+            cascade=_build_sweep_cascade(
+                config, "ai-robotics", tier2_extractor=extractor
+            ),
+        )
+
+        # The reconstructed Acquired carried the persisted archive path.
+        assert seen == ["arxiv/2026/04/paper.pdf"]
+
+        rewritten = self._last_write_args(client)
+        assert "## Full Text" in rewritten["content"]
+        assert "Recovered full text body." in rewritten["content"]
+        assert "full-text" in rewritten["tags"]
+        # Archive + text + full-text present, Tier 3 waived at score 8.
+        assert "influx:repair-needed" not in rewritten["tags"]
+
+    async def test_tier2_counted_failure_at_cap_flips_terminal_and_logs(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """At the counted-failure cap the sweep persists ``tier2_attempts: 3``,
+        adds ``influx:tier2-terminal``, and logs
+        ``sweep_stage=tier2_terminal_flip`` — the persistence/logging step
+        that lives in repair.py, not cascade.py."""
+        import logging
+
+        items = [{"id": "n1", "title": "Paper"}]
+        note = self._note_for_tier2(
+            "n1",
+            score=8,
+            repair_section=(
+                "## Repair\n"
+                "- tier2_attempts: 2\n"
+                '- tier2_last_stage: "parse"\n'
+                '- tier2_last_error: "earlier failure"\n'
+                "- tier3_attempts: 0\n"
+                '- tier3_last_stage: ""\n'
+                '- tier3_last_error: ""\n\n'
+            ),
+        )
+
+        def failing(acquired: Acquired) -> Tier2Result:
+            del acquired
+            raise ExtractionError("archive unparseable", stage="parse")
+
+        config = _make_config()
+        client = _make_client(list_items=items, read_responses=[note])
+
+        with caplog.at_level(logging.WARNING, logger="influx.repair"):
+            await sweep(
+                "ai-robotics",
+                client=client,
+                config=config,
+                hooks=SweepHooks(),
+                cascade=_build_sweep_cascade(
+                    config, "ai-robotics", tier2_extractor=failing
+                ),
+            )
+
+        rewritten = self._last_write_args(client)
+        assert "influx:tier2-terminal" in rewritten["tags"]
+        assert "tier2_attempts: 3" in rewritten["content"]
+        # Stage still failed → repair-needed stays for the (now-capped) note.
+        assert "influx:repair-needed" in rewritten["tags"]
+
+        flip_logs = [
+            r
+            for r in caplog.records
+            if getattr(r, "sweep_stage", None) == "tier2_terminal_flip"
+        ]
+        assert flip_logs, "expected tier2_terminal_flip log"
+        rec = flip_logs[0]
+        assert getattr(rec, "tier2_attempts", None) == 3
+        assert getattr(rec, "stage", None) == "parse"
+
+
 # ── Layer 2 self-repair: counter + terminal flip ─────────────────────
 
 

--- a/tests/unit/test_repair_sweep.py
+++ b/tests/unit/test_repair_sweep.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from influx.cascade import Acquired, Tier2Result
 from influx.config import AppConfig, RepairConfig
 from influx.errors import ExtractionError, LCMAError, LithosError
 from influx.repair import (
@@ -863,47 +864,76 @@ class TestStageFailureLogging:
         ]
         assert 'tier3_last_stage: "validate"' in write_calls[-1].args[1]["content"]
 
-    async def test_tier2_failure_logs_warning_with_extra(
-        self,
-        caplog: pytest.LogCaptureFixture,
-    ) -> None:
-        import logging
+    async def test_tier2_counted_failure_persists_counter_via_cascade(self) -> None:
+        """The sweep now runs Tier 2 through the shared Cascade (3a.3).
 
+        Unlike Tier 1 / Tier 3, a Tier-2 failure degrades *silently* at the
+        Cascade level (no per-pass WARNING) — but a counted-class failure
+        (here an unparseable archive → ``parse``) still advances the durable
+        ``## Repair`` counter and keeps ``influx:repair-needed`` for the next
+        pass, because ``enrich`` owns the counter lifecycle.
+        """
+        # Score 8 selects tier2 (>= full_text 8) but not tier3 (< deep_extract
+        # 9), isolating the Tier-2 path in a single-cascade sweep.
+        content = (
+            "---\n"
+            "source_url: https://example.com/n2\n"
+            "tags: []\n"
+            "confidence: 0.9\n"
+            "---\n"
+            "# Paper\n\n"
+            "## Archive\n"
+            "path: arxiv/2026/04/paper.pdf\n\n"
+            "## Summary\n"
+            "Summary\n\n"
+            "## Profile Relevance\n"
+            "### ai-robotics\n"
+            "Score: 8/10\n"
+            "Relevant\n\n"
+            "## User Notes\n"
+        )
+        note = {
+            "id": "n2",
+            "title": "Paper",
+            "content": content,
+            "tags": ["influx:repair-needed", "text:html"],
+            "source_url": "https://example.com/n2",
+            "confidence": 0.9,
+        }
         items = [{"id": "n2", "title": "Paper"}]
-        note = self._note("n2", with_full_text=False)
-        # Strip ``full-text`` so tier2_retry is selected.
-        note["tags"] = ["influx:repair-needed", "text:html"]
 
-        def failing(note: dict[str, object]) -> None:
-            del note
-            raise LCMAError(
-                "Tier 2 enrichment HTTP failure",
-                model="enrich",
-                stage="http",
-                detail="connect timeout",
+        def failing_extractor(acquired: Acquired) -> Tier2Result:
+            del acquired
+            raise ExtractionError(
+                "archive unparseable",
+                stage="parse",
+                detail="counted failure",
             )
 
         config = _make_config()
         client = _make_client(list_items=items, read_responses=[note])
 
-        with caplog.at_level(logging.WARNING, logger="influx.repair"):
-            await sweep(
-                "ai-robotics",
-                client=client,
-                config=config,
-                hooks=SweepHooks(tier2_enrich=failing),
-            )
+        await sweep(
+            "ai-robotics",
+            client=client,
+            config=config,
+            hooks=SweepHooks(),
+            cascade=_build_sweep_cascade(
+                config, "ai-robotics", tier2_extractor=failing_extractor
+            ),
+        )
 
-        matching = [
-            r
-            for r in caplog.records
-            if getattr(r, "sweep_stage", None) == "tier2_enrichment"
+        write_calls = [
+            c for c in client.call_tool.call_args_list if c.args[0] == "lithos_write"
         ]
-        assert matching
-        rec = matching[0]
-        assert getattr(rec, "exc_type", None) == "LCMAError"
-        assert getattr(rec, "stage", None) == "http"
-        assert rec.exc_info is not None
+        rewritten = write_calls[-1].args[1]
+        # Counted failure advanced the durable counter + persisted the stage.
+        assert "tier2_attempts: 1" in rewritten["content"]
+        assert 'tier2_last_stage: "parse"' in rewritten["content"]
+        # Stage failed → repair-needed stays, full-text not added, not terminal.
+        assert "influx:repair-needed" in rewritten["tags"]
+        assert "full-text" not in rewritten["tags"]
+        assert "influx:tier2-terminal" not in rewritten["tags"]
 
 
 # ── Layer 2 self-repair: counter + terminal flip ─────────────────────


### PR DESCRIPTION
**PR 3 of the finding-3a stack** (repair sweep reuses the Cascade — Lithos task `62aa58f4`, design in finding `6cea71c7`). Follows #259 (3a.2). This routes the sweep's **Tier 2** recovery through the shared `Cascade.enrich` instead of the bespoke `tier2_enrich` hook, deleting the last full-text enrichment duplication in `repair_hooks`.

Scoped to **Tier 2 only** (the source-agnostic *archive re-extraction* path — reads the note's already-downloaded archive, not the create-path fetch). Tier 1 recovery is 3a.4; the `_(proposed)_` marker cleanup is 3a.5.

## What changed

### Sweep runs Tier 2 through the Cascade
`_run_tier2_via_cascade` reconstructs an `Acquired` from the persisted note (doc-title, id, `## Archive` path → `archive_path`, `extracted_text=None` so the Tier-2 gate fires) and runs `enrich(acquired, score, stages={"tier2"}, counters=parse(## Repair))`. On success it inserts `## Full Text` + the `full-text` tag; on a counted failure it persists the advanced counters and flips `influx:tier2-terminal` at the cap — **`enrich` owns the counter lifecycle** (3a.1 Fork 6). A missing archive path stays a counted `parse` failure exactly as the old hook raised, so the Tier-2 cap still trips for a note that never gains an archive.

The Tier-2 and Tier-3 failure handlers now share `_apply_enrich_recovery_failure` (persist advanced counters, apply the newly-tripped terminal flag, emit the terminal-flip WARNING).

### The sweep's Tier-2 extractor
`repair_hooks.make_sweep_tier2_extractor(config)` builds the `influx.cascade.Tier2Extractor` — a source-agnostic `(Acquired) -> Tier2Result` closure over the existing `_read_archive_file` + `_extract_from_archive` helpers. `sweep()` wires it into `_build_sweep_cascade` when `hooks is None`; an absent cascade skips **both** tiers, exactly like an absent hook skips its stage.

The counted-vs-transient contract is preserved: no archive path → `parse` (**counted**, advances the counter); `archive_read` / `extract` / `min_length` → **transient** (repair-needed stays, no advance).

### Deleted the tier2 hook
`SweepHooks.tier2_enrich`, the `Tier2EnrichHook` protocol, `repair_hooks._make_tier2_enrich_hook`, the `DefaultSweepHooks` / `to_sweep_hooks` / `make_default_sweep_hooks` wiring, and the now-unused `_run_tier_retry` (both tiers run via `enrich`).

## Observability note (behaviour change, called out)
Tier-2 failures now degrade **silently** at the Cascade level — only Tier 1 / Tier 3 log a per-pass WARNING; Tier 2 just falls back to abstract-only + `influx:repair-needed`. This drops the old sweep-level `tier2_enrichment` WARNING (with `exc_info`) for per-pass failures. The counted **stage + error still survive durably** in the note's `## Repair` counters (`tier2_last_stage` / `tier2_last_error`), and the sweep still emits the `tier2_terminal_flip` WARNING at the cap — so root cause stays recoverable.

## Test migration
- **Unit** — `make_sweep_tier2_extractor` is covered directly (PDF/HTML `Tier2Result`; counted `parse` on no-path, transient `archive_read` on missing file). The sweep's Tier-2 failure test now drives a **real Cascade + fake `tier2_extractor`** and asserts the durable `## Repair` counter advance + repair-needed retention (Score 8 isolates Tier 2 from Tier 3).
- **Integration** (zero-monkeypatch) — the RSS recovery pass-2 injects one `Tier2Tier3SuccessCascade` fake driving both tiers via `sweep(cascade=...)`; the high-score-terminal test's single `SpyCascade` now proves **both** tiers are skipped. Removed the obsolete `Tier2EnrichHook` substitution test and the `tier2_enrich` rollback test (their premise — a hook mutating-then-raising — no longer exists; the extractor returns a value).

## Test plan
- [x] `make check` green — full suite; only the pre-existing `test_run_conflict_exit_1` subprocess-timeout flake (confirmed identical on clean `main`).
- [x] All migrated repair unit + integration sweep tests pass (151 in the touched files).
- [x] No `docs/generated/` drift — the `Repair → Enrich` component edge already existed (via `repair_hooks → enrich`), now fully realised via `repair → cascade`.
- [x] pyright + ruff (check + format) clean.

## Next in the stack
3a.4 routes **Tier 1** recovery through the Cascade (extend `_reconstruct_acquired` with `abstract`, regenerate `## Summary`). Then 3a.5 (cleanup + drop the `_(proposed)_` markers; possibly fold Tier 2 + Tier 3 into one `enrich` call).
