### PR TITLE
fix(repair): count unsupported_source toward the archive cap

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -577,6 +577,20 @@ Tier 2 and Tier 3 hook failures are partitioned into transient (HTTP, transport,
 
 When `tier{N}_attempts` reaches the cap (currently 3), `influx:tier{N}-terminal` is added to the note's tags and that stage is skipped on subsequent sweeps. Transient failures never advance the counter, so flaky network conditions do not burn the cap.
 
+#### Stage-scoped counting: `unsupported_source` on archive
+
+Most discriminators classify the same way everywhere. `unsupported_source` does not — it is **counted for the archive stage only**.
+
+The archive-download hook raises it when no registered adapter owns the note, i.e. `repair_hooks._reacquirer_for_note` returns `None`. That is not a failed attempt but the absence of a code path, so retrying cannot change it — only shipping a resolver can. Left transient, such a note was re-selected and rewritten on every sweep indefinitely (observed in production at v108 after 36 days, with `archive_attempts` still 0), which pinned `updated_at` to "now" and dominated retrieval ranking.
+
+Counted, it converges: `archive_attempts` reaches the cap, `influx:archive-terminal` is applied, the archive clearing condition is waived (§5.3), `influx:repair-needed` is cleared, and the note leaves the sweep set. **`influx:archive-missing` is retained** — it remains factually true that no archive is stored.
+
+Dispatch resolves ownership by source-tag family (`arxiv`; `rss` / `blog` / `rss-<feed>`) **and** by durable identity markers on the note — an `rss-` id, or a `feed-slug:` tag plus a doc-level `source_url`. The identity fallback exists precisely because this failure is now permanent: dispatching on the tag alone would terminalise notes `archive_download_identity` could actually resolve.
+
+Text extraction keeps classifying `unsupported_source` as transient. It has its own terminal path (`repair._terminate_unsupported_text_source` applies `influx:text-terminal` directly rather than through a counter), and counting it globally would double-handle that.
+
+**Operational consequence:** adding a resolver no longer recovers already-terminalised notes automatically. They must be re-armed — see below.
+
 #### Re-arming a terminal stage
 
 **The persisted counter is authoritative, not the tag.** Two different mechanisms read the terminal state, and a re-arm has to satisfy both:

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -120,7 +120,7 @@
         "qualname": "influx.promotion_gate.evaluate_promotion_gate"
       }
     ],
-    "total_functions": 652
+    "total_functions": 653
   },
   "domain": {
     "associations": 5,
@@ -420,13 +420,13 @@
       },
       "Repair": {
         "classes": 17,
-        "functions": 79,
+        "functions": 80,
         "largest_module": "influx.repair",
         "largest_module_lines": 1711,
-        "lines": 3839,
+        "lines": 3886,
         "modules": 5,
         "public_symbols": 39,
-        "sloc": 2964
+        "sloc": 3002
       },
       "Schemas": {
         "classes": 4,
@@ -474,13 +474,13 @@
       "influx.sources.rss",
       "influx.telemetry"
     ],
-    "total_lines": 27994,
+    "total_lines": 28041,
     "total_modules": 58,
-    "total_sloc": 21698
+    "total_sloc": 21736
   },
   "tests": {
     "ratio": 2.56,
-    "src_lines": 27994,
-    "test_lines": 71647
+    "src_lines": 28041,
+    "test_lines": 71764
   }
 }

--- a/docs/generated/metrics.json
+++ b/docs/generated/metrics.json
@@ -423,10 +423,10 @@
         "functions": 79,
         "largest_module": "influx.repair",
         "largest_module_lines": 1711,
-        "lines": 3794,
+        "lines": 3839,
         "modules": 5,
         "public_symbols": 39,
-        "sloc": 2935
+        "sloc": 2964
       },
       "Schemas": {
         "classes": 4,
@@ -474,13 +474,13 @@
       "influx.sources.rss",
       "influx.telemetry"
     ],
-    "total_lines": 27949,
+    "total_lines": 27994,
     "total_modules": 58,
-    "total_sloc": 21669
+    "total_sloc": 21698
   },
   "tests": {
     "ratio": 2.56,
-    "src_lines": 27949,
-    "test_lines": 71494
+    "src_lines": 27994,
+    "test_lines": 71647
   }
 }

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -45,14 +45,14 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Notifications | 1 | 581 | 509 | 2 | 2 | 0.50 | 13 (`influx.notifications.dispatch_notifications`) | 2 |
 | Observability | 3 | 1912 | 1401 | 9 | 0 | 0.00 | 10 (`influx.logging_config.setup_logging`) | 0 |
 | Orchestration | 6 | 4103 | 3241 | 1 | 11 | 0.92 | 52 (`influx.run_service.ledger_lifecycle`) | 11 |
