### PR TITLE
refactor(backfill): delete run_backfill pass-through; slim backfill.py (finding 4, slice 1/3)

### DIFF
--- a/docs/generated/components/HttpApi.md
+++ b/docs/generated/components/HttpApi.md
@@ -11,7 +11,7 @@ FastAPI HTTP surface (/runs, /backfills, /ready) and backfill request handling.
 
 | Module | Size | Classes | Functions |
 |---|---|---:|---:|
-| `influx.backfill` | S | 1 | 2 |
+| `influx.backfill` | XS | 1 | 1 |
 | `influx.http_api` | L | 2 | 8 |
 | `influx.service` | M | 1 | 4 |
 
@@ -20,7 +20,6 @@ FastAPI HTTP surface (/runs, /backfills, /ready) and backfill request handling.
 ### `influx.backfill`
 - class `BackfillRangeError` — Raised when the backfill range inputs are invalid.
 - def `validate_backfill_range` — Validate and normalise backfill range inputs into a ``run_range`` dict.
-- def `run_backfill` — Execute a backfill run for a single profile.
 
 ### `influx.http_api`
 - def `install_exception_handlers` — Install structured JSON error handlers for the admin API.

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -120,7 +120,7 @@
         "qualname": "influx.promotion_gate.evaluate_promotion_gate"
       }
     ],
-    "total_functions": 650
+    "total_functions": 648
   },
   "domain": {
     "associations": 5,
@@ -222,12 +222,11 @@
       }
     },
     "cross_component_edges": 62,
