### PR TITLE
docs(context): close out finding-3a — drop stale _(proposed)_ markers (3a.5)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,20 +24,20 @@ The score-gated entry to ingestion. Calls `models.filter` with the configured pr
 _Avoid_: classifier, scorer.
 
 **Cascade**:
-The score-gated enrichment pipeline that turns an **Acquired** item into **EnrichedSections**: Tier 1 summary at `score >= relevance`, Tier 2 full text at `score >= full_text`, Tier 3 deep extraction at `score >= deep_extract`. _(proposed as a single module shared across Sources)_
+The score-gated enrichment pipeline that turns an **Acquired** item into **EnrichedSections**: Tier 1 summary at `score >= relevance`, Tier 2 full text at `score >= full_text`, Tier 3 deep extraction at `score >= deep_extract`.
 _Avoid_: enrichment chain, tier pipeline.
 
 **Tier 1 / Tier 2 / Tier 3**:
 The three enrichment levels, each gated by a different threshold and producing different note sections. Tier 1 = `models.enrich` summary. Tier 2 = full text extraction. Tier 3 = `models.extract` claims/datasets/builds_on/open_questions/potential_connections.
 
 **Acquired**:
-The bundle a **Source** produces for one Candidate after download/archive/extract: identity, source URL, archive path (or repair flag), extracted text (or `None`), text source flavour (`html`/`pdf`/`summary-fallback`), and source-specific signals (e.g. `archive_terminal`). _(proposed)_
+The bundle a **Source** produces for one Candidate after download/archive/extract: identity, source URL, archive path (or repair flag), extracted text (or `None`), text source flavour (`html`/`pdf`/`summary-fallback`), and source-specific signals (e.g. `archive_terminal`).
 
 **EnrichedSections**:
-The **Cascade**'s output for one Acquired: optional Tier 1 result, optional full text + flavour, optional Tier 3 result, plus `repair_flags` and `terminal_flags` for the Renderer to apply as note tags. _(proposed)_
+The **Cascade**'s output for one Acquired: optional Tier 1 result, optional full text + flavour, optional Tier 3 result, plus `repair_flags` and `terminal_flags` for the Renderer to apply as note tags.
 
 **Renderer**:
-Produces a **CanonicalNote** from an Acquired plus EnrichedSections plus the score/reason. Owns the canonical Markdown shape from spec section 9. _(proposed as a separate module from the cascade)_
+Produces a **CanonicalNote** from an Acquired plus EnrichedSections plus the score/reason. Owns the canonical Markdown shape from spec section 9.
 
 **CanonicalNote**:
 An Influx-authored Markdown note: typed frontmatter, fixed section order (`## Archive`, `## Summary`, `## Full Text`, `## Claims`, `## Datasets & Benchmarks`, `## Builds On`, `## Open Questions`, `## Profile Relevance`, `## User Notes`), and stable tag conventions. `## User Notes` is preserved byte-exactly across rewrites.

--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -1126,7 +1126,8 @@ def _run_text_extraction_retry(
 # hooks: reconstruct an ``Acquired`` from the persisted note, run only the
 # stage being retried with the note's ``## Repair`` counters, and apply the
 # outcome surgically via the canonical section ops.  Tier 1 recovery stays
-# outside the Cascade for now — 3a.4.
+# outside the Cascade: re-running Tier 1 needs the source abstract, which a
+# note does not persist, so it awaits the Source-seam re-acquire (finding 3b).
 
 _TIER2_ONLY: frozenset[Tier] = frozenset(("tier2",))
 _TIER3_ONLY: frozenset[Tier] = frozenset(("tier3",))
@@ -1168,8 +1169,10 @@ def _reconstruct_acquired(
     reads ``extracted_text`` (the note's existing full text).  ``title``
     comes from the note's doc-level title (``read_note`` strips the
     ``# Title`` from ``content``), a strictly more reliable source than the
-    old hooks' parse of the stripped body.  Tier 1 (3a.4) will add
-    ``abstract``.
+    old hooks' parse of the stripped body.  ``abstract`` stays ``""``: Tier 1
+    recovery needs the source abstract, which the note does not persist, so
+    it awaits the Source-seam re-acquire (finding 3b) rather than this
+    note-only reconstruction.
     """
     return Acquired(
         item_id=str(note.get("id") or ""),


### PR DESCRIPTION
**PR 5 of the finding-3a stack** (repair sweep reuses the Cascade — Lithos task `62aa58f4`). Follows #260 (3a.3). This is the **cleanup / close-out** PR: doc + comment only, no behaviour change.

## What changed

### Drop stale `_(proposed)_` markers (CONTEXT.md)
Cascade, Acquired, EnrichedSections, and Renderer all landed across the CONTEXT-unification and 3a.1–3a.3 work, so their "proposed" markers are stale — dropped.

**Kept** (deliberately):
- **Source** — the unified Source seam is finding 2, not done. Marker stays.
- **RepairCounters** — the *module* landed, but "shared between the create path and the repair sweep" is only half-realised (the create path still passes no counters; making create-path counters real-or-removed is an open finding-3 decision). Marker stays until that lands.

### Reword the two stale `3a.4` comments (`repair.py`)
The Tier 2 / Tier 3 recovery section header and `_reconstruct_acquired` both pointed Tier 1 recovery at an imminent "3a.4". Tier 1 recovery is now **deferred** — re-running `tier1_enrich` needs the source **abstract**, which a note does not persist:
- the create path suppresses `## Summary` entirely on a Tier-1 failure, and
- the abstract only appears in the transient `abstract_or_summary` dedup field, never as durable note metadata / a rendered section.

So Tier 1 is exactly the case where "rebuild `Acquired` from the persisted note" breaks down — it awaits the **Source-seam re-acquire (finding 3b)**, not a note-only reconstruction. The comments now say so.

## Why Tier 1 recovery isn't in this stack
Full write-up in Lithos finding `821dc209` on task `62aa58f4`. Short version: Tier 2/3 recovery worked because their inputs (`## Archive` path, `## Full Text`) **are** persisted; Tier 1's input (the abstract) is not, so it belongs on the 3b/finding-2 track. A **secondary bug** is logged there too — `compute_clearing` has no Tier-1 term, so a note whose only defect is a missing summary gets `influx:repair-needed` silently cleared; the proper fix (a `tier1-terminal`/exemption concept) rides along with the 3b re-acquire.

Deliberately **out of scope**: folding Tier 2 + Tier 3 into a single `enrich(stages={t2,t3})` call — that's a behaviour-adjacent consolidation (shared counter read, single reconstructed `Acquired` whose `extracted_text` means different things per selected stage), not cleanup. Held for a separate change.

## Test plan
- [x] `make check` green (only the pre-existing `test_run_conflict_exit_1` sandbox subprocess-timeout flake).
- [x] `make diagrams` — **no `docs/generated/` drift** (comment line-count changes don't move any architecture metric).
- [x] ruff (check + format) + pyright clean.

This closes the finding-3a stack (3a.1 → 3a.5). Tier 1 recovery + the create-path-counters decision live on the finding-2 / 3b track.
