### PR TITLE
refactor(sources): hoist shared builder back-half into note_builder (2.2)

### DIFF
--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -51,9 +51,13 @@ from influx.errors import NetworkError
 from influx.extraction.pipeline import extract_arxiv_text
 from influx.filter import FilterScorerError
 from influx.http_client import guarded_fetch
-from influx.renderer import render
 from influx.repair_hooks import has_usable_source
 from influx.source import BoundScoredCandidate, Candidate, ScoredCandidate
+from influx.sources.note_builder import (
+    append_cascade_outcome_tags,
+    profile_item_dict,
+    render_note_content,
+)
 from influx.storage import download_archive
 from influx.telemetry import (
     current_archive_terminal_arxiv_ids,
@@ -1323,55 +1327,41 @@ def build_arxiv_note_item(
     # missing archive is visible in tags before the cascade's outcomes.
     if archive_missing and "influx:repair-needed" not in tags:
         tags.append("influx:repair-needed")
-    if sections.tier3 is not None:
-        tags.append("influx:deep-extracted")
-    for flag in sections.repair_flags:
-        if flag not in tags:
-            tags.append(flag)
-    for flag in sections.terminal_flags:
-        if flag not in tags:
-            tags.append(flag)
+    append_cascade_outcome_tags(tags, sections)
 
     # ── Render note ───────────────────────────────────────────────
-    # When Tier 1 was attempted but failed, suppress the plain-text
-    # summary so ## Summary is omitted entirely (AC-07-A / FR-ENR-6).
-    summary_text = item.abstract
-    if sections.tier1_attempted and sections.tier1 is None:
-        summary_text = ""
-
-    content = render(
+    # The Tier-1-attempted-but-failed summary suppression (AC-07-A /
+    # FR-ENR-6) lives in the shared renderer helper.
+    content = render_note_content(
         title=item.title,
         tags=tags,
         confidence=confidence,
         archive_path=archive_path,
-        summary=summary_text,
+        summary=item.abstract,
         profile_name=profile_name,
         score=score,
         reason=reason,
-        full_text=sections.full_text,
-        tier1_enrichment=sections.tier1,
-        tier3_extraction=sections.tier3,
+        sections=sections,
     )
 
     pub = item.published
     path = f"papers/arxiv/{pub.year}/{pub.month:02d}"
 
-    return {
-        "id": f"arxiv-{item.arxiv_id}",
-        "title": item.title,
-        "source": "arxiv",
-        "source_url": source_url,
-        "content": content,
-        "tags": tags,
-        "filter_tags": list(filter_tags) if filter_tags is not None else [],
-        "score": score,
-        "confidence": confidence,
-        "reason": reason,
-        "path": path,
-        "abstract_or_summary": item.abstract,
-        "contributions": sections.tier1.contributions if sections.tier1 else None,
-        "builds_on": list(sections.tier3.builds_on) if sections.tier3 else None,
-    }
+    return profile_item_dict(
+        item_id=f"arxiv-{item.arxiv_id}",
+        title=item.title,
+        source="arxiv",
+        source_url=source_url,
+        content=content,
+        tags=tags,
+        filter_tags=filter_tags,
+        score=score,
+        confidence=confidence,
+        reason=reason,
+        path=path,
+        abstract_or_summary=item.abstract,
+        sections=sections,
+    )
 
 
 def _make_arxiv_tier2_extractor(

--- a/src/influx/sources/inbox.py
+++ b/src/influx/sources/inbox.py
@@ -34,7 +34,11 @@ from influx.cascade import Acquired, Cascade, TextFlavour
 from influx.errors import ExtractionError, NetworkError
 from influx.extraction.article import extract_article_from_html
 from influx.extraction.pdf import extract_pdf
-from influx.renderer import render
+from influx.sources.note_builder import (
+    append_cascade_outcome_tags,
+    profile_item_dict,
+    render_note_content,
+)
 from influx.storage import archive_bytes, download_archive_autodetect
 from influx.thin_summary import is_thin_summary
 from influx.urls import normalise_url, url_hash
@@ -320,51 +324,38 @@ def build_inbox_note_item(
             tags.append("influx:repair-needed")
     if sections.full_text is not None:
         tags.append("full-text")
-    if sections.tier3 is not None:
-        tags.append("influx:deep-extracted")
-    for flag in sections.repair_flags:
-        if flag not in tags:
-            tags.append(flag)
-    for flag in sections.terminal_flags:
-        if flag not in tags:
-            tags.append(flag)
+    append_cascade_outcome_tags(tags, sections)
 
     now = datetime.now(UTC)
     path = f"articles/{source_tag}/{now.year}/{now.month:02d}"
 
-    # Suppress fallback summary when Tier 1 was attempted but failed
-    # (AC-07-A / FR-ENR-6) — mirrors the RSS builder.
-    summary_for_note = (
-        "" if sections.tier1_attempted and sections.tier1 is None else acquired.summary
-    )
-
-    content = render(
+    # The Tier-1-attempted-but-failed summary suppression (AC-07-A /
+    # FR-ENR-6) lives in the shared renderer helper — mirrors the RSS
+    # and arXiv builders.
+    content = render_note_content(
         title=title,
         tags=tags,
         confidence=confidence,
         archive_path=acquired.archive_path,
-        summary=summary_for_note,
+        summary=acquired.summary,
         profile_name=profile_name,
         score=score,
         reason=reason,
-        tier1_enrichment=sections.tier1,
-        full_text=sections.full_text,
-        tier3_extraction=sections.tier3,
+        sections=sections,
     )
 
-    return {
-        "id": f"inbox-{acquired.url_hash}",
-        "title": title,
-        "source": INBOX_SOURCE,
-        "source_url": source_url,
-        "content": content,
-        "tags": tags,
-        "filter_tags": list(filter_tags),
-        "score": score,
-        "confidence": confidence,
-        "reason": reason,
-        "path": path,
-        "abstract_or_summary": acquired.summary,
-        "contributions": sections.tier1.contributions if sections.tier1 else None,
-        "builds_on": list(sections.tier3.builds_on) if sections.tier3 else None,
-    }
+    return profile_item_dict(
+        item_id=f"inbox-{acquired.url_hash}",
+        title=title,
+        source=INBOX_SOURCE,
+        source_url=source_url,
+        content=content,
+        tags=tags,
+        filter_tags=filter_tags,
+        score=score,
+        confidence=confidence,
+        reason=reason,
+        path=path,
+        abstract_or_summary=acquired.summary,
+        sections=sections,
+    )

--- a/src/influx/sources/note_builder.py
+++ b/src/influx/sources/note_builder.py
@@ -31,10 +31,15 @@ if TYPE_CHECKING:
 def append_cascade_outcome_tags(tags: list[str], sections: EnrichedSections) -> None:
     """Append the cascade-driven outcome tags every builder emits.
 
-    ``influx:deep-extracted`` (Tier 3 produced content) followed by the
-    cascade's ``repair_flags`` then ``terminal_flags``, each
-    de-duplicated against ``tags``.  This is the byte-identical tail all
-    three builders share after their provenance / archive tags.
+    ``influx:deep-extracted`` (when Tier 3 produced content), then the
+    cascade's ``repair_flags`` and ``terminal_flags`` — each appended
+    only if not already present in ``tags``.  This is the byte-identical
+    tail all three builders share after their provenance / archive tags.
+
+    The three source builders never pre-seed ``influx:deep-extracted``
+    (this helper is its sole emitter), so guarding it is inert for the
+    current callers; the guard keeps the helper's contract uniform —
+    "append each outcome tag at most once" — for any future caller.
 
     ``full-text`` and ``influx:repair-needed`` deliberately stay with
     each caller: their placement relative to the source-specific archive
@@ -44,7 +49,7 @@ def append_cascade_outcome_tags(tags: list[str], sections: EnrichedSections) -> 
 
     Mutates ``tags`` in place, matching the callers' existing style.
     """
-    if sections.tier3 is not None:
+    if sections.tier3 is not None and "influx:deep-extracted" not in tags:
         tags.append("influx:deep-extracted")
     for flag in sections.repair_flags:
         if flag not in tags:

--- a/src/influx/sources/note_builder.py
+++ b/src/influx/sources/note_builder.py
@@ -1,0 +1,136 @@
+"""Shared back-half helpers for the Source note builders.
+
+Once :func:`~influx.sources.arxiv.build_arxiv_note_item`,
+:func:`~influx.sources.rss.build_rss_note_item`, and
+:func:`~influx.sources.inbox.build_inbox_note_item` have each produced
+their source-specific :class:`~influx.cascade.Acquired` bundle,
+provenance / archive tags, and enriched ``sections``, the remainder of
+the pipeline is identical across all three: the cascade-outcome tag
+tail, the Tier-1-aware note render, and the ``ProfileItem`` dict
+assembly.  Hoisting those three pieces here keeps the shared shape in
+one place so a change lands once instead of drifting across three
+copies.  Each adapter keeps only what genuinely differs — fetch /
+download, the id + archive-path scheme, the provenance / policy tags,
+and arXiv's ``text:*`` provenance tag + Tier-2 extractor.
+
+Finding 2, scope 2.2 (finish the Source seam).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from influx.renderer import render
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from influx.cascade import EnrichedSections
+
+
+def append_cascade_outcome_tags(tags: list[str], sections: EnrichedSections) -> None:
+    """Append the cascade-driven outcome tags every builder emits.
+
+    ``influx:deep-extracted`` (Tier 3 produced content) followed by the
+    cascade's ``repair_flags`` then ``terminal_flags``, each
+    de-duplicated against ``tags``.  This is the byte-identical tail all
+    three builders share after their provenance / archive tags.
+
+    ``full-text`` and ``influx:repair-needed`` deliberately stay with
+    each caller: their placement relative to the source-specific archive
+    tags differs (arXiv / RSS interleave ``influx:repair-needed`` between
+    ``full-text`` and this tail; inbox emits it earlier), so hoisting
+    them would either reorder tags or need a placement flag.
+
+    Mutates ``tags`` in place, matching the callers' existing style.
+    """
+    if sections.tier3 is not None:
+        tags.append("influx:deep-extracted")
+    for flag in sections.repair_flags:
+        if flag not in tags:
+            tags.append(flag)
+    for flag in sections.terminal_flags:
+        if flag not in tags:
+            tags.append(flag)
+
+
+def render_note_content(
+    *,
+    title: str,
+    tags: list[str],
+    confidence: float,
+    archive_path: str | None,
+    summary: str,
+    profile_name: str,
+    score: int,
+    reason: str,
+    sections: EnrichedSections,
+) -> str:
+    """Render the canonical note, applying the shared Tier-1 summary rule.
+
+    When Tier 1 was attempted but failed (``tier1_attempted`` is true and
+    ``tier1`` is ``None``), the plain-text summary is suppressed so
+    ``## Summary`` is omitted entirely (AC-07-A / FR-ENR-6).  All three
+    builders apply this identically before calling
+    :func:`influx.renderer.render`; only the *summary* source differs
+    (arXiv abstract / RSS extraction-fallback / inbox summary), which the
+    caller passes in.
+    """
+    summary_for_note = (
+        "" if sections.tier1_attempted and sections.tier1 is None else summary
+    )
+    return render(
+        title=title,
+        tags=tags,
+        confidence=confidence,
+        archive_path=archive_path,
+        summary=summary_for_note,
+        profile_name=profile_name,
+        score=score,
+        reason=reason,
+        tier1_enrichment=sections.tier1,
+        full_text=sections.full_text,
+        tier3_extraction=sections.tier3,
+    )
+
+
+def profile_item_dict(
+    *,
+    item_id: str,
+    title: str,
+    source: str,
+    source_url: str,
+    content: str,
+    tags: list[str],
+    filter_tags: Iterable[str] | None,
+    score: int,
+    confidence: float,
+    reason: str,
+    path: str,
+    abstract_or_summary: str,
+    sections: EnrichedSections,
+) -> dict[str, Any]:
+    """Assemble the 14-key ``ProfileItem`` dict the scheduler consumes.
+
+    The dict shape is identical across all three builders; only the id /
+    source / path / summary values differ (passed in).  ``filter_tags``
+    is normalised to a list (``[]`` when ``None``); ``contributions`` and
+    ``builds_on`` are derived from the cascade ``sections`` the same way
+    everywhere.
+    """
+    return {
+        "id": item_id,
+        "title": title,
+        "source": source,
+        "source_url": source_url,
+        "content": content,
+        "tags": tags,
+        "filter_tags": list(filter_tags) if filter_tags is not None else [],
+        "score": score,
+        "confidence": confidence,
+        "reason": reason,
+        "path": path,
+        "abstract_or_summary": abstract_or_summary,
+        "contributions": sections.tier1.contributions if sections.tier1 else None,
+        "builds_on": list(sections.tier3.builds_on) if sections.tier3 else None,
+    }

--- a/src/influx/sources/rss.py
+++ b/src/influx/sources/rss.py
@@ -46,10 +46,14 @@ from influx.errors import ExtractionError, NetworkError
 from influx.extraction.article import extract_article, extract_article_from_html
 from influx.filter import FilterScorerError, _acall_filter_model_with_retry
 from influx.http_client import aguarded_fetch as _aguarded_fetch
-from influx.renderer import render
 from influx.repair_hooks import has_usable_source
 from influx.slugs import slugify_feed_name
 from influx.source import BoundScoredCandidate, Candidate, ScoredCandidate
+from influx.sources.note_builder import (
+    append_cascade_outcome_tags,
+    profile_item_dict,
+    render_note_content,
+)
 from influx.storage import download_archive
 from influx.telemetry import (
     current_run_id,
@@ -689,56 +693,42 @@ def build_rss_note_item(
         tags.append("full-text")
     if archive_missing and "influx:repair-needed" not in tags:
         tags.append("influx:repair-needed")
-    if sections.tier3 is not None:
-        tags.append("influx:deep-extracted")
-    for flag in sections.repair_flags:
-        if flag not in tags:
-            tags.append(flag)
-    for flag in sections.terminal_flags:
-        if flag not in tags:
-            tags.append(flag)
+    append_cascade_outcome_tags(tags, sections)
 
     # Note storage path: articles/{source_tag}/{YYYY}/{MM} (FR-NOTE-2)
     path = f"articles/{item.source_tag}/{pub.year}/{pub.month:02d}"
 
-    # Suppress the plain-text summary when Tier 1 was attempted but
-    # failed (AC-07-A / FR-ENR-6).  When Tier 1 was not attempted
-    # (e.g. score below threshold), keep the extracted/feed summary so
-    # ``## Summary`` renders the fallback body.
-    summary_for_note = (
-        "" if sections.tier1_attempted and sections.tier1 is None else summary
-    )
-
-    content = render(
+    # The Tier-1-attempted-but-failed summary suppression (AC-07-A /
+    # FR-ENR-6) lives in the shared renderer helper.  When Tier 1 was
+    # not attempted (e.g. score below threshold), the extracted/feed
+    # summary is kept so ``## Summary`` renders the fallback body.
+    content = render_note_content(
         title=item.title,
         tags=tags,
         confidence=confidence,
         archive_path=archive_path,
-        summary=summary_for_note,
+        summary=summary,
         profile_name=profile_name,
         score=score,
         reason=reason,
-        tier1_enrichment=sections.tier1,
-        full_text=sections.full_text,
-        tier3_extraction=sections.tier3,
+        sections=sections,
     )
 
-    return {
-        "id": f"rss-{feed_slug}-{hash_val}",
-        "title": item.title,
-        "source": "rss",
-        "source_url": source_url,
-        "content": content,
-        "tags": tags,
-        "filter_tags": list(filter_tags) if filter_tags is not None else [],
-        "score": score,
-        "confidence": confidence,
-        "reason": reason,
-        "path": path,
-        "abstract_or_summary": summary,
-        "contributions": sections.tier1.contributions if sections.tier1 else None,
-        "builds_on": list(sections.tier3.builds_on) if sections.tier3 else None,
-    }
+    return profile_item_dict(
+        item_id=f"rss-{feed_slug}-{hash_val}",
+        title=item.title,
+        source="rss",
+        source_url=source_url,
+        content=content,
+        tags=tags,
+        filter_tags=filter_tags,
+        score=score,
+        confidence=confidence,
+        reason=reason,
+        path=path,
+        abstract_or_summary=summary,
+        sections=sections,
+    )
 
 
 async def _score_rss_items(

--- a/tests/unit/test_note_builder.py
+++ b/tests/unit/test_note_builder.py
@@ -48,6 +48,13 @@ class TestAppendCascadeOutcomeTags:
         append_cascade_outcome_tags(tags, EnrichedSections())
         assert "influx:deep-extracted" not in tags
 
+    def test_deep_extracted_deduplicated_against_existing_tags(self) -> None:
+        # A pre-seeded influx:deep-extracted is not duplicated — the
+        # helper appends each outcome tag at most once.
+        tags: list[str] = ["influx:deep-extracted"]
+        append_cascade_outcome_tags(tags, EnrichedSections(tier3=_tier3()))
+        assert tags.count("influx:deep-extracted") == 1
+
     def test_repair_and_terminal_flags_appended(self) -> None:
         tags: list[str] = []
         sections = EnrichedSections(

--- a/tests/unit/test_note_builder.py
+++ b/tests/unit/test_note_builder.py
@@ -1,0 +1,247 @@
+"""Unit tests for the shared Source note-builder helpers (finding 2.2).
+
+Covers the three pieces hoisted out of ``build_arxiv_note_item`` /
+``build_rss_note_item`` / ``build_inbox_note_item``:
+``append_cascade_outcome_tags``, ``render_note_content`` (the shared
+Tier-1 summary-suppression rule), and ``profile_item_dict``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from influx.cascade import EnrichedSections
+from influx.schemas import Tier1Enrichment, Tier3Extraction
+from influx.sources.note_builder import (
+    append_cascade_outcome_tags,
+    profile_item_dict,
+    render_note_content,
+)
+
+
+def _tier1(contributions: list[str] | None = None) -> Tier1Enrichment:
+    return Tier1Enrichment(
+        contributions=contributions or ["c1"],
+        method="m",
+        result="r",
+        relevance="rel",
+    )
+
+
+def _tier3(builds_on: list[str] | None = None) -> Tier3Extraction:
+    return Tier3Extraction(claims=["claim1"], builds_on=builds_on or ["b1"])
+
+
+# ── append_cascade_outcome_tags ───────────────────────────────────
+
+
+class TestAppendCascadeOutcomeTags:
+    def test_deep_extracted_added_when_tier3_present(self) -> None:
+        tags: list[str] = ["source:arxiv"]
+        append_cascade_outcome_tags(tags, EnrichedSections(tier3=_tier3()))
+        assert "influx:deep-extracted" in tags
+
+    def test_no_deep_extracted_without_tier3(self) -> None:
+        tags: list[str] = ["source:arxiv"]
+        append_cascade_outcome_tags(tags, EnrichedSections())
+        assert "influx:deep-extracted" not in tags
+
+    def test_repair_and_terminal_flags_appended(self) -> None:
+        tags: list[str] = []
+        sections = EnrichedSections(
+            repair_flags=("influx:repair-needed",),
+            terminal_flags=("influx:tier3-terminal",),
+        )
+        append_cascade_outcome_tags(tags, sections)
+        assert tags == ["influx:repair-needed", "influx:tier3-terminal"]
+
+    def test_flags_deduplicated_against_existing_tags(self) -> None:
+        tags: list[str] = ["influx:repair-needed"]
+        sections = EnrichedSections(
+            repair_flags=("influx:repair-needed",),
+            terminal_flags=("influx:repair-needed",),
+        )
+        append_cascade_outcome_tags(tags, sections)
+        # The already-present tag is not duplicated.
+        assert tags == ["influx:repair-needed"]
+
+    def test_order_is_deep_extracted_then_repair_then_terminal(self) -> None:
+        tags: list[str] = []
+        sections = EnrichedSections(
+            tier3=_tier3(),
+            repair_flags=("r1",),
+            terminal_flags=("t1",),
+        )
+        append_cascade_outcome_tags(tags, sections)
+        assert tags == ["influx:deep-extracted", "r1", "t1"]
+
+
+# ── render_note_content ───────────────────────────────────────────
+
+
+class TestRenderNoteContent:
+    def _spy_render(
+        self, monkeypatch: pytest.MonkeyPatch, captured: dict[str, Any]
+    ) -> None:
+        def _spy(**kwargs: Any) -> str:
+            captured.update(kwargs)
+            return "RENDERED"
+
+        monkeypatch.setattr("influx.sources.note_builder.render", _spy)
+
+    def test_summary_suppressed_when_tier1_attempted_and_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, Any] = {}
+        self._spy_render(monkeypatch, captured)
+        out = render_note_content(
+            title="T",
+            tags=["x"],
+            confidence=1.0,
+            archive_path=None,
+            summary="the abstract",
+            profile_name="p",
+            score=8,
+            reason="r",
+            sections=EnrichedSections(tier1_attempted=True, tier1=None),
+        )
+        assert out == "RENDERED"
+        assert captured["summary"] == ""
+
+    def test_summary_passed_through_when_tier1_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, Any] = {}
+        self._spy_render(monkeypatch, captured)
+        render_note_content(
+            title="T",
+            tags=[],
+            confidence=1.0,
+            archive_path=None,
+            summary="body",
+            profile_name="p",
+            score=8,
+            reason="r",
+            sections=EnrichedSections(tier1_attempted=True, tier1=_tier1()),
+        )
+        assert captured["summary"] == "body"
+
+    def test_summary_kept_when_tier1_not_attempted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, Any] = {}
+        self._spy_render(monkeypatch, captured)
+        render_note_content(
+            title="T",
+            tags=[],
+            confidence=0.0,
+            archive_path="p/a.pdf",
+            summary="fallback body",
+            profile_name="p",
+            score=0,
+            reason="",
+            sections=EnrichedSections(tier1_attempted=False, tier1=None),
+        )
+        assert captured["summary"] == "fallback body"
+        # Section-derived render args are forwarded verbatim.
+        assert captured["tier1_enrichment"] is None
+        assert captured["full_text"] is None
+        assert captured["tier3_extraction"] is None
+
+
+# ── profile_item_dict ─────────────────────────────────────────────
+
+
+class TestProfileItemDict:
+    def test_all_14_keys_present_and_derived_fields(self) -> None:
+        d = profile_item_dict(
+            item_id="arxiv-1",
+            title="T",
+            source="arxiv",
+            source_url="https://x",
+            content="C",
+            tags=["a"],
+            filter_tags=["ft"],
+            score=8,
+            confidence=1.0,
+            reason="r",
+            path="papers/arxiv/2026/01",
+            abstract_or_summary="abs",
+            sections=EnrichedSections(tier1=_tier1(["c1", "c2"]), tier3=_tier3(["b1"])),
+        )
+        assert set(d) == {
+            "id",
+            "title",
+            "source",
+            "source_url",
+            "content",
+            "tags",
+            "filter_tags",
+            "score",
+            "confidence",
+            "reason",
+            "path",
+            "abstract_or_summary",
+            "contributions",
+            "builds_on",
+        }
+        assert d["id"] == "arxiv-1"
+        assert d["contributions"] == ["c1", "c2"]
+        assert d["builds_on"] == ["b1"]
+
+    def test_filter_tags_none_becomes_empty_list(self) -> None:
+        d = profile_item_dict(
+            item_id="x",
+            title="t",
+            source="s",
+            source_url="u",
+            content="c",
+            tags=[],
+            filter_tags=None,
+            score=0,
+            confidence=0.0,
+            reason="",
+            path="p",
+            abstract_or_summary="",
+            sections=EnrichedSections(),
+        )
+        assert d["filter_tags"] == []
+
+    def test_filter_tags_tuple_normalised_to_list(self) -> None:
+        d = profile_item_dict(
+            item_id="x",
+            title="t",
+            source="s",
+            source_url="u",
+            content="c",
+            tags=[],
+            filter_tags=("a", "b"),
+            score=0,
+            confidence=0.0,
+            reason="",
+            path="p",
+            abstract_or_summary="",
+            sections=EnrichedSections(),
+        )
+        assert d["filter_tags"] == ["a", "b"]
+
+    def test_contributions_and_builds_on_none_without_tiers(self) -> None:
+        d = profile_item_dict(
+            item_id="x",
+            title="t",
+            source="s",
+            source_url="u",
+            content="c",
+            tags=[],
+            filter_tags=[],
+            score=0,
+            confidence=0.0,
+            reason="",
+            path="p",
+            abstract_or_summary="",
+            sections=EnrichedSections(),
+        )
+        assert d["contributions"] is None
+        assert d["builds_on"] is None


### PR DESCRIPTION
**PR 2 of the finding-2 stack** (finish the Source seam — Lithos task `989db18f`). Follows #262 (2.1). Behaviour-preserving.

## Problem

`build_arxiv_note_item`, `build_rss_note_item`, and `build_inbox_note_item` each end with the **same three steps** once they've produced their source-specific `Acquired` bundle, provenance tags, and enriched `sections`: the cascade-outcome tag tail, the Tier-1-aware note render, and the 14-key `ProfileItem` dict. That tail was copy-pasted three ways.

## What changed

New `src/influx/sources/note_builder.py` owns the shared back-half; all three builders call it:

- **`append_cascade_outcome_tags`** — `influx:deep-extracted` + `repair_flags` + `terminal_flags`, de-duplicated. Byte-identical and flag-free in all three builders.
- **`render_note_content`** — the shared *"suppress `## Summary` when Tier 1 was attempted but failed"* rule (AC-07-A / FR-ENR-6) followed by `render()`. Only the *summary source* differs per builder (arXiv abstract / RSS extraction-fallback / inbox summary), passed in.
- **`profile_item_dict`** — the 14-key `ProfileItem` assembly, including the `filter_tags` `None → []` normalisation and the `contributions` / `builds_on` derivation from `sections`.

Each builder keeps everything genuinely its own (fetch/download, id + archive-path scheme, provenance/policy tags, arXiv's Tier-2 extractor). New `tests/unit/test_note_builder.py` covers the three helpers directly (15 tests).

The win is **locality/leverage**, not raw LOC: a change to the outcome-tail, the summary rule, or the dict shape is now one edit instead of three. Deletion test: remove the helpers and ~105 lines of duplication reappear across the three builders.

## Deliberately *not* hoisted (genuinely per-source — not drift)

The tag **HEAD** (provenance/identity) and **MIDDLE** — arXiv's `text:*` tag + `is-archive-terminal`; the archive-missing / policy-tag / `policy → terminal-flip` block (whose terminal-flip set differs between arXiv and RSS, and which inbox lacks entirely). Folding these in would need a parameter-soup helper that fails the deletion test.

## ⚠️ Deferred drift — flagged for a decision (NOT changed here)

Kept behaviour-preserving, but the review surfaced three genuine inbox divergences from arXiv/RSS worth a follow-up:

1. **inbox emits no `summary_thin_drops` metric** (nor `record_summary_thin_drop()`) on a thin-summary drop — arXiv/RSS both do.
2. **inbox has no empty-source guard** (`has_usable_source` count+log) — arXiv/RSS both do.
3. **inbox orders `influx:repair-needed` differently** (right after `archive-missing`, vs arXiv/RSS interleaving it between `full-text` and the outcome tail).

Normalising any of these changes inbox's **production note bytes / metrics**, so it's out of scope for a behaviour-preserving hoist. Happy to do a follow-up "normalise inbox builder to match arXiv/RSS" PR if you want the drift closed — or leave inbox as-is if the differences are intentional.

## Test plan
- [x] `make check` green — ruff (check + format) + pyright clean; `2691 passed`, only the pre-existing `test_run_conflict_exit_1` sandbox subprocess-timeout flake (passes in CI).
- [x] `tests/unit/test_note_builder.py` (15) + the three builders' existing suites (`test_build_arxiv_note_item.py`, `test_rss_fetcher.py`, `test_inbox_tick.py`) all green — those end-to-end suites are the behaviour-preservation net.
- [x] `make diagrams` — no `docs/generated/` drift (new module is auto-covered by the `influx.sources` component prefix).

Next in the stack: 2.3 (unify scoring on the `Filter` seam), 2.4 (inbox ↔ Source decision + cleanup: drop the Source `_(proposed)_` marker, break the Sources↔Filter import cycle).

Refs Lithos task `989db18f` (finding 2, scope 2.2).