-| Repair | 5 | 3839 | 2964 | 4 | 7 | 0.64 | 26 (`influx.repair._process_sweep_note`) | 6 |
+| Repair | 5 | 3886 | 3002 | 4 | 7 | 0.64 | 26 (`influx.repair._process_sweep_note`) | 6 |
 | Schemas | 1 | 240 | 183 | 3 | 0 | 0.00 | 14 (`influx.schemas._harden_for_openai_strict`) | 1 |
 | Sources | 10 | 4343 | 3323 | 3 | 8 | 0.73 | 28 (`influx.sources.arxiv.build_arxiv_note_item`) | 7 |
 | Storage | 1 | 720 | 588 | 3 | 3 | 0.50 | 14 (`influx.storage.download_archive`) | 2 |
 
 ## Size
 
-- Modules: **58**, lines: **27994**, SLOC: **21698**
+- Modules: **58**, lines: **28041**, SLOC: **21736**
 - Largest module: `influx.sources.arxiv` (1830 lines)
 - Modules over 800 lines: **11**
   - `influx.config`
@@ -69,7 +69,7 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 
 ## Complexity
 
-- Functions: **652**, cyclomatic > 10: **47**
+- Functions: **653**, cyclomatic > 10: **47**
 
 Top 10 most complex functions:
 
@@ -133,4 +133,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 ## Domain & tests
 
 - Domain models: **17** (5 associations, 0 without docstrings)
-- Test-to-source line ratio: **2.56** (71647 test lines / 27994 source lines)
+- Test-to-source line ratio: **2.56** (71764 test lines / 28041 source lines)

--- a/docs/generated/metrics.md
+++ b/docs/generated/metrics.md
@@ -45,14 +45,14 @@ Instability I = fan-out / (fan-in + fan-out): 0 = stable (many dependents),
 | Notifications | 1 | 581 | 509 | 2 | 2 | 0.50 | 13 (`influx.notifications.dispatch_notifications`) | 2 |
 | Observability | 3 | 1912 | 1401 | 9 | 0 | 0.00 | 10 (`influx.logging_config.setup_logging`) | 0 |
 | Orchestration | 6 | 4103 | 3241 | 1 | 11 | 0.92 | 52 (`influx.run_service.ledger_lifecycle`) | 11 |
-| Repair | 5 | 3794 | 2935 | 4 | 7 | 0.64 | 26 (`influx.repair._process_sweep_note`) | 6 |
+| Repair | 5 | 3839 | 2964 | 4 | 7 | 0.64 | 26 (`influx.repair._process_sweep_note`) | 6 |
 | Schemas | 1 | 240 | 183 | 3 | 0 | 0.00 | 14 (`influx.schemas._harden_for_openai_strict`) | 1 |
 | Sources | 10 | 4343 | 3323 | 3 | 8 | 0.73 | 28 (`influx.sources.arxiv.build_arxiv_note_item`) | 7 |
 | Storage | 1 | 720 | 588 | 3 | 3 | 0.50 | 14 (`influx.storage.download_archive`) | 2 |
 
 ## Size
 
-- Modules: **58**, lines: **27949**, SLOC: **21669**
+- Modules: **58**, lines: **27994**, SLOC: **21698**
 - Largest module: `influx.sources.arxiv` (1830 lines)
 - Modules over 800 lines: **11**
   - `influx.config`
@@ -133,4 +133,4 @@ Private-name reaches across module seams. Both counts can be pinned as
 ## Domain & tests
 
 - Domain models: **17** (5 associations, 0 without docstrings)
-- Test-to-source line ratio: **2.56** (71494 test lines / 27949 source lines)
+- Test-to-source line ratio: **2.56** (71647 test lines / 27994 source lines)

