### PR TITLE
refactor(run): inject LithosClient via RunDeps + surface written note ids (finding 6)

### DIFF
--- a/docs/generated/domain_model.md
+++ b/docs/generated/domain_model.md
@@ -39,6 +39,7 @@ classDiagram
   class IngestResult {
     +ingested tuple[HighlightItem, ...]
     +sources_checked int
+    +written_note_ids tuple[str, ...]
   }
   class RepairResult {
     +candidates_visited int
@@ -50,6 +51,7 @@ classDiagram
     +probe_loop Any | None
     +ledger RunLedger | None
     +run_id str | None
+    +client_factory Callable[[], LithosClient] | None
   }
   class RunOutcome {
     +sources_checked int
@@ -62,6 +64,7 @@ classDiagram
     +profile_run_result ProfileRunResult | None
     +skipped bool
     +skip_reason str | None
+    +written_note_ids tuple[str, ...]
   }
   class RunPlan {
     +profile str

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -88,7 +88,7 @@
         "qualname": "influx.run_ledger.RunLedger.complete"
       },
       {
-        "complexity": 31,
+        "complexity": 32,
         "qualname": "influx.inbox.InboxTick._ingest_item"
       },
       {
@@ -104,7 +104,7 @@
         "qualname": "influx.repair._process_sweep_note"
       },
       {
-        "complexity": 23,
+        "complexity": 24,
         "qualname": "influx.run._run_ingest_stage"
       },
       {
@@ -120,7 +120,7 @@
         "qualname": "influx.promotion_gate.evaluate_promotion_gate"
       }
     ],
-    "total_functions": 651
+    "total_functions": 650
   },
   "domain": {
     "associations": 5,
@@ -410,13 +410,13 @@
       },
       "Orchestration": {
         "classes": 20,
-        "functions": 63,
+        "functions": 62,
         "largest_module": "influx.inbox",
-        "largest_module_lines": 1192,
-        "lines": 3753,
+        "largest_module_lines": 1182,
+        "lines": 3771,
         "modules": 5,
         "public_symbols": 30,
-        "sloc": 2929
+        "sloc": 2942
       },
       "Repair": {
         "classes": 17,
@@ -475,13 +475,13 @@
       "influx.sources.rss",
       "influx.telemetry"
     ],
-    "total_lines": 27962,
+    "total_lines": 27980,
     "total_modules": 57,