-    "cross_component_module_edges": 190,
+    "cross_component_module_edges": 185,
     "longest_component_chain": 4,
     "module_cycle_count": 3,
     "module_cycles": [
       [
-        "influx.backfill",
         "influx.http_api",
         "influx.inbox",
         "influx.run",
@@ -370,13 +369,13 @@
       },
       "HttpApi": {
         "classes": 4,
-        "functions": 43,
+        "functions": 41,
         "largest_module": "influx.http_api",
-        "largest_module_lines": 1007,
-        "lines": 1529,
+        "largest_module_lines": 956,
+        "lines": 1410,
         "modules": 3,
-        "public_symbols": 18,
-        "sloc": 1276
+        "public_symbols": 17,
+        "sloc": 1167
       },
       "LithosBridge": {
         "classes": 13,
@@ -475,13 +474,13 @@
       "influx.sources.rss",
       "influx.telemetry"
     ],
-    "total_lines": 27980,
+    "total_lines": 27861,
     "total_modules": 57,
-    "total_sloc": 21720
+    "total_sloc": 21611
   },
   "tests": {
-    "ratio": 2.53,
-    "src_lines": 27980,
-    "test_lines": 70854
+    "ratio": 2.54,
+    "src_lines": 27861,
+    "test_lines": 70863
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -21,9 +21,9 @@ lower a budget after improving the code to lock in the gain.
 
 ## Import graph
 
-- Cross-component edges: **62** (190 module-level)
+- Cross-component edges: **62** (185 module-level)
 - Component cycles: Common ↔ Config; Enrich ↔ Repair ↔ Sources ↔ Storage; HttpApi ↔ Orchestration
-- Module cycles: influx.backfill ↔ influx.http_api ↔ influx.inbox ↔ influx.run ↔ influx.run_service ↔ influx.scheduler ↔ influx.service; influx.repair ↔ influx.repair_hooks; influx.sources ↔ influx.sources.arxiv ↔ influx.sources.rss
+- Module cycles: influx.http_api ↔ influx.inbox ↔ influx.run ↔ influx.run_service ↔ influx.scheduler ↔ influx.service; influx.repair ↔ influx.repair_hooks; influx.sources ↔ influx.sources.arxiv ↔ influx.sources.rss
 - Tier-skipping edges (Entrypoints → Foundation): 9 (Entrypoint -> Common, Entrypoint -> Config, Entrypoint -> Observability, HttpApi -> Common, HttpApi -> Config, HttpApi -> Observability, Orchestration -> Common, Orchestration -> Config, Orchestration -> Observability)
 - Longest component dependency chain: 4
 
@@ -40,7 +40,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Entrypoint | 2 | 573 | 454 | 0 | 5 | 1.00 | 14 (`influx.main._cmd_backfill`) | 2 |
 | Feedback | 3 | 571 | 450 | 1 | 4 | 0.80 | 15 (`influx.run_dedup.dedup_scored_candidates`) | 1 |
 | Filter | 1 | 474 | 398 | 3 | 4 | 0.57 | 11 (`influx.filter.make_default_batch_scorer._scorer`) | 1 |
-| HttpApi | 3 | 1529 | 1276 | 2 | 8 | 0.80 | 17 (`influx.http_api.post_backfills`) | 3 |
+| HttpApi | 3 | 1410 | 1167 | 2 | 8 | 0.80 | 17 (`influx.http_api.post_backfills`) | 3 |
 | LithosBridge | 8 | 4097 | 3254 | 6 | 3 | 0.33 | 17 (`influx.notes.merge_tags`) | 4 |
 | Notifications | 1 | 581 | 509 | 2 | 2 | 0.50 | 13 (`influx.notifications.dispatch_notifications`) | 2 |
 | Observability | 3 | 1912 | 1401 | 9 | 0 | 0.00 | 10 (`influx.logging_config.setup_logging`) | 0 |
@@ -52,7 +52,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **57**, lines: **27980**, SLOC: **21720**
+- Modules: **57**, lines: **27861**, SLOC: **21611**
 - Largest module: `influx.sources.arxiv` (1830 lines)
 - Modules over 800 lines: **12**
   - `influx.config`
@@ -70,7 +70,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Complexity
 
-- Functions: **650**, cyclomatic > 10: **47**
+- Functions: **648**, cyclomatic > 10: **47**
 
 Top 10 most complex functions:
 
@@ -134,4 +134,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 ## Domain & tests
 
 - Domain models: **17** (5 associations, 0 without docstrings)
-- Test-to-source line ratio: **2.53** (70854 test lines / 27980 source lines)
+- Test-to-source line ratio: **2.54** (70863 test lines / 27861 source lines)

--- a/src/influx/backfill.py
+++ b/src/influx/backfill.py
@@ -1,41 +1,24 @@
-"""Backfill orchestration module.
+"""Backfill request validation.
 
-Houses the backfill-specific run flow, range validation, estimator
-integration, and the :func:`run_backfill` entry point that drives
-``run_profile(kind=BACKFILL)`` with the proper ``run_range``.
+Backfill *execution* is just a Run with ``RunKind.BACKFILL`` — it flows
+through the same ``run_profile`` → ``RunService`` path as any other run,
+with the kind driving the backfill-specific gating downstream:
 
-Cache-lookup skip (FR-BF-2): items already ingested are skipped
-in ``run_profile`` when ``kind == RunKind.BACKFILL`` — the write
-attempt is elided entirely so that large backfills avoid redundant
-network traffic.
+- Repair sweep is skipped (FR-REP-2).
+- Webhook POST is skipped (FR-NOT-4).
+- Cache-hit items are skipped entirely (FR-BF-2).
+- ArXiv pacing is enforced by the arXiv fetcher (FR-BF-3).
+- Same-profile serialisation is enforced by the coordinator (AC-M3-7).
 
-ArXiv pacing (FR-BF-3): the arXiv item provider sleeps for
-``ResilienceConfig.arxiv_request_min_interval_seconds`` before each
-backfill fetch when ``kind == RunKind.BACKFILL`` so a multi-day
-backfill does not burst against the arXiv API.  The provider also
-threads the resolved :class:`~influx.sources.arxiv.BackfillRange`
-into ``fetch_arxiv``, replacing the standard lookback window with
-the requested historical bounds.
-
-Same-profile serialisation (AC-M3-7): enforced by the coordinator
-— ``POST /backfills`` acquires the profile lock before launching
-``run_backfill``, and the scheduler fire path does the same.
+There is therefore no backfill-specific run entry point; the only piece
+that is genuinely backfill-shaped is validating the CLI's requested
+date range, which lives here.
 """
 
 from __future__ import annotations
 
-from typing import Any
-
-from influx.config import AppConfig
-from influx.coordinator import RunKind
-from influx.http_api import estimate_backfill_items
-from influx.notifications import ProfileRunResult
-from influx.run_ledger import RunLedger
-from influx.scheduler import ItemProvider, run_profile
-
 __all__ = [
-    "estimate_backfill_items",
-    "run_backfill",
+    "BackfillRangeError",
     "validate_backfill_range",
 ]
 
@@ -89,54 +72,3 @@ def validate_backfill_range(
         run_range["to"] = date_to
 
     return run_range
-
-
-async def run_backfill(
-    profile: str,
-    *,
-    run_range: dict[str, str | int],
-    config: AppConfig,
-    item_provider: ItemProvider | None = None,
-    probe_loop: Any | None = None,
-    run_id: str | None = None,
-    run_ledger: RunLedger | None = None,
-) -> ProfileRunResult | None:
-    """Execute a backfill run for a single profile.
-
-    Delegates to :func:`~influx.scheduler.run_profile` with
-    ``kind=RunKind.BACKFILL``.  The run_profile function handles
-    backfill-specific gating:
-
-    - Repair sweep is skipped (FR-REP-2).
-    - Webhook POST is skipped (FR-NOT-4).
-    - Cache-hit items are skipped entirely (FR-BF-2) — no write
-      attempt is made for items that ``lithos_cache_lookup`` reports
-      as already ingested.
-    - ArXiv pacing is enforced by the arXiv fetcher (FR-BF-3).
-    - Same-profile serialisation is enforced by the coordinator
-      (AC-M3-7).
-
-    Parameters
-    ----------
-    profile:
-        Profile name from the loaded config.
-    run_range:
-        Date-range dict (e.g. ``{"days": 7}`` or
-        ``{"from": "2026-04-01", "to": "2026-04-08"}``).
-    config:
-        Loaded :class:`~influx.config.AppConfig`.
-    item_provider:
-        Optional override for the item provider.
-    probe_loop:
-        Optional probe loop for readiness tracking.
-    """
-    return await run_profile(
-        profile,
-        RunKind.BACKFILL,
-        run_range=run_range,
-        config=config,
-        item_provider=item_provider,
-        probe_loop=probe_loop,
-        run_id=run_id,
-        run_ledger=run_ledger,
-    )

--- a/src/influx/http_api.py
+++ b/src/influx/http_api.py
@@ -487,60 +487,6 @@ async def _run_and_release(
             fetch_cache.end_fire()
 
 
-async def _backfill_and_release(
-    coordinator: Coordinator,
-    profile: str,
-    run_range: dict[str, str | int],
-    *,
-    config: Any = None,
-    item_provider: Any = None,
-    probe_loop: Any = None,
-    fetch_cache: Any = None,
-    run_id: str | None = None,
-    run_ledger: RunLedger | None = None,
-) -> None:
-    """Run ``backfill.run_backfill`` and release the coordinator lock afterward.
-
-    Analogous to :func:`_run_and_release` but routes through the
-    :mod:`influx.backfill` module so that backfill-specific logic
-    (cache-hit skip, pacing) is exercised end-to-end (US-009).
-    """
-    from influx.backfill import run_backfill
-
-    if fetch_cache is not None:
-        fetch_cache.begin_fire()
-    try:
-        try:
-            await run_backfill(
-                profile,
-                run_range=run_range,
-                config=config,
-                item_provider=item_provider,
-                probe_loop=probe_loop,
-                run_id=run_id,
-                run_ledger=run_ledger,
-            )
-        except Exception:
-            logger.warning(
-                "run_backfill %r aborted request_id=%s",
-                profile,
-                run_id,
-                exc_info=True,
-                extra={
-                    "request_id": run_id,
-                    "kind": "backfill",
-                    "scope": profile,
-                    "profile": profile,
-                    "status": "failed",
-                },
-            )
-            raise
-    finally:
-        coordinator.release(profile)
-        if fetch_cache is not None:
-            fetch_cache.end_fire()
-
-
 async def _run_many_and_release(
     coordinator: Coordinator,
     profiles: list[str],
@@ -898,12 +844,15 @@ async def post_backfills(body: BackfillRequest, request: Request) -> JSONRespons
                 ledger=run_ledger,
             )
 
-        # Launch the backfill in the background via backfill.run_backfill.
+        # Launch the single-profile backfill in the background. A backfill is
+        # just a Run with RunKind.BACKFILL, so it shares _run_and_release with
+        # manual runs — the kind drives repair/cache/notify gating downstream.
         _spawn_tracked_task(
             request.app,
-            _backfill_and_release(
+            _run_and_release(
                 coordinator,
                 body.profile,
+                RunKind.BACKFILL,
                 run_range,
                 config=config,
                 item_provider=getattr(request.app.state, "item_provider", None),

--- a/src/influx/scheduler.py
+++ b/src/influx/scheduler.py
@@ -122,7 +122,7 @@ async def run_profile(
     """Backward-compatible thin wrapper over :class:`influx.run_service.RunService`.
 
     Existing callers (HTTP admin handlers, ``InfluxScheduler._fire_profile``,
-    ``influx.backfill.run_backfill``, integration tests) still call
+    integration tests) still call
     ``run_profile`` with the legacy signature.  Internally we now build
     a :class:`RunPlan`, hand it to :class:`RunService`, and unwrap the
     :class:`RunOutcome` back into a legacy :class:`ProfileRunResult` so

