### PR TITLE
refactor(sources): route arXiv scoring through Filter (2.3a)

### DIFF
--- a/src/influx/filter.py
+++ b/src/influx/filter.py
@@ -6,9 +6,8 @@ that scores a batch of fetched arXiv items in one LLM call.
 
 This is the production default that satisfies the score-gating contract
 in PRD 07 §5.6 / US-014 / US-015 — without it the production
-``InfluxService`` path would write every arXiv item abstract-only with
-no extraction or enrichment, regardless of the candidate's real
-relevance.
+``InfluxService`` path would score nothing and the run would yield zero
+items, regardless of the candidates' real relevance.
 
 Design notes
 ------------
@@ -16,19 +15,16 @@ Design notes
   an ``arxiv_filter_scorer`` override so integration tests can substitute
   a deterministic batch scorer without standing up a real LLM filter.
 - ``models.filter`` configuration is required for the default scorer to
-  exist.  When it is missing we return ``None`` and the provider falls
-  back to its existing no-scorer behaviour (every item written
-  abstract-only) so misconfigured deployments still produce notes
-  rather than crashing.
-- Scorer failure is non-fatal at the per-item level: items the LLM
-  filter omits from its ``results`` array are dropped; transport / parse
-  / validation failures raise :class:`FilterScorerError` so the caller
-  (the arXiv item provider) can fall every item in the batch back to
-  abstract-only ingestion instead of dropping the batch entirely
-  (§5.6 graceful degradation).  An empty returned mapping therefore
-  unambiguously means "the LLM intentionally scored nothing above
-  ``filter.min_score_in_results``" — drop the items, do not emit
-  abstract-only notes for them.
+  exist.  When it is missing we return ``None``; :meth:`Filter.score`
+  then yields zero items (its scorer is ``None``) so misconfigured
+  deployments complete the run cleanly rather than crashing.
+- Scorer failure is handled at the batch level: items the LLM filter
+  omits from its ``results`` array are dropped, and transport / parse /
+  validation failures raise :class:`FilterScorerError`, which
+  :meth:`Filter.score` catches to skip the whole batch (zero items) and
+  record a ``filter_error`` (FR-FLT-6 / §7.1).  An empty returned mapping
+  therefore unambiguously means "the LLM intentionally scored nothing
+  above ``filter.min_score_in_results``" — drop the items.
 """
 
 from __future__ import annotations
@@ -76,11 +72,11 @@ class FilterScorerError(RuntimeError):
     """Hard failure of the production-default LLM filter scorer.
 
     Raised when the scorer cannot produce a valid scoring decision at
-    all (provider misconfigured, HTTP error, malformed response).  The
-    arXiv item provider catches this and falls every item in the batch
-    back to abstract-only ingestion (score=0) so a misconfigured /
-    transient-LLM-failure deployment still produces notes instead of
-    silently dropping the run (PRD 07 §5.6 graceful degradation).
+    all (provider misconfigured, HTTP error, malformed response).
+    :meth:`Filter.score` catches this and skips the whole batch — the run
+    yields zero items and records a ``filter_error`` (FR-FLT-6 / §7.1) —
+    so a misconfigured / transient-LLM-failure deployment fails cleanly
+    instead of crashing or ingesting unscored notes.
     """
 
 
@@ -276,9 +272,9 @@ def make_default_arxiv_filter_scorer(
     (OpenAI-compatible ``/chat/completions``) and parses the response
     against :class:`~influx.schemas.FilterResponse`.
 
-    Returns ``None`` when ``[models.filter]`` is not configured — the
-    provider then falls back to its no-scorer behaviour (every item
-    written abstract-only) instead of crashing.
+    Returns ``None`` when ``[models.filter]`` is not configured —
+    :meth:`Filter.score` then yields zero items (its scorer is ``None``)
+    instead of crashing.
     """
     if "filter" not in config.models:
         return None