-    "total_sloc": 21707
+    "total_sloc": 21720
   },
   "tests": {
     "ratio": 2.53,
-    "src_lines": 27962,
-    "test_lines": 70756
+    "src_lines": 27980,
+    "test_lines": 70854
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -44,7 +44,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | LithosBridge | 8 | 4097 | 3254 | 6 | 3 | 0.33 | 17 (`influx.notes.merge_tags`) | 4 |
 | Notifications | 1 | 581 | 509 | 2 | 2 | 0.50 | 13 (`influx.notifications.dispatch_notifications`) | 2 |
 | Observability | 3 | 1912 | 1401 | 9 | 0 | 0.00 | 10 (`influx.logging_config.setup_logging`) | 0 |
-| Orchestration | 5 | 3753 | 2929 | 1 | 11 | 0.92 | 52 (`influx.run_service.ledger_lifecycle`) | 11 |
+| Orchestration | 5 | 3771 | 2942 | 1 | 11 | 0.92 | 52 (`influx.run_service.ledger_lifecycle`) | 11 |
 | Repair | 5 | 3769 | 2927 | 4 | 7 | 0.64 | 26 (`influx.repair._process_sweep_note`) | 6 |
 | Schemas | 1 | 240 | 183 | 3 | 0 | 0.00 | 14 (`influx.schemas._harden_for_openai_strict`) | 1 |
 | Sources | 10 | 4343 | 3323 | 3 | 8 | 0.73 | 28 (`influx.sources.arxiv.build_arxiv_note_item`) | 7 |
@@ -52,7 +52,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **57**, lines: **27962**, SLOC: **21707**
+- Modules: **57**, lines: **27980**, SLOC: **21720**
 - Largest module: `influx.sources.arxiv` (1830 lines)
 - Modules over 800 lines: **12**
   - `influx.config`
@@ -70,7 +70,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Complexity
 
-- Functions: **651**, cyclomatic > 10: **47**
+- Functions: **650**, cyclomatic > 10: **47**
 
 Top 10 most complex functions:
 
@@ -78,11 +78,11 @@ Top 10 most complex functions:
 |---:|---|
 | 52 | `influx.run_service.ledger_lifecycle` |
 | 47 | `influx.run_ledger.RunLedger.complete` |
-| 31 | `influx.inbox.InboxTick._ingest_item` |
+| 32 | `influx.inbox.InboxTick._ingest_item` |
 | 28 | `influx.sources.arxiv.build_arxiv_note_item` |
 | 28 | `influx.sources.rss.build_rss_note_item` |
 | 26 | `influx.repair._process_sweep_note` |
-| 23 | `influx.run._run_ingest_stage` |
+| 24 | `influx.run._run_ingest_stage` |
 | 23 | `influx.run_ledger.build_degradation_summary` |
 | 22 | `influx.cascade.Cascade.enrich` |
 | 20 | `influx.promotion_gate.evaluate_promotion_gate` |
@@ -134,4 +134,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 ## Domain & tests
 
 - Domain models: **17** (5 associations, 0 without docstrings)
-- Test-to-source line ratio: **2.53** (70756 test lines / 27962 source lines)
+- Test-to-source line ratio: **2.53** (70854 test lines / 27980 source lines)

--- a/src/influx/inbox.py
+++ b/src/influx/inbox.py
@@ -830,10 +830,16 @@ class InboxTick:
             name for name, (o, _rid) in dispatched.items() if o.ingested > 0
         ]
         # On a cache hit the canonical note id is already known; otherwise
-        # recover it after the first write created it.
+        # take it from the first ingesting dispatch's RunOutcome — the single
+        # inbox item merges into one canonical note across profiles, and
+        # finding 6 surfaces its id, so no extra cache_lookup_by_url_body.
         note_id = cache_note_id
