### PR TITLE
refactor(http_api): extract RunDispatcher request-orchestration collaborator (finding 4, slice 2/3)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,6 +72,10 @@ The post-write step that calls `lithos_retrieve` for related notes, upserts `rel
 **RunService**:
 The collaborator that owns "build RunPlan → execute Run → dispatch notifications → record outcome" for one request. The scheduler's three entry points (scheduled tick, `POST /runs`, `POST /backfills`) are thin RunPlan builders that hand off to RunService. Lives in `src/influx/run_service.py` as `RunService.execute()`.
 
+**RunDispatcher**:
+The request-orchestration collaborator that turns an admin `POST /runs` or `POST /backfills` request into background Runs. Acquires the per-Profile Coordinator locks all-or-nothing (any busy Profile releases everything acquired so far and rejects the request — no partial fan-out), launches the Run(s) as tracked background tasks so the response returns immediately, registers them on the shutdown-grace set so `InfluxService.stop` can drain them, and releases the locks. Kind-agnostic — manual runs and backfills share one lock lifecycle and one fan-out path — so the HTTP router stays thin translation, turning a `RunAccepted` / `RunRejectedBusy` outcome into a `202` / `409`. Lives in `src/influx/run_dispatch.py`.
+_Avoid_: for the single per-(item, Profile) inbox dispatch use InboxTick, not RunDispatcher.
+
 ### Domain — Inbox (manual submission)
 
 **InboxTask**:

--- a/docs/architecture.toml
+++ b/docs/architecture.toml
@@ -46,7 +46,7 @@ Common        = "Cross-cutting foundation: errors, per-Profile run coordinator, 
 [components]
 Entrypoint    = ["influx.main", "influx.__main__"]
 HttpApi       = ["influx.http_api", "influx.service", "influx.backfill"]
-Orchestration = ["influx.scheduler", "influx.run_service", "influx.run", "influx.inbox", "influx.audit_invalid_source"]
+Orchestration = ["influx.scheduler", "influx.run_service", "influx.run", "influx.run_dispatch", "influx.inbox", "influx.audit_invalid_source"]
 Sources       = ["influx.sources", "influx.extraction"]
 Filter        = ["influx.filter"]
 Enrich        = ["influx.enrich", "influx.cascade"]
@@ -80,7 +80,7 @@ Foundation  = ["Config", "Observability", "Schemas", "Common"]
 cross_component_edges  = 62   # measured 2026-07 (64->62 after #267 broke Sources<->Filter); direction: down
 component_cycles       = 3    # Common<->Config, a Core SCC, HttpApi<->Orchestration; goal: fewer
 module_cycles          = 3    # goal: 0
-modules_over_800_lines = 12   # existing god modules; direction: down, no new ones
+modules_over_800_lines = 11   # 12->11 after finding 4 split http_api's orchestration into run_dispatch; direction: down, no new ones
 max_module_lines       = 2000 # stop-loss; largest today is sources.arxiv at 1912
 cross_module_private_refs = 5   # measured 2026-07; extraction.html helpers x4, telemetry x1; goal: 0
 tests_private_imports     = 80  # 91->80 after 3b moved archive-identity tests onto the Source seam; direction: down
@@ -115,6 +115,7 @@ exclude_modules = [
     "influx.repair_counters",
     "influx.repair_hooks",
     "influx.run_dedup",
+    "influx.run_dispatch",
     "influx.run_ledger",
     "influx.run_service",
     "influx.source",

--- a/docs/generated/components/HttpApi.md
+++ b/docs/generated/components/HttpApi.md
@@ -12,7 +12,7 @@ FastAPI HTTP surface (/runs, /backfills, /ready) and backfill request handling.
 | Module | Size | Classes | Functions |
 |---|---|---:|---:|
 | `influx.backfill` | XS | 1 | 1 |
-| `influx.http_api` | L | 2 | 8 |
+| `influx.http_api` | M | 2 | 8 |
 | `influx.service` | M | 1 | 4 |
 
 ## Public API

--- a/docs/generated/components/Orchestration.md
+++ b/docs/generated/components/Orchestration.md
@@ -14,6 +14,7 @@ Schedules ticks and drives per-Profile Runs / inbox ticks end-to-end (Run / RunS
 | `influx.audit_invalid_source` | S | 1 | 5 |
 | `influx.inbox` | L | 2 | 2 |
 | `influx.run` | L | 12 | 2 |
+| `influx.run_dispatch` | M | 3 | 0 |
 | `influx.run_service` | L | 1 | 2 |
 | `influx.scheduler` | M | 1 | 2 |
 
@@ -48,6 +49,11 @@ Schedules ticks and drives per-Profile Runs / inbox ticks end-to-end (Run / RunS
 - def `lithos_task_lifecycle` — Inner lifecycle CM — Lithos task bracketing.
 - class `Run` — Score-gated ingestion executor (CONTEXT.md ``Run``).
 - def `default_item_provider` — No-op fallback (mirrors ``influx.scheduler.default_item_provider``).
+
+### `influx.run_dispatch`
+- class `RunAccepted` — A dispatch was admitted; the Run(s) are executing in the background.
+- class `RunRejectedBusy` — A dispatch was refused because a Profile lock was already held.
+- class `RunDispatcher` — Acquire Profile locks, launch background Runs, and track them.
 
 ### `influx.run_service`
 - def `ledger_lifecycle` — Outer lifecycle CM — ledger entry + run-level metrics + contextvars.

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -33,7 +33,7 @@
       },
       "HttpApi": {
         "functions_over_10": 3,
-        "max_complexity": 17,
+        "max_complexity": 15,
         "max_function": "influx.http_api.post_backfills"
       },
       "LithosBridge": {
@@ -120,7 +120,7 @@
         "qualname": "influx.promotion_gate.evaluate_promotion_gate"
       }
     ],
-    "total_functions": 648
+    "total_functions": 652
   },
   "domain": {
     "associations": 5,
@@ -222,7 +222,7 @@
       }
     },
     "cross_component_edges": 62,
-    "cross_component_module_edges": 185,
+    "cross_component_module_edges": 189,
     "longest_component_chain": 4,
     "module_cycle_count": 3,
     "module_cycles": [
@@ -230,6 +230,7 @@
         "influx.http_api",
         "influx.inbox",
         "influx.run",
+        "influx.run_dispatch",
         "influx.run_service",
         "influx.scheduler",
         "influx.service"
@@ -369,13 +370,13 @@
       },
       "HttpApi": {
         "classes": 4,
-        "functions": 41,
+        "functions": 37,
         "largest_module": "influx.http_api",
-        "largest_module_lines": 956,
-        "lines": 1410,
+        "largest_module_lines": 687,
+        "lines": 1141,
         "modules": 3,
         "public_symbols": 17,
-        "sloc": 1167
+        "sloc": 918
       },
       "LithosBridge": {
         "classes": 13,
@@ -408,14 +409,14 @@
         "sloc": 1401
       },
       "Orchestration": {
-        "classes": 20,
-        "functions": 62,
+        "classes": 23,
+        "functions": 70,
         "largest_module": "influx.inbox",
         "largest_module_lines": 1182,
-        "lines": 3771,
-        "modules": 5,
-        "public_symbols": 30,
-        "sloc": 2942
+        "lines": 4121,
+        "modules": 6,
+        "public_symbols": 33,
+        "sloc": 3253
       },
       "Repair": {
         "classes": 17,
@@ -462,7 +463,6 @@
     "max_module_lines": 1830,
     "modules_over_800": [
       "influx.config",
-      "influx.http_api",
       "influx.inbox",
       "influx.lithos_client",
       "influx.repair",
@@ -474,13 +474,13 @@
       "influx.sources.rss",
       "influx.telemetry"
     ],
-    "total_lines": 27861,
-    "total_modules": 57,
-    "total_sloc": 21611
+    "total_lines": 27942,
+    "total_modules": 58,
+    "total_sloc": 21673
   },
   "tests": {
     "ratio": 2.54,
-    "src_lines": 27861,
-    "test_lines": 70863
+    "src_lines": 27942,
+    "test_lines": 71043
   }
 }

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -413,10 +413,10 @@
         "functions": 70,
         "largest_module": "influx.inbox",
         "largest_module_lines": 1182,
-        "lines": 4121,
+        "lines": 4124,
         "modules": 6,
         "public_symbols": 33,
-        "sloc": 3253
+        "sloc": 3255
       },
       "Repair": {
         "classes": 17,
@@ -474,13 +474,13 @@
       "influx.sources.rss",
       "influx.telemetry"
     ],
-    "total_lines": 27942,
+    "total_lines": 27945,
     "total_modules": 58,
-    "total_sloc": 21673
+    "total_sloc": 21675
   },
   "tests": {
-    "ratio": 2.54,
-    "src_lines": 27942,
-    "test_lines": 71043
+    "ratio": 2.55,
+    "src_lines": 27945,
+    "test_lines": 71202
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -16,14 +16,14 @@ lower a budget after improving the code to lock in the gain.
 | `cross_module_private_refs` | 5 | 5 | 0 |
 | `max_module_lines` | 1830 | 2000 | 170 |
 | `module_cycles` | 3 | 3 | 0 |
-| `modules_over_800_lines` | 12 | 12 | 0 |
+| `modules_over_800_lines` | 11 | 11 | 0 |
 | `tests_private_imports` | 80 | 80 | 0 |
 
 ## Import graph
 
-- Cross-component edges: **62** (185 module-level)
+- Cross-component edges: **62** (189 module-level)
 - Component cycles: Common ↔ Config; Enrich ↔ Repair ↔ Sources ↔ Storage; HttpApi ↔ Orchestration
-- Module cycles: influx.http_api ↔ influx.inbox ↔ influx.run ↔ influx.run_service ↔ influx.scheduler ↔ influx.service; influx.repair ↔ influx.repair_hooks; influx.sources ↔ influx.sources.arxiv ↔ influx.sources.rss
+- Module cycles: influx.http_api ↔ influx.inbox ↔ influx.run ↔ influx.run_dispatch ↔ influx.run_service ↔ influx.scheduler ↔ influx.service; influx.repair ↔ influx.repair_hooks; influx.sources ↔ influx.sources.arxiv ↔ influx.sources.rss
 - Tier-skipping edges (Entrypoints → Foundation): 9 (Entrypoint -> Common, Entrypoint -> Config, Entrypoint -> Observability, HttpApi -> Common, HttpApi -> Config, HttpApi -> Observability, Orchestration -> Common, Orchestration -> Config, Orchestration -> Observability)
 - Longest component dependency chain: 4
 
@@ -40,11 +40,11 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Entrypoint | 2 | 573 | 454 | 0 | 5 | 1.00 | 14 (`influx.main._cmd_backfill`) | 2 |
 | Feedback | 3 | 571 | 450 | 1 | 4 | 0.80 | 15 (`influx.run_dedup.dedup_scored_candidates`) | 1 |
 | Filter | 1 | 474 | 398 | 3 | 4 | 0.57 | 11 (`influx.filter.make_default_batch_scorer._scorer`) | 1 |
-| HttpApi | 3 | 1410 | 1167 | 2 | 8 | 0.80 | 17 (`influx.http_api.post_backfills`) | 3 |
+| HttpApi | 3 | 1141 | 918 | 2 | 8 | 0.80 | 15 (`influx.http_api.post_backfills`) | 3 |
 | LithosBridge | 8 | 4097 | 3254 | 6 | 3 | 0.33 | 17 (`influx.notes.merge_tags`) | 4 |
 | Notifications | 1 | 581 | 509 | 2 | 2 | 0.50 | 13 (`influx.notifications.dispatch_notifications`) | 2 |
 | Observability | 3 | 1912 | 1401 | 9 | 0 | 0.00 | 10 (`influx.logging_config.setup_logging`) | 0 |
-| Orchestration | 5 | 3771 | 2942 | 1 | 11 | 0.92 | 52 (`influx.run_service.ledger_lifecycle`) | 11 |
+| Orchestration | 6 | 4121 | 3253 | 1 | 11 | 0.92 | 52 (`influx.run_service.ledger_lifecycle`) | 11 |
 | Repair | 5 | 3769 | 2927 | 4 | 7 | 0.64 | 26 (`influx.repair._process_sweep_note`) | 6 |
 | Schemas | 1 | 240 | 183 | 3 | 0 | 0.00 | 14 (`influx.schemas._harden_for_openai_strict`) | 1 |
 | Sources | 10 | 4343 | 3323 | 3 | 8 | 0.73 | 28 (`influx.sources.arxiv.build_arxiv_note_item`) | 7 |
@@ -52,11 +52,10 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **57**, lines: **27861**, SLOC: **21611**
+- Modules: **58**, lines: **27942**, SLOC: **21673**
 - Largest module: `influx.sources.arxiv` (1830 lines)
-- Modules over 800 lines: **12**
+- Modules over 800 lines: **11**
   - `influx.config`
-  - `influx.http_api`
   - `influx.inbox`
   - `influx.lithos_client`
   - `influx.repair`
@@ -70,7 +69,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Complexity
 
-- Functions: **648**, cyclomatic > 10: **47**
+- Functions: **652**, cyclomatic > 10: **47**
 
 Top 10 most complex functions:
 
@@ -134,4 +133,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 ## Domain & tests
 
 - Domain models: **17** (5 associations, 0 without docstrings)
-- Test-to-source line ratio: **2.54** (70863 test lines / 27861 source lines)
+- Test-to-source line ratio: **2.54** (71043 test lines / 27942 source lines)

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -44,7 +44,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | LithosBridge | 8 | 4097 | 3254 | 6 | 3 | 0.33 | 17 (`influx.notes.merge_tags`) | 4 |
 | Notifications | 1 | 581 | 509 | 2 | 2 | 0.50 | 13 (`influx.notifications.dispatch_notifications`) | 2 |
 | Observability | 3 | 1912 | 1401 | 9 | 0 | 0.00 | 10 (`influx.logging_config.setup_logging`) | 0 |
-| Orchestration | 6 | 4121 | 3253 | 1 | 11 | 0.92 | 52 (`influx.run_service.ledger_lifecycle`) | 11 |
+| Orchestration | 6 | 4124 | 3255 | 1 | 11 | 0.92 | 52 (`influx.run_service.ledger_lifecycle`) | 11 |
 | Repair | 5 | 3769 | 2927 | 4 | 7 | 0.64 | 26 (`influx.repair._process_sweep_note`) | 6 |
 | Schemas | 1 | 240 | 183 | 3 | 0 | 0.00 | 14 (`influx.schemas._harden_for_openai_strict`) | 1 |
 | Sources | 10 | 4343 | 3323 | 3 | 8 | 0.73 | 28 (`influx.sources.arxiv.build_arxiv_note_item`) | 7 |
@@ -52,7 +52,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Size
 
-- Modules: **58**, lines: **27942**, SLOC: **21673**
+- Modules: **58**, lines: **27945**, SLOC: **21675**
 - Largest module: `influx.sources.arxiv` (1830 lines)
 - Modules over 800 lines: **11**
   - `influx.config`
@@ -133,4 +133,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 ## Domain & tests
 
 - Domain models: **17** (5 associations, 0 without docstrings)
-- Test-to-source line ratio: **2.54** (71043 test lines / 27942 source lines)
+- Test-to-source line ratio: **2.55** (71202 test lines / 27945 source lines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ forbidden_modules = [
     "influx.scheduler",
     "influx.run_service",
     "influx.run",
+    "influx.run_dispatch",
     "influx.inbox",
     "influx.audit_invalid_source",
 ]
@@ -171,6 +172,7 @@ forbidden_modules = [
     "influx.scheduler",
     "influx.run_service",
     "influx.run",
+    "influx.run_dispatch",
     "influx.inbox",
     "influx.audit_invalid_source",
 ]

--- a/src/influx/http_api.py
+++ b/src/influx/http_api.py
@@ -17,7 +17,6 @@ import asyncio
 import logging
 import os
 import uuid
-from collections.abc import Callable, Coroutine
 from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any, cast
@@ -30,9 +29,9 @@ from pydantic import BaseModel, Field, model_validator
 
 import influx
 from influx.config import AppConfig
-from influx.coordinator import Coordinator, ProfileBusyError, RunKind
+from influx.coordinator import Coordinator, RunKind
+from influx.run_dispatch import RunDispatcher, RunRejectedBusy
 from influx.run_ledger import RunLedger
-from influx.scheduler import run_profile
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -290,12 +289,12 @@ async def post_runs(body: RunRequest, request: Request) -> JSONResponse:
     on acceptance or ``409 Conflict`` with ``reason="profile_busy"``
     when the profile is already running.
 
-    Multi-profile (``all_profiles``) fan-out of ``run_profile()``
-    execution is deferred to PRD 09.
+    ``all_profiles`` fans out with all-or-nothing lock acquisition via the
+    request-orchestration collaborator (:class:`RunDispatcher`).
     """
-    coordinator: Coordinator = request.app.state.coordinator
     config: AppConfig = request.app.state.config
     run_ledger = _get_run_ledger(request)
+    dispatcher = _run_dispatcher(request, run_ledger)
 
     request_id = str(uuid.uuid4())
     submitted_at = datetime.now(UTC).isoformat()
@@ -310,31 +309,10 @@ async def post_runs(body: RunRequest, request: Request) -> JSONResponse:
                 profile=body.profile,
             )
 
-        try:
-            acquired = await coordinator.try_acquire(body.profile)
-            if not acquired:
-                raise ProfileBusyError(body.profile)
-        except ProfileBusyError:
-            return _profile_busy_response(
-                profile=body.profile,
-                request_id=request_id,
-                ledger=run_ledger,
-            )
-
-        # Launch the run in the background so the response returns immediately.
-        _spawn_tracked_task(
-            request.app,
-            _run_and_release(
-                coordinator,
-                body.profile,
-                RunKind.MANUAL,
-                config=config,
-                item_provider=getattr(request.app.state, "item_provider", None),
-                probe_loop=getattr(request.app.state, "probe_loop", None),
-                fetch_cache=getattr(request.app.state, "fetch_cache", None),
-                run_id=request_id,
-                run_ledger=run_ledger,
-            ),
+        outcome = await dispatcher.dispatch_one(
+            body.profile,
+            RunKind.MANUAL,
+            request_id=request_id,
             log_context={
                 "request_id": request_id,
                 "kind": "manual",
@@ -342,6 +320,13 @@ async def post_runs(body: RunRequest, request: Request) -> JSONResponse:
                 "profile": body.profile,
             },
         )
+        if isinstance(outcome, RunRejectedBusy):
+            return _profile_busy_response(
+                profile=outcome.profile,
+                request_id=request_id,
+                ledger=run_ledger,
+            )
+
         logger.info(
             "manual run accepted request_id=%s profile=%s submitted_at=%s",
             request_id,
@@ -368,51 +353,33 @@ async def post_runs(body: RunRequest, request: Request) -> JSONResponse:
             status_code=202,
         )
 
-    acquired_profiles: list[str] = []
-    for profile_cfg in config.profiles:
-        acquired = await coordinator.try_acquire(profile_cfg.name)
-        if not acquired:
-            for acquired_profile in acquired_profiles:
-                coordinator.release(acquired_profile)
-            return _profile_busy_response(
-                profile=profile_cfg.name,
-                request_id=request_id,
-                ledger=run_ledger,
-            )
-        acquired_profiles.append(profile_cfg.name)
-
-    run_log_context: dict[str, Any] = {
-        "request_id": request_id,
-        "kind": "manual",
-        "scope": "all",
-        "profiles": list(acquired_profiles),
-    }
-    _spawn_tracked_task(
-        request.app,
-        _run_many_and_release(
-            coordinator,
-            acquired_profiles,
-            RunKind.MANUAL,
-            config=config,
-            item_provider=getattr(request.app.state, "item_provider", None),
-            probe_loop=getattr(request.app.state, "probe_loop", None),
-            fetch_cache=getattr(request.app.state, "fetch_cache", None),
-            request_id=request_id,
-            run_ledger=run_ledger,
-            log_context=run_log_context,
-        ),
-        log_context=run_log_context,
+    outcome = await dispatcher.dispatch_all(
+        RunKind.MANUAL,
+        request_id=request_id,
+        log_context={
+            "request_id": request_id,
+            "kind": "manual",
+            "scope": "all",
+            "profiles": [p.name for p in config.profiles],
+        },
     )
+    if isinstance(outcome, RunRejectedBusy):
+        return _profile_busy_response(
+            profile=outcome.profile,
+            request_id=request_id,
+            ledger=run_ledger,
+        )
+
     logger.info(
         "manual run accepted request_id=%s scope=all profiles=%s submitted_at=%s",
         request_id,
-        acquired_profiles,
+        list(outcome.profiles),
         submitted_at,
         extra={
             "request_id": request_id,
             "kind": "manual",
             "scope": "all",
-            "profiles": list(acquired_profiles),
+            "profiles": list(outcome.profiles),
             "submitted_at": submitted_at,
             "status": "accepted",
         },
@@ -429,234 +396,29 @@ async def post_runs(body: RunRequest, request: Request) -> JSONResponse:
     )
 
 
-async def _run_and_release(
-    coordinator: Coordinator,
-    profile: str,
-    kind: RunKind,
-    run_range: dict[str, str | int] | None = None,
-    *,
-    config: Any = None,
-    item_provider: Any = None,
-    probe_loop: Any = None,
-    fetch_cache: Any = None,
-    run_id: str | None = None,
-    run_ledger: RunLedger | None = None,
-) -> None:
-    """Run ``run_profile`` and release the coordinator lock afterward.
+def _run_dispatcher(request: Request, run_ledger: RunLedger) -> RunDispatcher:
+    """Build the request-orchestration collaborator from the app state.
 
-    Failures in ``run_profile`` (e.g. Lithos unreachable per AC-M1-11)
-    are logged with request context and re-raised; the surrounding
-    asyncio task captures the exception and the request-level done-
-    callback (#105) records a failure log keyed by ``request_id``. The
-    coordinator lock is always released via ``finally`` so the service
-    stays alive (FR-HTTP-4 + AC-M1-11).
+    Ensures the shutdown-grace task set exists on ``app.state`` and passes
+    that same set into the dispatcher so :meth:`InfluxService.stop` still
+    sees HTTP-launched background tasks (US-008).
     """
-    if fetch_cache is not None:
-        fetch_cache.begin_fire()
-    try:
-        try:
-            await run_profile(
-                profile,
-                kind,
-                run_range=run_range,
-                config=config,
-                item_provider=item_provider,
-                probe_loop=probe_loop,
-                run_id=run_id,
-                run_ledger=run_ledger,
-            )
-        except Exception:
-            logger.warning(
-                "run_profile %r aborted request_id=%s kind=%s",
-                profile,
-                run_id,
-                kind.value,
-                exc_info=True,
-                extra={
-                    "request_id": run_id,
-                    "kind": kind.value,
-                    "scope": profile,
-                    "profile": profile,
-                    "status": "failed",
-                },
-            )
-            raise
-    finally:
-        coordinator.release(profile)
-        if fetch_cache is not None:
-            fetch_cache.end_fire()
-
-
-async def _run_many_and_release(
-    coordinator: Coordinator,
-    profiles: list[str],
-    kind: RunKind,
-    run_range: dict[str, str | int] | None = None,
-    *,
-    config: Any = None,
-    item_provider: Any = None,
-    probe_loop: Any = None,
-    fetch_cache: Any = None,
-    request_id: str | None = None,
-    run_ledger: RunLedger | None = None,
-    log_context: dict[str, Any] | None = None,
-) -> None:
-    """Run several already-acquired profiles and release all locks.
-
-    Per-profile failures from the underlying ``asyncio.gather`` are
-    logged with request context (#105) so that multi-profile partial
-    failures are visible. When ``log_context`` is supplied, the helper
-    records ``failed_count`` / ``total_count`` / ``failed_profiles``
-    onto it so the request-level done-callback can distinguish
-    ``completed`` from ``partial_failure`` for the same ``request_id``.
-    """
-    if fetch_cache is not None:
-        fetch_cache.begin_fire()
-    try:
-        results = await asyncio.gather(
-            *(
-                run_profile(
-                    profile,
-                    kind,
-                    run_range=run_range,
-                    config=config,
-                    item_provider=item_provider,
-                    probe_loop=probe_loop,
-                    run_id=f"{request_id}:{profile}" if request_id else None,
-                    run_ledger=run_ledger,
-                )
-                for profile in profiles
-            ),
-            return_exceptions=True,
-        )
-        failed: list[tuple[str, BaseException]] = []
-        for profile, result in zip(profiles, results, strict=True):
-            if isinstance(result, BaseException):
-                failed.append((profile, result))
-                logger.warning(
-                    "profile %r in %s run %s failed: %s",
-                    profile,
-                    kind.value,
-                    request_id,
-                    result,
-                    exc_info=result,
-                    extra={
-                        "request_id": request_id,
-                        "kind": kind.value,
-                        "scope": "all",
-                        "profile": profile,
-                        "status": "failed",
-                    },
-                )
-            else:
-                logger.info(
-                    "profile %r in %s run %s completed",
-                    profile,
-                    kind.value,
-                    request_id,
-                    extra={
-                        "request_id": request_id,
-                        "kind": kind.value,
-                        "scope": "all",
-                        "profile": profile,
-                        "status": "completed",
-                    },
-                )
-        if log_context is not None:
-            log_context["failed_count"] = len(failed)
-            log_context["total_count"] = len(profiles)
-            log_context["failed_profiles"] = [p for p, _ in failed]
-    finally:
-        for profile in profiles:
-            coordinator.release(profile)
-        if fetch_cache is not None:
-            fetch_cache.end_fire()
-
-
-def _log_task_completion(
-    log_context: dict[str, Any],
-) -> Callable[[asyncio.Task[Any]], None]:
-    """Build a done-callback that logs task outcome with request context (#105).
-
-    Treats cancellation as graceful shutdown rather than failure so that
-    the US-008 shutdown path stays quiet, and routes uncaught exceptions
-    to ``logger.error`` with ``exc_info`` so operators can find them by
-    ``request_id``.
-    """
-
-    def _callback(task: asyncio.Task[Any]) -> None:
-        if task.cancelled():
-            return
-        exc = task.exception()
-        if exc is not None:
-            logger.error(
-                "background task failed request_id=%s kind=%s scope=%s: %s",
-                log_context.get("request_id"),
-                log_context.get("kind"),
-                log_context.get("scope"),
-                exc,
-                exc_info=exc,
-                extra={**log_context, "status": "failed"},
-            )
-            return
-        # Task itself succeeded — but for all-profiles fan-out a
-        # partial failure surfaces via ``failed_count`` written back
-        # onto the shared ``log_context`` by ``_run_many_and_release``.
-        # We must NOT report ``completed`` for those requests (#105).
-        failed_count = int(log_context.get("failed_count") or 0)
-        if failed_count > 0:
-            logger.warning(
-                "background task partial failure request_id=%s kind=%s "
-                "scope=%s failed=%d/%d",
-                log_context.get("request_id"),
-                log_context.get("kind"),
-                log_context.get("scope"),
-                failed_count,
-                int(log_context.get("total_count") or 0),
-                extra={**log_context, "status": "partial_failure"},
-            )
-            return
-        logger.info(
-            "background task completed request_id=%s kind=%s scope=%s",
-            log_context.get("request_id"),
-            log_context.get("kind"),
-            log_context.get("scope"),
-            extra={**log_context, "status": "completed"},
-        )
-
-    return _callback
-
-
-def _spawn_tracked_task(
-    app: FastAPI,
-    coro: Coroutine[Any, Any, Any],
-    *,
-    log_context: dict[str, Any] | None = None,
-) -> asyncio.Task[Any]:
-    """Create an ``asyncio.Task`` and register it on ``app.state.active_tasks``.
-
-    The task set is consulted by :meth:`InfluxService.stop` so HTTP-triggered
-    work can complete within ``schedule.shutdown_grace_seconds`` before
-    the service shuts down (US-008 shutdown-grace contract).
-
-    When ``log_context`` is provided the task gets a second done-callback
-    that logs request-keyed completion or failure (#105).
-    """
-    # Preserve the existing set even when empty — ``... or set()`` would
-    # treat an empty set as falsy and replace it with a throwaway local
-    # set that is never written back to ``app.state``.
+    app = request.app
     active_tasks: set[asyncio.Task[Any]] | None = getattr(
         app.state, "active_tasks", None
     )
     if active_tasks is None:
         active_tasks = set()
         app.state.active_tasks = active_tasks
-    task = asyncio.get_event_loop().create_task(coro)
-    active_tasks.add(task)
-    task.add_done_callback(active_tasks.discard)
-    if log_context is not None:
-        task.add_done_callback(_log_task_completion(log_context))
-    return task
+    return RunDispatcher(
+        app.state.coordinator,
+        app.state.config,
+        run_ledger=run_ledger,
+        active_tasks=active_tasks,
+        item_provider=getattr(app.state, "item_provider", None),
+        probe_loop=getattr(app.state, "probe_loop", None),
+        fetch_cache=getattr(app.state, "fetch_cache", None),
+    )
 
 
 # ── POST /backfills ────────────────────────────────────────────────
@@ -776,9 +538,9 @@ async def post_backfills(body: BackfillRequest, request: Request) -> JSONRespons
     Backfills go through the same coordinator as scheduled and manual
     runs, ensuring non-overlap for the same profile (AC-M3-7).
     """
-    coordinator: Coordinator = request.app.state.coordinator
     config: AppConfig = request.app.state.config
     run_ledger = _get_run_ledger(request)
+    dispatcher = _run_dispatcher(request, run_ledger)
 
     request_id = str(uuid.uuid4())
     submitted_at = datetime.now(UTC).isoformat()
@@ -833,34 +595,14 @@ async def post_backfills(body: BackfillRequest, request: Request) -> JSONRespons
                 profile=body.profile,
             )
 
-        try:
-            acquired = await coordinator.try_acquire(body.profile)
-            if not acquired:
-                raise ProfileBusyError(body.profile)
-        except ProfileBusyError:
-            return _profile_busy_response(
-                profile=body.profile,
-                request_id=request_id,
-                ledger=run_ledger,
-            )
-
-        # Launch the single-profile backfill in the background. A backfill is
-        # just a Run with RunKind.BACKFILL, so it shares _run_and_release with
-        # manual runs — the kind drives repair/cache/notify gating downstream.
-        _spawn_tracked_task(
-            request.app,
-            _run_and_release(
-                coordinator,
-                body.profile,
-                RunKind.BACKFILL,
-                run_range,
-                config=config,
-                item_provider=getattr(request.app.state, "item_provider", None),
-                probe_loop=getattr(request.app.state, "probe_loop", None),
-                fetch_cache=getattr(request.app.state, "fetch_cache", None),
-                run_id=request_id,
-                run_ledger=run_ledger,
-            ),
+        # A backfill is just a Run with RunKind.BACKFILL, so it shares the
+        # dispatcher's lock lifecycle with manual runs — the kind drives
+        # repair/cache/notify gating downstream.
+        outcome = await dispatcher.dispatch_one(
+            body.profile,
+            RunKind.BACKFILL,
+            run_range=run_range,
+            request_id=request_id,
             log_context={
                 "request_id": request_id,
                 "kind": "backfill",
@@ -868,6 +610,13 @@ async def post_backfills(body: BackfillRequest, request: Request) -> JSONRespons
                 "profile": body.profile,
             },
         )
+        if isinstance(outcome, RunRejectedBusy):
+            return _profile_busy_response(
+                profile=outcome.profile,
+                request_id=request_id,
+                ledger=run_ledger,
+            )
+
         logger.info(
             "backfill accepted request_id=%s profile=%s submitted_at=%s",
             request_id,
@@ -894,52 +643,34 @@ async def post_backfills(body: BackfillRequest, request: Request) -> JSONRespons
             status_code=202,
         )
 
-    acquired_profiles = []
-    for profile_cfg in config.profiles:
-        acquired = await coordinator.try_acquire(profile_cfg.name)
-        if not acquired:
-            for acquired_profile in acquired_profiles:
-                coordinator.release(acquired_profile)
-            return _profile_busy_response(
-                profile=profile_cfg.name,
-                request_id=request_id,
-                ledger=run_ledger,
-            )
-        acquired_profiles.append(profile_cfg.name)
-
-    backfill_log_context: dict[str, Any] = {
-        "request_id": request_id,
-        "kind": "backfill",
-        "scope": "all",
-        "profiles": list(acquired_profiles),
-    }
-    _spawn_tracked_task(
-        request.app,
-        _run_many_and_release(
-            coordinator,
-            acquired_profiles,
-            RunKind.BACKFILL,
-            run_range=run_range,
-            config=config,
-            item_provider=getattr(request.app.state, "item_provider", None),
-            probe_loop=getattr(request.app.state, "probe_loop", None),
-            fetch_cache=getattr(request.app.state, "fetch_cache", None),
-            request_id=request_id,
-            run_ledger=run_ledger,
-            log_context=backfill_log_context,
-        ),
-        log_context=backfill_log_context,
+    outcome = await dispatcher.dispatch_all(
+        RunKind.BACKFILL,
+        run_range=run_range,
+        request_id=request_id,
+        log_context={
+            "request_id": request_id,
+            "kind": "backfill",
+            "scope": "all",
+            "profiles": [p.name for p in config.profiles],
+        },
     )
+    if isinstance(outcome, RunRejectedBusy):
+        return _profile_busy_response(
+            profile=outcome.profile,
+            request_id=request_id,
+            ledger=run_ledger,
+        )
+
     logger.info(
         "backfill accepted request_id=%s scope=all profiles=%s submitted_at=%s",
         request_id,
-        acquired_profiles,
+        list(outcome.profiles),
         submitted_at,
         extra={
             "request_id": request_id,
             "kind": "backfill",
             "scope": "all",
-            "profiles": list(acquired_profiles),
+            "profiles": list(outcome.profiles),
             "submitted_at": submitted_at,
             "status": "accepted",
         },

--- a/src/influx/run_dispatch.py
+++ b/src/influx/run_dispatch.py
@@ -209,8 +209,11 @@ class RunDispatcher:
         ``schedule.shutdown_grace_seconds`` before the service shuts down.
         When ``log_context`` is provided the task gets a second done-callback
         that logs request-keyed completion or failure (#105).
+
+        Dispatch always happens inside an active request coroutine, so we bind
+        the task to the running loop explicitly.
         """
-        task = asyncio.get_event_loop().create_task(coro)
+        task = asyncio.get_running_loop().create_task(coro)
         self._active_tasks.add(task)
         task.add_done_callback(self._active_tasks.discard)
         if log_context is not None:

--- a/src/influx/run_dispatch.py
+++ b/src/influx/run_dispatch.py
@@ -1,0 +1,350 @@
+"""Request-orchestration collaborator for admin run / backfill requests.
+
+The HTTP router (:mod:`influx.http_api`) does *translation*: it parses a
+request body, validates it, and turns an outcome into a status code. The
+*orchestration* lives here:
+
+- acquire the per-Profile coordinator locks all-or-nothing (no partial
+  fan-out — if any Profile is busy, everything acquired so far is released
+  and the request is rejected),
+- launch the background Run(s) so the response can return immediately,
+- register each task on the shutdown-grace set so :meth:`InfluxService.stop`
+  can drain it (US-008),
+- release the locks in a ``finally`` so a failed Run never wedges a Profile.
+
+A backfill is just a Run with :attr:`RunKind.BACKFILL`, so this collaborator
+is kind-agnostic: manual runs and backfills share one lock lifecycle and one
+fan-out path. The router chooses the kind and translates the outcome.
+
+Because it takes plain dependencies (a coordinator, a task set) rather than a
+FastAPI app, the orchestration is testable without an ASGI stack.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+from typing import Any
+
+from influx.config import AppConfig
+from influx.coordinator import Coordinator, RunKind
+from influx.run_ledger import RunLedger
+from influx.scheduler import run_profile
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class RunAccepted:
+    """A dispatch was admitted; the Run(s) are executing in the background."""
+
+    scope: str
+    """The request scope label — a Profile name, or ``"all"``."""
+    profiles: tuple[str, ...]
+    """The Profiles whose locks were acquired, in config order."""
+
+
+@dataclass(frozen=True, slots=True)
+class RunRejectedBusy:
+    """A dispatch was refused because a Profile lock was already held."""
+
+    profile: str
+    """The Profile found busy; nothing was launched and no lock is held."""
+
+
+DispatchOutcome = RunAccepted | RunRejectedBusy
+
+
+def _log_task_completion(
+    log_context: dict[str, Any],
+) -> Callable[[asyncio.Task[Any]], None]:
+    """Build a done-callback that logs task outcome with request context (#105).
+
+    Treats cancellation as graceful shutdown rather than failure so that
+    the US-008 shutdown path stays quiet, and routes uncaught exceptions
+    to ``logger.error`` with ``exc_info`` so operators can find them by
+    ``request_id``.
+    """
+
+    def _callback(task: asyncio.Task[Any]) -> None:
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.error(
+                "background task failed request_id=%s kind=%s scope=%s: %s",
+                log_context.get("request_id"),
+                log_context.get("kind"),
+                log_context.get("scope"),
+                exc,
+                exc_info=exc,
+                extra={**log_context, "status": "failed"},
+            )
+            return
+        # Task itself succeeded — but for all-profiles fan-out a
+        # partial failure surfaces via ``failed_count`` written back
+        # onto the shared ``log_context`` by ``_run_many_and_release``.
+        # We must NOT report ``completed`` for those requests (#105).
+        failed_count = int(log_context.get("failed_count") or 0)
+        if failed_count > 0:
+            logger.warning(
+                "background task partial failure request_id=%s kind=%s "
+                "scope=%s failed=%d/%d",
+                log_context.get("request_id"),
+                log_context.get("kind"),
+                log_context.get("scope"),
+                failed_count,
+                int(log_context.get("total_count") or 0),
+                extra={**log_context, "status": "partial_failure"},
+            )
+            return
+        logger.info(
+            "background task completed request_id=%s kind=%s scope=%s",
+            log_context.get("request_id"),
+            log_context.get("kind"),
+            log_context.get("scope"),
+            extra={**log_context, "status": "completed"},
+        )
+
+    return _callback
+
+
+class RunDispatcher:
+    """Acquire Profile locks, launch background Runs, and track them.
+
+    Holds the run dependencies resolved from the app for a single request.
+    ``active_tasks`` is the same set object :meth:`InfluxService.stop`
+    consults on shutdown (US-008) — the dispatcher only *adds* to it.
+    """
+
+    def __init__(
+        self,
+        coordinator: Coordinator,
+        config: AppConfig,
+        *,
+        run_ledger: RunLedger,
+        active_tasks: set[asyncio.Task[Any]],
+        item_provider: Any = None,
+        probe_loop: Any = None,
+        fetch_cache: Any = None,
+    ) -> None:
+        self._coordinator = coordinator
+        self._config = config
+        self._run_ledger = run_ledger
+        self._active_tasks = active_tasks
+        self._item_provider = item_provider
+        self._probe_loop = probe_loop
+        self._fetch_cache = fetch_cache
+
+    async def dispatch_one(
+        self,
+        profile: str,
+        kind: RunKind,
+        *,
+        run_range: dict[str, str | int] | None = None,
+        request_id: str,
+        log_context: dict[str, Any],
+    ) -> DispatchOutcome:
+        """Acquire one Profile lock and launch a single background Run.
+
+        Returns :class:`RunRejectedBusy` (holding no lock) when the Profile
+        is already running, otherwise :class:`RunAccepted` once the Run has
+        been launched.
+        """
+        if not await self._coordinator.try_acquire(profile):
+            return RunRejectedBusy(profile)
+        self._spawn_tracked(
+            self._run_and_release(
+                profile, kind, run_range=run_range, run_id=request_id
+            ),
+            log_context=log_context,
+        )
+        return RunAccepted(scope=profile, profiles=(profile,))
+
+    async def dispatch_all(
+        self,
+        kind: RunKind,
+        *,
+        run_range: dict[str, str | int] | None = None,
+        request_id: str,
+        log_context: dict[str, Any],
+    ) -> DispatchOutcome:
+        """Acquire every configured Profile lock all-or-nothing, then fan out.
+
+        If any Profile is busy, every lock acquired so far is released and
+        the request is rejected with :class:`RunRejectedBusy` — there is no
+        partial fan-out.
+        """
+        acquired: list[str] = []
+        for profile_cfg in self._config.profiles:
+            if not await self._coordinator.try_acquire(profile_cfg.name):
+                for held in acquired:
+                    self._coordinator.release(held)
+                return RunRejectedBusy(profile_cfg.name)
+            acquired.append(profile_cfg.name)
+        self._spawn_tracked(
+            self._run_many_and_release(
+                acquired,
+                kind,
+                run_range=run_range,
+                request_id=request_id,
+                log_context=log_context,
+            ),
+            log_context=log_context,
+        )
+        return RunAccepted(scope="all", profiles=tuple(acquired))
+
+    def _spawn_tracked(
+        self,
+        coro: Coroutine[Any, Any, Any],
+        *,
+        log_context: dict[str, Any] | None = None,
+    ) -> asyncio.Task[Any]:
+        """Create a task and register it on the shutdown-grace set.
+
+        The task set is consulted by :meth:`InfluxService.stop` so
+        HTTP-triggered work can complete within
+        ``schedule.shutdown_grace_seconds`` before the service shuts down.
+        When ``log_context`` is provided the task gets a second done-callback
+        that logs request-keyed completion or failure (#105).
+        """
+        task = asyncio.get_event_loop().create_task(coro)
+        self._active_tasks.add(task)
+        task.add_done_callback(self._active_tasks.discard)
+        if log_context is not None:
+            task.add_done_callback(_log_task_completion(log_context))
+        return task
+
+    async def _run_and_release(
+        self,
+        profile: str,
+        kind: RunKind,
+        *,
+        run_range: dict[str, str | int] | None = None,
+        run_id: str | None = None,
+    ) -> None:
+        """Run ``run_profile`` and release the coordinator lock afterward.
+
+        Failures in ``run_profile`` (e.g. Lithos unreachable per AC-M1-11)
+        are logged with request context and re-raised; the surrounding
+        asyncio task captures the exception and the request-level done-
+        callback (#105) records a failure log keyed by ``request_id``. The
+        coordinator lock is always released via ``finally`` so the service
+        stays alive (FR-HTTP-4 + AC-M1-11).
+        """
+        if self._fetch_cache is not None:
+            self._fetch_cache.begin_fire()
+        try:
+            try:
+                await run_profile(
+                    profile,
+                    kind,
+                    run_range=run_range,
+                    config=self._config,
+                    item_provider=self._item_provider,
+                    probe_loop=self._probe_loop,
+                    run_id=run_id,
+                    run_ledger=self._run_ledger,
+                )
+            except Exception:
+                logger.warning(
+                    "run_profile %r aborted request_id=%s kind=%s",
+                    profile,
+                    run_id,
+                    kind.value,
+                    exc_info=True,
+                    extra={
+                        "request_id": run_id,
+                        "kind": kind.value,
+                        "scope": profile,
+                        "profile": profile,
+                        "status": "failed",
+                    },
+                )
+                raise
+        finally:
+            self._coordinator.release(profile)
+            if self._fetch_cache is not None:
+                self._fetch_cache.end_fire()
+
+    async def _run_many_and_release(
+        self,
+        profiles: list[str],
+        kind: RunKind,
+        *,
+        run_range: dict[str, str | int] | None = None,
+        request_id: str | None = None,
+        log_context: dict[str, Any] | None = None,
+    ) -> None:
+        """Run several already-acquired profiles and release all locks.
+
+        Per-profile failures from the underlying ``asyncio.gather`` are
+        logged with request context (#105) so that multi-profile partial
+        failures are visible. When ``log_context`` is supplied, the helper
+        records ``failed_count`` / ``total_count`` / ``failed_profiles``
+        onto it so the request-level done-callback can distinguish
+        ``completed`` from ``partial_failure`` for the same ``request_id``.
+        """
+        if self._fetch_cache is not None:
+            self._fetch_cache.begin_fire()
+        try:
+            results = await asyncio.gather(
+                *(
+                    run_profile(
+                        profile,
+                        kind,
+                        run_range=run_range,
+                        config=self._config,
+                        item_provider=self._item_provider,
+                        probe_loop=self._probe_loop,
+                        run_id=f"{request_id}:{profile}" if request_id else None,
+                        run_ledger=self._run_ledger,
+                    )
+                    for profile in profiles
+                ),
+                return_exceptions=True,
+            )
+            failed: list[tuple[str, BaseException]] = []
+            for profile, result in zip(profiles, results, strict=True):
+                if isinstance(result, BaseException):
+                    failed.append((profile, result))
+                    logger.warning(
+                        "profile %r in %s run %s failed: %s",
+                        profile,
+                        kind.value,
+                        request_id,
+                        result,
+                        exc_info=result,
+                        extra={
+                            "request_id": request_id,
+                            "kind": kind.value,
+                            "scope": "all",
+                            "profile": profile,
+                            "status": "failed",
+                        },
+                    )
+                else:
+                    logger.info(
+                        "profile %r in %s run %s completed",
+                        profile,
+                        kind.value,
+                        request_id,
+                        extra={
+                            "request_id": request_id,
+                            "kind": kind.value,
+                            "scope": "all",
+                            "profile": profile,
+                            "status": "completed",
+                        },
+                    )
+            if log_context is not None:
+                log_context["failed_count"] = len(failed)
+                log_context["total_count"] = len(profiles)
+                log_context["failed_profiles"] = [p for p, _ in failed]
+        finally:
+            for profile in profiles:
+                self._coordinator.release(profile)
+            if self._fetch_cache is not None:
+                self._fetch_cache.end_fire()

--- a/tests/integration/test_arxiv_to_lithos.py
+++ b/tests/integration/test_arxiv_to_lithos.py
@@ -2,7 +2,7 @@
 
 Drives the real production ``run_profile`` body through ``POST /runs``
 against a local fake Lithos SSE server and a local fake webhook
-receiver — no monkeypatching of ``influx.http_api.run_profile``.
+receiver — no monkeypatching of ``influx.run_dispatch.run_profile``.
 Source acquisition is supplied by the ``app.state.item_provider``
 seam that PRD 04 will replace with the real arXiv + RSS fetcher.
 
@@ -248,7 +248,7 @@ def _make_app(
 
     The injected ``app.state.item_provider`` plugs source acquisition
     into the real production ``run_profile`` so tests do NOT
-    monkeypatch ``influx.http_api.run_profile`` (US-019).
+    monkeypatch ``influx.run_dispatch.run_profile`` (US-019).
     """
     app = FastAPI()
     app.include_router(router)

--- a/tests/integration/test_http_api.py
+++ b/tests/integration/test_http_api.py
@@ -849,14 +849,14 @@ class TestRunObservability:
     ) -> None:
         import httpx
 
-        from influx import http_api as http_api_mod
+        from influx import run_dispatch as run_dispatch_mod
 
         async def fake_run_profile(*args: Any, **kwargs: Any) -> None:
             return None
 
-        monkeypatch.setattr(http_api_mod, "run_profile", fake_run_profile)
+        monkeypatch.setattr(run_dispatch_mod, "run_profile", fake_run_profile)
 
-        with caplog.at_level("INFO", logger="influx.http_api"):
+        with caplog.at_level("INFO", logger="influx"):
             transport = httpx.ASGITransport(app=app_with_state)
             async with httpx.AsyncClient(
                 transport=transport, base_url="http://test"
@@ -887,14 +887,14 @@ class TestRunObservability:
     ) -> None:
         import httpx
 
-        from influx import http_api as http_api_mod
+        from influx import run_dispatch as run_dispatch_mod
 
         async def boom(*args: Any, **kwargs: Any) -> None:
             raise RuntimeError("boom")
 
-        monkeypatch.setattr(http_api_mod, "run_profile", boom)
+        monkeypatch.setattr(run_dispatch_mod, "run_profile", boom)
 
-        with caplog.at_level("INFO", logger="influx.http_api"):
+        with caplog.at_level("INFO", logger="influx"):
             transport = httpx.ASGITransport(app=app_with_state)
             async with httpx.AsyncClient(
                 transport=transport, base_url="http://test"
@@ -936,7 +936,7 @@ class TestRunObservability:
     ) -> None:
         import httpx
 
-        from influx import http_api as http_api_mod
+        from influx import run_dispatch as run_dispatch_mod
 
         async def selective_run_profile(
             profile: str, *args: Any, **kwargs: Any
@@ -945,9 +945,9 @@ class TestRunObservability:
                 raise RuntimeError("web-tech blew up")
             return None
 
-        monkeypatch.setattr(http_api_mod, "run_profile", selective_run_profile)
+        monkeypatch.setattr(run_dispatch_mod, "run_profile", selective_run_profile)
 
-        with caplog.at_level("INFO", logger="influx.http_api"):
+        with caplog.at_level("INFO", logger="influx"):
             transport = httpx.ASGITransport(app=app_with_state)
             async with httpx.AsyncClient(
                 transport=transport, base_url="http://test"
@@ -1013,14 +1013,14 @@ class TestBackfillObservability:
     ) -> None:
         import httpx
 
-        from influx import http_api as http_api_mod
+        from influx import run_dispatch as run_dispatch_mod
 
         async def fake_run_profile(*args: Any, **kwargs: Any) -> None:
             return None
 
-        monkeypatch.setattr(http_api_mod, "run_profile", fake_run_profile)
+        monkeypatch.setattr(run_dispatch_mod, "run_profile", fake_run_profile)
 
-        with caplog.at_level("INFO", logger="influx.http_api"):
+        with caplog.at_level("INFO", logger="influx"):
             transport = httpx.ASGITransport(app=app_with_state)
             async with httpx.AsyncClient(
                 transport=transport, base_url="http://test"
@@ -1066,7 +1066,7 @@ class TestBackfillObservability:
     ) -> None:
         import httpx
 
-        from influx import http_api as http_api_mod
+        from influx import run_dispatch as run_dispatch_mod
 
         async def selective_run_profile(
             profile: str, *args: Any, **kwargs: Any
@@ -1075,9 +1075,9 @@ class TestBackfillObservability:
                 raise RuntimeError("ai-robotics blew up")
             return None
 
-        monkeypatch.setattr(http_api_mod, "run_profile", selective_run_profile)
+        monkeypatch.setattr(run_dispatch_mod, "run_profile", selective_run_profile)
 
-        with caplog.at_level("INFO", logger="influx.http_api"):
+        with caplog.at_level("INFO", logger="influx"):
             transport = httpx.ASGITransport(app=app_with_state)
             async with httpx.AsyncClient(
                 transport=transport, base_url="http://test"

--- a/tests/unit/test_run_dispatch.py
+++ b/tests/unit/test_run_dispatch.py
@@ -44,18 +44,67 @@ def _make_dispatcher(
     config: AppConfig,
     active_tasks: set[asyncio.Task[object]],
     tmp_path: Path,
+    fetch_cache: object = None,
 ) -> RunDispatcher:
     return RunDispatcher(
         coordinator,
         config,
         run_ledger=RunLedger(tmp_path / "state"),
         active_tasks=active_tasks,
+        fetch_cache=fetch_cache,
     )
 
 
 async def _drain(active_tasks: set[asyncio.Task[object]]) -> None:
-    """Let every launched background task run to completion."""
-    await asyncio.gather(*list(active_tasks))
+    """Let every launched background task run to completion.
+
+    ``return_exceptions=True`` so failure-path tests (where ``run_profile``
+    re-raises) can still assert on side effects without the drain re-raising.
+    The done-callback already retrieves each task's exception.
+    """
+    await asyncio.gather(*list(active_tasks), return_exceptions=True)
+
+
+class _RecordingRunProfile:
+    """Records the args each ``run_profile`` call receives."""
+
+    def __init__(self, *, raises: bool = False) -> None:
+        self.calls: list[dict[str, object]] = []
+        self._raises = raises
+
+    async def __call__(
+        self,
+        profile: str,
+        kind: RunKind,
+        run_range: object = None,
+        *,
+        run_id: object = None,
+        **_: object,
+    ) -> None:
+        self.calls.append(
+            {
+                "profile": profile,
+                "kind": kind,
+                "run_range": run_range,
+                "run_id": run_id,
+            }
+        )
+        if self._raises:
+            raise RuntimeError("run_profile blew up")
+
+
+class _FakeFetchCache:
+    """Counts begin_fire / end_fire so tests can assert they balance."""
+
+    def __init__(self) -> None:
+        self.begins = 0
+        self.ends = 0
+
+    def begin_fire(self) -> None:
+        self.begins += 1
+
+    def end_fire(self) -> None:
+        self.ends += 1
 
 
 async def test_dispatch_one_launches_and_tracks(
@@ -177,4 +226,114 @@ async def test_dispatch_all_rolls_back_on_busy(
     assert active_tasks == set()
     assert called is False
     # Rollback released the lock acquired before hitting the busy profile.
+    assert not coordinator.is_busy("alpha")
+
+
+async def test_dispatch_one_forwards_run_range_and_run_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recorder = _RecordingRunProfile()
+    monkeypatch.setattr("influx.run_dispatch.run_profile", recorder)
+
+    coordinator = Coordinator()
+    config = _make_config(["alpha"])
+    active_tasks: set[asyncio.Task[object]] = set()
+    dispatcher = _make_dispatcher(coordinator, config, active_tasks, tmp_path)
+
+    await dispatcher.dispatch_one(
+        "alpha",
+        RunKind.BACKFILL,
+        run_range={"days": 7},
+        request_id="r1",
+        log_context={"request_id": "r1", "kind": "backfill", "scope": "alpha"},
+    )
+    await _drain(active_tasks)
+
+    assert recorder.calls == [
+        {
+            "profile": "alpha",
+            "kind": RunKind.BACKFILL,
+            "run_range": {"days": 7},
+            "run_id": "r1",
+        }
+    ]
+
+
+async def test_dispatch_all_forwards_run_range_and_per_profile_run_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recorder = _RecordingRunProfile()
+    monkeypatch.setattr("influx.run_dispatch.run_profile", recorder)
+
+    coordinator = Coordinator()
+    config = _make_config(["alpha", "beta"])
+    active_tasks: set[asyncio.Task[object]] = set()
+    dispatcher = _make_dispatcher(coordinator, config, active_tasks, tmp_path)
+
+    await dispatcher.dispatch_all(
+        RunKind.BACKFILL,
+        run_range={"days": 3},
+        request_id="r1",
+        log_context={"request_id": "r1", "kind": "backfill", "scope": "all"},
+    )
+    await _drain(active_tasks)
+
+    # Each fanned-out run gets the shared run_range and a per-profile run id.
+    by_profile = {c["profile"]: c for c in recorder.calls}
+    assert by_profile["alpha"]["run_id"] == "r1:alpha"
+    assert by_profile["beta"]["run_id"] == "r1:beta"
+    assert by_profile["alpha"]["run_range"] == {"days": 3}
+    assert by_profile["beta"]["run_range"] == {"days": 3}
+
+
+async def test_fetch_cache_begin_end_balanced_on_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("influx.run_dispatch.run_profile", _RecordingRunProfile())
+
+    coordinator = Coordinator()
+    config = _make_config(["alpha"])
+    active_tasks: set[asyncio.Task[object]] = set()
+    fetch_cache = _FakeFetchCache()
+    dispatcher = _make_dispatcher(
+        coordinator, config, active_tasks, tmp_path, fetch_cache=fetch_cache
+    )
+
+    await dispatcher.dispatch_one(
+        "alpha",
+        RunKind.MANUAL,
+        request_id="r1",
+        log_context={"request_id": "r1", "kind": "manual", "scope": "alpha"},
+    )
+    await _drain(active_tasks)
+
+    assert (fetch_cache.begins, fetch_cache.ends) == (1, 1)
+
+
+async def test_fetch_cache_begin_end_balanced_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "influx.run_dispatch.run_profile", _RecordingRunProfile(raises=True)
+    )
+
+    coordinator = Coordinator()
+    config = _make_config(["alpha"])
+    active_tasks: set[asyncio.Task[object]] = set()
+    fetch_cache = _FakeFetchCache()
+    dispatcher = _make_dispatcher(
+        coordinator, config, active_tasks, tmp_path, fetch_cache=fetch_cache
+    )
+
+    await dispatcher.dispatch_one(
+        "alpha",
+        RunKind.MANUAL,
+        request_id="r1",
+        log_context={"request_id": "r1", "kind": "manual", "scope": "alpha"},
+    )
+    await _drain(active_tasks)
+
+    # end_fire runs in the finally even when the run raises, and the lock is
+    # still released.
+    assert (fetch_cache.begins, fetch_cache.ends) == (1, 1)
     assert not coordinator.is_busy("alpha")

--- a/tests/unit/test_run_dispatch.py
+++ b/tests/unit/test_run_dispatch.py
@@ -1,0 +1,180 @@
+"""Unit tests for the request-orchestration collaborator (finding 4).
+
+These drive :class:`influx.run_dispatch.RunDispatcher` directly — a real
+``Coordinator`` and a plain ``set`` for the task registry, with
+``run_profile`` patched to a recorder. No FastAPI / ASGI stack is needed,
+which is the point of extracting the orchestration out of the HTTP router:
+the acquire-all-or-rollback loop and background-task tracking are testable
+on their own.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from influx.config import (
+    AppConfig,
+    ProfileConfig,
+    PromptEntryConfig,
+    PromptsConfig,
+    ScheduleConfig,
+)
+from influx.coordinator import Coordinator, RunKind
+from influx.run_dispatch import RunAccepted, RunDispatcher, RunRejectedBusy
+from influx.run_ledger import RunLedger
+
+
+def _make_config(profiles: list[str]) -> AppConfig:
+    return AppConfig(
+        schedule=ScheduleConfig(cron="0 6 * * *", timezone="UTC"),
+        profiles=[ProfileConfig(name=name) for name in profiles],
+        prompts=PromptsConfig(
+            filter=PromptEntryConfig(text="test"),
+            tier1_enrich=PromptEntryConfig(text="test"),
+            tier3_extract=PromptEntryConfig(text="test"),
+        ),
+    )
+
+
+def _make_dispatcher(
+    coordinator: Coordinator,
+    config: AppConfig,
+    active_tasks: set[asyncio.Task[object]],
+    tmp_path: Path,
+) -> RunDispatcher:
+    return RunDispatcher(
+        coordinator,
+        config,
+        run_ledger=RunLedger(tmp_path / "state"),
+        active_tasks=active_tasks,
+    )
+
+
+async def _drain(active_tasks: set[asyncio.Task[object]]) -> None:
+    """Let every launched background task run to completion."""
+    await asyncio.gather(*list(active_tasks))
+
+
+async def test_dispatch_one_launches_and_tracks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[tuple[str, RunKind]] = []
+
+    async def record(profile: str, kind: RunKind, run_range=None, **_: object) -> None:  # type: ignore[no-untyped-def]
+        calls.append((profile, kind))
+
+    monkeypatch.setattr("influx.run_dispatch.run_profile", record)
+
+    coordinator = Coordinator()
+    config = _make_config(["alpha", "beta"])
+    active_tasks: set[asyncio.Task[object]] = set()
+    dispatcher = _make_dispatcher(coordinator, config, active_tasks, tmp_path)
+
+    outcome = await dispatcher.dispatch_one(
+        "alpha",
+        RunKind.MANUAL,
+        request_id="r1",
+        log_context={"request_id": "r1", "kind": "manual", "scope": "alpha"},
+    )
+
+    assert outcome == RunAccepted(scope="alpha", profiles=("alpha",))
+    # The background task is registered before it completes (shutdown grace).
+    assert len(active_tasks) == 1
+    await _drain(active_tasks)
+    assert calls == [("alpha", RunKind.MANUAL)]
+    # The lock is released once the run finishes.
+    assert not coordinator.is_busy("alpha")
+
+
+async def test_dispatch_one_rejects_when_busy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    called = False
+
+    async def record(*_: object, **__: object) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("influx.run_dispatch.run_profile", record)
+
+    coordinator = Coordinator()
+    config = _make_config(["alpha"])
+    active_tasks: set[asyncio.Task[object]] = set()
+    dispatcher = _make_dispatcher(coordinator, config, active_tasks, tmp_path)
+
+    assert await coordinator.try_acquire("alpha") is True  # someone else holds it
+
+    outcome = await dispatcher.dispatch_one(
+        "alpha",
+        RunKind.MANUAL,
+        request_id="r1",
+        log_context={"request_id": "r1", "kind": "manual", "scope": "alpha"},
+    )
+
+    assert outcome == RunRejectedBusy("alpha")
+    assert active_tasks == set()
+    assert called is False
+
+
+async def test_dispatch_all_launches_every_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str] = []
+
+    async def record(profile: str, kind: RunKind, run_range=None, **_: object) -> None:  # type: ignore[no-untyped-def]
+        calls.append(profile)
+
+    monkeypatch.setattr("influx.run_dispatch.run_profile", record)
+
+    coordinator = Coordinator()
+    config = _make_config(["alpha", "beta"])
+    active_tasks: set[asyncio.Task[object]] = set()
+    dispatcher = _make_dispatcher(coordinator, config, active_tasks, tmp_path)
+
+    outcome = await dispatcher.dispatch_all(
+        RunKind.MANUAL,
+        request_id="r1",
+        log_context={"request_id": "r1", "kind": "manual", "scope": "all"},
+    )
+
+    assert outcome == RunAccepted(scope="all", profiles=("alpha", "beta"))
+    await _drain(active_tasks)
+    assert sorted(calls) == ["alpha", "beta"]
+    assert not coordinator.is_busy("alpha")
+    assert not coordinator.is_busy("beta")
+
+
+async def test_dispatch_all_rolls_back_on_busy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    called = False
+
+    async def record(*_: object, **__: object) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("influx.run_dispatch.run_profile", record)
+
+    coordinator = Coordinator()
+    config = _make_config(["alpha", "beta"])
+    active_tasks: set[asyncio.Task[object]] = set()
+    dispatcher = _make_dispatcher(coordinator, config, active_tasks, tmp_path)
+
+    # 'beta' is already held, so the all-or-nothing acquire must roll back the
+    # 'alpha' lock it grabbed first and reject naming the busy profile.
+    assert await coordinator.try_acquire("beta") is True
+
+    outcome = await dispatcher.dispatch_all(
+        RunKind.MANUAL,
+        request_id="r1",
+        log_context={"request_id": "r1", "kind": "manual", "scope": "all"},
+    )
+
+    assert outcome == RunRejectedBusy("beta")
+    assert active_tasks == set()
+    assert called is False
+    # Rollback released the lock acquired before hitting the busy profile.
+    assert not coordinator.is_busy("alpha")

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -316,7 +316,7 @@ class TestInfluxService:
         )
 
     async def test_stop_awaits_http_triggered_work_on_real_app(self) -> None:
-        """Regression for Finding 1: ``_spawn_tracked_task`` must register
+        """Regression for Finding 1: the ``RunDispatcher`` must register
         HTTP-triggered tasks on the existing (possibly empty) set on
         ``app.state`` so ``InfluxService.stop`` can actually await them.
         """
@@ -345,7 +345,7 @@ class TestInfluxService:
                 raise
 
         transport = httpx.ASGITransport(app=svc.app)
-        with patch("influx.http_api.run_profile", slow_run_profile):
+        with patch("influx.run_dispatch.run_profile", slow_run_profile):
             async with httpx.AsyncClient(
                 transport=transport, base_url="http://test"
             ) as client:
@@ -358,7 +358,7 @@ class TestInfluxService:
             # The real bug: with the empty-set replacement, this would
             # stay at 0 because the task went into a throwaway local set.
             assert len(svc.app.state.active_tasks) >= 1, (
-                "_spawn_tracked_task must register task on app.state.active_tasks"
+                "RunDispatcher must register task on app.state.active_tasks"
             )
 
             await svc.stop()


### PR DESCRIPTION
## What & why (finding 4, slice 2 of 3)

The architectural heart of finding 4. Half of `http_api.py` was *orchestration*, not HTTP translation: the router hand-rolled `coordinator.try_acquire`/`release`, duplicated the all-or-nothing multi-profile acquire+rollback loop **verbatim** across `post_runs` and `post_backfills`, carried two near-identical release wrappers, and owned the background-task lifecycle.

## The seam

New **`RunDispatcher`** (`src/influx/run_dispatch.py`, Orchestration component) — a kind-agnostic collaborator that owns the lock lifecycle:

- acquire the per-Profile locks **all-or-nothing** (busy → release everything acquired so far, reject naming the busy Profile — no partial fan-out),
- launch the background Run(s), register them on the shutdown-grace set so `InfluxService.stop` drains them (US-008),
- release the locks in `finally`.

`dispatch_one` / `dispatch_all` return a `RunAccepted | RunRejectedBusy` union; the router turns it into `202` / `409` and keeps **only translation**: body parse, profile-name validation, the backfill confirm gate, and the accepted-log + response. A backfill is just `RunKind.BACKFILL`, so manual runs and backfills now share one lock lifecycle and one fan-out path.

Because the dispatcher takes plain deps (a `Coordinator`, a task `set`) rather than a FastAPI app, the orchestration is **unit-testable without an ASGI stack** — see the new `tests/unit/test_run_dispatch.py` (acquire-all-or-rollback, task tracking, busy rejection).

### `post_runs` before → after

```python
# before: router hand-rolls the lock lifecycle
acquired_profiles: list[str] = []
for profile_cfg in config.profiles:
    acquired = await coordinator.try_acquire(profile_cfg.name)
    if not acquired:
        for p in acquired_profiles:
            coordinator.release(p)
        return _profile_busy_response(...)
    acquired_profiles.append(profile_cfg.name)
