### PR TITLE
refactor(repair): preserve ## Repair counters across multi-profile merge (3a.4)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,7 +43,7 @@ Produces a **CanonicalNote** from an Acquired plus EnrichedSections plus the sco
 An Influx-authored Markdown note: typed frontmatter, fixed section order (`## Archive`, `## Summary`, `## Full Text`, `## Claims`, `## Datasets & Benchmarks`, `## Builds On`, `## Open Questions`, `## Profile Relevance`, `## User Notes`), and stable tag conventions. `## User Notes` is preserved byte-exactly across rewrites.
 
 **RepairCounters**:
-Per-tier attempt counter persisted in the note's `## Repair` section. Read on tier entry (skip if `tier{N}-terminal` is set), advanced on counted (parse/validate) failures, never advanced on transient failures. Reaches the cap → adds `influx:tier{N}-terminal`. _(proposed as a module shared between the create path and the repair sweep)_
+Per-tier attempt counter persisted in the note's `## Repair` section. Read on tier entry (skip if `tier{N}-terminal` is set), advanced on counted (parse/validate) failures, never advanced on transient failures. Reaches the cap → adds `influx:tier{N}-terminal`. The repair sweep owns the full lifecycle (read → advance → terminal) via `Cascade.enrich`; the create path enriches with a zero counter but preserves an existing note's `## Repair` section across a multi-profile re-ingest, so caps survive.
 
 ### Domain — execution
 

--- a/docs/generated/components/LithosBridge.md
+++ b/docs/generated/components/LithosBridge.md
@@ -40,7 +40,7 @@ Renders CanonicalNotes and is the write-mostly MCP/SSE client to Lithos (WriteRe
 - def `drop_tier2` — Remove the ``## Full Text`` (Tier 2) section, keeping Tier 1/Tier 3.
 - def `drop_tier2_and_tier3` — Remove ``## Full Text`` and all Tier 3 sections, keeping Tier 1.
 - def `extract_section_body` — Return the trailing-stripped body of *heading*, or ``""`` if absent.
-- def `carry_forward_section` — Copy *heading*'s section from *source* into *target* verbatim.
+- def `carry_forward_section` — Copy *heading*'s section from *source* into *target*.
 - def `upsert_archive_path` — Set the ``## Archive`` ``path:`` line, idempotently.
 - def `replace_profile_relevance_section` — Replace the ``## Profile Relevance`` section body with *entries*.
 - def `upsert_section_text` — Insert or replace a full section with *rendered_section*.

--- a/docs/generated/components/LithosBridge.md
+++ b/docs/generated/components/LithosBridge.md
@@ -11,7 +11,7 @@ Renders CanonicalNotes and is the write-mostly MCP/SSE client to Lithos (WriteRe
 
 | Module | Size | Classes | Functions |
 |---|---|---:|---:|
-| `influx.canonical_note` | M | 4 | 17 |
+| `influx.canonical_note` | L | 4 | 18 |
 | `influx.dedup` | XS | 0 | 2 |
 | `influx.lcma` | M | 0 | 4 |
 | `influx.lcma_wiring` | S | 2 | 1 |
@@ -40,6 +40,7 @@ Renders CanonicalNotes and is the write-mostly MCP/SSE client to Lithos (WriteRe
 - def `drop_tier2` — Remove the ``## Full Text`` (Tier 2) section, keeping Tier 1/Tier 3.
 - def `drop_tier2_and_tier3` — Remove ``## Full Text`` and all Tier 3 sections, keeping Tier 1.
 - def `extract_section_body` — Return the trailing-stripped body of *heading*, or ``""`` if absent.
+- def `carry_forward_section` — Copy *heading*'s section from *source* into *target* verbatim.
 - def `upsert_archive_path` — Set the ``## Archive`` ``path:`` line, idempotently.
 - def `replace_profile_relevance_section` — Replace the ``## Profile Relevance`` section body with *entries*.
 - def `upsert_section_text` — Insert or replace a full section with *rendered_section*.

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -340,10 +340,10 @@
         "functions": 115,
         "largest_module": "influx.lithos_client",
         "largest_module_lines": 1789,
-        "lines": 4091,
+        "lines": 4097,
         "modules": 8,
         "public_symbols": 52,
-        "sloc": 3248
+        "sloc": 3254
       },
       "Notifications": {
         "classes": 5,
@@ -432,13 +432,13 @@
       "influx.sources.rss",
       "influx.telemetry"
     ],
-    "total_lines": 27751,
+    "total_lines": 27757,
     "total_modules": 57,
-    "total_sloc": 21542
+    "total_sloc": 21548
   },
   "tests": {
     "ratio": 2.53,
-    "src_lines": 27751,
-    "test_lines": 70200
+    "src_lines": 27757,
+    "test_lines": 70237
   }
 }

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -120,7 +120,7 @@
         "qualname": "influx.promotion_gate.evaluate_promotion_gate"
       }
     ],
