### PR TITLE
refactor(sources): drive RSS ingestion through RssSource in production (2.1)

### DIFF
--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -861,43 +861,76 @@ class RssSource:
     ) -> list[Candidate]:
         """Fetch every configured feed and flatten into a list of Candidates.
 
+        Composes :meth:`fetch_feed_candidates` across the profile's feeds.
         Each :class:`Candidate.payload` is the original
         :class:`RssFeedItem`, so :meth:`acquire` can reconstruct the
         feed-specific metadata (source_tag, feed_name) without a
         secondary lookup.
         """
         del kind, run_range
-        config = self._config
         candidates: list[Candidate] = []
         for feed_entry in profile_cfg.sources.rss:
-            items = await _fetch_rss_feed(
-                feed_entry,
-                self._cache,
-                max_download_bytes=config.storage.max_download_bytes,
-                timeout_seconds=config.storage.download_timeout_seconds,
-                profile=profile_cfg.name,
-                resilience=config.resilience,
+            candidates.extend(
+                await self.fetch_feed_candidates(feed_entry, profile_cfg=profile_cfg)
             )
-            metrics.candidates_fetched().add(
-                len(items), {"profile": profile_cfg.name, "source": "rss"}
-            )
-            # #85: per-feed pre-filter count.  Multiple feeds on one
-            # profile accumulate.  Sum-of-feeds is the correct
-            # ``fetched_total`` for filter_stall discrimination — what
-            # matters is whether ANY items reached the filter, not
-            # which feed they came from.
-            record_fetched_items(len(items))
-            for item in items:
-                candidates.append(
-                    Candidate(
-                        item_id=_rss_filter_id(item),
-                        title=item.title,
-                        abstract=item.summary,
-                        source_url=item.url,
-                        payload=item,
-                    )
-                )
         return candidates
+
+    async def fetch_feed_candidates(
+        self,
+        feed_entry: RssSourceEntry,
+        *,
+        profile_cfg: ProfileConfig,
+    ) -> list[Candidate]:
+        """Fetch a single feed and wrap its items as :class:`Candidate` records.
+
+        The per-feed fetch unit shared by :meth:`fetch_candidates` (which
+        flattens across the profile's feeds) and
+        :func:`make_rss_item_provider` (which keeps the per-feed boundary so
+        :func:`_score_rss_items` scores each feed independently).  Emits the
+        per-feed fetch telemetry: ``candidates_fetched`` + the run-level
+        ``fetched_total`` count (#85) plus the fetch start/complete INFO logs.
+        """
+        config = self._config
+        profile = profile_cfg.name
+        _log.info(
+            "rss feed fetch started profile=%s feed=%r url=%s source_tag=%s",
+            profile,
+            feed_entry.name,
+            feed_entry.url,
+            feed_entry.source_tag,
+        )
+        items = await _fetch_rss_feed(
+            feed_entry,
+            self._cache,
+            max_download_bytes=config.storage.max_download_bytes,
+            timeout_seconds=config.storage.download_timeout_seconds,
+            profile=profile,
+            resilience=config.resilience,
+        )
+        metrics.candidates_fetched().add(
+            len(items), {"profile": profile, "source": "rss"}
+        )
+        # #85: per-feed pre-filter count.  Multiple feeds on one profile
+        # accumulate.  Sum-of-feeds is the correct ``fetched_total`` for
+        # filter_stall discrimination — what matters is whether ANY items
+        # reached the filter, not which feed they came from.
+        record_fetched_items(len(items))
+        _log.info(
+            "rss feed fetch completed profile=%s feed=%r items=%d",
+            profile,
+            feed_entry.name,
+            len(items),
+        )
+        return [
+            Candidate(
+                item_id=_rss_filter_id(item),
+                title=item.title,
+                abstract=item.summary or "",
+                source_url=item.url,
+                payload=item,
+            )
+            for item in items
+        ]
 
     def acquire(
         self,
@@ -965,6 +998,13 @@ def make_rss_item_provider(
             _log.info("rss source skipped profile=%s reason=unknown_profile", profile)
             return ()
 
+        # ── Source.fetch_feed_candidates + Source.acquire (issue #57) ──
+        # Fetch and acquire route through the RssSource adapter; scoring
+        # stays on the per-feed boundary (one ``_score_rss_items`` call per
+        # feed) so chunk packing and filter-error granularity are
+        # unchanged.  Unifying scoring onto the Filter seam is finding 2.3.
+        source = RssSource(config, fetch_cache=cache)
+
         # ── Telemetry: influx.fetch.rss span (FR-OBS-4) ──
         _tracer = get_tracer()
         with _tracer.span(
@@ -977,33 +1017,10 @@ def make_rss_item_provider(
         ) as fetch_span:
             bounds: list[BoundScoredCandidate] = []
             for feed_entry in profile_cfg.sources.rss:
-                _log.info(
-                    "rss feed fetch started profile=%s feed=%r url=%s source_tag=%s",
-                    profile,
-                    feed_entry.name,
-                    feed_entry.url,
-                    feed_entry.source_tag,
+                candidates = await source.fetch_feed_candidates(
+                    feed_entry, profile_cfg=profile_cfg
                 )
-                items = await _fetch_rss_feed(
-                    feed_entry,
-                    cache,
-                    max_download_bytes=config.storage.max_download_bytes,
-                    timeout_seconds=config.storage.download_timeout_seconds,
-                    profile=profile,
-                    resilience=config.resilience,
-                )
-                metrics.candidates_fetched().add(
-                    len(items), {"profile": profile, "source": "rss"}
-                )
-                # #85: per-feed pre-filter count for the run-level
-                # ``fetched_total`` (filter_stall vs fetch_stall split).
-                record_fetched_items(len(items))
-                _log.info(
-                    "rss feed fetch completed profile=%s feed=%r items=%d",
-                    profile,
-                    feed_entry.name,
-                    len(items),
-                )
+                items = [c.payload for c in candidates]
                 try:
                     scores = await _score_rss_items(
                         items=items,
@@ -1033,8 +1050,9 @@ def make_rss_item_provider(
                 )
                 drop_attrs = {"profile": profile, "decision": "drop"}
                 pass_attrs = {"profile": profile, "decision": "pass"}
-                for item in items:
-                    scored = scores.get(_rss_filter_id(item))
+                for cand in candidates:
+                    item = cand.payload
+                    scored = scores.get(cand.item_id)
                     if scored is None:
                         metrics.articles_filtered().add(1, drop_attrs)
                         _log.info(
@@ -1079,18 +1097,12 @@ def make_rss_item_provider(
                     # Issue #125: emit a BoundScoredCandidate so the Run
                     # stage can run pre-acquire ``lithos_cache_lookup``
                     # before paying the article fetch / archive / extract
-                    # cost.  ``build_rss_note_item`` is the per-item
-                    # acquire entrypoint; issue #124's ``asyncio.to_thread``
-                    # offload moves into the closure, fired only when the
+                    # cost.  ``Source.acquire`` is the per-item acquire
+                    # entrypoint; issue #124's ``asyncio.to_thread`` offload
+                    # moves into the closure, fired only when the
                     # orchestrator decides this candidate must be acquired.
                     sc = ScoredCandidate(
-                        candidate=Candidate(
-                            item_id=_rss_filter_id(item),
-                            title=item.title,
-                            abstract=item.summary or "",
-                            source_url=item.url,
-                            payload=item,
-                        ),
+                        candidate=cand,
                         score=scored.score,
                         confidence=1.0,
                         reason=scored.reason,
@@ -1098,18 +1110,13 @@ def make_rss_item_provider(
                     )
 
                     async def _acquire(
-                        item: RssFeedItem = item,
-                        scored: Any = scored,
+                        sc: ScoredCandidate = sc,
                     ) -> dict[str, Any] | None:
                         return await asyncio.to_thread(
-                            build_rss_note_item,
-                            item=item,
-                            profile_name=profile,
+                            source.acquire,
+                            sc,
+                            profile_cfg=profile_cfg,
                             config=config,
-                            score=scored.score,
-                            confidence=1.0,
-                            reason=scored.reason,
-                            filter_tags=scored.tags,
                         )
 
                     bounds.append(


### PR DESCRIPTION
**PR 1 of the finding-2 stack** (finish the Source seam — Lithos task `989db18f`). Behaviour-preserving; `src/influx/sources/rss.py` only.

## Problem

Only arXiv is driven through the `Source` protocol in production. `make_rss_item_provider` re-inlined its own per-feed fetch loop and its acquire closure called `build_rss_note_item` directly — so `RssSource` was instantiated **only by tests**: a real seam's name on a test-only object.

## What changed

Route both the fetch and acquire stages through the `RssSource` adapter, mirroring `make_arxiv_item_provider`:

- **Extract `RssSource.fetch_feed_candidates`** — the per-feed fetch + `Candidate`-wrap unit (fetch → `candidates_fetched` metric → `fetched_total` count (#85) → start/complete INFO logs → wrap). The flat `fetch_candidates` protocol method now **composes** it across the profile's feeds, so the fetch logic lives once instead of being duplicated between `fetch_candidates` and the provider.
- **The provider constructs one `RssSource`** and drives it: `fetch_feed_candidates` per feed, then `Source.acquire` inside the bound acquire closure — replacing the inline `build_rss_note_item` call. The kwargs are identical (`item`, `profile_name`, `config`, `score`, `confidence=1.0`, `reason`, `filter_tags`), so the output is identical.

## What deliberately did *not* change

Scoring stays on the **per-feed boundary** — one `_score_rss_items` call per feed. `RssSource.fetch_candidates` flattens across feeds, but routing production scoring through the flat list would repack the LLM batches (fewer, fuller chunks → different request count) and change per-feed `filter_error` granularity. That unification belongs to **finding 2.3** (unify scoring on the `Filter` seam), so it's held back here to keep 2.1 behaviour-preserving.

## Behaviour note (one intentional cross-path change)

`fetch_candidates` now normalises `Candidate.abstract` to `item.summary or ""` (was `item.summary`). This matches what the production provider already emitted — it aligns the previously test-only protocol path with prod, and is the only observable delta. The production path is unchanged.

## Test plan
- [x] `make check` green — ruff (check + format) + pyright clean; `2679 passed`, only the pre-existing `test_run_conflict_exit_1` sandbox subprocess-timeout flake (passes in CI).
- [x] `tests/unit/test_source_protocol.py`, `tests/unit/test_rss_fetcher.py`, `tests/unit/test_telemetry_wiring.py`, `tests/integration/test_otel_spans.py` — all green (52 tests). Covers the `influx.fetch.rss` span (`item_count` unchanged), the `_aguarded_fetch`/`_score_rss_items`/`build_rss_note_item` patch points, and the localhost-rejection regression guard.
- [x] `make diagrams` — no `docs/generated/` drift.

Next in the stack: 2.2 (hoist the shared builder skeleton), 2.3 (unify scoring on `Filter`), 2.4 (inbox ↔ Source decision + cleanup).

Refs Lithos task `989db18f` (finding 2, scope 2.1).