_spawn_tracked_task(request.app, _run_many_and_release(coordinator, acquired_profiles, ...), ...)

# after: router translates; the dispatcher orchestrates
outcome = await dispatcher.dispatch_all(RunKind.MANUAL, request_id=request_id, log_context=...)
if isinstance(outcome, RunRejectedBusy):
    return _profile_busy_response(profile=outcome.profile, ...)
```

## Effects (from regenerated `docs/generated/`)

- **`http_api.py` drops to 687 lines** — below 800, so `modules_over_800_lines` ratchets **12 → 11** (locks in the gain, matching how 3b lowered `tests_private_imports`).
- HttpApi component **−269 lines**; `post_backfills` cyclomatic **17 → 15**.
- Cross-component edges unchanged (62, budget satisfied).
- **Module-cycle count unchanged (still 3):** `run_dispatch` joins the existing orchestration SCC as a node. Slice 3 (retire the `run_profile` / `run_via_service` shims) is what actually shrinks it — this slice sets that up.

## Notable behaviour note

The background-task completion/failure done-callback logs now emit under the **`influx.run_dispatch`** logger (the dispatcher owns them). The observability tests that asserted on these now capture the `influx` parent namespace, which covers both the router's "accepted" logs and the dispatcher's completion logs. No log *message* changed.

## Registration + docs

`influx.run_dispatch` added to `architecture.toml` (Orchestration component + domain exclude), both import-linter contracts (Entrypoints forbidden lists), and a `CONTEXT.md` **RunDispatcher** entry. `make diagrams` regenerated the component drill-downs + metrics.

## Verification

- `make check` fully green — lint + pyright + **2772 tests pass** (including the usually-flaky `test_run_conflict_exit_1` this run).
- `make diagrams` committed; no drift.

Refs Lithos task 9d943825-d970-423a-a9c0-155ac8647393 (finding 4, slice 2/3)
