### PR TITLE
fix(repair): waive clearing conditions for per-stage terminal tags

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -137,7 +137,7 @@ _Avoid_: probes (one input to Health), readiness (one output of Health).
 >
 > **Dev:** "If **Tier 2** extraction fails three times for one Acquired, what happens on the next scheduled Run?"
 >
-> **Domain expert:** "**RepairCounters** sees `tier2_attempts >= cap`, the **Cascade** skips Tier 2, the **Renderer** emits the note with `influx:tier2-terminal`, and the note drops out of the sweep set. To re-enable that stage on that note an operator removes the terminal tag *and* re-adds `influx:repair-needed` — sweeps select on that tag alone, so dropping the terminal tag by itself re-arms nothing."
+> **Domain expert:** "**RepairCounters** sees `tier2_attempts >= cap`, the **Cascade** skips Tier 2, the **Renderer** emits the note with `influx:tier2-terminal`, and the note drops out of the sweep set. Re-arming that stage takes three edits: reset the counter below the cap, remove the terminal tag, re-add `influx:repair-needed`. The counter is the authoritative gate — the **Cascade** checks it before calling the extractor, so removing the tag alone gets you a sweep that attempts nothing and re-terminates."
 
 ## Flagged ambiguities
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -137,7 +137,7 @@ _Avoid_: probes (one input to Health), readiness (one output of Health).
 >
 > **Dev:** "If **Tier 2** extraction fails three times for one Acquired, what happens on the next scheduled Run?"
 >
-> **Domain expert:** "**RepairCounters** sees `tier2_attempts >= cap`, the **Cascade** skips Tier 2, the **Renderer** emits the note with `influx:tier2-terminal`. Operator removes the tag manually to re-enable that stage on that note."
+> **Domain expert:** "**RepairCounters** sees `tier2_attempts >= cap`, the **Cascade** skips Tier 2, the **Renderer** emits the note with `influx:tier2-terminal`, and the note drops out of the sweep set. To re-enable that stage on that note an operator removes the terminal tag *and* re-adds `influx:repair-needed` — sweeps select on that tag alone, so dropping the terminal tag by itself re-arms nothing."
 
 ## Flagged ambiguities
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -577,7 +577,11 @@ Tier 2 and Tier 3 hook failures are partitioned into transient (HTTP, transport,
 
 When `tier{N}_attempts` reaches the cap (currently 3), `influx:tier{N}-terminal` is added to the note's tags and that stage is skipped on subsequent sweeps. Transient failures never advance the counter, so flaky network conditions do not burn the cap.
 
-To re-enable a stage on a single note, an operator removes the `influx:tier{N}-terminal` tag (and optionally clears the `## Repair` section) — the next sweep retries from a clean slate. This mirrors the existing `influx:text-terminal` escape hatch.
+To re-enable a stage on a single note, an operator removes the `influx:tier{N}-terminal` tag (and optionally clears the `## Repair` section) **and re-adds `influx:repair-needed`** — the next sweep then retries from a clean slate.
+
+Both steps are required. Sweeps select candidates by the `influx:repair-needed` tag alone, and a terminal flip waives the clearing condition that tag gated (§5.3), so the note drops out of the sweep set when it goes terminal. Removing the terminal tag on its own leaves a note no sweep will ever select again.
+
+This mirrors the existing `influx:text-terminal` escape hatch, which has always behaved this way: `audit_invalid_source.reconstruct_tags` drops `influx:text-terminal` **and** re-adds `influx:repair-needed` for exactly this reason, and is the reference implementation for a re-arm.
 
 ---
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -577,11 +577,32 @@ Tier 2 and Tier 3 hook failures are partitioned into transient (HTTP, transport,
 
 When `tier{N}_attempts` reaches the cap (currently 3), `influx:tier{N}-terminal` is added to the note's tags and that stage is skipped on subsequent sweeps. Transient failures never advance the counter, so flaky network conditions do not burn the cap.
 
-To re-enable a stage on a single note, an operator removes the `influx:tier{N}-terminal` tag (and optionally clears the `## Repair` section) **and re-adds `influx:repair-needed`** — the next sweep then retries from a clean slate.
+#### Re-arming a terminal stage
 
-Both steps are required. Sweeps select candidates by the `influx:repair-needed` tag alone, and a terminal flip waives the clearing condition that tag gated (§5.3), so the note drops out of the sweep set when it goes terminal. Removing the terminal tag on its own leaves a note no sweep will ever select again.
+**The persisted counter is authoritative, not the tag.** Two different mechanisms read the terminal state, and a re-arm has to satisfy both:
 
-This mirrors the existing `influx:text-terminal` escape hatch, which has always behaved this way: `audit_invalid_source.reconstruct_tags` drops `influx:text-terminal` **and** re-adds `influx:repair-needed` for exactly this reason, and is the reference implementation for a re-arm.
+| State | Read by | Effect |
+| ----- | ------- | ------ |
+| `tier{N}_attempts >= cap` in `## Repair` | `Cascade.enrich` | Skips the extractor and **re-emits** `influx:tier{N}-terminal` |
+| `influx:tier{N}-terminal` tag | `select_stages` | Excludes the stage from the sweep pass |
+| `influx:tier{N}-terminal` tag | `compute_clearing` (§5.3) | Waives that stage's clearing condition, so `influx:repair-needed` is dropped |
+
+Re-arming Tier 2 or Tier 3 therefore takes **three** edits, all required:
+
+1. **Reset `tier{N}_attempts` below the cap** in the `## Repair` section. Reset only the stage you are re-arming — the other stages' counters and error history are still wanted.
+2. **Remove the `influx:tier{N}-terminal` tag.**
+3. **Re-add `influx:repair-needed`.**
+
+Omitting (1) is the trap: the sweep selects the note, `Cascade.enrich` sees the capped counter, skips the extractor without attempting recovery, re-applies the terminal tag, and the §5.3 waiver drops `influx:repair-needed` again. The note returns to its terminal state having tried nothing. Omitting (3) is equally silent — sweeps only ever select notes carrying `influx:repair-needed`, so the note is never visited at all.
+
+Two stage-specific notes:
+
+- **`influx:archive-terminal`** — removing the tag and re-adding `influx:repair-needed` does permit one download attempt, because the archive cap is enforced at failure-recording time rather than before the attempt. But a counter left at the cap re-terminates on the first counted failure, so reset `archive_attempts` too for a genuine clean slate.
+- **`influx:text-terminal`** — has no counter, so only steps (2) and (3) apply. `audit_invalid_source.reconstruct_tags` is the reference implementation: it drops `influx:text-terminal` **and** re-adds `influx:repair-needed` for exactly this reason.
+
+Sweep candidate selection is profile-qualified: the query filters on `influx:repair-needed` **and** `profile:<profile>`. A note that has lost its `profile:*` tag is unreachable by any sweep regardless of its repair tags.
+
+See `docs/operations/runbook.md` §6 for the per-tag operator table.
 
 ---
 

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -422,8 +422,8 @@
         "classes": 17,
         "functions": 79,
         "largest_module": "influx.repair",
-        "largest_module_lines": 1709,
-        "lines": 3792,
+        "largest_module_lines": 1711,
+        "lines": 3794,
         "modules": 5,
         "public_symbols": 39,
         "sloc": 2935
@@ -474,13 +474,13 @@
       "influx.sources.rss",
       "influx.telemetry"
     ],
-    "total_lines": 27947,
+    "total_lines": 27949,
     "total_modules": 58,
     "total_sloc": 21669
   },
   "tests": {
-    "ratio": 2.55,
-    "src_lines": 27947,
-    "test_lines": 71291
+    "ratio": 2.56,
+    "src_lines": 27949,
+    "test_lines": 71494
   }
 }

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -422,11 +422,11 @@
         "classes": 17,
         "functions": 79,
         "largest_module": "influx.repair",