--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -522,7 +522,7 @@ def _apply_counted_failure(
     stage flip in logs.  The ``<stage>_attempts`` log field is named per
     *stage* so existing log-filter rules keep matching.
     """
-    if classify_failure(exc) != "counted":
+    if classify_failure(exc, stage=stage) != "counted":
         return current_tags
     advance = record_counted_failure(
         content=str(note.get("content", "")),

--- a/src/influx/repair.py
+++ b/src/influx/repair.py
@@ -522,7 +522,7 @@ def _apply_counted_failure(
     stage flip in logs.  The ``<stage>_attempts`` log field is named per
     *stage* so existing log-filter rules keep matching.
     """
-    if classify_failure(exc, stage=stage) != "counted":
+    if classify_failure(exc, repair_stage=stage) != "counted":
         return current_tags
     advance = record_counted_failure(
         content=str(note.get("content", "")),

--- a/src/influx/repair_counters.py
+++ b/src/influx/repair_counters.py
@@ -225,7 +225,7 @@ _COUNTED_STAGES: frozenset[str] = frozenset({"parse", "validate", "oversize"})
 # Discriminators that are permanent for *one* stage but not globally.
 #
 # ``unsupported_source``: the note's ``source:*`` tag has no registered
-# reacquirer, so ``repair_hooks._reacquirer_for_source`` returns ``None``
+# reacquirer, so ``repair_hooks._reacquirer_for_note`` returns ``None``
 # and the archive hook raises before any network call.  Nothing about a
 # retry changes that — it is fixed only by shipping a resolver — so for
 # the archive stage it advances the cap rather than retrying forever.
@@ -242,7 +242,7 @@ _STAGE_SCOPED_COUNTED_STAGES: dict[CountedStage, frozenset[str]] = {
 def classify_failure(
     exc: BaseException,
     *,
-    stage: CountedStage | None = None,
+    repair_stage: CountedStage | None = None,
 ) -> Literal["transient", "counted"]:
     """Partition a sweep stage failure into transient vs counted.
 
@@ -260,17 +260,22 @@ def classify_failure(
     ----------
     exc:
         The stage failure to classify.
-    stage:
-        The sweep stage that raised, when known.  Some discriminators
-        are permanent for one stage and transient for another — see
+    repair_stage:
+        The *repair* stage that raised, when known — deliberately not
+        named ``stage``, which on the exception means the failure
+        discriminator (``parse`` / ``http`` / ``unsupported_source``).
+        Some discriminators are permanent for one repair stage and
+        transient for another — see
         :data:`_STAGE_SCOPED_COUNTED_STAGES`.  Omitting it yields the
         global classification.
     """
     if isinstance(exc, (LCMAError, ExtractionError)):
         exc_stage = getattr(exc, "stage", "") or ""
         counted = _COUNTED_STAGES
-        if stage is not None:
-            counted = counted | _STAGE_SCOPED_COUNTED_STAGES.get(stage, frozenset())
+        if repair_stage is not None:
+            counted = counted | _STAGE_SCOPED_COUNTED_STAGES.get(
+                repair_stage, frozenset()
+            )
         if exc_stage in counted:
             return "counted"
     return "transient"

--- a/src/influx/repair_counters.py
+++ b/src/influx/repair_counters.py
@@ -222,8 +222,28 @@ def upsert_repair_section(content: str, counters: RepairCounters) -> str:
 # size violations (oversize) which won't shrink on retry.
 _COUNTED_STAGES: frozenset[str] = frozenset({"parse", "validate", "oversize"})
 
+# Discriminators that are permanent for *one* stage but not globally.
+#
+# ``unsupported_source``: the note's ``source:*`` tag has no registered
+# reacquirer, so ``repair_hooks._reacquirer_for_source`` returns ``None``
+# and the archive hook raises before any network call.  Nothing about a
+# retry changes that — it is fixed only by shipping a resolver — so for
+# the archive stage it advances the cap rather than retrying forever.
+#
+# The text-extraction path deliberately keeps classifying it transient:
+# it has its own terminal handling in
+# ``repair._terminate_unsupported_text_source``, which flips
+# ``influx:text-terminal`` directly instead of going through a counter.
+_STAGE_SCOPED_COUNTED_STAGES: dict[CountedStage, frozenset[str]] = {
+    "archive": frozenset({"unsupported_source"}),
+}
 
-def classify_failure(exc: BaseException) -> Literal["transient", "counted"]:
+
+def classify_failure(
+    exc: BaseException,
+    *,
+    stage: CountedStage | None = None,
+) -> Literal["transient", "counted"]:
     """Partition a sweep stage failure into transient vs counted.
 
     *Counted* failures advance the per-stage attempt counter and
@@ -235,10 +255,23 @@ def classify_failure(exc: BaseException) -> Literal["transient", "counted"]:
     *Transient* failures (HTTP, transport, resolve, archive_read, or
     anything we don't specifically recognise) leave the counter alone.
     The next sweep retries them indefinitely.
+
+    Parameters
+    ----------
+    exc:
+        The stage failure to classify.
+    stage:
+        The sweep stage that raised, when known.  Some discriminators
+        are permanent for one stage and transient for another — see
+        :data:`_STAGE_SCOPED_COUNTED_STAGES`.  Omitting it yields the
+        global classification.
     """
     if isinstance(exc, (LCMAError, ExtractionError)):
-        stage = getattr(exc, "stage", "") or ""
-        if stage in _COUNTED_STAGES:
+        exc_stage = getattr(exc, "stage", "") or ""
+        counted = _COUNTED_STAGES
+        if stage is not None:
+            counted = counted | _STAGE_SCOPED_COUNTED_STAGES.get(stage, frozenset())
+        if exc_stage in counted:
             return "counted"
     return "transient"
 

--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -371,11 +371,22 @@ def _raise_unsupported_source(
 ) -> None:
     """Raise ``ExtractionError(stage="unsupported_source")`` for an unknown source.
 
-    The text-extraction path flips this to terminal via
-    :func:`influx.repair._terminate_unsupported_text_source`; the
-    archive-download path leaves it transient (the note re-enters the
-    sweep next pass and is repaired automatically once a per-source
-    resolver is added).
+    Both paths treat this as permanent, by different mechanisms:
+
+    * text extraction flips ``influx:text-terminal`` directly via
+      :func:`influx.repair._terminate_unsupported_text_source`;
+    * archive download counts it toward the per-stage cap (see
+      ``_STAGE_SCOPED_COUNTED_STAGES`` in ``influx.repair_counters``),
+      flipping ``influx:archive-terminal`` at
+      ``REPAIR_COUNTED_CAP``.
+
+    The archive path classified this transient until the note churn it
+    caused was measured in production: a note whose source has no
+    resolver was re-swept and rewritten on every pass indefinitely,
+    pinning ``updated_at`` to "now" and dominating retrieval ranking.
+    Retrying cannot help — only shipping a resolver can — so it now
+    advances the cap.  Once a resolver lands, re-arm affected notes per
+    ``docs/operations/runbook.md`` §6.
     """
     raise ExtractionError(
         f"{stage_label}: source {source!r} not supported",
@@ -468,10 +479,11 @@ def _make_archive_download_hook(
     :meth:`~influx.source.Source.archive_download_identity` (finding 3b)
     — so the acquire-time identity scheme and its repair-time
     reconstruction live in one module and cannot drift.  A note whose
-    source has no registered reacquirer raises
-    ``ExtractionError(stage="unsupported_source")`` (transient) — the
-    note re-enters the sweep next pass, preserving the pre-3b behaviour
-    for sources without a resolver (e.g. inbox — GH #248).  A note whose
+    source has no registered reacquirer (e.g. inbox — GH #248) raises
+    ``ExtractionError(stage="unsupported_source")``, which is *counted*
+    for the archive stage: the note reaches ``influx:archive-terminal``
+    at the cap and leaves the sweep instead of re-entering it forever.
+    A note whose
     reacquirer cannot rebuild the identity (missing fields) raises
     ``ExtractionError(stage="resolve")`` (also transient) awaiting an
     operator hand-fix.

--- a/src/influx/repair_hooks.py
+++ b/src/influx/repair_hooks.py
@@ -142,6 +142,10 @@ def _extract_from_archive(
 _SOURCE_TAG_PREFIX = "source:"
 _NOTE_PATH_SOURCE_RE = re.compile(r"(?:^|/)(?:papers|articles)/(?P<source>[^/]+)/")
 _RSS_NOTE_ID_PREFIX = "rss-"
+# Mirrors ``influx.sources.rss._FEED_SLUG_TAG_PREFIX``.  Duplicated
+# rather than imported because ``sources.*`` already import from this
+# module, so importing back would close a cycle.
+_FEED_SLUG_TAG_PREFIX = "feed-slug:"
 _ARXIV_NOTE_ID_PREFIX = "arxiv-"
 _ARXIV_HOSTNAMES: frozenset[str] = frozenset({"arxiv.org", "www.arxiv.org"})
 
@@ -165,9 +169,33 @@ def _is_rss_source(source: str) -> bool:
 
     Production RSS notes carry ``source:rss-<feed-slug>``; the bare
     ``source:rss`` sentinel is accepted to keep the dispatcher robust
-    to historical or hand-edited notes.
+    to historical or hand-edited notes.  ``source:blog`` is the other
+    value :class:`~influx.config.RssSourceEntry` permits for
+    ``source_tag`` (``Literal["rss", "blog"]``) and is written verbatim
+    by RSS acquisition, so it names the same family.
     """
-    return source == "rss" or source.startswith(_RSS_NOTE_ID_PREFIX)
+    return source in ("rss", "blog") or source.startswith(_RSS_NOTE_ID_PREFIX)
+
+
+def _has_rss_identity(note: dict[str, object]) -> bool:
+    """Return whether *note* carries recoverable RSS archive identity.
+
+    :meth:`~influx.sources.rss.RssSource.archive_download_identity`
+    rebuilds the retry identity from an ``rss-`` note id, or from a
+    ``feed-slug:`` tag plus a doc-level ``source_url``.  Neither
+    requires a recognised ``source:*`` tag, so a note can be
+    reacquirable even when its source tag is one the dispatcher does
+    not name — e.g. a feed whose ``source_tag`` was renamed, or a
+    historical value predating the current vocabulary.
+
+    Checking identity rather than the tag alone keeps recoverable notes
+    out of the ``unsupported_source`` path, which is now *counted* for
+    the archive stage and therefore permanent at the cap.
+    """
+    if str(note.get("id", "")).startswith(_RSS_NOTE_ID_PREFIX):
+        return True
+    has_feed_slug = find_note_tag(note_tags(note), _FEED_SLUG_TAG_PREFIX) is not None
+    return has_feed_slug and bool(note_source_url(note))
 
 
 # ── Source metadata invariant (#150) ────────────────────────────────
@@ -441,19 +469,33 @@ def _classify_download_kind(error: str) -> str:
 # ── Hook factories ──────────────────────────────────────────────────
 
 
-def _reacquirer_for_source(
-    source: str, reacquirers: Mapping[str, Source]
+def _reacquirer_for_note(
+    note: dict[str, object],
+    source: str,
+    reacquirers: Mapping[str, Source],
 ) -> Source | None:
-    """Pick the Source that owns *source*'s archive-identity scheme.
+    """Pick the Source that owns *note*'s archive-identity scheme.
 
-    Maps the note's ``source:*`` tag suffix to a canonical family key —
-    ``"arxiv"`` or ``"rss"`` (any ``rss-<feed>`` variant).  Returns
-    ``None`` for a source with no registered reacquirer (e.g. inbox),
-    which the hook treats as ``unsupported_source`` (transient).
+    Resolution is by source-tag family first (``"arxiv"``; ``"rss"`` for
+    any of ``rss`` / ``blog`` / ``rss-<feed>``), then by durable RSS
+    identity markers on the note itself — an ``rss-`` id, or a
+    ``feed-slug:`` tag plus a doc-level ``source_url``.
+
+    The identity fallback matters because the archive stage now *counts*
+    ``unsupported_source`` toward its cap, making it permanent at the
+    cap.  Dispatching on the tag alone would terminalise notes that
+    :meth:`~influx.source.Source.archive_download_identity` could in
+    fact resolve — ``source:blog`` is a currently-valid
+    :class:`~influx.config.RssSourceEntry` ``source_tag`` and was the
+    concrete instance of this.
+
+    Returns ``None`` only when no registered adapter can own the note
+    (e.g. inbox — GH #248), which the hook raises as
+    ``unsupported_source``.
     """
     if source == "arxiv":
         return reacquirers.get("arxiv")
-    if _is_rss_source(source):
+    if _is_rss_source(source) or _has_rss_identity(note):
         return reacquirers.get("rss")
     return None
 
@@ -503,7 +545,7 @@ def _make_archive_download_hook(
 
     def hook(note: dict[str, object]) -> str:
         source = _note_source_tag(note)
-        reacquirer = _reacquirer_for_source(source, archive_reacquirers)
+        reacquirer = _reacquirer_for_note(note, source, archive_reacquirers)
         if reacquirer is None:
             _raise_unsupported_source(
                 note, stage_label="archive_download retry", source=source

--- a/tests/unit/test_repair_counters.py
+++ b/tests/unit/test_repair_counters.py
@@ -356,7 +356,7 @@ class TestArchiveScopedCountedStages:
 
     def test_unsupported_source_counted_for_archive_stage(self) -> None:
         exc = ExtractionError("source 'x' not supported", stage="unsupported_source")
-        assert classify_failure(exc, stage="archive") == "counted"
+        assert classify_failure(exc, repair_stage="archive") == "counted"
 
     def test_unsupported_source_transient_without_stage(self) -> None:
         """Default (text-extraction) classification is unchanged."""
@@ -365,16 +365,16 @@ class TestArchiveScopedCountedStages:
 
     def test_unsupported_source_transient_for_tier_stages(self) -> None:
         exc = ExtractionError("source 'x' not supported", stage="unsupported_source")
-        assert classify_failure(exc, stage="tier2") == "transient"
-        assert classify_failure(exc, stage="tier3") == "transient"
+        assert classify_failure(exc, repair_stage="tier2") == "transient"
+        assert classify_failure(exc, repair_stage="tier3") == "transient"
 
     def test_archive_stage_does_not_widen_other_transients(self) -> None:
         """Only ``unsupported_source`` is added for archive — not all stages."""
         for stage in ("http", "resolve", "archive_read"):
             exc = ExtractionError("boom", stage=stage)
-            assert classify_failure(exc, stage="archive") == "transient", stage
+            assert classify_failure(exc, repair_stage="archive") == "transient", stage
 
     def test_archive_stage_keeps_globally_counted_stages(self) -> None:
         for stage in ("parse", "validate", "oversize"):
             exc = ExtractionError("boom", stage=stage)
-            assert classify_failure(exc, stage="archive") == "counted", stage
+            assert classify_failure(exc, repair_stage="archive") == "counted", stage

--- a/tests/unit/test_repair_counters.py
+++ b/tests/unit/test_repair_counters.py
@@ -333,3 +333,48 @@ class TestCountedFailureResultShape:
         assert isinstance(result.cap_reached, bool)
         assert result.terminal_tag == "influx:tier2-terminal"
         assert isinstance(result.terminal_tag_added, bool)
+
+
+# ── Archive-scoped counted stages (unsupported_source) ─────────────
+
+
+class TestArchiveScopedCountedStages:
+    """``unsupported_source`` is counted for the archive stage only.
+
+    A note whose ``source:*`` tag has no registered reacquirer raises
+    ``ExtractionError(stage="unsupported_source")`` from the archive
+    hook on every pass.  Treated as transient it retries forever, which
+    kept notes in the sweep set indefinitely.  It is definitionally
+    permanent — unlike an HTTP 5xx, re-running changes nothing until
+    code ships — so the archive stage counts it toward the cap.
+
+    The text-extraction path must keep classifying it transient: it has
+    its own terminal handling in
+    ``repair._terminate_unsupported_text_source``, which flips
+    ``influx:text-terminal`` directly rather than via the counter.
+    """
+
+    def test_unsupported_source_counted_for_archive_stage(self) -> None:
+        exc = ExtractionError("source 'x' not supported", stage="unsupported_source")
+        assert classify_failure(exc, stage="archive") == "counted"
+
+    def test_unsupported_source_transient_without_stage(self) -> None:
+        """Default (text-extraction) classification is unchanged."""
+        exc = ExtractionError("source 'x' not supported", stage="unsupported_source")
+        assert classify_failure(exc) == "transient"
+
+    def test_unsupported_source_transient_for_tier_stages(self) -> None:
+        exc = ExtractionError("source 'x' not supported", stage="unsupported_source")
+        assert classify_failure(exc, stage="tier2") == "transient"
+        assert classify_failure(exc, stage="tier3") == "transient"
+
+    def test_archive_stage_does_not_widen_other_transients(self) -> None:
+        """Only ``unsupported_source`` is added for archive — not all stages."""
+        for stage in ("http", "resolve", "archive_read"):
+            exc = ExtractionError("boom", stage=stage)
+            assert classify_failure(exc, stage="archive") == "transient", stage
+
+    def test_archive_stage_keeps_globally_counted_stages(self) -> None:
+        for stage in ("parse", "validate", "oversize"):
+            exc = ExtractionError("boom", stage=stage)
+            assert classify_failure(exc, stage="archive") == "counted", stage

--- a/tests/unit/test_repair_hooks_production.py
+++ b/tests/unit/test_repair_hooks_production.py
@@ -634,8 +634,125 @@ class TestArchiveDownloadHookMetadataRecovery:
         with pytest.raises(ExtractionError) as exc_info:
             hooks.archive_download(note)
         assert exc_info.value.stage == "unsupported_source"
-        # Transient — future sources can land later without a forced cap.
+        # Counted for the archive stage: no adapter can resolve this note,
+        # so retrying cannot help and the note converges to
+        # influx:archive-terminal at the cap rather than churning forever.
+        # Landing a resolver later requires re-arming affected notes per
+        # docs/operations/runbook.md §6.
+        assert classify_failure(exc_info.value, repair_stage="archive") == "counted"
+        # Context-free (and text-extraction) classification is unchanged —
+        # that path has its own terminal handling via
+        # repair._terminate_unsupported_text_source.
         assert classify_failure(exc_info.value) == "transient"
+
+    def test_blog_source_reaches_rss_reacquirer(self, tmp_path: Path) -> None:
+        """``source:blog`` is a valid RssSourceEntry source_tag (#281 review).
+
+        581 notes in production carry it.  Dispatching on ``source:rss*``
+        alone routed them to ``unsupported_source``, which is now counted
+        — so they would have been permanently terminalised despite
+        ``RssSource.archive_download_identity`` being able to rebuild
+        their retry identity from ``feed-slug`` + ``source_url``.
+        """
+        from influx.repair_counters import classify_failure
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(
+            config, archive_reacquirers=_reacquirers(config)
+        )
+        note = _make_archive_missing_note()
+        note["id"] = "550e8400-e29b-41d4-a716-446655440000"
+        note["tags"] = [
+            "profile:ai-robotics",
+            "ingested-by:influx",
+            "source:blog",
+            "feed-slug:openai-news",
+            "influx:repair-needed",
+            "influx:archive-missing",
+        ]
+        note["source_url"] = "https://openai.com/index/concrete-ai-safety-problems"
+        note["path"] = "articles/blog/2016/06/concrete-ai-safety-problems.md"
+
+        assert hooks.archive_download is not None
+        with pytest.raises(ExtractionError) as exc_info:
+            hooks.archive_download(note)
+        # Reached RssSource and attempted a real download — NOT rejected
+        # at dispatch.  The network failure here is transient, so the
+        # note stays recoverable.
+        assert exc_info.value.stage != "unsupported_source"
+        assert classify_failure(exc_info.value, repair_stage="archive") == "transient"
+
+    def test_unknown_source_with_feed_slug_reaches_rss_reacquirer(
+        self, tmp_path: Path
+    ) -> None:
+        """Identity markers win over an unrecognised source tag.
+
+        A note whose ``source:*`` value the dispatcher does not name is
+        still reacquirable when it carries ``feed-slug`` + ``source_url``
+        — the exact inputs ``archive_download_identity`` needs.
+        """
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(
+            config, archive_reacquirers=_reacquirers(config)
+        )
+        note = _make_archive_missing_note()
+        note["id"] = "550e8400-e29b-41d4-a716-446655440001"
+        note["tags"] = [
+            "profile:ai-robotics",
+            "ingested-by:influx",
+            "source:some-renamed-feed",
+            "feed-slug:some-renamed-feed",
+            "influx:repair-needed",
+        ]
+        note["source_url"] = "https://example.com/post"
+        note["path"] = "articles/some-renamed-feed/2026/06/post.md"
+
+        assert hooks.archive_download is not None
+        with pytest.raises(ExtractionError) as exc_info:
+            hooks.archive_download(note)
+        assert exc_info.value.stage != "unsupported_source"
+
+    def test_inbox_shape_without_rss_identity_is_unsupported(
+        self, tmp_path: Path
+    ) -> None:
+        """The real production shape behind #279 — no RSS identity at all.
+
+        Mirrors notes 0cff8956 / 3b1500c5: ``source:ai-agents-briefing``
+        with a ``submitter:`` tag, a UUID id, and NO ``feed-slug``.
+        ``_rss_item_id_from_note`` needs an ``rss-`` id or feed-slug +
+        source_url and has neither, so routing this to RssSource would
+        only swap ``unsupported_source`` for ``resolve`` — both would
+        churn.  It is genuinely unsupported, and counting it is what
+        makes it converge.
+        """
+        from influx.repair_counters import classify_failure
+
+        config = _make_config(tmp_path)
+        hooks = make_default_sweep_hooks(
+            config, archive_reacquirers=_reacquirers(config)
+        )
+        note = _make_archive_missing_note()
+        note["id"] = "0cff8956-c5b7-4a8f-8086-1de58fd3b1ef"
+        note["tags"] = [
+            "profile:knowledge-systems",
+            "ingested-by:influx",
+            "source:ai-agents-briefing",
+            "submitter:ai-agents-briefing",
+            "influx:repair-needed",
+            "influx:archive-missing",
+            "text:abstract-only",
+            "influx:text-terminal",
+        ]
+        note["source_url"] = (
+            "https://origintrail.io/blog/the-next-big-shift-in-ai-agents"
+        )
+        note["path"] = "articles/ai-agents-briefing/2026/06/shared-context-graphs.md"
+
+        assert hooks.archive_download is not None
+        with pytest.raises(ExtractionError) as exc_info:
+            hooks.archive_download(note)
+        assert exc_info.value.stage == "unsupported_source"
+        assert classify_failure(exc_info.value, repair_stage="archive") == "counted"
 
 
 # ── text_extraction hook (issue #24, FR-REP-1 stage 2) ───────────────

--- a/tests/unit/test_repair_sweep.py
+++ b/tests/unit/test_repair_sweep.py
@@ -2051,7 +2051,7 @@ class TestSweepUnsupportedSourceArchiveConvergence:
     Reproduces the production shape that survived the terminal-waiver
     fix: ``influx:archive-missing`` + ``text:abstract-only`` +
     ``influx:text-terminal``, whose ``source:*`` tag has no registered
-    reacquirer.  ``_reacquirer_for_source`` returns ``None``, the archive
+    reacquirer.  ``_reacquirer_for_note`` returns ``None``, the archive
     hook raises ``ExtractionError(stage="unsupported_source")`` before
     any network call, and — while that was classified transient — the
     counter never moved, the note never reached a cap, and every sweep

--- a/tests/unit/test_repair_sweep.py
+++ b/tests/unit/test_repair_sweep.py
@@ -2043,3 +2043,111 @@ class TestSweepNoteParse:
             str(note.get("content") or ""), fallback_title=_doc_title(note)
         )
         assert parsed.title == "T"
+
+
+class TestSweepUnsupportedSourceArchiveConvergence:
+    """A source with no reacquirer converges instead of churning forever.
+
+    Reproduces the production shape that survived the terminal-waiver
+    fix: ``influx:archive-missing`` + ``text:abstract-only`` +
+    ``influx:text-terminal``, whose ``source:*`` tag has no registered
+    reacquirer.  ``_reacquirer_for_source`` returns ``None``, the archive
+    hook raises ``ExtractionError(stage="unsupported_source")`` before
+    any network call, and — while that was classified transient — the
+    counter never moved, the note never reached a cap, and every sweep
+    rewrote it (observed at v108/v101 after ~36 days).
+    """
+
+    @staticmethod
+    def _note(archive_attempts: int) -> dict[str, Any]:
+        body = (
+            "---\n"
+            "source_url: https://origintrail.io/blog/shared-context-graphs\n"
+            "tags: []\n"
+            "confidence: 1.0\n"
+            "---\n"
+            "# Shared Context Graphs\n\n"
+            "## Archive\n\n"
+            "## Summary\nSummary\n\n"
+            "## Repair\n"
+            f"- archive_attempts: {archive_attempts}\n"
+            '- archive_last_kind: "unsupported_source"\n'
+            '- archive_last_error: "earlier failure"\n\n'
+            "## Profile Relevance\n"
+            "### ai-robotics\nScore: 9/10\nRelevant\n\n"
+            "## User Notes\n"
+        )
+        return {
+            "id": "n1",
+            "title": "Shared Context Graphs",
+            "content": body,
+            "tags": [
+                "influx:repair-needed",
+                "influx:archive-missing",
+                "text:abstract-only",
+                "influx:text-terminal",
+            ],
+            "source_url": "https://origintrail.io/blog/shared-context-graphs",
+            "confidence": 1.0,
+        }
+
+    @staticmethod
+    def _unsupported(note: dict[str, object]) -> str:
+        del note
+        raise ExtractionError(
+            "archive_download retry: source 'ai-agents-briefing' not supported",
+            stage="unsupported_source",
+        )
+
+    @staticmethod
+    def _write_args(client: AsyncMock) -> dict[str, Any]:
+        write_calls = [
+            c for c in client.call_tool.call_args_list if c.args[0] == "lithos_write"
+        ]
+        assert write_calls, "expected lithos_write call"
+        return dict(write_calls[-1].args[1])
+
+    async def test_unsupported_source_advances_archive_counter(self) -> None:
+        """Below the cap: counter moves, note stays in the sweep."""
+        config = _make_config()
+        client = _make_client(
+            list_items=[{"id": "n1", "title": "Shared Context Graphs"}],
+            read_responses=[self._note(0)],
+        )
+
+        await sweep(
+            "ai-robotics",
+            client=client,
+            config=config,
+            hooks=SweepHooks(archive_download=self._unsupported),
+        )
+
+        rewritten = self._write_args(client)
+        assert "archive_attempts: 1" in rewritten["content"]
+        assert "influx:archive-terminal" not in rewritten["tags"]
+        assert "influx:repair-needed" in rewritten["tags"]
+
+    async def test_at_cap_flips_terminal_and_releases_note(self) -> None:
+        """At the cap the note goes terminal and leaves the sweep set."""
+        from influx.repair_counters import REPAIR_COUNTED_CAP
+
+        config = _make_config()
+        client = _make_client(
+            list_items=[{"id": "n1", "title": "Shared Context Graphs"}],
+            read_responses=[self._note(REPAIR_COUNTED_CAP - 1)],
+        )
+
+        await sweep(
+            "ai-robotics",
+            client=client,
+            config=config,
+            hooks=SweepHooks(archive_download=self._unsupported),
+        )
+
+        rewritten = self._write_args(client)
+        assert f"archive_attempts: {REPAIR_COUNTED_CAP}" in rewritten["content"]
+        assert "influx:archive-terminal" in rewritten["tags"]
+        # The whole point: it stops being an immortal sweep candidate.
+        assert "influx:repair-needed" not in rewritten["tags"]
+        # Still factually archive-less.
+        assert "influx:archive-missing" in rewritten["tags"]


### PR DESCRIPTION
Follow-up to #278, which fixed the terminal-waiver half of the sweep churn but explicitly could not reach this class.

## Problem

A note whose `source:*` tag has no registered reacquirer churns forever. `_reacquirer_for_source` maps only `arxiv` and `rss-*`; anything else returns `None`, so `_raise_unsupported_source` raises `ExtractionError(stage="unsupported_source")` before any network call. That stage classified as **transient**, so `archive_attempts` never advanced, no cap was reached, `influx:repair-needed` was never cleared, and — because the sweep rewrites every visited note to advance retry order (AC-X-8) — the note accrued one version per sweep indefinitely.

Since `updated_at` is also Lithos's recency signal, such notes become permanently the freshest thing in the KB.

Measured in production 2026-07-29 — the two articles that triggered the original investigation:

| Note | Version | Created | `archive_attempts` |
|---|---|---|---|
| `0cff8956` Shared Context Graphs | 108 | 2026-06-23 | **0** |
| `3b1500c5` A2A Protocol v1 2026 | 101 | 2026-06-24 | **0** |

~100 sweeps each, counter never moved. #278 could not help: with no counted failure there is no terminal tag for its waiver to act on.

Worth recording that the archive-policy route also cannot fix this — `[storage.archive_policy.unsupported]` is consulted inside `download_archive`, which is never reached.

## Change

`classify_failure` gains an optional `stage` parameter backed by a `_STAGE_SCOPED_COUNTED_STAGES` table. `unsupported_source` is counted for `stage="archive"` only.

The text-extraction path deliberately keeps classifying it transient — it has its own terminal handling in `_terminate_unsupported_text_source`, which flips `influx:text-terminal` directly rather than through a counter. Making it globally counted would double-handle that path.

With #278's `archive_ok` waiver already merged, affected notes converge in `REPAIR_COUNTED_CAP` (3) sweeps: counter caps → `influx:archive-terminal` → archive condition waived → `influx:repair-needed` cleared → note leaves the sweep set. `influx:archive-missing` is retained, since it stays factually true.

## Tradeoff — this reverses a documented intent

The archive path left the stage transient so a note would recover automatically once a per-source resolver shipped. That auto-recovery is real, but it costs unbounded churn while waiting, and these notes waited 36 days. Retrying cannot help a failure that means "no code path exists for this source" — only shipping a resolver can.

After this, landing a resolver means re-arming affected notes per `docs/operations/runbook.md` §6 — bounded and documented, though currently three manual edits. #280 proposes an operator command for that.

## Test plan

- [x] `make check` green — 2795 passed, ruff + pyright clean
- [x] `TestArchiveScopedCountedStages` — counted for `archive`; transient with no stage, for `tier2`/`tier3`; archive scoping does not widen other transients (`http`, `resolve`, `archive_read`) nor drop globally-counted stages (`parse`, `validate`, `oversize`)
- [x] `TestSweepUnsupportedSourceArchiveConvergence` — reproduces the exact production note shape (`archive-missing` + `abstract-only` + `text-terminal`): below the cap the counter advances and the note stays; at the cap `influx:archive-terminal` flips, `influx:repair-needed` is cleared, `influx:archive-missing` retained
- [x] Both `repair_hooks` docstrings describing the old transient behaviour corrected
- [ ] Post-deploy: `0cff8956` and `3b1500c5` should reach `influx:archive-terminal` after 3 sweeps and stop accruing versions

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCT69UAC62JFJDX7AcHSAb