-    "total_functions": 649
+    "total_functions": 650
   },
   "domain": {
     "associations": 5,
@@ -289,11 +289,11 @@
         "classes": 4,
         "functions": 12,
         "largest_module": "influx.cascade",
-        "largest_module_lines": 683,
-        "lines": 986,
+        "largest_module_lines": 685,
+        "lines": 988,
         "modules": 2,
         "public_symbols": 6,
-        "sloc": 798
+        "sloc": 800
       },
       "Entrypoint": {
         "classes": 0,
@@ -337,13 +337,13 @@
       },
       "LithosBridge": {
         "classes": 13,
-        "functions": 114,
+        "functions": 115,
         "largest_module": "influx.lithos_client",
-        "largest_module_lines": 1780,
-        "lines": 4064,
+        "largest_module_lines": 1789,
+        "lines": 4091,
         "modules": 8,
-        "public_symbols": 51,
-        "sloc": 3230
+        "public_symbols": 52,
+        "sloc": 3248
       },
       "Notifications": {
         "classes": 5,
@@ -417,7 +417,7 @@
       }
     },
     "max_module": "influx.lithos_client",
-    "max_module_lines": 1780,
+    "max_module_lines": 1789,
     "modules_over_800": [
       "influx.config",
       "influx.http_api",
@@ -432,13 +432,13 @@
       "influx.sources.rss",
       "influx.telemetry"
     ],
-    "total_lines": 27722,
+    "total_lines": 27751,
     "total_modules": 57,