--- a/tests/integration/test_backfill_arxiv.py
+++ b/tests/integration/test_backfill_arxiv.py
@@ -27,7 +27,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from influx.backfill import run_backfill
 from influx.config import (
     AppConfig,
     ArxivSourceConfig,
@@ -190,7 +189,7 @@ def clear_fakes(fake_lithos: FakeLithosServer) -> None:
 
 
 class TestBackfillRunCompletes:
-    """Backfill --profile X --days 7 completes via run_backfill."""
+    """Backfill --profile X --days 7 completes via run_profile(kind=BACKFILL)."""
 
     def test_backfill_days_7_completes(
         self,
@@ -214,8 +213,9 @@ class TestBackfillRunCompletes:
             return_value=list(_FIXTURE_ARXIV_ITEMS),
         ):
             result = asyncio.run(
-                run_backfill(
+                run_profile(
                     PROFILE,
+                    RunKind.BACKFILL,
                     run_range={"days": 7},
                     config=config,
                     item_provider=provider,
@@ -256,8 +256,9 @@ class TestBackfillRunCompletes:
             return_value=list(_FIXTURE_ARXIV_ITEMS),
         ):
             result = asyncio.run(
-                run_backfill(
+                run_profile(
                     PROFILE,
+                    RunKind.BACKFILL,
                     run_range={"from": "2026-04-20", "to": "2026-04-27"},
                     config=config,
                     item_provider=provider,
@@ -312,8 +313,9 @@ class TestBackfillCacheLookupSkip:
             return_value=list(_FIXTURE_ARXIV_ITEMS),
         ):
             result = asyncio.run(
-                run_backfill(
+                run_profile(
                     PROFILE,
+                    RunKind.BACKFILL,
                     run_range={"days": 7},
                     config=config,
                     item_provider=provider,
@@ -364,8 +366,9 @@ class TestBackfillCacheLookupSkip:
             return_value=list(_FIXTURE_ARXIV_ITEMS),
         ):
             result = asyncio.run(
-                run_backfill(
+                run_profile(
                     PROFILE,
+                    RunKind.BACKFILL,
                     run_range={"days": 7},
                     config=config,
                     item_provider=provider,
@@ -433,8 +436,9 @@ class TestBackfillNoOverlap:
             ) as mock_sweep,
         ):
             asyncio.run(
-                run_backfill(
+                run_profile(
                     PROFILE,
+                    RunKind.BACKFILL,
                     run_range={"days": 7},
                     config=config,
                     item_provider=provider,
@@ -471,8 +475,9 @@ class TestBackfillNoOverlap:
             ) as mock_webhook,
         ):
             asyncio.run(
-                run_backfill(
+                run_profile(
                     PROFILE,
+                    RunKind.BACKFILL,
                     run_range={"days": 7},
                     config=config,
                     item_provider=provider,
@@ -565,8 +570,9 @@ class TestBackfillTaskTagging:
             return_value=list(_FIXTURE_ARXIV_ITEMS),
         ):
             result = asyncio.run(
-                run_backfill(
+                run_profile(
                     PROFILE,
+                    RunKind.BACKFILL,
                     run_range={"days": 7},
                     config=config,
                     item_provider=provider,
@@ -684,8 +690,9 @@ class TestBackfillRangePropagation:
             patch("influx.sources.arxiv._sleep") as mock_sleep,
         ):
             asyncio.run(
-                run_backfill(
+                run_profile(
                     PROFILE,
+                    RunKind.BACKFILL,
                     run_range={"days": 7},
                     config=config,
                     item_provider=provider,
@@ -764,8 +771,9 @@ class TestBackfillRangePropagation:
             patch("influx.sources.arxiv._sleep"),
         ):
             asyncio.run(
-                run_backfill(
+                run_profile(
                     PROFILE,
+                    RunKind.BACKFILL,
                     run_range={"from": "2026-04-20", "to": "2026-04-27"},
                     config=config,
                     item_provider=provider,
@@ -855,8 +863,8 @@ def _wait_for_idle(
 class TestBackfillEndpointEndToEnd:
     """Review finding 3: drive ``POST /backfills`` through the real app.
 
-    The earlier tests in this module call ``run_backfill`` directly and
-    mock ``post_run_webhook_hook`` / ``repair_sweep``.  Those tests
+    The earlier tests in this module call ``run_profile(kind=BACKFILL)``
+    directly and mock ``post_run_webhook_hook`` / ``repair_sweep``.  Those tests
     cannot prove that ``kind="backfill"`` propagates from the HTTP layer
     down to task tagging, that the webhook gate prevents a real outbound
     HTTP call, or that the repair-sweep gate prevents a real

--- a/tests/integration/test_http_api.py
+++ b/tests/integration/test_http_api.py
@@ -1013,12 +1013,12 @@ class TestBackfillObservability:
     ) -> None:
         import httpx
 
-        import influx.backfill as backfill_mod
+        from influx import http_api as http_api_mod
 
-        async def fake_run_backfill(*args: Any, **kwargs: Any) -> None:
+        async def fake_run_profile(*args: Any, **kwargs: Any) -> None:
             return None
 
-        monkeypatch.setattr(backfill_mod, "run_backfill", fake_run_backfill)
+        monkeypatch.setattr(http_api_mod, "run_profile", fake_run_profile)
 
         with caplog.at_level("INFO", logger="influx.http_api"):
             transport = httpx.ASGITransport(app=app_with_state)

--- a/tests/integration/test_pre_acquire_dedup.py
+++ b/tests/integration/test_pre_acquire_dedup.py
@@ -35,7 +35,6 @@ from unittest.mock import patch
 
 import pytest
 
-from influx.backfill import run_backfill
 from influx.config import (
     AppConfig,
     ArxivSourceConfig,
@@ -250,8 +249,9 @@ class TestPreAcquireDedupArxivBackfill:
             patch("influx.sources.arxiv.build_arxiv_note_item") as mock_build,
         ):
             result = asyncio.run(
-                run_backfill(
+                run_profile(
                     PROFILE,
+                    RunKind.BACKFILL,
                     run_range={"days": 7},
                     config=config,
                     item_provider=provider,
@@ -321,8 +321,9 @@ class TestPreAcquireDedupRssBackfill:
             patch("influx.sources.rss.build_rss_note_item") as mock_build,
         ):
             result = asyncio.run(
-                run_backfill(
+                run_profile(
                     PROFILE,
+                    RunKind.BACKFILL,
                     run_range={"days": 7},
                     config=config,
                     item_provider=provider,


### PR DESCRIPTION
## What & why (finding 4, slice 1 of 3)

First slice of finding 4 (*"half of `http_api.py` is the request-orchestration layer"*). This one removes the dead `backfill.run_backfill` pass-through and the coupling it created.

`backfill.run_backfill` failed the deletion test — its entire body forwarded to `run_profile(kind=RunKind.BACKFILL)` and added nothing, and the **multi-profile backfill path already bypassed it**, calling `run_profile` directly. Worse, `backfill.py` imported `estimate_backfill_items` back *from* `http_api`, which is what put `backfill` inside the 7-module import cycle.

## Changes

- **Route single-profile backfill through the existing `_run_and_release(kind=RunKind.BACKFILL)`.** A backfill is just a Run with that kind — the kind already drives repair/cache/notify gating downstream. Deletes the near-duplicate `_backfill_and_release` wrapper (~50 lines).
- **Slim `backfill.py` to `validate_backfill_range` + `BackfillRangeError`** — now a leaf module that imports nothing from `influx`. `estimate_backfill_items` stays in `http_api` (its only importers already reference it there, so the re-export had zero consumers).
- Tests that drove `run_backfill` directly now call `run_profile(profile, RunKind.BACKFILL, run_range=...)` — they already imported both symbols. The single-profile backfill observability test patches `http_api.run_profile`, matching its all-profiles sibling.

## Impact (from regenerated `docs/generated/`)

- **`influx.backfill` drops out of the module cycle**: the SCC shrinks from `backfill ↔ http_api ↔ inbox ↔ run ↔ run_service ↔ scheduler ↔ service` (7) to `http_api ↔ inbox ↔ run ↔ run_service ↔ scheduler ↔ service` (6).
- Module-level import edges 190 → 185; HttpApi component −119 lines; total −109 SLOC.
- Cross-component edges unchanged (62, budget satisfied); no new cycles.

**Honest scope note:** the *component-level* `HttpApi ↔ Orchestration` cycle persists — it's driven by `http_api → scheduler.run_profile` and `run → service` (post-run webhook), which slices 2 (extract the orchestration collaborator) and 3 (retire the `run_profile`/`run_via_service` shims) target.

## Verification

- `make check` green (lint + pyright + 2767 tests). Sole failure is the known local-only flake `test_run_conflict_exit_1` (10s subprocess timeout; passes in CI).
- `make diagrams` regenerated `docs/generated/` (metrics + HttpApi drill-down); committed, no drift.

Refs Lithos task 9d943825-d970-423a-a9c0-155ac8647393 (finding 4, slice 1/3)