-        if note_id is None and ingested_names:
-            note_id = await self._recover_note_id(client, acquired.source_url)
+        if note_id is None:
+            for name in ingested_names:
+                written = dispatched[name][0].written_note_ids
+                if written:
+                    note_id = written[0]
+                    break
 
         per_profile = self._build_per_profile(
             scored_profiles, dispatched, busy, dispatch_failed, note_id
@@ -1087,22 +1093,6 @@ class InboxTick:
         if not issues and len(ingested_names) == total:
             return f"ingested into {len(ingested_names)} profile(s): {names}"
         return f"ingested into {len(ingested_names)}/{total} profiles ({names}){tail}"
-
-    async def _recover_note_id(
-        self, client: LithosClient, source_url: str
-    ) -> str | None:
-        """Recover the canonical note id for ``cited_nodes`` (§7.2).
-
-        ``RunOutcome`` does not surface the written note id, so re-resolve
-        it by exact source-URL cache lookup after the dispatch.  Best-effort
-        — a recovery miss simply leaves ``cited_nodes`` empty.
-        """
-        try:
-            body = await client.cache_lookup_by_url_body(source_url=source_url)
-        except (LithosError, LCMAError):
-            logger.debug("note-id recovery failed for %s", source_url, exc_info=True)
-            return None
-        return _extract_note_id(body)
 
     async def _complete(
         self, client: LithosClient, task_id: str, result: _ItemOutcome

--- a/src/influx/run.py
+++ b/src/influx/run.py
@@ -130,6 +130,12 @@ class RunOutcome:
     ``sources_checked == 0`` space into ``fetch_stall`` (no items
     reached the filter) and ``filter_stall`` (items reached the
     filter, all rejected).
+
+    ``written_note_ids`` carries the Lithos note ids of the notes this
+    Run created/updated, in ingest order (finding 6).  The single-item
+    ``RunKind.INBOX`` dispatch reads it to attribute the write without a
+    second ``cache_lookup_by_url_body`` round-trip; empty for Runs that
+    ingested nothing.
     """
 
     sources_checked: int = 0
@@ -142,6 +148,7 @@ class RunOutcome:
     profile_run_result: ProfileRunResult | None = None
     skipped: bool = False
     skip_reason: str | None = None
+    written_note_ids: tuple[str, ...] = ()
 
 
 # ── StageDiagnostics + HealthAction (Q1 grilling — hybrid C) ────────
@@ -219,6 +226,8 @@ class IngestResult:
 
     ingested: tuple[HighlightItem, ...] = ()
     sources_checked: int = 0
+    # Lithos note ids of created/updated notes, in ingest order (finding 6).
+    written_note_ids: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -255,6 +264,13 @@ class RunDeps:
     ``probe_loop`` and ``ledger`` are typed as ``Any`` to avoid an
     import cycle and to mirror the legacy ``run_profile`` signature
     (which accepted duck-typed substitutes from tests).
+
+    ``client_factory`` is the LithosClient seam (finding 6), mirroring
+    :class:`~influx.inbox.InboxTick`'s: ``None`` builds the production
+    client from ``config.lithos`` (the scheduler / inbox paths), while
+    tests inject a fake transport double so the Run's interface — not a
+    module-level ``patch("influx.run.LithosClient")`` — is its test
+    surface.
     """
 
     config: AppConfig
@@ -262,6 +278,7 @@ class RunDeps:
     probe_loop: Any | None = None
     ledger: RunLedger | None = None
     run_id: str | None = None
+    client_factory: Callable[[], LithosClient] | None = None
 
 
 @asynccontextmanager
@@ -500,6 +517,7 @@ async def _run_ingest_stage(
     """
     profile = plan.profile
     ingested: list[HighlightItem] = []
+    written_note_ids: list[str] = []
     sources_checked = 0
     tracer = get_tracer()
 
@@ -679,6 +697,10 @@ async def _run_ingest_stage(
                     related_in_lithos=related_in_lithos,
                 )
             )
+            # Surface the Lithos note id so the inbox dispatch need not
+            # re-resolve it via cache_lookup_by_url_body (finding 6).
+            if write_result.note_id:
+                written_note_ids.append(write_result.note_id)
         elif not cache_hit:
             logger.warning(
                 "article write skipped profile=%s source_url=%s title=%r "
@@ -719,6 +741,7 @@ async def _run_ingest_stage(
         IngestResult(
             ingested=tuple(ingested),
             sources_checked=sources_checked,
+            written_note_ids=tuple(written_note_ids),
         ),
         StageDiagnostics(),
     )
@@ -778,6 +801,7 @@ async def _run_finalise_stage(
         fetched_total=fetched_total,
         profile_run_result=profile_run_result,
         source_acquisition_errors=tuple(current_source_acquisition_errors.get() or []),
+        written_note_ids=ingest.written_note_ids,
     )
     return FinaliseResult(outcome=outcome), StageDiagnostics()
 
@@ -852,7 +876,11 @@ class Run:
         config = deps.config
         probe_loop = deps.probe_loop
 
-        client = LithosClient(url=config.lithos.url, transport=config.lithos.transport)
+        client = (
+            deps.client_factory()
+            if deps.client_factory is not None
+            else LithosClient(url=config.lithos.url, transport=config.lithos.transport)
+        )
         try:
             async with lithos_task_lifecycle(plan, client) as run_task_id:
                 profile_cfg = next(

--- a/tests/unit/test_inbox_tick.py
+++ b/tests/unit/test_inbox_tick.py
@@ -75,11 +75,11 @@ class FakeClient:
     ) -> None:
         self._tasks = tasks
         self._claim_success = claim_success
-        # ``note_id`` is what post-dispatch recovery resolves for a *fresh*
-        # item; ``existing_note_id`` (+ ``existing_note``) drive the
-        # cache-hit gate + read_note for replay tests.  cache_lookup is
-        # called twice on the fresh path (gate miss, then recovery hit), so
-        # the first call models the gate and later calls model recovery.
+        # ``existing_note_id`` (+ ``existing_note``) drive the cache-hit gate
+        # + read_note for replay tests.  Since finding 6 the fresh path calls
+        # cache_lookup only ONCE (the gate) — the note id comes from
+        # ``RunOutcome.written_note_ids``, so ``note_id`` here only models a
+        # stray second lookup (asserted absent via ``cache_lookup_calls``).
         self._note_id = note_id
         self._existing_note_id = existing_note_id
         self._existing_note = existing_note or {"content": "", "tags": []}
@@ -88,6 +88,7 @@ class FakeClient:
         self.updated: list[tuple[str, dict[str, Any]]] = []
         self.completed: list[dict[str, Any]] = []
         self.list_calls = 0
+        self.cache_lookup_calls = 0
 
     async def task_list_body(self, **_: Any) -> dict[str, Any]:
         self.list_calls += 1
@@ -117,8 +118,10 @@ class FakeClient:
         return {"status": "completed"}
 
     async def cache_lookup_by_url_body(self, *, source_url: str) -> dict[str, Any]:
-        # First lookup for a URL is the cache-hit gate; later lookups for the
-        # same URL are post-dispatch note-id recovery (fresh path).
+        # The only lookup per URL is the cache-hit gate (finding 6 removed the
+        # post-dispatch recovery lookup); the second-call branch is retained
+        # to prove, via ``cache_lookup_calls``, that it never fires.
+        self.cache_lookup_calls += 1
         if source_url not in self._gated:
             self._gated.add(source_url)
             if self._existing_note_id:
@@ -219,7 +222,8 @@ async def test_happy_path_ingests_and_completes_with_cited_nodes() -> None:
         ),
         patch("influx.inbox.build_filter_prompt", return_value="prompt"),
         patch(
-            "influx.inbox.dispatch_profile", return_value=RunOutcome(ingested=1)
+            "influx.inbox.dispatch_profile",
+            return_value=RunOutcome(ingested=1, written_note_ids=("note-xyz",)),
         ) as mock_dispatch,
     ):
         await _tick(client).execute()
@@ -230,7 +234,10 @@ async def test_happy_path_ingests_and_completes_with_cited_nodes() -> None:
     assert len(client.completed) == 1
     done = client.completed[0]
     assert "ingested into 1 profile(s): alpha" in done["outcome"]
+    # note id comes from RunOutcome.written_note_ids (finding 6) …
     assert done["cited_nodes"] == ["note-xyz"]
+    # … with no post-dispatch recovery round-trip: only the cache-hit gate.
+    assert client.cache_lookup_calls == 1
     # Structured inbox_result attached before completion.
     assert client.updated[0][1]["inbox_result"]["per_profile"]["alpha"]["ingested"]
 
@@ -449,7 +456,8 @@ async def test_per_profile_dispatch_failure_isolated() -> None:
 
 
 def test_extract_note_id_key_fallback() -> None:
-    """note-id recovery tolerates id / note_id / existing_id; miss → None."""
+    """The cache-hit gate's id extraction tolerates id / note_id / existing_id;
+    a miss → None."""
     assert _extract_note_id({"hit": True, "id": "n1"}) == "n1"
     assert _extract_note_id({"hit": True, "note_id": "n2"}) == "n2"
     assert _extract_note_id({"hit": True, "existing_id": "n3"}) == "n3"
@@ -472,7 +480,8 @@ async def test_fans_out_to_all_clearing_profiles() -> None:
         ),
         patch("influx.inbox.build_filter_prompt", return_value="prompt"),
         patch(
-            "influx.inbox.dispatch_profile", return_value=RunOutcome(ingested=1)
+            "influx.inbox.dispatch_profile",
+            return_value=RunOutcome(ingested=1, written_note_ids=("note-1",)),
         ) as mock_dispatch,
     ):
         await _tick(client, config).execute()
@@ -996,7 +1005,8 @@ async def test_pdf_happy_path_ingests(tmp_path: Path) -> None:
         ),
         patch("influx.inbox.build_filter_prompt", return_value="prompt"),
         patch(
-            "influx.inbox.dispatch_profile", return_value=RunOutcome(ingested=1)
+            "influx.inbox.dispatch_profile",
+            return_value=RunOutcome(ingested=1, written_note_ids=("note-pdf",)),
         ) as mock_dispatch,
     ):
         await _tick(client, config).execute()

--- a/tests/unit/test_run_module.py
+++ b/tests/unit/test_run_module.py
@@ -506,8 +506,93 @@ async def test_run_execute_walks_provider_and_writes_per_item() -> None:
 
     assert outcome.sources_checked == 1
     assert outcome.ingested == 1
+    # finding 6: the written Lithos note id is surfaced on the outcome.
+    assert outcome.written_note_ids == ("note-new",)
     mock_client.write_note.assert_awaited_once()
     wire.assert_awaited_once()
+
+
+async def test_run_execute_uses_injected_client_factory() -> None:
+    """finding 6: ``RunDeps.client_factory`` supplies the LithosClient.
+
+    With a factory injected, ``Run.execute`` never constructs its own
+    ``LithosClient`` — so tests plug a fake straight in without having to
+    ``patch("influx.run.LithosClient")``.  This test deliberately does NOT
+    patch that symbol, proving the seam carries the dependency.
+    """
+    config = _make_config()
+    plan = _scheduled_plan()
+
+    items = [
+        {
+            "title": "Test Paper",
+            "source_url": "https://arxiv.org/abs/2401.00001",
+            "content": "# Summary\n\nbody",
+            "tags": ["profile:alpha", "source:arxiv"],
+            "confidence": 0.9,
+            "score": 9,
+            "path": "papers/arxiv/2024/01",
+            "abstract_or_summary": "abs",
+        }
+    ]
+
+    async def provider(
+        profile: str, kind: RunKind, run_range: Any, filter_prompt: str
+    ) -> list[BoundScoredCandidate]:
+        return [_bound_for(it) for it in items]
+
+    from mcp import types as mcp_types
+
+    mock_client = MagicMock()
+    mock_client.close = AsyncMock()
+    mock_client.list_archive_terminal_arxiv_ids = AsyncMock(return_value=frozenset())
+    mock_client.task_create_body = AsyncMock(return_value={"task_id": "task-1"})
+    mock_client.task_complete = AsyncMock(
+        return_value=mcp_types.CallToolResult(
+            content=[
+                mcp_types.TextContent(
+                    type="text", text=json.dumps({"status": "completed"})
+                )
+            ]
+        )
+    )
+    mock_client.cache_lookup_for_item_body = AsyncMock(return_value={"hit": False})
+    mock_client.cache_lookup_by_url_body = AsyncMock(return_value={"hit": False})
+    write_result = MagicMock()
+    write_result.status = "created"
+    write_result.note_id = "note-injected"
+    mock_client.write_note = AsyncMock(return_value=write_result)
+
+    factory_calls = 0
+
+    def client_factory() -> Any:
+        nonlocal factory_calls
+        factory_calls += 1
+        return mock_client
+
+    deps = RunDeps(
+        config=config,
+        item_provider=provider,
+        probe_loop=None,
+        client_factory=client_factory,
+    )
+
+    # No patch("influx.run.LithosClient") — the factory is the only source.
+    with (
+        patch("influx.run.repair_sweep", new_callable=AsyncMock, return_value=[]),
+        patch(
+            "influx.feedback.build_negative_examples_block",
+            side_effect=_empty_neg_block,
+        ),
+        patch("influx.run.lcma_wire", new_callable=AsyncMock, return_value=[]),
+        patch("influx.service.post_run_webhook_hook"),
+    ):
+        outcome = await Run(plan, deps).execute()
+
+    assert factory_calls == 1
+    assert outcome.ingested == 1
+    assert outcome.written_note_ids == ("note-injected",)
+    mock_client.write_note.assert_awaited_once()
 
 
 async def test_run_execute_threads_tags_source_url_confidence_to_lithos_write() -> None:
@@ -705,6 +790,9 @@ async def test_run_execute_continues_after_lcma_wiring_failure() -> None:
 
     assert outcome.sources_checked == 2
     assert outcome.ingested == 2
+    # finding 6: both written note ids surface in ingest order even when a
+    # post-write LCMA wiring failure occurs for one of them.
+    assert outcome.written_note_ids == ("note-1", "note-2")
     assert wire.await_count == 2
 
 


### PR DESCRIPTION
## What & why (finding 6)

Two coupled defects in the Run module, from the 2026-07-06 architecture review:

1. **`Run.execute` hard-constructed its own `LithosClient`.** Every Run test had to `patch("influx.run.LithosClient")` and hand-roll a ~10-method stub — `RunDeps` already carries every other injected dependency, and `InboxTick` already has a `client_factory` seam for the *same* client. Inconsistent DI for the same dependency.
2. **`RunOutcome` dropped the written note id.** `Run` knew `write_result.note_id` and discarded it (`HighlightItem.id` was a fabricated placeholder). `InboxTick` therefore re-resolved the id with an extra `cache_lookup_by_url_body` round-trip after every dispatch (`_recover_note_id`) — pure waste, adjacent to the #211 replay-side-effects surface.

## Changes

- **`RunDeps.client_factory`** — optional `Callable[[], LithosClient] | None`, mirroring `InboxTick`. `None` builds the production client exactly as before; tests inject a fake. **Backward compatible**: the fallback keeps `patch("influx.run.LithosClient")` working, so no existing Run/scheduler/telemetry test changes.
- **`RunOutcome.written_note_ids` / `IngestResult.written_note_ids`** — created/updated Lithos note ids in ingest order. `_run_ingest_stage` collects `write_result.note_id`; `_run_finalise_stage` threads it onto the outcome.
- **`InboxTick`** reads `written_note_ids[0]` from the single-item dispatch outcome instead of a second cache lookup. `_recover_note_id` deleted (`_extract_note_id`, used by the pre-dispatch existence check, stays).

The inbox dispatch builds a **single-item** Run, so `written_note_ids[0]` is unambiguous and equal to what the deleted `_recover_note_id` cache lookup would have returned (same canonical note, no round-trip, no race).

## Tests

- `test_run_execute_uses_injected_client_factory` (new) — proves the seam carries the dependency **without** `patch("influx.run.LithosClient")`.
- `written_note_ids` assertions added to the single-write and multi-write Run tests.
- `test_inbox_tick`: `FakeClient` now counts `cache_lookup_calls`; the happy-path test asserts exactly **one** cache lookup (the pre-dispatch existence check — the recovery lookup is gone) and reads the cited node from `written_note_ids`.

## Verification

- `make check` green (lint + pyright + 2767 tests). Sole failure is the known local-only flake `test_run_conflict_exit_1` (10s subprocess timeout; passes in CI).
- `make diagrams` regenerated `docs/generated/` — new fields appear in `domain_model.md`; `metrics.md` reflects the small line/complexity deltas. Budgets held.

Refs #211
Refs Lithos task d44d9151-fd9f-4f7e-b0a7-ba5a0aa6a1d5 (finding 6)