-    "total_sloc": 21522
+    "total_sloc": 21542
   },
   "tests": {
     "ratio": 2.53,
-    "src_lines": 27722,
-    "test_lines": 70085
+    "src_lines": 27751,
+    "test_lines": 70200
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -39,7 +39,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Feedback | 3 | 571 | 450 | 1 | 4 | 0.80 | 15 (`influx.run_dedup.dedup_scored_candidates`) | 1 |
 | Filter | 1 | 474 | 398 | 3 | 4 | 0.57 | 11 (`influx.filter.make_default_batch_scorer._scorer`) | 1 |
 | HttpApi | 3 | 1529 | 1276 | 2 | 8 | 0.80 | 17 (`influx.http_api.post_backfills`) | 3 |
-| LithosBridge | 8 | 4091 | 3248 | 6 | 3 | 0.33 | 17 (`influx.notes.merge_tags`) | 4 |
+| LithosBridge | 8 | 4097 | 3254 | 6 | 3 | 0.33 | 17 (`influx.notes.merge_tags`) | 4 |
 | Notifications | 1 | 581 | 509 | 2 | 2 | 0.50 | 13 (`influx.notifications.dispatch_notifications`) | 2 |
 | Observability | 3 | 1912 | 1401 | 9 | 0 | 0.00 | 10 (`influx.logging_config.setup_logging`) | 0 |
 | Orchestration | 5 | 3732 | 2911 | 1 | 11 | 0.92 | 52 (`influx.run_service.ledger_lifecycle`) | 11 |
@@ -50,7 +50,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **57**, lines: **27751**, SLOC: **21542**
+- Modules: **57**, lines: **27757**, SLOC: **21548**
 - Largest module: `influx.lithos_client` (1789 lines)
 - Modules over 800 lines: **12**
   - `influx.config`
@@ -88,4 +88,4 @@ Top 10 most complex functions:
 ## Domain & tests
 
 - Domain models: **17** (5 associations, 0 without docstrings)
-- Test-to-source line ratio: **2.53** (70200 test lines / 27751 source lines)
+- Test-to-source line ratio: **2.53** (70237 test lines / 27757 source lines)

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -13,7 +13,7 @@ lower a budget after improving the code to lock in the gain.
 |---|---:|---:|---:|
 | `component_cycles` | 3 | 3 | 0 |
 | `cross_component_edges` | 62 | 62 | 0 |
-| `max_module_lines` | 1780 | 2000 | 220 |
+| `max_module_lines` | 1789 | 2000 | 211 |
 | `module_cycles` | 3 | 3 | 0 |
 | `modules_over_800_lines` | 12 | 12 | 0 |
 
@@ -34,12 +34,12 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 |---|---:|---:|---:|---:|---:|---:|---|---:|
 | Common | 7 | 2670 | 1949 | 12 | 1 | 0.08 | 47 (`influx.run_ledger.RunLedger.complete`) | 4 |
 | Config | 4 | 1567 | 1134 | 11 | 1 | 0.08 | 14 (`influx.config.NotificationWebhookConfig._validate_type_specific_fields`) | 1 |
-| Enrich | 2 | 986 | 798 | 2 | 5 | 0.71 | 22 (`influx.cascade.Cascade.enrich`) | 2 |
+| Enrich | 2 | 988 | 800 | 2 | 5 | 0.71 | 22 (`influx.cascade.Cascade.enrich`) | 2 |
 | Entrypoint | 2 | 573 | 454 | 0 | 5 | 1.00 | 14 (`influx.main._cmd_backfill`) | 2 |
 | Feedback | 3 | 571 | 450 | 1 | 4 | 0.80 | 15 (`influx.run_dedup.dedup_scored_candidates`) | 1 |
 | Filter | 1 | 474 | 398 | 3 | 4 | 0.57 | 11 (`influx.filter.make_default_batch_scorer._scorer`) | 1 |
 | HttpApi | 3 | 1529 | 1276 | 2 | 8 | 0.80 | 17 (`influx.http_api.post_backfills`) | 3 |
-| LithosBridge | 8 | 4064 | 3230 | 6 | 3 | 0.33 | 17 (`influx.notes.merge_tags`) | 4 |
+| LithosBridge | 8 | 4091 | 3248 | 6 | 3 | 0.33 | 17 (`influx.notes.merge_tags`) | 4 |
 | Notifications | 1 | 581 | 509 | 2 | 2 | 0.50 | 13 (`influx.notifications.dispatch_notifications`) | 2 |
 | Observability | 3 | 1912 | 1401 | 9 | 0 | 0.00 | 10 (`influx.logging_config.setup_logging`) | 0 |
 | Orchestration | 5 | 3732 | 2911 | 1 | 11 | 0.92 | 52 (`influx.run_service.ledger_lifecycle`) | 11 |
@@ -50,8 +50,8 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **57**, lines: **27722**, SLOC: **21522**
-- Largest module: `influx.lithos_client` (1780 lines)
+- Modules: **57**, lines: **27751**, SLOC: **21542**
+- Largest module: `influx.lithos_client` (1789 lines)
 - Modules over 800 lines: **12**
   - `influx.config`
   - `influx.http_api`
@@ -68,7 +68,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Complexity
 
-- Functions: **649**, cyclomatic > 10: **47**
+- Functions: **650**, cyclomatic > 10: **47**
 
 Top 10 most complex functions:
 
@@ -88,4 +88,4 @@ Top 10 most complex functions:
 ## Domain & tests
 
 - Domain models: **17** (5 associations, 0 without docstrings)
-- Test-to-source line ratio: **2.53** (70085 test lines / 27722 source lines)
+- Test-to-source line ratio: **2.53** (70200 test lines / 27751 source lines)

--- a/src/influx/canonical_note.py
+++ b/src/influx/canonical_note.py
@@ -76,6 +76,7 @@ __all__ = [
     "NoteParseError",
     "ProfileRelevanceEntry",
     "Section",
+    "carry_forward_section",
     "drop_tier2",
     "drop_tier2_and_tier3",
     "extract_section_body",
@@ -581,6 +582,23 @@ def extract_section_body(content: str, heading: str) -> str:
     if next_match is not None:
         return content[body_start : next_match.start()].rstrip()
     return content[body_start:].rstrip()
+
+
+def carry_forward_section(source: str, target: str, heading: str) -> str:
+    """Copy *heading*'s section from *source* into *target* verbatim.
+
+    Used by the multi-profile / cache-hit merge to preserve a section the
+    freshly-rendered *target* does not itself carry — notably ``## Repair``
+    counters, which only the repair sweep writes.  The existing note's
+    section body is copied byte-for-byte (no parse / re-render round-trip)
+    and placed at :func:`insertion_point` (or replaces an existing section
+    of the same heading in *target*).  A no-op when *source* has no such
+    section.
+    """
+    body = extract_section_body(source, heading)
+    if not body:
+        return target
+    return upsert_section_text(target, heading, f"## {heading}\n{body}\n")
 
 
 def upsert_archive_path(content: str, archive_path: str) -> str:

--- a/src/influx/canonical_note.py
+++ b/src/influx/canonical_note.py
@@ -585,15 +585,21 @@ def extract_section_body(content: str, heading: str) -> str:
 
 
 def carry_forward_section(source: str, target: str, heading: str) -> str:
-    """Copy *heading*'s section from *source* into *target* verbatim.
+    """Copy *heading*'s section from *source* into *target*.
 
     Used by the multi-profile / cache-hit merge to preserve a section the
     freshly-rendered *target* does not itself carry — notably ``## Repair``
-    counters, which only the repair sweep writes.  The existing note's
-    section body is copied byte-for-byte (no parse / re-render round-trip)
-    and placed at :func:`insertion_point` (or replaces an existing section
-    of the same heading in *target*).  A no-op when *source* has no such
-    section.
+    counters, which only the repair sweep writes.  The section *body* is
+    carried across as text (no ``RepairCounters`` parse / re-render
+    round-trip, so unknown or hand-added bullets survive), then written
+    via :func:`upsert_section_text`.  Like every canonical section op,
+    that normalises the section it writes to LF boundaries and drops the
+    body's trailing whitespace — so this is semantic preservation of the
+    section's content, not a byte-exact copy: a hand-edited ``## Repair``
+    keeps its bullets but loses trailing blank lines / CRLF *within* the
+    section.  The section is placed at :func:`insertion_point`, or
+    replaces an existing section of the same heading in *target*.  A no-op
+    when *source* has no such section.
     """
     body = extract_section_body(source, heading)
     if not body:

--- a/src/influx/cascade.py
+++ b/src/influx/cascade.py
@@ -158,11 +158,13 @@ class EnrichedSections:
     Counter state (Fork 6):
 
     - ``counters`` — the post-enrich :class:`RepairCounters`.  When the
-      caller passed a ``counters`` value (the repair sweep, or the
-      create-path merge onto a note that already has a ``## Repair``
-      section), a counted-class Tier 2 / Tier 3 failure advances it; the
-      caller persists the result.  On the initial-write path (no
-      ``counters`` passed) it is the zero default and no advance happens.
+      caller passed a ``counters`` value (the repair sweep), a
+      counted-class Tier 2 / Tier 3 failure advances it; the caller
+      persists the result.  The create path always enriches with the
+      zero default (no ``counters``); when it re-ingests an existing note
+      its accumulated ``## Repair`` counters are preserved at the
+      multi-profile merge (``lithos_client``, 3a.4) rather than fed back
+      into ``enrich``.
       Note ``repair_flags`` (``influx:repair-needed``) is emitted for
       *any* tier failure — transient or counted — but only *counted*
       failures advance ``counters`` (see
@@ -226,15 +228,15 @@ class Cascade:
             text without re-extracting.
         counters:
             Optional :class:`RepairCounters` to consult.  When provided
-            (repair sweep, or a create-path merge onto a note that
-            already carries a ``## Repair`` section) the Cascade owns the
-            full counter lifecycle: it skips a tier already at the cap
-            (emitting ``influx:tier{2,3}-terminal``), and on a
-            counted-class failure advances the counter and emits the
-            terminal flag when the cap is reached.  When omitted
-            (initial-write path) it defaults to a zero-counter value and
-            no advance happens — counted failures still emit
-            ``influx:repair-needed`` for the first sweep to pick up.
+            (the repair sweep) the Cascade owns the full counter
+            lifecycle: it skips a tier already at the cap (emitting
+            ``influx:tier{2,3}-terminal``), and on a counted-class failure
+            advances the counter and emits the terminal flag when the cap
+            is reached.  When omitted (the create path, always) it defaults
+            to a zero-counter value and no advance happens — counted
+            failures still emit ``influx:repair-needed`` for the first
+            sweep to pick up.  A re-ingested note's existing ``## Repair``
+            counters are preserved at the multi-profile merge, not here.
 
         Returns
         -------

--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -26,6 +26,8 @@ from mcp.client.sse import sse_client
 from mcp.shared.exceptions import McpError
 
 from influx.canonical_note import (
+    REPAIR,
+    carry_forward_section,
     drop_tier2,
     drop_tier2_and_tier3,
     graft_user_notes,
@@ -1135,6 +1137,13 @@ class LithosClient:
         merged_content = _merge_profile_relevance_in_content(
             existing_content, merged_content, merged_tags
         )
+        # 3a.4: preserve the existing note's ``## Repair`` counters.  Only
+        # the repair sweep writes that section; the freshly-ingested
+        # create-path content has none, so a naive merge would drop the
+        # accumulated counters and reset a tier-terminal note's caps on
+        # re-ingest.  Carry the section forward verbatim so re-ingesting a
+        # capped note keeps respecting its caps.
+        merged_content = carry_forward_section(existing_content, merged_content, REPAIR)
         retry_args = {
             **args,
             "tags": merged_tags,

--- a/src/influx/lithos_client.py
+++ b/src/influx/lithos_client.py
@@ -1141,7 +1141,7 @@ class LithosClient:
         # the repair sweep writes that section; the freshly-ingested
         # create-path content has none, so a naive merge would drop the
         # accumulated counters and reset a tier-terminal note's caps on
-        # re-ingest.  Carry the section forward verbatim so re-ingesting a
+        # re-ingest.  Carry the section forward (as text) so re-ingesting a
         # capped note keeps respecting its caps.
         merged_content = carry_forward_section(existing_content, merged_content, REPAIR)
         retry_args = {

--- a/tests/contract/test_lithos_client.py
+++ b/tests/contract/test_lithos_client.py
@@ -1959,6 +1959,87 @@ class TestWriteEnvelopeVersionConflict:
         finally:
             await client.close()
 
+    async def test_version_conflict_preserves_repair_section(
+        self,
+        fake_lithos_url: str,
+        fake_lithos_server: FakeLithosServer,
+        clear_fake_calls: None,
+    ) -> None:
+        """3a.4: a multi-profile re-ingest preserves the existing note's
+        ``## Repair`` counters so a tier-terminal note keeps its caps.
+
+        The freshly-ingested create-path content carries no ``## Repair``
+        section (only the sweep writes one), so without the carry-forward
+        the merge would drop the accumulated counters and let the next
+        sweep re-attempt a capped tier from zero.
+        """
+        import json as _json
+
+        repair_section = (
+            "## Repair\n"
+            "- tier2_attempts: 3\n"
+            '- tier2_last_stage: "parse"\n'
+            '- tier2_last_error: "unparseable full text"\n'
+            "- tier3_attempts: 0\n"
+            '- tier3_last_stage: ""\n'
+            '- tier3_last_error: ""\n'
+            "- archive_attempts: 0\n"
+            '- archive_last_kind: ""\n'
+            '- archive_last_error: ""\n'
+        )
+        fake_lithos_server.write_responses.extend(
+            [
+                '{"status": "version_conflict", "note_id": "note-050"}',
+                '{"status": "updated"}',
+            ]
+        )
+        fake_lithos_server.read_responses.append(
+            _json.dumps(
+                {
+                    "id": "note-050",
+                    "content": (
+                        f"## Summary\nOld summary.\n\n{repair_section}\n"
+                        "## User Notes\nHand notes."
+                    ),
+                    "tags": [
+                        "profile:ml-research",
+                        "influx:tier2-terminal",
+                    ],
+                    "version": 5,
+                }
+            )
+        )
+        client = LithosClient(url=fake_lithos_url)
+        try:
+            result = await client.write_note(
+                title="Re-ingested Paper",
+                # Fresh create-path content: no ## Repair section.
+                content="## Summary\nFresh summary.",
+                path="papers/arxiv/2026/03",
+                source_url="https://arxiv.org/abs/2601.22222",
+                tags=["profile:cv-research", "source:arxiv"],
+                confidence=0.9,
+            )
+            assert result.status == "updated"
+
+            write_calls = [
+                c for c in fake_lithos_server.calls if c[0] == "lithos_write"
+            ]
+            retry_content = write_calls[1][1]["content"]
+            # The accumulated ## Repair counters survive the merge — this is
+            # the cap's source of truth.  (The ``influx:tier2-terminal``
+            # *tag* is Influx-owned and intentionally replaced by the fresh
+            # write per the merge_tags contract; the next sweep re-derives
+            # it from these preserved counters — attempts=3 ≥ cap.)
+            assert "## Repair" in retry_content
+            assert "tier2_attempts: 3" in retry_content
+            assert 'tier2_last_error: "unparseable full text"' in retry_content
+            # The fresh content + preserved user notes are still there.
+            assert "Fresh summary" in retry_content
+            assert "Hand notes" in retry_content
+        finally:
+            await client.close()
+
     async def test_version_conflict_preserves_user_notes_block(
         self,
         fake_lithos_url: str,

--- a/tests/unit/test_canonical_note.py
+++ b/tests/unit/test_canonical_note.py
@@ -489,9 +489,9 @@ def test_render_tier3_sections_emits_all_four_headings_when_lists_empty() -> Non
 
 
 class TestCarryForwardSection:
-    """``carry_forward_section`` copies a section verbatim from a source
-    note into a target note (the 3a.4 multi-profile-merge ## Repair
-    preservation seam).
+    """``carry_forward_section`` copies a section (as text, with LF-
+    normalised boundaries) from a source note into a target note (the
+    3a.4 multi-profile-merge ## Repair preservation seam).
     """
 
     _REPAIR = '## Repair\n- tier2_attempts: 3\n- tier2_last_error: "boom"\n'

--- a/tests/unit/test_canonical_note.py
+++ b/tests/unit/test_canonical_note.py
@@ -521,6 +521,43 @@ class TestCarryForwardSection:
         assert "tier2_attempts: 3" in result
         assert "tier2_attempts: 0" not in result
 
+    def test_exact_output_for_canonical_lf_content(self) -> None:
+        # Pins the full output for canonical LF notes: ## Repair lands
+        # before ## User Notes with a single blank-line separator.
+        source = (
+            "## Summary\nold\n\n"
+            '## Repair\n- tier2_attempts: 3\n- tier2_last_error: "boom"\n\n'
+            "## User Notes\nmine\n"
+        )
+        target = "## Summary\nfresh\n\n## User Notes\nmine\n"
+        assert cn.carry_forward_section(source, target, REPAIR) == (
+            "## Summary\nfresh\n\n"
+            '## Repair\n- tier2_attempts: 3\n- tier2_last_error: "boom"\n\n'
+            "## User Notes\nmine\n"
+        )
+
+    def test_normalises_trailing_blank_lines(self) -> None:
+        # Documented non-byte-exactness: extra trailing blank lines inside
+        # the source ## Repair are normalised away (extract_section_body
+        # rstrips; upsert_section_text re-renders LF boundaries).
+        source = "## Repair\n- tier2_attempts: 3\n\n\n## User Notes\nx\n"
+        target = "## Summary\nfresh\n"
+        result = cn.carry_forward_section(source, target, REPAIR)
+        assert result == "## Summary\nfresh\n\n## Repair\n- tier2_attempts: 3\n"
+        assert "\n\n\n" not in result
+
+    def test_inserts_before_profile_relevance(self) -> None:
+        source = "## Repair\n- tier2_attempts: 2\n\n## User Notes\nn\n"
+        target = (
+            "## Summary\ns\n\n"
+            "## Profile Relevance\n### p\nScore: 5/10\nr\n\n"
+            "## User Notes\nn\n"
+        )
+        result = cn.carry_forward_section(source, target, REPAIR)
+        # SECTION_ORDER places ## Repair before ## Profile Relevance.
+        assert result.index("## Repair") < result.index("## Profile Relevance")
+        assert "tier2_attempts: 2" in result
+
 
 class TestSectionInsertBytes:
     """Exact-byte splice behaviour for the section-insert ops.

--- a/tests/unit/test_canonical_note.py
+++ b/tests/unit/test_canonical_note.py
@@ -488,6 +488,40 @@ def test_render_tier3_sections_emits_all_four_headings_when_lists_empty() -> Non
         assert heading in rendered
 
 
+class TestCarryForwardSection:
+    """``carry_forward_section`` copies a section verbatim from a source
+    note into a target note (the 3a.4 multi-profile-merge ## Repair
+    preservation seam).
+    """
+
+    _REPAIR = '## Repair\n- tier2_attempts: 3\n- tier2_last_error: "boom"\n'
+
+    def test_copies_section_when_target_lacks_it(self) -> None:
+        source = f"## Summary\nold\n\n{self._REPAIR}\n## User Notes\nmine\n"
+        target = "## Summary\nfresh\n\n## User Notes\nmine\n"
+        result = cn.carry_forward_section(source, target, REPAIR)
+        assert "## Repair" in result
+        assert "tier2_attempts: 3" in result
+        assert 'tier2_last_error: "boom"' in result
+        # Placed before ## User Notes (insertion-point fallback chain).
+        assert result.index("## Repair") < result.index("## User Notes")
+        # Target's own content is preserved.
+        assert "fresh" in result
+
+    def test_noop_when_source_lacks_section(self) -> None:
+        source = "## Summary\nold\n"
+        target = "## Summary\nfresh\n"
+        assert cn.carry_forward_section(source, target, REPAIR) == target
+
+    def test_existing_target_section_replaced_by_source(self) -> None:
+        source = f"## Summary\ns\n\n{self._REPAIR}"
+        target = "## Summary\ns\n\n## Repair\n- tier2_attempts: 0\n"
+        result = cn.carry_forward_section(source, target, REPAIR)
+        # Source (accumulated) counters win over the target's zero baseline.
+        assert "tier2_attempts: 3" in result
+        assert "tier2_attempts: 0" not in result
+
+
 class TestSectionInsertBytes:
     """Exact-byte splice behaviour for the section-insert ops.
 


### PR DESCRIPTION
## What

Finishes the **create-path half of finding-3a's RepairCounters wiring** (scope 3a.4). Only the repair sweep writes a note's `## Repair` section; the create path enriches with a zero counter and never emits one. So when an existing — possibly **tier-terminal** — note is re-ingested by another profile, `LithosClient._retry_version_conflict` merged the fresh create-path content (no `## Repair`) over the existing note and **dropped the accumulated counters**, resetting a capped tier to zero. The next sweep would then re-attempt that tier from scratch, forever — the terminal cap was never respected on re-ingest.

## Fix

Carry the existing note's `## Repair` section forward verbatim into the merged content, mirroring how `graft_user_notes` / `_merge_profile_relevance_in_content` already preserve existing sections at the merge.

- New `canonical_note.carry_forward_section(source, target, heading)` — a generic section-copy op (`extract_section_body` + `upsert_section_text`). It carries the section *body* as text (no `RepairCounters` parse/re-render round-trip, so unknown/hand-added bullets survive), but — like every canonical section op — normalises the section it writes to LF boundaries. So it's **semantic** preservation of the counter content, **not** byte-exact: a hand-edited `## Repair` keeps its bullets but loses trailing blank lines / CRLF within the section. _(Wording corrected after review; exact-output + normalisation tests added.)_
- Kept in `canonical_note` (not `repair_counters`) deliberately: `LithosClient` (LithosBridge) importing `repair_counters` (Repair) would add a **LithosBridge↔Repair component cycle** (`repair.py` already imports `lithos_client`). The verbatim copy needs only the section ops, no bullet grammar.

A capped note's counters now survive re-ingest. Note the `influx:tierN-terminal` **tag** is Influx-owned and intentionally *replaced* by `notes.merge_tags` (the fresh write re-derives its own `influx:*` tags), so it's the preserved **counters**, not the tag, that carry the cap — the next sweep re-derives the terminal tag from `attempts ≥ cap`. The contract test documents this.

## ⚠️ Approach decision (Option B vs A) — worth a look

The `cascade.py` docstring anticipated the create-path merge **passing counters into `enrich`** (Option A). But `enrich` runs in the Source at *Acquire* time — before the merge target is read — so Option A would thread the existing counters through `acquire closure → Source.acquire → build_*_note_item → enrich` across **all three sources**, i.e. through the very Source seam **finding-3b** reworks.

I chose **Option B** (preserve the section at the merge): localized to the one function that already reads the existing note, achieves the same goal ("re-ingest respects caps"), and leaves the Source seam untouched for 3b. Trade-off: the fresh enrich still spends one (bounded, rare) re-attempt on re-ingest, and a re-ingested note may briefly carry `influx:repair-needed` until the next sweep re-terminalizes it from the preserved counters — no worse than today and self-healing. Updated the `cascade.py` docstrings + `CONTEXT.md` RepairCounters entry to describe the actual mechanism (dropped its `_(proposed)_` marker).

## Tests

- `TestCarryForwardSection` — the canonical section-copy op (copy / no-op / replace-existing).
- `test_version_conflict_preserves_repair_section` — contract test vs `FakeLithosServer`: a tier-terminal note re-ingested by a second profile keeps its `## Repair` counters + user notes; fresh content still merges.
- `make check` green: **2752 passed**, lint + pyright + guardrails clean. Only the known `test_run_conflict_exit_1` sandbox flake fails locally (subprocess-startup timeout; passes in CI).

## Scope

Refs Lithos task `62aa58f4` (finding 3, scope **3a.4**). **Tier 1 recovery** — the remaining 3a-labelled item — is folded into **3b** (task `7103dd79`), since re-running Tier 1 needs the source *abstract*, which only 3b's Source-seam re-acquire provides. 3b is next (now unblocked by finding 2).