-        "largest_module_lines": 1686,
-        "lines": 3769,
+        "largest_module_lines": 1709,
+        "lines": 3792,
         "modules": 5,
         "public_symbols": 39,
-        "sloc": 2927
+        "sloc": 2935
       },
       "Schemas": {
         "classes": 4,
@@ -474,13 +474,13 @@
       "influx.sources.rss",
       "influx.telemetry"
     ],
-    "total_lines": 27924,
+    "total_lines": 27947,
     "total_modules": 58,
-    "total_sloc": 21661
+    "total_sloc": 21669
   },
   "tests": {
     "ratio": 2.55,
-    "src_lines": 27924,
-    "test_lines": 71178
+    "src_lines": 27947,
+    "test_lines": 71275
   }
 }

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -481,6 +481,6 @@
   "tests": {
     "ratio": 2.55,
     "src_lines": 27947,
-    "test_lines": 71275
+    "test_lines": 71291
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -45,14 +45,14 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Notifications | 1 | 581 | 509 | 2 | 2 | 0.50 | 13 (`influx.notifications.dispatch_notifications`) | 2 |
 | Observability | 3 | 1912 | 1401 | 9 | 0 | 0.00 | 10 (`influx.logging_config.setup_logging`) | 0 |
 | Orchestration | 6 | 4103 | 3241 | 1 | 11 | 0.92 | 52 (`influx.run_service.ledger_lifecycle`) | 11 |
-| Repair | 5 | 3769 | 2927 | 4 | 7 | 0.64 | 26 (`influx.repair._process_sweep_note`) | 6 |
+| Repair | 5 | 3792 | 2935 | 4 | 7 | 0.64 | 26 (`influx.repair._process_sweep_note`) | 6 |
 | Schemas | 1 | 240 | 183 | 3 | 0 | 0.00 | 14 (`influx.schemas._harden_for_openai_strict`) | 1 |
 | Sources | 10 | 4343 | 3323 | 3 | 8 | 0.73 | 28 (`influx.sources.arxiv.build_arxiv_note_item`) | 7 |
 | Storage | 1 | 720 | 588 | 3 | 3 | 0.50 | 14 (`influx.storage.download_archive`) | 2 |
 
 ## Size
 
-- Modules: **58**, lines: **27924**, SLOC: **21661**
+- Modules: **58**, lines: **27947**, SLOC: **21669**
 - Largest module: `influx.sources.arxiv` (1830 lines)
 - Modules over 800 lines: **11**
   - `influx.config`
@@ -133,4 +133,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 ## Domain & tests
 
 - Domain models: **17** (5 associations, 0 without docstrings)
-- Test-to-source line ratio: **2.55** (71178 test lines / 27924 source lines)
+- Test-to-source line ratio: **2.55** (71275 test lines / 27947 source lines)

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -133,4 +133,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 ## Domain & tests
 
 - Domain models: **17** (5 associations, 0 without docstrings)
-- Test-to-source line ratio: **2.55** (71275 test lines / 27947 source lines)
+- Test-to-source line ratio: **2.55** (71291 test lines / 27947 source lines)

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -45,14 +45,14 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Notifications | 1 | 581 | 509 | 2 | 2 | 0.50 | 13 (`influx.notifications.dispatch_notifications`) | 2 |
 | Observability | 3 | 1912 | 1401 | 9 | 0 | 0.00 | 10 (`influx.logging_config.setup_logging`) | 0 |
 | Orchestration | 6 | 4103 | 3241 | 1 | 11 | 0.92 | 52 (`influx.run_service.ledger_lifecycle`) | 11 |
-| Repair | 5 | 3792 | 2935 | 4 | 7 | 0.64 | 26 (`influx.repair._process_sweep_note`) | 6 |
+| Repair | 5 | 3794 | 2935 | 4 | 7 | 0.64 | 26 (`influx.repair._process_sweep_note`) | 6 |
 | Schemas | 1 | 240 | 183 | 3 | 0 | 0.00 | 14 (`influx.schemas._harden_for_openai_strict`) | 1 |
 | Sources | 10 | 4343 | 3323 | 3 | 8 | 0.73 | 28 (`influx.sources.arxiv.build_arxiv_note_item`) | 7 |
 | Storage | 1 | 720 | 588 | 3 | 3 | 0.50 | 14 (`influx.storage.download_archive`) | 2 |
 
 ## Size
 
-- Modules: **58**, lines: **27947**, SLOC: **21669**
+- Modules: **58**, lines: **27949**, SLOC: **21669**
 - Largest module: `influx.sources.arxiv` (1830 lines)
 - Modules over 800 lines: **11**
   - `influx.config`
@@ -133,4 +133,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 ## Domain & tests
 
 - Domain models: **17** (5 associations, 0 without docstrings)
-- Test-to-source line ratio: **2.55** (71291 test lines / 27947 source lines)
+- Test-to-source line ratio: **2.56** (71494 test lines / 27949 source lines)

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -288,12 +288,32 @@ prints the exact restart command for the current environment.
 Influx never clears `influx:*-terminal` tags by itself. To re-arm a
 note after fixing the underlying cause:
 
-| Tag                          | Cap counter (`## Repair`) | Re-arm steps                                                                                       |
-| ---------------------------- | ------------------------- | -------------------------------------------------------------------------------------------------- |
-| `influx:archive-terminal`    | `archive_attempts`        | Remove the tag in Lithos. Optionally also delete the `## Repair` block. Next sweep retries from 0. |
-| `influx:tier2-terminal`      | `tier2_attempts`          | Same — remove the tag, optionally clear the counter, next sweep retries Tier 2.                    |
-| `influx:tier3-terminal`      | `tier3_attempts`          | Same — remove the tag, optionally clear the counter, next sweep retries Tier 3.                    |
-| `influx:text-terminal`       | _n/a_ (set explicitly when abstract-only re-extraction returns TERMINAL) | Remove the tag — abstract-only re-extraction will run next sweep. |
+**Resetting the counter is not optional.** `Cascade.enrich` checks
+`tier{N}_attempts >= cap` *before* calling the extractor, so a note whose
+tag you removed but whose counter is still at the cap gets no recovery
+attempt — the stage is skipped, the terminal tag is re-applied, and the
+note drops back out of the sweep set having tried nothing.
+
+**Re-adding `influx:repair-needed` is also required.** A terminal flip
+waives that stage's clearing condition, so the note loses
+`influx:repair-needed` when it goes terminal, and sweeps only ever select
+notes that carry it.
+
+| Tag                       | Cap counter (`## Repair`) | Re-arm steps                                                                                                             |
+| ------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `influx:tier2-terminal`   | `tier2_attempts`          | **All three:** reset `tier2_attempts` below the cap, remove the tag, re-add `influx:repair-needed`.                       |
+| `influx:tier3-terminal`   | `tier3_attempts`          | **All three:** reset `tier3_attempts` below the cap, remove the tag, re-add `influx:repair-needed`.                       |
+| `influx:archive-terminal` | `archive_attempts`        | Remove the tag + re-add `influx:repair-needed` buys one attempt; also reset `archive_attempts` or the first counted failure re-terminates it. |
+| `influx:text-terminal`    | _n/a_ (set explicitly when abstract-only re-extraction returns TERMINAL) | Remove the tag + re-add `influx:repair-needed`. No counter to reset.        |
+
+Reset only the counter for the stage you are re-arming — deleting the
+whole `## Repair` block discards the other stages' attempt history and
+last-error diagnostics. `audit_invalid_source.reconstruct_tags` is the
+reference implementation of a correct re-arm.
+
+Candidate selection is profile-qualified (`influx:repair-needed` **and**
+`profile:<profile>`), so a note missing its `profile:*` tag is
+unreachable by any sweep whatever its repair tags say.
 
 The full per-stage cap contract lives in
 [`docs/SPECIFICATION.md` §11.1](../SPECIFICATION.md#111-per-stage-cap-and-self-repair).

--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -692,12 +692,27 @@ def compute_clearing(
     is_text_terminal = "influx:text-terminal" in tag_set
 
     # FR-NOTE-9: clear influx:archive-missing iff archive path stored.
+    # Deliberately NOT waived by influx:archive-terminal — that tag is a
+    # factual statement about the note (no path is stored), whereas the
+    # terminal waivers below are statements about whether a *stage* can
+    # still make progress.
     clear_archive_missing = archive_path is not None
 
     # §5.3: clear influx:repair-needed iff ALL four conditions hold.
+    #
+    # Each condition is additionally waived by its own
+    # ``influx:<stage>-terminal`` tag.  ``record_counted_failure``
+    # applies those at ``REPAIR_COUNTED_CAP``: the stage has exhausted
+    # its retries and can never satisfy the condition.  Without the
+    # waiver the note keeps ``influx:repair-needed`` forever and is
+    # re-selected by every sweep, which — because the sweep rewrites
+    # every visited note to advance retry order (AC-X-8) — pins its
+    # ``updated_at`` to "now" on each pass and permanently outranks
+    # genuinely fresh material in retrieval.  Mirrors the pre-existing
+    # ``influx:text-terminal`` exemption (AC-X-7).
 
     # (a) Non-empty path: line in ## Archive.
-    archive_ok = archive_path is not None
+    archive_ok = archive_path is not None or "influx:archive-terminal" in tag_set
 
     # (b) Text quality: text:html or text:pdf, OR (text:abstract-only
     #     accompanied by influx:text-terminal).
@@ -712,7 +727,11 @@ def compute_clearing(
     # (c) Tier 2 satisfied: only required when score ≥ full_text
     #     threshold AND influx:text-terminal absent.
     #     AC-X-7: terminal exemption waives Tier 2.
-    if is_text_terminal or max_profile_score < full_text_threshold:
+    if (
+        is_text_terminal
+        or "influx:tier2-terminal" in tag_set
+        or max_profile_score < full_text_threshold
+    ):
         tier2_ok = True
     else:
         tier2_ok = "full-text" in tag_set
@@ -720,7 +739,11 @@ def compute_clearing(
     # (d) Tier 3 satisfied: only required when score ≥ deep_extract
     #     threshold AND influx:text-terminal absent.
     #     AC-X-7: terminal exemption waives Tier 3.
-    if is_text_terminal or max_profile_score < deep_extract_threshold:
+    if (
+        is_text_terminal
+        or "influx:tier3-terminal" in tag_set
+        or max_profile_score < deep_extract_threshold
+    ):
         tier3_ok = True
     else:
         tier3_ok = "influx:deep-extracted" in tag_set

--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -692,10 +692,12 @@ def compute_clearing(
     is_text_terminal = "influx:text-terminal" in tag_set
 
     # FR-NOTE-9: clear influx:archive-missing iff archive path stored.
-    # Deliberately NOT waived by influx:archive-terminal — that tag is a
-    # factual statement about the note (no path is stored), whereas the
-    # terminal waivers below are statements about whether a *stage* can
-    # still make progress.
+    # Deliberately NOT waived by influx:archive-terminal.
+    # ``influx:archive-missing`` is a factual statement about the note —
+    # no ``path:`` line is stored — and stays true however many times
+    # the archive stage has given up.  ``influx:archive-terminal`` is a
+    # statement about stage reachability, and only that second kind of
+    # claim can waive a repair condition (see below).
     clear_archive_missing = archive_path is not None
 
     # §5.3: clear influx:repair-needed iff ALL four conditions hold.

--- a/tests/unit/test_repair_clearing_rules.py
+++ b/tests/unit/test_repair_clearing_rules.py
@@ -579,3 +579,34 @@ class TestPerStageTerminalExemptions:
         # The note still leaves the sweep — the two decisions are
         # independent.
         assert d.clear_repair_needed is True
+
+    def test_tier2_terminal_alone_does_not_waive_tier3(self) -> None:
+        """Each tier's waiver is scoped to its own condition.
+
+        Guards against an "either tier terminal waives both tiers"
+        implementation, which the positive cases above cannot detect.
+        """
+        d = _clear(
+            ["influx:repair-needed", "text:html", "influx:tier2-terminal"],
+            archive_path="/archives/doc.html",
+            max_profile_score=HIGH_SCORE,
+        )
+        # Tier 2 waived, but deep-extract is still outstanding.
+        assert d.clear_repair_needed is False
+
+    def test_tier3_terminal_alone_does_not_waive_tier2(self) -> None:
+        d = _clear(
+            ["influx:repair-needed", "text:html", "influx:tier3-terminal"],
+            archive_path="/archives/doc.html",
+            max_profile_score=HIGH_SCORE,
+        )
+        # Tier 3 waived, but full-text is still outstanding.
+        assert d.clear_repair_needed is False
+
+    def test_archive_terminal_alone_does_not_waive_tiers(self) -> None:
+        d = _clear(
+            ["influx:repair-needed", "text:html", "influx:archive-terminal"],
+            archive_path=None,
+            max_profile_score=HIGH_SCORE,
+        )
+        assert d.clear_repair_needed is False

--- a/tests/unit/test_repair_clearing_rules.py
+++ b/tests/unit/test_repair_clearing_rules.py
@@ -537,6 +537,9 @@ class TestPerStageTerminalExemptions:
             max_profile_score=LOW_SCORE,
         )
         assert d.clear_repair_needed is True
+        # Pins the decoupling: the waiver releases the note from the
+        # sweep without asserting an archive exists.
+        assert d.clear_archive_missing is False
 
     def test_tier_terminal_does_not_waive_text_condition(self) -> None:
         """Terminal tiers must not paper over an un-terminal text stage.
@@ -557,9 +560,22 @@ class TestPerStageTerminalExemptions:
         assert d.clear_repair_needed is False
 
     def test_archive_terminal_does_not_clear_archive_missing(self) -> None:
-        """``influx:archive-missing`` stays factual: no path is no path."""
+        """``influx:archive-missing`` stays factual: no path is no path.
+
+        The terminal tag must be present for this to test what it
+        claims — without it the assertion would hold for the trivial
+        reason that nothing waives anything.
+        """
         d = _clear(
-            ["influx:repair-needed", "influx:archive-missing", "text:html"],
+            [
+                "influx:repair-needed",
+                "influx:archive-missing",
+                "influx:archive-terminal",
+                "text:html",
+            ],
             archive_path=None,
         )
         assert d.clear_archive_missing is False
+        # The note still leaves the sweep — the two decisions are
+        # independent.
+        assert d.clear_repair_needed is True

--- a/tests/unit/test_repair_clearing_rules.py
+++ b/tests/unit/test_repair_clearing_rules.py
@@ -471,3 +471,95 @@ class TestPartialRepair:
             max_profile_score=HIGH_SCORE,
         )
         assert d.clear_repair_needed is False
+
+
+# ── Per-stage terminal exemptions (repeat-recommendation bug) ────────
+
+
+class TestPerStageTerminalExemptions:
+    """A stage that has gone terminal can never improve again.
+
+    ``compute_clearing`` historically honoured only
+    ``influx:text-terminal``, so a note whose Tier 2 / Tier 3 stages had
+    already exhausted ``REPAIR_COUNTED_CAP`` kept ``influx:repair-needed``
+    forever and was re-selected by every sweep.  Combined with the
+    unconditional rewrite that pinned ``updated_at`` to "now" on every
+    pass, permanently outranking every other note in retrieval.
+    """
+
+    def test_tier2_terminal_waives_full_text_requirement(self) -> None:
+        d = _clear(
+            ["influx:repair-needed", "text:html", "influx:tier2-terminal"],
+            archive_path="/archives/doc.html",
+            max_profile_score=FULL_TEXT_THRESHOLD,
+        )
+        assert d.clear_repair_needed is True
+
+    def test_tier3_terminal_waives_deep_extract_requirement(self) -> None:
+        d = _clear(
+            [
+                "influx:repair-needed",
+                "text:html",
+                "full-text",
+                "influx:tier3-terminal",
+            ],
+            archive_path="/archives/doc.html",
+            max_profile_score=HIGH_SCORE,
+        )
+        assert d.clear_repair_needed is True
+
+    def test_both_tier_terminals_clear_at_high_score(self) -> None:
+        """Regression for note 0a3a8e2b (v125, rewritten ~2.5x/day).
+
+        Both tiers terminal + text:html + archive stored -> nothing
+        further is achievable, so the note must exit the sweep.
+        """
+        d = _clear(
+            [
+                "influx:repair-needed",
+                "text:html",
+                "influx:tier2-terminal",
+                "influx:tier3-terminal",
+            ],
+            archive_path="/archives/doc.html",
+            max_profile_score=HIGH_SCORE,
+        )
+        assert d.clear_repair_needed is True
+
+    def test_archive_terminal_waives_archive_path_requirement(self) -> None:
+        d = _clear(
+            [
+                "influx:repair-needed",
+                "text:html",
+                "influx:archive-terminal",
+            ],
+            archive_path=None,
+            max_profile_score=LOW_SCORE,
+        )
+        assert d.clear_repair_needed is True
+
+    def test_tier_terminal_does_not_waive_text_condition(self) -> None:
+        """Terminal tiers must not paper over an un-terminal text stage.
+
+        ``text:abstract-only`` without ``influx:text-terminal`` still
+        locks the note per AC-06-C.
+        """
+        d = _clear(
+            [
+                "influx:repair-needed",
+                "text:abstract-only",
+                "influx:tier2-terminal",
+                "influx:tier3-terminal",
+            ],
+            archive_path="/archives/doc.html",
+            max_profile_score=HIGH_SCORE,
+        )
+        assert d.clear_repair_needed is False
+
+    def test_archive_terminal_does_not_clear_archive_missing(self) -> None:
+        """``influx:archive-missing`` stays factual: no path is no path."""
+        d = _clear(
+            ["influx:repair-needed", "influx:archive-missing", "text:html"],
+            archive_path=None,
+        )
+        assert d.clear_archive_missing is False

--- a/tests/unit/test_repair_sweep.py
+++ b/tests/unit/test_repair_sweep.py
@@ -1077,8 +1077,13 @@ class TestSweepTier2RecoveryViaCascade:
         rewritten = self._last_write_args(client)
         assert "influx:tier2-terminal" in rewritten["tags"]
         assert "tier2_attempts: 3" in rewritten["content"]
-        # Stage still failed → repair-needed stays for the (now-capped) note.
-        assert "influx:repair-needed" in rewritten["tags"]
+        # At the cap, Tier 2 can never succeed, so the condition it gates
+        # is waived and the note leaves the sweep.  Keeping
+        # influx:repair-needed here is what made capped notes immortal
+        # sweep candidates: re-selected every run, and rewritten every
+        # run for retry-order advancement (AC-X-8), which pinned
+        # updated_at to "now" forever and dominated retrieval ranking.
+        assert "influx:repair-needed" not in rewritten["tags"]
 
         flip_logs = [
             r

--- a/tests/unit/test_repair_sweep.py
+++ b/tests/unit/test_repair_sweep.py
@@ -1099,6 +1099,117 @@ class TestSweepTier2RecoveryViaCascade:
 # ── Layer 2 self-repair: counter + terminal flip ─────────────────────
 
 
+class TestSweepTier2ReArmContract:
+    """The persisted counter — not the terminal tag — gates execution.
+
+    ``Cascade.enrich`` checks ``counters.tier2_attempts >=
+    REPAIR_COUNTED_CAP`` *before* calling the extractor
+    (``cascade.py``), so an operator who removes
+    ``influx:tier2-terminal`` and re-adds ``influx:repair-needed`` but
+    leaves the counter at the cap gets no recovery attempt: the stage is
+    skipped, the terminal tag is re-emitted, the clearing waiver drops
+    ``influx:repair-needed`` again, and the note leaves the sweep
+    unchanged in substance.
+
+    These two tests pin that contract in both directions so the
+    documented re-arm procedure in ``docs/SPECIFICATION.md`` §11.1 and
+    ``docs/operations/runbook.md`` §6 cannot silently drift from it.
+    """
+
+    @staticmethod
+    def _note(repair_section: str) -> dict[str, Any]:
+        return TestSweepTier2RecoveryViaCascade._note_for_tier2(
+            "n1", score=8, repair_section=repair_section
+        )
+
+    @staticmethod
+    def _repair_section(attempts: int) -> str:
+        return (
+            "## Repair\n"
+            f"- tier2_attempts: {attempts}\n"
+            '- tier2_last_stage: "parse"\n'
+            '- tier2_last_error: "earlier failure"\n'
+            "- tier3_attempts: 0\n"
+            '- tier3_last_stage: ""\n'
+            '- tier3_last_error: ""\n\n'
+        )
+
+    async def test_removing_terminal_tag_alone_does_not_re_run_tier2(self) -> None:
+        """Tag removed, counter still at cap -> extractor never invoked."""
+        from influx.repair_counters import REPAIR_COUNTED_CAP
+
+        note = self._note(self._repair_section(REPAIR_COUNTED_CAP))
+        # Operator removed influx:tier2-terminal and left repair-needed.
+        assert "influx:tier2-terminal" not in note["tags"]
+        assert "influx:repair-needed" in note["tags"]
+
+        calls = 0
+
+        def extractor(acquired: Acquired) -> Tier2Result:
+            nonlocal calls
+            calls += 1
+            del acquired
+            return Tier2Result(text="recovered", flavour="pdf", text_tag="text:pdf")
+
+        config = _make_config()
+        client = _make_client(
+            list_items=[{"id": "n1", "title": "Paper"}], read_responses=[note]
+        )
+
+        await sweep(
+            "ai-robotics",
+            client=client,
+            config=config,
+            hooks=SweepHooks(),
+            cascade=_build_sweep_cascade(
+                config, "ai-robotics", tier2_extractor=extractor
+            ),
+        )
+
+        # The capped counter wins: no recovery attempt at all.
+        assert calls == 0
+        rewritten = TestSweepTier2RecoveryViaCascade._last_write_args(client)
+        # And the terminal tag is immediately re-applied, so the note
+        # drops straight back out of the sweep set.
+        assert "influx:tier2-terminal" in rewritten["tags"]
+        assert "influx:repair-needed" not in rewritten["tags"]
+
+    async def test_resetting_counter_below_cap_re_runs_tier2(self) -> None:
+        """Counter reset -> extractor runs and the note actually recovers."""
+        note = self._note(self._repair_section(0))
+
+        calls = 0
+
+        def extractor(acquired: Acquired) -> Tier2Result:
+            nonlocal calls
+            calls += 1
+            del acquired
+            return Tier2Result(
+                text="recovered body", flavour="pdf", text_tag="text:pdf"
+            )
+
+        config = _make_config()
+        client = _make_client(
+            list_items=[{"id": "n1", "title": "Paper"}], read_responses=[note]
+        )
+
+        await sweep(
+            "ai-robotics",
+            client=client,
+            config=config,
+            hooks=SweepHooks(),
+            cascade=_build_sweep_cascade(
+                config, "ai-robotics", tier2_extractor=extractor
+            ),
+        )
+
+        assert calls == 1
+        rewritten = TestSweepTier2RecoveryViaCascade._last_write_args(client)
+        assert "influx:tier2-terminal" not in rewritten["tags"]
+        assert "full-text" in rewritten["tags"]
+        assert "recovered body" in rewritten["content"]
+
+
 class TestSweepCapCounterAndTerminalFlip:
     """Repeat-fail sweeps cap counted failures at REPAIR_COUNTED_CAP and add
     ``influx:tier{N}-terminal`` so future sweeps skip the broken stage.
@@ -1246,6 +1357,12 @@ class TestSweepCapCounterAndTerminalFlip:
         rewritten = self._last_write_args(client)
         assert "influx:tier3-terminal" in rewritten["tags"]
         assert "tier3_attempts: 3" in rewritten["content"]
+        # This fixture is otherwise complete (archive + text:html +
+        # full-text), so the Tier 3 waiver is the last outstanding
+        # condition and the note must leave the sweep set.  Asserted at
+        # the sweep level, not just on compute_clearing, because the
+        # regression is the tag surviving into the persisted write.
+        assert "influx:repair-needed" not in rewritten["tags"]
 
         flip_logs = [
             r
@@ -1435,6 +1552,61 @@ class TestSweepArchiveTerminalCap:
         rec = flip_logs[0]
         assert getattr(rec, "archive_attempts", None) == 3
         assert getattr(rec, "kind", None) == "oversize"
+
+    async def test_archive_terminal_releases_otherwise_complete_note(self) -> None:
+        """Archive cap on a note with every *other* condition satisfied.
+
+        ``_note_for_archive`` carries no ``text:*`` tag, so its cap-flip
+        test cannot show that ``influx:archive-terminal`` actually
+        releases a note — condition (b) fails independently.  This
+        fixture satisfies text and both tiers, leaving the archive
+        waiver as the only thing standing between the note and the exit,
+        and pins that ``influx:archive-missing`` survives the release.
+        """
+        items = [{"id": "n1", "title": "Paper"}]
+        note = self._note_for_archive("n1")
+        note["tags"] = [
+            "influx:repair-needed",
+            "influx:archive-missing",
+            "text:html",
+            "full-text",
+            "influx:deep-extracted",
+        ]
+        note["content"] = note["content"].replace(
+            "## User Notes\n",
+            (
+                "## Repair\n"
+                "- archive_attempts: 2\n"
+                '- archive_last_kind: "oversize"\n'
+                '- archive_last_error: "earlier failure"\n\n'
+                "## User Notes\n"
+            ),
+        )
+
+        def failing(note: dict[str, object]) -> str:
+            del note
+            raise ExtractionError(
+                "Response body exceeds 100000000 bytes",
+                url="https://arxiv.org/pdf/x.pdf",
+                stage="oversize",
+            )
+
+        config = _make_config()
+        client = _make_client(list_items=items, read_responses=[note])
+
+        await sweep(
+            "ai-robotics",
+            client=client,
+            config=config,
+            hooks=SweepHooks(archive_download=failing),
+        )
+
+        rewritten = self._last_write_args(client)
+        assert "influx:archive-terminal" in rewritten["tags"]
+        # Released from the sweep set...
+        assert "influx:repair-needed" not in rewritten["tags"]
+        # ...but the factual "no archive stored" tag is retained.
+        assert "influx:archive-missing" in rewritten["tags"]
 
     async def test_archive_terminal_present_skips_archive_retry(self) -> None:
         """Once ``influx:archive-terminal`` is set, archive_download is not called."""


### PR DESCRIPTION
## Problem

Dave reported being repeatedly recommended the same agent-protocol articles. The filed diagnosis blamed duplicate ingestion; it isn't. The real cause is **write amplification in the repair sweep**.

`select_stages` honours all four `influx:<stage>-terminal` tags when deciding which stages to *run* (`repair.py:342-383`). `compute_clearing` honoured only `influx:text-terminal` when deciding whether to clear `influx:repair-needed`. So a note whose Tier 2 / Tier 3 / archive stage had exhausted `REPAIR_COUNTED_CAP` kept `influx:repair-needed` forever — even though `select_stages` would never run those stages again.

The sweep deliberately rewrites every visited note so `updated_at` advances (AC-X-8 retry-order advancement, which prevents candidate starvation when the backlog exceeds `max_items_per_run`). Combined with a note that never leaves the sweep set, that means **one spurious version per sweep, forever**.

Lithos retrieval weights recency, so these notes were permanently the freshest thing in the KB.

## Evidence from production

- **24 of 25** notes carrying `influx:repair-needed` were rewritten on 2026-07-29, out of 2225 `ingested-by:influx` notes.
- Note `0a3a8e2b` ("A Mike's-Eye View of ARC's Research") — carries **both** `influx:tier2-terminal` and `influx:tier3-terminal`, so nothing further is achievable — sits at **version 125**, created 2026-06-10 (~2.5 rewrites/day for 49 days).
- Rewrite timestamps cluster by profile (03:06 `ai-agents`, 04:18 `knowledge-systems`, 04:55 `ai-foundations`, 05:35 `ai-coding`, 06:15 `retro-computing`) = one rewrite per note per profile sweep.
- Four of the 24 are agent-protocol articles, which is why that cluster dominated every "agent protocols" query and read as duplicate ingestion.

## Change

Each clearing condition is now waived by its own terminal tag, mirroring the existing `influx:text-terminal` exemption (AC-X-7):

| Condition | Waived by |
|---|---|
| (a) archive path stored | `influx:archive-terminal` |
| (c) Tier 2 satisfied | `influx:tier2-terminal` |
| (d) Tier 3 satisfied | `influx:tier3-terminal` |

`clear_archive_missing` is deliberately **unchanged** — `influx:archive-missing` states a fact about the note (no path is stored), not the reachability of a stage.

Side benefit: this makes the `unsupported` archive-policy escape hatch effective. Previously even an operator-declared `influx:archive-terminal` could not release a note from the sweep.

## Re-arm contract (corrected in review)

Making terminal stages release notes exposed that the documented operator re-arm workflow was wrong, on three doc surfaces. **The persisted counter is authoritative, not the tag**: `Cascade.enrich` checks `tier{N}_attempts >= REPAIR_COUNTED_CAP` before calling the extractor and re-emits the terminal tag from the counter alone.

Re-arming Tier 2/3 therefore takes three edits — reset the stage counter below the cap, remove the terminal tag, re-add `influx:repair-needed` — now documented in `SPECIFICATION.md` §11.1, `CONTEXT.md`, and `runbook.md` §6, and pinned by `TestSweepTier2ReArmContract` in both directions. No runtime change: the counter was already authoritative, the docs just claimed otherwise.

Also corrected: candidate selection is profile-qualified (`influx:repair-needed` **and** `profile:<profile>`), not repair-needed alone.

## What I deliberately did NOT do

My first attempt was a diff-guard skipping the `lithos_write` when a sweep pass produced no change. **That was wrong** and is not in this PR. It breaks AC-X-8: the sweep selects candidates `order_by="updated_at", order="asc"`, so the rewrite is what rotates the cursor. Skipping it would leave unchanged notes at the front of the queue forever and starve the rest of the backlog. It failed 29 existing tests, including `test_no_progress_still_rewrites` — which encodes the invariant explicitly. The correct fix is to stop notes being immortal sweep candidates, not to stop writing them.

## Known remaining case (not fixed here)

Notes whose archive download fails **transiently** forever — e.g. a URL that always 403s — never reach a counted cap, so they stay in the sweep legitimately per the transient-retry design and keep churning. Dave's two articles (`0cff8956`, `3b1500c5`) are in this class: `influx:archive-missing` + `influx:text-terminal`, `archive_attempts: 0`. Their `source:ai-agents-briefing` has no registered reacquirer, so `_reacquirer_for_source` returns `None` and `_raise_unsupported_source` raises `stage="unsupported_source"`, which the archive path leaves transient by design.

Two options, both beyond this PR's scope:
1. Operator declares the domains `unsupported` in archive policy — **does not help this class**, because `download_archive` (where policy is consulted) is never reached.
2. Classify `unsupported_source` as counted on the archive path, so a source with no resolver goes terminal instead of retrying forever. Composes with this PR's `archive_ok` waiver. Needs its own issue — it reverses a documented intent.

## Test plan

- [x] `make check` green — 2788 passed, ruff + pyright clean
- [x] 9 cases in `tests/unit/test_repair_clearing_rules.py::TestPerStageTerminalExemptions` — positive waivers for archive/Tier 2/Tier 3, a regression case for note `0a3a8e2b`, and negative controls (terminal tiers must not bypass the text condition; each tier's waiver is scoped to its own condition; `archive-missing` stays factual)
- [x] Sweep-level convergence: Tier 2 and Tier 3 cap-flips assert `influx:repair-needed` removal survives into the persisted write; new archive test proves `archive-terminal` releases an otherwise-complete note while retaining `archive-missing`
- [x] `TestSweepTier2ReArmContract` — capped counter with tag removed invokes the extractor **zero** times and re-terminates; counter reset below cap invokes it once and recovers full-text
- [x] `test_tier2_counted_failure_at_cap_flips_terminal_and_logs` updated — it asserted `influx:repair-needed` *stays* after a cap flip, which is precisely the bug
- [x] `docs/generated/` regenerated
- [ ] Post-deploy: confirm the 24 notes stop accruing versions; those with terminal tags should drop out of the sweep on their next pass

## Note for review

The affected notes keep a misleadingly recent `updated_at` after this lands — they will simply stop advancing. Correcting the existing timestamps would itself require a write, so that is better done Lithos-side if it matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCT69UAC62JFJDX7AcHSAb