@@ -298,7 +294,7 @@ def make_default_arxiv_filter_scorer(
         if provider is None:
             _log.warning(
                 "filter provider %r not configured for profile %r; "
-                "falling back to abstract-only ingestion",
+                "skipping this batch (zero items)",
                 slot.provider,
                 profile,
             )
@@ -373,8 +369,9 @@ def make_default_batch_scorer(config: AppConfig) -> BatchScorer | None:
     Returns an async :data:`BatchScorer` that posts the rendered filter
     prompt + candidates to the ``models.filter`` slot and parses the
     response against :class:`FilterResponse`.  Returns ``None`` when
-    ``[models.filter]`` is not configured so misconfigured deployments
-    still ingest abstract-only notes (PRD 07 §5.6 graceful degradation).
+    ``[models.filter]`` is not configured so :meth:`Filter.score` yields
+    zero items and the run completes cleanly (PRD 07 §5.6 graceful
+    degradation).
     """
     if "filter" not in config.models:
         return None

--- a/src/influx/sources/arxiv.py
+++ b/src/influx/sources/arxiv.py
@@ -24,6 +24,7 @@ import threading
 import time
 import xml.etree.ElementTree as ET
 from collections.abc import Awaitable, Callable, Iterable
+from contextlib import nullcontext
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from email.utils import parsedate_to_datetime
@@ -49,7 +50,7 @@ from influx.config import (
 from influx.coordinator import RunKind
 from influx.errors import NetworkError
 from influx.extraction.pipeline import extract_arxiv_text
-from influx.filter import FilterScorerError
+from influx.filter import BatchScorer, Filter
 from influx.http_client import guarded_fetch
 from influx.repair_hooks import has_usable_source
 from influx.source import BoundScoredCandidate, Candidate, ScoredCandidate
@@ -65,7 +66,6 @@ from influx.telemetry import (
     get_tracer,
     record_empty_source_write,
     record_fetched_items,
-    record_filter_error,
     record_source_acquisition_error,
     record_source_cooldown_skip,
     record_source_retry,
@@ -1705,10 +1705,11 @@ def make_arxiv_item_provider(
     tests that want deterministic scoring without standing up a real
     LLM.  When set it takes precedence over *filter_scorer*.
 
-    When NEITHER scorer is configured the provider falls back to
-    score ``0`` (abstract-only, no extraction or enrichment) so a
-    misconfigured deployment still produces notes — it does NOT
-    fabricate a score equal to ``thresholds.full_text``.
+    When NEITHER scorer is configured (no ``[models.filter]`` slot) the
+    run yields zero items rather than fabricating scores, so a
+    misconfigured deployment completes cleanly instead of ingesting
+    unscored notes (``Filter.score`` returns an empty list when its
+    scorer is ``None``).
 
     Parameters
     ----------
@@ -1741,15 +1742,43 @@ def make_arxiv_item_provider(
         if not candidates:
             return ()
 
-        # ── 2. Filter.score (per-item or batched seams) ───────────
-        scored_list = await _score_arxiv_candidates(
-            candidates,
-            profile_cfg=profile_cfg,
-            filter_prompt=filter_prompt,
-            batch_size=int(config.filter.batch_size),
-            scorer=scorer,
-            filter_scorer=filter_scorer,
+        # ── 2. Filter.score (shared score-gated seam, finding 2.3) ──
+        # The per-item ``scorer`` (test) and batched ``filter_scorer``
+        # (production) seams are adapted onto the source-agnostic
+        # ``BatchScorer`` and driven through ``influx.filter.Filter`` so
+        # arXiv shares its chunk + threshold-gate + drop implementation
+        # with the other sources instead of re-implementing it.  The
+        # ``influx.filter`` span stays at this call site (rather than
+        # moving into ``Filter.score``) so it keeps arXiv's exact
+        # telemetry and does not change ``Filter`` for other callers.
+        if scorer is not None:
+            batch_scorer: BatchScorer | None = _batch_scorer_from_item_scorer(scorer)
+        elif filter_scorer is not None:
+            batch_scorer = _batch_scorer_from_arxiv_filter_scorer(filter_scorer)
+        else:
+            batch_scorer = None
+        arxiv_filter = Filter(
+            config=config, profile_cfg=profile_cfg, scorer=batch_scorer
         )
+        # Batched LLM scoring is wrapped in the ``influx.filter`` span; the
+        # per-item test scorer path emits none, matching the prior
+        # ``_score_arxiv_candidates`` behaviour.
+        span_cm = (
+            get_tracer().span(
+                "influx.filter",
+                attributes={
+                    "influx.profile": profile,
+                    "influx.run_id": current_run_id.get() or "",
+                    "influx.item_count": len(candidates),
+                },
+            )
+            if (filter_scorer is not None and scorer is None)
+            else nullcontext()
+        )
+        with span_cm:
+            scored_list = await arxiv_filter.score(
+                candidates, filter_prompt=filter_prompt, source="arxiv"
+            )
 
         # ── 3. Bind per-item acquire as closures (#125) ────────────
         # ``Source.acquire`` is invoked by the Run's Acquire stage after
@@ -1787,116 +1816,70 @@ def make_arxiv_item_provider(
     return provider
 
 
-# ── Score helper for the legacy provider seams ─────────────────────
+# ── Filter BatchScorer adapters (finding 2.3) ──────────────────────
 
 
-async def _score_arxiv_candidates(
-    candidates: list[Candidate],
-    *,
-    profile_cfg: ProfileConfig,
-    filter_prompt: str,
-    batch_size: int,
-    scorer: ArxivScorer | None,
-    filter_scorer: ArxivFilterScorer | None,
-) -> list[ScoredCandidate]:
-    """Score arXiv candidates via the per-item or batched legacy seams.
+def _batch_scorer_from_item_scorer(scorer: ArxivScorer) -> BatchScorer:
+    """Adapt a per-item :data:`ArxivScorer` (test seam) to a ``BatchScorer``.
 
-    Mirrors the contract from PRD 07 §5.6:
-
-    - Per-item *scorer* takes precedence when supplied (test seam).
-    - Batched *filter_scorer* is the production default.  When the
-      scorer raises :class:`FilterScorerError`, the whole batch is
-      skipped (FR-FLT-6 / spec §7.1) — items are not ingested with a
-      default score.
-    - Items absent from the filter response are dropped (FR-FLT-7).
-    - Items below ``profile_cfg.thresholds.relevance`` are dropped.
-    - When NEITHER scorer is wired the function returns an empty list
-      so misconfigured deployments still complete the run cleanly.
+    The synchronous per-item scorer maps each ``ArxivItem`` to an
+    ``ArxivScoreResult`` (or ``None`` to drop); the adapter runs it over a
+    chunk's candidates and returns the ``{item_id: ScoredCandidate}``
+    mapping :meth:`influx.filter.Filter.score` consumes.  It never raises
+    :class:`FilterScorerError`, so ``Filter`` never drops the batch on
+    this path.
     """
-    profile = profile_cfg.name
-    threshold = profile_cfg.thresholds.relevance
-    drop_attrs = {"profile": profile, "decision": "drop"}
-    pass_attrs = {"profile": profile, "decision": "pass"}
 
-    # Per-item synchronous scorer (test seam)
-    if scorer is not None:
-        kept: list[ScoredCandidate] = []
+    async def _batch(
+        candidates: list[Candidate], profile: str, filter_prompt: str
+    ) -> dict[str, ScoredCandidate]:
+        del filter_prompt
+        out: dict[str, ScoredCandidate] = {}
         for cand in candidates:
-            arxiv_item = cand.payload
-            score_result = scorer(arxiv_item, profile)
-            if score_result is None or score_result.score < threshold:
-                metrics.articles_filtered().add(1, drop_attrs)
-                continue
-            metrics.articles_filtered().add(1, pass_attrs)
-            kept.append(
-                ScoredCandidate(
+            result = scorer(cand.payload, profile)
+            if result is not None:
+                out[cand.item_id] = ScoredCandidate(
                     candidate=cand,
-                    score=score_result.score,
-                    confidence=score_result.confidence,
-                    reason=score_result.reason,
-                    filter_tags=score_result.filter_tags,
+                    score=result.score,
+                    confidence=result.confidence,
+                    reason=result.reason,
+                    filter_tags=result.filter_tags,
                 )
-            )
-        return kept
+        return out
 
-    if filter_scorer is None:
-        # No scorer wired: drop every item rather than fabricating a score.
-        for _ in candidates:
-            metrics.articles_filtered().add(1, drop_attrs)
-        return []
+    return _batch
 
-    # Batched scorer is the production default — chunk into
-    # ``filter.batch_size`` requests so the configured tunable shapes
-    # runtime behaviour (AC-X-1).
-    batch_size = max(batch_size, 1)
-    chunked_scores: dict[str, ArxivScoreResult] = {}
-    tracer = get_tracer()
-    with tracer.span(
-        "influx.filter",
-        attributes={
-            "influx.profile": profile,
-            "influx.run_id": current_run_id.get() or "",
-            "influx.item_count": len(candidates),
-        },
-    ):
-        for chunk_start in range(0, len(candidates), batch_size):
-            chunk = candidates[chunk_start : chunk_start + batch_size]
-            chunk_items = [c.payload for c in chunk]
-            try:
-                chunk_scores = await filter_scorer(chunk_items, profile, filter_prompt)
-            except FilterScorerError:
-                _log.warning(
-                    "filter_scorer failed for profile %r; skipping batch",
-                    profile,
-                    exc_info=True,
-                )
-                # FR-FLT-6 / spec §7.1: failed batch is skipped, not
-                # ingested with a default score.
-                for _ in candidates:
-                    metrics.articles_filtered().add(1, drop_attrs)
-                # #85 review: distinguish a scorer execution failure
-                # (transport/parse/provider error) from a clean filter
-                # rejection.  The ledger uses this to fire
-                # ``filter_error`` instead of misclassifying as
-                # ``filter_stall``.
-                record_filter_error()
-                return []
-            chunked_scores.update(chunk_scores)
 
-    kept = []
-    for cand in candidates:
-        score_result = chunked_scores.get(cand.item_id)
-        if score_result is None or score_result.score < threshold:
-            metrics.articles_filtered().add(1, drop_attrs)
-            continue
-        metrics.articles_filtered().add(1, pass_attrs)
-        kept.append(
-            ScoredCandidate(
-                candidate=cand,
-                score=score_result.score,
-                confidence=score_result.confidence,
-                reason=score_result.reason,
-                filter_tags=score_result.filter_tags,
-            )
+def _batch_scorer_from_arxiv_filter_scorer(
+    filter_scorer: ArxivFilterScorer,
+) -> BatchScorer:
+    """Adapt a batched :data:`ArxivFilterScorer` to a ``BatchScorer``.
+
+    The arXiv filter scorer returns ``{arxiv_id: ArxivScoreResult}`` for a
+    chunk of items; the adapter re-associates each result with its
+    ``Candidate`` and yields the ``{item_id: ScoredCandidate}`` mapping
+    :meth:`influx.filter.Filter.score` consumes.  :class:`FilterScorerError`
+    from the underlying scorer propagates so ``Filter`` applies its
+    whole-batch-drop (FR-FLT-6).
+    """
+
+    async def _batch(
+        candidates: list[Candidate], profile: str, filter_prompt: str
+    ) -> dict[str, ScoredCandidate]:
+        by_id = {c.item_id: c for c in candidates}
+        results = await filter_scorer(
+            [c.payload for c in candidates], profile, filter_prompt
         )
-    return kept
+        return {
+            rid: ScoredCandidate(
+                candidate=by_id[rid],
+                score=r.score,
+                confidence=r.confidence,
+                reason=r.reason,
+                filter_tags=r.filter_tags,
+            )
+            for rid, r in results.items()
+            if rid in by_id
+        }
+
+    return _batch

--- a/tests/unit/test_arxiv_filter_adapters.py
+++ b/tests/unit/test_arxiv_filter_adapters.py
@@ -1,0 +1,109 @@
+"""Unit tests for the arXiv → Filter BatchScorer adapters (finding 2.3).
+
+``make_arxiv_item_provider`` drives scoring through
+:class:`influx.filter.Filter`; the per-item ``ArxivScorer`` (test seam)
+and batched ``ArxivFilterScorer`` (production) are adapted onto the
+source-agnostic ``BatchScorer`` by these two helpers.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from influx.filter import FilterScorerError
+from influx.source import Candidate
+from influx.sources.arxiv import (
+    ArxivItem,
+    ArxivScoreResult,
+    _batch_scorer_from_arxiv_filter_scorer,
+    _batch_scorer_from_item_scorer,
+)
+
+
+def _item(arxiv_id: str) -> ArxivItem:
+    return ArxivItem(
+        arxiv_id=arxiv_id,
+        title=f"Title {arxiv_id}",
+        abstract="abstract",
+        published=datetime(2026, 1, 1, tzinfo=UTC),
+        categories=["cs.AI"],
+    )
+
+
+def _cand(arxiv_id: str) -> Candidate:
+    it = _item(arxiv_id)
+    return Candidate(
+        item_id=it.arxiv_id,
+        title=it.title,
+        abstract=it.abstract,
+        source_url=f"https://arxiv.org/abs/{arxiv_id}",
+        payload=it,
+    )
+
+
+class TestItemScorerAdapter:
+    async def test_keeps_scored_and_drops_none(self) -> None:
+        def scorer(item: ArxivItem, profile: str) -> ArxivScoreResult | None:
+            if item.arxiv_id == "drop":
+                return None
+            return ArxivScoreResult(
+                score=8, confidence=0.9, reason="ok", filter_tags=("t",)
+            )
+
+        batch = _batch_scorer_from_item_scorer(scorer)
+        out = await batch([_cand("keep"), _cand("drop")], "p", "prompt")
+
+        assert set(out) == {"keep"}
+        sc = out["keep"]
+        assert sc.candidate.item_id == "keep"
+        assert (sc.score, sc.confidence, sc.reason) == (8, 0.9, "ok")
+        assert sc.filter_tags == ("t",)
+
+    async def test_empty_when_no_candidates(self) -> None:
+        batch = _batch_scorer_from_item_scorer(lambda item, profile: None)
+        assert await batch([], "p", "prompt") == {}
+
+
+class TestArxivFilterScorerAdapter:
+    async def test_reassociates_results_with_candidates(self) -> None:
+        async def filter_scorer(
+            items: list[ArxivItem], profile: str, prompt: str
+        ) -> dict[str, ArxivScoreResult]:
+            return {
+                it.arxiv_id: ArxivScoreResult(score=7, confidence=1.0, reason="r")
+                for it in items
+            }
+
+        batch = _batch_scorer_from_arxiv_filter_scorer(filter_scorer)
+        out = await batch([_cand("a"), _cand("b")], "p", "prompt")
+
+        assert set(out) == {"a", "b"}
+        assert out["a"].candidate.payload.arxiv_id == "a"
+        assert out["a"].score == 7
+
+    async def test_ignores_ids_not_in_chunk(self) -> None:
+        async def filter_scorer(
+            items: list[Any], profile: str, prompt: str
+        ) -> dict[str, ArxivScoreResult]:
+            return {
+                "a": ArxivScoreResult(score=7, confidence=1.0, reason="r"),
+                "ghost": ArxivScoreResult(score=9, confidence=1.0, reason="x"),
+            }
+
+        batch = _batch_scorer_from_arxiv_filter_scorer(filter_scorer)
+        out = await batch([_cand("a")], "p", "prompt")
+
+        assert set(out) == {"a"}
+
+    async def test_propagates_filter_scorer_error(self) -> None:
+        async def filter_scorer(
+            items: list[Any], profile: str, prompt: str
+        ) -> dict[str, ArxivScoreResult]:
+            raise FilterScorerError("boom")
+
+        batch = _batch_scorer_from_arxiv_filter_scorer(filter_scorer)
+        with pytest.raises(FilterScorerError):
+            await batch([_cand("a")], "p", "prompt")

--- a/tests/unit/test_arxiv_filter_adapters.py
+++ b/tests/unit/test_arxiv_filter_adapters.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from influx.coordinator import RunKind
 from influx.filter import FilterScorerError
 from influx.source import Candidate
 from influx.sources.arxiv import (
@@ -20,7 +22,31 @@ from influx.sources.arxiv import (
     ArxivScoreResult,
     _batch_scorer_from_arxiv_filter_scorer,
     _batch_scorer_from_item_scorer,
+    make_arxiv_item_provider,
 )
+
+
+def _config_without_filter() -> Any:
+    """Minimal AppConfig with an arXiv profile and no ``[models.filter]``."""
+    from influx.config import (
+        AppConfig,
+        ProfileConfig,
+        PromptEntryConfig,
+        PromptsConfig,
+        ScheduleConfig,
+    )
+
+    return AppConfig(
+        schedule=ScheduleConfig(
+            cron="0 6 * * *", timezone="UTC", misfire_grace_seconds=3600
+        ),
+        profiles=[ProfileConfig(name="ai-robotics")],
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="t"),
+            tier1_enrich=PromptEntryConfig(text="t"),
+            tier3_extract=PromptEntryConfig(text="t"),
+        ),
+    )
 
 
 def _item(arxiv_id: str) -> ArxivItem:
@@ -107,3 +133,22 @@ class TestArxivFilterScorerAdapter:
         batch = _batch_scorer_from_arxiv_filter_scorer(filter_scorer)
         with pytest.raises(FilterScorerError):
             await batch([_cand("a")], "p", "prompt")
+
+
+class TestProviderNoScorer:
+    async def test_no_scorer_yields_zero_items(self) -> None:
+        """With neither scorer wired, the provider scores nothing and
+        yields zero bound candidates — it never fabricates a score."""
+        config = _config_without_filter()
+        provider = make_arxiv_item_provider(config)  # no scorer, no filter_scorer
+
+        with patch(
+            "influx.sources.arxiv.fetch_arxiv",
+            new_callable=MagicMock,
+            return_value=[_item("2401.00001")],
+        ):
+            bounds = list(
+                await provider("ai-robotics", RunKind.SCHEDULED, None, "prompt")
+            )
+
+        assert bounds == []


### PR DESCRIPTION
**PR 3 of the finding-2 stack** (finish the Source seam — Lithos task `989db18f`). Follows #263 (2.2).

## Problem

The canonical score-gated seam `influx.filter.Filter` had **zero production callers**. arXiv carried its own copy of the chunk → threshold-gate → drop logic in `_score_arxiv_candidates` (≈110 lines that duplicate `Filter.score`).

## What changed

`make_arxiv_item_provider` now builds a `Filter` and calls `Filter.score` — **`Filter`'s first production caller**. The provider's `scorer` (per-item test seam) and `filter_scorer` (batched production) parameters are **preserved** and adapted onto the source-agnostic `BatchScorer` by two thin converters, so there's **no provider-signature or wiring change** and the ~19 test sites that inject scorers keep working unchanged:

- `_batch_scorer_from_item_scorer` — wraps a per-item `ArxivScorer`; never raises `FilterScorerError`.
- `_batch_scorer_from_arxiv_filter_scorer` — wraps a batched `ArxivFilterScorer`, re-associating `{arxiv_id: ArxivScoreResult}` with candidates; propagates `FilterScorerError` so `Filter` applies its whole-batch-drop.

`_score_arxiv_candidates` is deleted.

## Behaviour reconciliation (approved — adopt `Filter`'s behaviour)

On a filter **error** (`FilterScorerError`) or when **no scorer** is wired, `Filter.score` returns `[]` and records `filter_error` **without** bumping `articles_filtered{drop}` for each candidate. arXiv previously bumped the drop counter in those cases. No test pinned it, and `Filter`'s split (`filter_error` vs `articles_filtered`) is the cleaner signal — a failed filter *call* isn't a per-item *rejection*.

## Telemetry note

The `influx.filter` span deliberately **stays at the arXiv provider call site** (wrapping `Filter.score` for the batched path) rather than moving into `Filter.score`. This preserves arXiv's exact telemetry, keeps the span off the per-item test path (matching prior behaviour), and avoids changing `Filter`'s contract for future callers. (Cleaner than the "move into Filter" option I floated — no test churn, no cross-caller change.)

Also fixes a stale `make_arxiv_item_provider` docstring: with no scorer the run yields **zero items** (it never "fell back to score 0").

## Out of scope (deliberate)

- **RSS (2.3b)** — routing RSS through `Filter` changes production behaviour (fewer LLM filter calls via cross-feed chunk packing; whole-batch-drop instead of continue-past-failed-chunk). Coming as its own PR for review before merge, per our agreement.
- **inbox** — deliberately keeps below-threshold scores + opts out of `articles_filtered`; stays on its own path (revisited in 2.4).

## Test plan
- [x] `make check` green — ruff (check + format) + pyright clean; `2697 passed`, only the pre-existing `test_run_conflict_exit_1` sandbox subprocess-timeout flake (passes in CI).
- [x] New `tests/unit/test_arxiv_filter_adapters.py` (5) covers both adapters (keep/drop, re-association, chunk-id filtering, `FilterScorerError` propagation).
- [x] The `influx.filter` span suites (`test_telemetry_wiring.py`, `test_otel_spans.py`), `test_filter.py`, `test_filter_batch_size.py`, and the arXiv pipeline end-to-end all green — those pin the preserved scoring + span behaviour.
- [x] `make diagrams` — no `docs/generated/` drift.

Refs Lithos task `989db18f` (finding 2, scope 2.3a).
